### PR TITLE
fix: resolve multiple bugs across importers, models, API streaming, and desktop UI

### DIFF
--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -46,11 +46,58 @@ class ChatMessage {
 
   final int? durationMs;
 
-  ChatMessage({
+  factory ChatMessage({
     String? id,
+    required String role,
+    required String content,
+    DateTime? timestamp,
+    String? modelId,
+    String? providerId,
+    int? totalTokens,
+    required String conversationId,
+    bool isStreaming = false,
+    String? reasoningText,
+    DateTime? reasoningStartAt,
+    DateTime? reasoningFinishedAt,
+    String? translation,
+    String? reasoningSegmentsJson,
+    String? groupId,
+    int? version,
+    int? promptTokens,
+    int? completionTokens,
+    int? cachedTokens,
+    int? durationMs,
+  }) {
+    final resolvedId = id ?? const Uuid().v4();
+    return ChatMessage._(
+      id: resolvedId,
+      role: role,
+      content: content,
+      timestamp: timestamp ?? DateTime.now(),
+      modelId: modelId,
+      providerId: providerId,
+      totalTokens: totalTokens,
+      conversationId: conversationId,
+      isStreaming: isStreaming,
+      reasoningText: reasoningText,
+      reasoningStartAt: reasoningStartAt,
+      reasoningFinishedAt: reasoningFinishedAt,
+      translation: translation,
+      reasoningSegmentsJson: reasoningSegmentsJson,
+      groupId: groupId ?? resolvedId,
+      version: version ?? 0,
+      promptTokens: promptTokens,
+      completionTokens: completionTokens,
+      cachedTokens: cachedTokens,
+      durationMs: durationMs,
+    );
+  }
+
+  ChatMessage._({
+    required this.id,
     required this.role,
     required this.content,
-    DateTime? timestamp,
+    required this.timestamp,
     this.modelId,
     this.providerId,
     this.totalTokens,
@@ -61,16 +108,13 @@ class ChatMessage {
     this.reasoningFinishedAt,
     this.translation,
     this.reasoningSegmentsJson,
-    String? groupId,
-    int? version,
+    this.groupId,
+    required this.version,
     this.promptTokens,
     this.completionTokens,
     this.cachedTokens,
     this.durationMs,
-  }) : id = id ?? const Uuid().v4(),
-       timestamp = timestamp ?? DateTime.now(),
-       groupId = groupId ?? id,
-       version = version ?? 0;
+  });
 
   ChatMessage copyWith({
     String? id,

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -116,7 +116,8 @@ class Conversation {
       title: json['title'] as String,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
-      messageIds: (json['messageIds'] as List<dynamic>).cast<String>(),
+      messageIds:
+          (json['messageIds'] as List?)?.cast<String>() ?? const <String>[],
       isPinned: json['isPinned'] as bool? ?? false,
       mcpServerIds:
           (json['mcpServerIds'] as List?)?.cast<String>() ?? const <String>[],

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -2559,7 +2559,7 @@ class SettingsProvider extends ChangeNotifier {
         try {
           final oldFile = File(old.avatarValue!);
           if ((oldFile.path.contains('/avatars/') ||
-                  oldFile.path.contains('\\\\avatars\\\\')) &&
+                  oldFile.path.contains('\\avatars\\')) &&
               await oldFile.exists()) {
             await oldFile.delete();
           }
@@ -2607,8 +2607,7 @@ class SettingsProvider extends ChangeNotifier {
     if (old.avatarType == 'file' && (old.avatarValue ?? '').isNotEmpty) {
       try {
         final f = File(old.avatarValue!);
-        if ((f.path.contains('/avatars/') ||
-                f.path.contains('\\\\avatars\\\\')) &&
+        if ((f.path.contains('/avatars/') || f.path.contains('\\avatars\\')) &&
             await f.exists()) {
           await f.delete();
         }

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -723,8 +723,8 @@ Stream<ChatStreamChunk> _sendClaudeStream(
                 }
               } else if (delta['type'] == 'thinking_delta') {
                 final idx = parseIndex(obj['index']);
-                final thinking =
-                    (delta['thinking'] ?? delta['text'] ?? '') as String;
+                final thinking = (delta['thinking'] ?? delta['text'] ?? '')
+                    .toString();
                 if (thinking.isNotEmpty) {
                   yield ChatStreamChunk(
                     content: '',

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -2239,7 +2239,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           } else if (type == 'response.output_item.added') {
             try {
               final item = json['item'];
-              final idx = (json['output_index'] ?? 0) as int;
+              final idx = (json['output_index'] ?? 0) as int? ?? 0;
               if (item is Map && (item['type'] ?? '') == 'function_call') {
                 final name = (item['name'] ?? '').toString();
                 final callId = (item['call_id'] ?? '').toString();
@@ -2260,7 +2260,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             try {
               final b64 = (json['partial_image_b64'] ?? '').toString();
               if (b64.isNotEmpty) {
-                final idx = (json['output_index'] ?? 0) as int;
+                final idx = (json['output_index'] ?? 0) as int? ?? 0;
                 responsesImagesByIndex[idx] = _ResponsesImageGenerationResult(
                   base64: b64,
                   outputFormat: (json['output_format'] ?? '').toString(),
@@ -2269,7 +2269,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             } catch (_) {}
           } else if (type == 'response.function_call_arguments.delta') {
             try {
-              final idx = (json['output_index'] ?? 0) as int;
+              final idx = (json['output_index'] ?? 0) as int? ?? 0;
               final delta = (json['delta'] ?? '').toString();
               final entry = respToolCallsByIndex.putIfAbsent(
                 idx,
@@ -2282,7 +2282,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           } else if (type == 'response.output_item.done') {
             try {
               final item = json['item'];
-              final idx = (json['output_index'] ?? 0) as int;
+              final idx = (json['output_index'] ?? 0) as int? ?? 0;
               if (item is Map && (item['type'] ?? '') == 'function_call') {
                 final args = (item['arguments'] ?? '').toString();
                 final entry = respToolCallsByIndex.putIfAbsent(
@@ -2330,8 +2330,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           } else if (type == 'response.completed') {
             final u = json['response']?['usage'];
             if (u != null) {
-              final inTok = (u['input_tokens'] ?? 0) as int;
-              final outTok = (u['output_tokens'] ?? 0) as int;
+              final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
+              final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
               usage = (usage ?? const TokenUsage()).merge(
                 TokenUsage(promptTokens: inTok, completionTokens: outTok),
               );
@@ -2666,7 +2666,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       } else if (o is Map &&
                           (o['type'] ?? '') == 'response.output_item.added') {
                         final item = o['item'];
-                        final idx2 = (o['output_index'] ?? 0) as int;
+                        final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
                         if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           respCalls2[idx2] = {
@@ -2678,7 +2678,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       } else if (o is Map &&
                           (o['type'] ?? '') ==
                               'response.function_call_arguments.delta') {
-                        final idx2 = (o['output_index'] ?? 0) as int;
+                        final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
                         final delta = (o['delta'] ?? '').toString();
                         final entry = respCalls2.putIfAbsent(
                           idx2,
@@ -2690,7 +2690,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       } else if (o is Map &&
                           (o['type'] ?? '') == 'response.output_item.done') {
                         final item = o['item'];
-                        final idx2 = (o['output_index'] ?? 0) as int;
+                        final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
                         if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           final args = (item['arguments'] ?? '').toString();
@@ -2709,8 +2709,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         // usage
                         final u2 = o['response']?['usage'];
                         if (u2 != null) {
-                          final inTok = (u2['input_tokens'] ?? 0) as int;
-                          final outTok = (u2['output_tokens'] ?? 0) as int;
+                          final inTok = (u2['input_tokens'] ?? 0) as int? ?? 0;
+                          final outTok =
+                              (u2['output_tokens'] ?? 0) as int? ?? 0;
                           usage = (usage ?? const TokenUsage()).merge(
                             TokenUsage(
                               promptTokens: inTok,
@@ -2872,8 +2873,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               approxCompletionChars += content.length;
               final u = json['usage'];
               if (u != null) {
-                final inTok = (u['input_tokens'] ?? 0) as int;
-                final outTok = (u['output_tokens'] ?? 0) as int;
+                final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
+                final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
                 usage = (usage ?? const TokenUsage()).merge(
                   TokenUsage(promptTokens: inTok, completionTokens: outTok),
                 );

--- a/lib/core/services/backup/chatbox_importer.dart
+++ b/lib/core/services/backup/chatbox_importer.dart
@@ -937,7 +937,7 @@ class ChatboxImporter {
   static String _inferModelIdFromChatboxMessage(Map<String, dynamic> msg) {
     final raw = (msg['model'] ?? '').toString().trim();
     if (raw.isEmpty) return '';
-    final m = RegExp(r'\\(([^)]+)\\)\\s*$').firstMatch(raw);
+    final m = RegExp(r'\(([^)]+)\)\s*$').firstMatch(raw);
     if (m != null) return (m.group(1) ?? '').trim();
     return raw;
   }
@@ -1014,7 +1014,7 @@ class ChatboxImporter {
       final hasKnownVersionSuffix =
           lower.endsWith('/v1') ||
           lower.endsWith('/v1beta') ||
-          RegExp(r'/api/v\\d+$').hasMatch(lower) ||
+          RegExp(r'/api/v\d+$').hasMatch(lower) ||
           lower.endsWith('/api/paas/v4') ||
           lower.endsWith('/compatible-mode/v1');
       if (path.isEmpty) {
@@ -1044,7 +1044,7 @@ class ChatboxImporter {
         host = '$host/v1';
       } else if (host.isNotEmpty &&
           !lower.endsWith('/v1') &&
-          !RegExp(r'/v\\d+$').hasMatch(lower)) {
+          !RegExp(r'/v\d+$').hasMatch(lower)) {
         host = '$host/v1';
       }
       return _NormalizedHostAndPath(apiHost: host, apiPath: '');

--- a/lib/core/services/backup/cherry_importer.dart
+++ b/lib/core/services/backup/cherry_importer.dart
@@ -664,7 +664,7 @@ class CherryImporter {
         final uuidLike = RegExp(r'^[0-9a-fA-F-]{10,}$');
         for (final e in archive) {
           if (!e.isFile) continue;
-          final norm = e.name.replaceAll('\\\\', '/');
+          final norm = e.name.replaceAll('\\', '/');
           final base = p.basename(norm);
           // by basename
           byBase[base] = e;
@@ -713,7 +713,7 @@ class CherryImporter {
             final abs = ent.path;
             final base = p.basename(abs);
             byBase[base] = abs;
-            final l = abs.replaceAll('\\\\', '/').toLowerCase();
+            final l = abs.replaceAll('\\', '/').toLowerCase();
             int idx = l.indexOf('/data/files/');
             if (idx != -1) {
               final rel = l.substring(idx + 1);
@@ -786,7 +786,7 @@ class CherryImporter {
       try {
         final mp = (meta['path'] ?? '').toString();
         if (mp.isNotEmpty) {
-          String rel = mp.replaceAll('\\\\', '/').trim();
+          String rel = mp.replaceAll('\\', '/').trim();
           if (rel.startsWith('file://')) rel = rel.substring('file://'.length);
           if (rel.startsWith('/')) rel = rel.substring(1);
           final lowerRel = rel.toLowerCase();

--- a/lib/core/services/backup/s3_client.dart
+++ b/lib/core/services/backup/s3_client.dart
@@ -813,7 +813,7 @@ class S3BackupClient {
       },
     );
     if (res.statusCode != 200) {
-      throw Exception('S3 test failed: ${_extractErrorMessage(manifestRes)}');
+      throw Exception('S3 test failed: ${_extractErrorMessage(res)}');
     }
   }
 

--- a/lib/core/services/search/providers/exa_search_service.dart
+++ b/lib/core/services/search/providers/exa_search_service.dart
@@ -46,7 +46,9 @@ class ExaSearchService extends SearchService<ExaOptions> {
       }
 
       final data = jsonDecode(response.body);
-      final results = (data['results'] as List).map((item) {
+      final results = (data['results'] as List? ?? const <dynamic>[]).map((
+        item,
+      ) {
         return SearchResultItem(
           title: item['title'] ?? '',
           url: item['url'] ?? '',

--- a/lib/core/services/search/providers/searxng_search_service.dart
+++ b/lib/core/services/search/providers/searxng_search_service.dart
@@ -60,7 +60,7 @@ class SearXNGSearchService extends SearchService<SearXNGOptions> {
       }
 
       final data = jsonDecode(response.body);
-      final results = (data['results'] as List)
+      final results = (data['results'] as List? ?? const <dynamic>[])
           .take(commonOptions.resultSize)
           .map((item) {
             return SearchResultItem(

--- a/lib/core/services/search/providers/tavily_search_service.dart
+++ b/lib/core/services/search/providers/tavily_search_service.dart
@@ -45,7 +45,9 @@ class TavilySearchService extends SearchService<TavilyOptions> {
       }
 
       final data = jsonDecode(response.body);
-      final results = (data['results'] as List).map((item) {
+      final results = (data['results'] as List? ?? const <dynamic>[]).map((
+        item,
+      ) {
         return SearchResultItem(
           title: item['title'] ?? '',
           url: item['url'] ?? '',

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -1519,9 +1519,18 @@ class _DesktopAssistantDialogShellState
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
     final a = context.watch<AssistantProvider>().getById(widget.assistantId);
-    final name =
-        a?.name ?? AppLocalizations.of(context)!.assistantEditPageTitle;
+    if (a == null) {
+      // Assistant was deleted while the dialog was open. Close the dialog and
+      // show a not-found placeholder instead of crashing on forced non-null
+      // access in the child panes (matches the mobile null guard above).
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) Navigator.of(context).maybePop();
+      });
+      return Center(child: Text(l10n.assistantEditPageNotFound));
+    }
+    final name = a.name;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [

--- a/lib/shared/widgets/emoji_picker_dialog.dart
+++ b/lib/shared/widgets/emoji_picker_dialog.dart
@@ -271,5 +271,5 @@ Future<String?> showEmojiPickerDialog(
         },
       );
     },
-  ).then((result) => result);
+  ).then((result) => result).whenComplete(() => controller.dispose());
 }


### PR DESCRIPTION
## Summary

Fixes 13 confirmed bugs found via static code review. Each fix is minimal and targeted; no unrelated refactoring.

## Changes

### Backup / Importers
- **chatbox_importer.dart** — Fix over-escaped regexes (`\(`, `\d` in raw strings = literal backslash, not regex metachar). ModelId extraction and version-suffix host normalization were silently broken.
- **cherry_importer.dart** — Fix double-backslash path replacement (`'\\'` → `'\'`). Windows single-backslash attachment paths were never normalized, breaking attachment indexing.
- **s3_client.dart** — Fix wrong response variable in `test()` error message (`manifestRes` → `res`).

### Models
- **chat_message.dart** — Fix `groupId` defaulting to `null` instead of the generated `id`. In the initializer list, `groupId = groupId ?? id` resolved `id` to the (still-null) parameter, not the assigned field. ~45 defensive `groupId ?? id` fallbacks across the codebase confirm the intended behavior. Converted to a redirecting factory so the id is computed once and reused. Field type stays `String?` for DB/serialization compatibility.
- **conversation.dart** — Fix `fromJson` crashing with `TypeError` when the `messageIds` key is missing (aligned with sibling `mcpServerIds` handling).

### Settings / UI
- **settings_provider.dart** — Fix double-backslash avatar path check (`'\\avatars\\'` → `'\avatars\'`) that prevented old avatar file cleanup on Windows (aligned with `user_provider.dart`).
- **emoji_picker_dialog.dart** — Dispose `TextEditingController` to fix a leak on every dialog open.
- **assistant_settings_edit_page.dart** — Add a null guard in the desktop edit-dialog shell to avoid a null-check crash when the assistant is deleted while the dialog is open (matches the existing mobile null guard).

### API Streaming
- **claude_official.dart** — Replace unsafe `as String` on the thinking delta with `.toString()`. A `TypeError` was swallowed by the surrounding try/catch, silently dropping thinking content.
- **openai_common.dart** — Replace unsafe `as int` casts on token counts (6 sites) and `output_index` (7 sites) with `as int? ?? 0`. `TypeError` was swallowed by try/catch, silently dropping usage stats and tool-call accumulation.
- **tavily / searxng / exa search services** — Add null fallback (`as List? ?? const <dynamic>[]`) for the results array to avoid whole-search failure when the API omits the key (aligned with sibling services).

## Verification

| Step | Result |
| --- | --- |
| `flutter pub get` | ✅ 245 dependencies resolved |
| `dart format` (changed paths) | ✅ 13 files formatted |
| `flutter analyze` (changed files) | ✅ No issues in the 13 changed files |
| `flutter test` (full suite) | ✅ 798 passed, 3 failed |

### Notes on the 3 failing tests
The 3 failures are **pre-existing** and **unrelated to this change**, confirmed by running the same tests against the unmodified `master`:
- `cherry_importer_test.dart` (×2): `PathAccessException` on Windows temp-dir teardown (file lock, errno 32) — environment issue in test cleanup, not an assertion failure.
- `settings_provider_local_font_test.dart` (×1): expects forward-slash path, actual uses backslash on Windows — pre-existing path-separator assertion issue in the local-font feature.

## Compatibility
- No DB schema, ARB, or generated-file changes.
- `ChatMessage.groupId` field type unchanged (`String?`); only the default-value logic changes (now non-null when a message is created without an explicit groupId). All existing `groupId ?? id` fallbacks remain correct (now redundant).
- No public API signatures changed.

## Pre-launch Checklist
- [x] All user-visible text uses existing `AppLocalizations` keys (no new strings added)
- [x] No ARB changes (no localization touched)
- [x] `dart format` run on changed paths
- [x] `flutter analyze` clean on changed files
- [x] `flutter test` run (full suite)
- [x] Self-review completed (maintainability, performance, security, style, compatibility)
- [x] No secrets, build artifacts, or unrelated files committed