### PR TITLE
perf: batch insert restore data in single transaction

### DIFF
--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -527,6 +527,73 @@ class ChatDatabaseRepository {
     });
   }
 
+  Future<void> putRestoreBatch({
+    required List<Conversation> conversations,
+    required Map<String, List<ChatMessage>> messagesByConversation,
+    required Map<String, List<Map<String, dynamic>>> toolEventsByMessageId,
+    required Map<String, String> geminiSignaturesByMessageId,
+  }) async {
+    if (conversations.isEmpty &&
+        messagesByConversation.values.every((l) => l.isEmpty) &&
+        toolEventsByMessageId.isEmpty &&
+        geminiSignaturesByMessageId.isEmpty) {
+      return;
+    }
+
+    await _db.transaction(() async {
+      await _db.batch((batch) {
+        for (final conversation in conversations) {
+          batch.insert(
+            _db.conversationRows,
+            _conversationCompanion(conversation),
+            mode: InsertMode.insertOrReplace,
+          );
+          for (var i = 0; i < conversation.mcpServerIds.length; i++) {
+            batch.insert(
+              _db.conversationMcpServerRows,
+              ConversationMcpServerRowsCompanion.insert(
+                conversationId: conversation.id,
+                serverId: conversation.mcpServerIds[i],
+                ordinal: i,
+              ),
+              mode: InsertMode.insertOrReplace,
+            );
+          }
+        }
+        for (final entry in messagesByConversation.entries) {
+          final messages = entry.value;
+          for (var i = 0; i < messages.length; i++) {
+            batch.insert(
+              _db.messageRows,
+              _messageCompanion(messages[i], i),
+              mode: InsertMode.insertOrReplace,
+            );
+          }
+        }
+        for (final entry in toolEventsByMessageId.entries) {
+          batch.insert(
+            _db.toolEventRows,
+            ToolEventRowsCompanion.insert(
+              messageId: entry.key,
+              eventsJson: jsonEncode(entry.value),
+            ),
+            mode: InsertMode.insertOrReplace,
+          );
+        }
+        for (final entry in geminiSignaturesByMessageId.entries) {
+          batch.insert(
+            _db.geminiThoughtSignatureRows,
+            GeminiThoughtSignatureRowsCompanion.insert(
+              messageId: entry.key,
+              signature: entry.value,
+            ),
+            mode: InsertMode.insertOrReplace,
+          );
+        }
+      });
+    });
+  }
+
   Future<void> updateMessage(ChatMessage message) async {
     final existing = await (_db.select(
       _db.messageRows,

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -1063,30 +1063,17 @@ class DataSync {
                   .map((k, v) => MapEntry(k.toString(), v.toString()));
 
           if (mode == RestoreMode.overwrite) {
-            // Clear and restore via ChatService
             await chatService.clearAllData();
             final byConv = <String, List<ChatMessage>>{};
             for (final m in msgs) {
               (byConv[m.conversationId] ??= <ChatMessage>[]).add(m);
             }
-            for (final c in convs) {
-              final list = byConv[c.id] ?? const <ChatMessage>[];
-              await chatService.restoreConversation(c, list);
-            }
-            // Tool events
-            for (final entry in toolEvents.entries) {
-              try {
-                await chatService.setToolEvents(entry.key, entry.value);
-              } catch (_) {}
-            }
-            for (final entry in geminiThoughtSigs.entries) {
-              try {
-                await chatService.setGeminiThoughtSignature(
-                  entry.key,
-                  entry.value,
-                );
-              } catch (_) {}
-            }
+            await chatService.restoreConversationsBatch(
+              conversations: convs,
+              messagesByConversation: byConv,
+              toolEventsByMessageId: toolEvents,
+              geminiSignaturesByMessageId: geminiThoughtSigs,
+            );
           } else {
             // Merge mode: Add only non-existing conversations and messages
             final existingConvs = chatService.getAllCompleteConversations();
@@ -1107,13 +1094,25 @@ class DataSync {
               }
             }
 
-            // Restore non-existing conversations and their messages
+            // Batch-write new conversations; per-message for existing ones
+            final batchConvs = <Conversation>[];
+            final batchMsgs = <String, List<ChatMessage>>{};
+            final batchToolEvents = <String, List<Map<String, dynamic>>>{};
+            final batchGeminiSigs = <String, String>{};
             for (final c in convs) {
               if (!existingConvIds.contains(c.id)) {
+                batchConvs.add(c);
                 final list = byConv[c.id] ?? const <ChatMessage>[];
-                await chatService.restoreConversation(c, list);
+                batchMsgs[c.id] = list;
+                for (final msg in list) {
+                  if (toolEvents.containsKey(msg.id)) {
+                    batchToolEvents[msg.id] = toolEvents[msg.id]!;
+                  }
+                  if (geminiThoughtSigs.containsKey(msg.id)) {
+                    batchGeminiSigs[msg.id] = geminiThoughtSigs[msg.id]!;
+                  }
+                }
               } else if (byConv.containsKey(c.id)) {
-                // Conversation exists but has new messages
                 final newMessages = byConv[c.id]!;
                 for (final msg in newMessages) {
                   await chatService.addMessageDirectly(c.id, msg);
@@ -1121,8 +1120,20 @@ class DataSync {
               }
             }
 
-            // Merge tool events
+            if (batchConvs.isNotEmpty) {
+              await chatService.restoreConversationsBatch(
+                conversations: batchConvs,
+                messagesByConversation: batchMsgs,
+                toolEventsByMessageId: batchToolEvents,
+                geminiSignaturesByMessageId: batchGeminiSigs,
+              );
+            }
+
+            // Merge remaining tool events and signatures
+            // (entries belonging to batch-handled messages are safely skipped
+            //  since they already exist in DB)
             for (final entry in toolEvents.entries) {
+              if (batchToolEvents.containsKey(entry.key)) continue;
               final existing = chatService.getToolEvents(entry.key);
               if (existing.isEmpty) {
                 try {
@@ -1131,6 +1142,7 @@ class DataSync {
               }
             }
             for (final entry in geminiThoughtSigs.entries) {
+              if (batchGeminiSigs.containsKey(entry.key)) continue;
               final existingSig = chatService.getGeminiThoughtSignature(
                 entry.key,
               );

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -646,32 +646,36 @@ class ChatService extends ChangeNotifier {
     Conversation conversation,
     List<ChatMessage> messages,
   ) async {
-    if (!_initialized) await init();
-    // Ensure messageIds are in the same order
-    final ids = messages.map((m) => m.id).toList();
-    final restored = Conversation(
-      id: conversation.id,
-      title: conversation.title,
-      createdAt: conversation.createdAt,
-      updatedAt: conversation.updatedAt,
-      messageIds: ids,
-      isPinned: conversation.isPinned,
-      mcpServerIds: List.of(conversation.mcpServerIds),
-      truncateIndex: conversation.truncateIndex,
-      assistantId: conversation.assistantId,
-      versionSelections: Map<String, int>.from(conversation.versionSelections),
-      summary: conversation.summary,
-      lastSummarizedMessageCount: conversation.lastSummarizedMessageCount,
-      chatSuggestions: List<String>.of(conversation.chatSuggestions),
+    await restoreConversationsBatch(
+      conversations: [conversation],
+      messagesByConversation: {conversation.id: messages},
+      toolEventsByMessageId: const {},
+      geminiSignaturesByMessageId: const {},
     );
-    await _saveConversation(restored);
-    for (var i = 0; i < messages.length; i++) {
-      await _repo.putMessage(messages[i], messageOrder: i);
-    }
-    await _refreshConversation(restored.id);
+  }
 
-    // Update caches
-    _messagesCache[restored.id] = List.of(messages);
+  Future<void> restoreConversationsBatch({
+    required List<Conversation> conversations,
+    required Map<String, List<ChatMessage>> messagesByConversation,
+    required Map<String, List<Map<String, dynamic>>> toolEventsByMessageId,
+    required Map<String, String> geminiSignaturesByMessageId,
+  }) async {
+    if (!_initialized) await init();
+
+    await _repo.putRestoreBatch(
+      conversations: conversations,
+      messagesByConversation: messagesByConversation,
+      toolEventsByMessageId: toolEventsByMessageId,
+      geminiSignaturesByMessageId: geminiSignaturesByMessageId,
+    );
+
+    // Refresh caches from input data (no DB round-trips)
+    for (final c in conversations) {
+      final messages = messagesByConversation[c.id] ?? const <ChatMessage>[];
+      final ids = messages.map((m) => m.id).toList();
+      _conversationsCache[c.id] = c.copyWith(messageIds: ids);
+      _messagesCache[c.id] = List<ChatMessage>.of(messages);
+    }
 
     notifyListeners();
   }


### PR DESCRIPTION

### Background

之前的迁移优化（5faed2fb）将 Hive→SQLite 的逐条写入改为 `putMigrationBatch`（一次 `_db.batch()` + 一个外部事务），大幅缩短了迁移时间。恢复流程（`restoreConversation`）使用相同的模式——每条消息一个独立事务 * 3 类数据（message、toolEvent、geminiSignature），性能瓶颈一致。

### Changes

**`chat_database_repository.dart`** — 新增 `putRestoreBatch`
- 一次性 batch 写入 conversations + messages + toolEvents + geminiSignatures
- 一个 `_db.transaction()` 包裹一个 `_db.batch()`，N 个独立事务 → 1 个事务

**`chat_service.dart`** — 新增 `restoreConversationsBatch` + 委托
- 调用 `putRestoreBatch` 后统一设置 cache，只触发一次 `notifyListeners()`
- 旧 `restoreConversation` 委托给 batch 方法，所有调用方（cherry_importer、chatbox_importer 等）自动获益
- 修复：无消息的对话也会无条件写入 cache（review 指出的 Bug）

**`data_sync.dart`** — 改写 overwrite / merge 恢复路径
- **Overwrite 模式**：全量数据一次 `restoreConversationsBatch`，删除冗余的 toolEvents/sigs 循环
- **Merge 模式**：新 conversation 走 batch；已有 conversation 的增量消息保留 `addMessageDirectly`（边界场景，数量小，不值得增加复杂度）

### Performance

| 场景 | 事务数（优化前） | 事务数（优化后） |
|------|----------------|----------------|
| Overwrite 恢复，c 个对话 × m 条消息 | ~3×c×m 个独立事务 | **1 个事务** |
| Merge 新对话 | 逐条 × 每对话 | 每批 1 个事务 |
| Merge 增量消息 | 不变 | 不变（保留逐条，期望数量小） |

