### PR TITLE
fix: resolve review issues in incremental backup dialog and mobile ba…

### DIFF
--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -863,6 +863,15 @@ class _BackupPageState extends State<BackupPage> {
                                     .read<BackupReminderProvider>()
                                     .recordBackupCompleted();
                               }
+                              if (!context.mounted) return;
+                              final rawMessage = vm.message;
+                              final message =
+                                  rawMessage ?? l10n.backupPageBackupUploaded;
+                              showAppSnackBar(
+                                context,
+                                message: message,
+                                type: NotificationType.info,
+                              );
                             },
                     ),
                   ],
@@ -1353,6 +1362,15 @@ class _BackupPageState extends State<BackupPage> {
                                     .read<BackupReminderProvider>()
                                     .recordBackupCompleted();
                               }
+                              if (!context.mounted) return;
+                              final rawMessage = s3Vm.message;
+                              final message =
+                                  rawMessage ?? l10n.backupPageBackupUploaded;
+                              showAppSnackBar(
+                                context,
+                                message: message,
+                                type: NotificationType.info,
+                              );
                             },
                     ),
                   ],

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -571,7 +571,6 @@
     }
   },
   "backupReminderSectionTitle": "备份提醒",
-  "backupReminderSectionTitle": "备份提醒",
   "backupReminderEnableTitle": "定期提醒我备份",
   "backupReminderFrequencyTitle": "提醒频率",
   "backupReminderTimeTitle": "提醒时间",

--- a/lib/shared/dialogs/incremental_backup_dialog.dart
+++ b/lib/shared/dialogs/incremental_backup_dialog.dart
@@ -96,8 +96,15 @@ class _IncrementalBackupDialogBodyState
 
   Future<void> _loadPersistence() async {
     final prefs = SharedPreferencesAsync();
-    _includeSettings = await prefs.getBool(_prefsIncludeSettingsKey) ?? true;
-    _updateBackupTime = await prefs.getBool(_prefsUpdateBackupTimeKey) ?? true;
+    final includeSettings =
+        await prefs.getBool(_prefsIncludeSettingsKey) ?? true;
+    final updateBackupTime =
+        await prefs.getBool(_prefsUpdateBackupTimeKey) ?? true;
+    if (!mounted) return;
+    setState(() {
+      _includeSettings = includeSettings;
+      _updateBackupTime = updateBackupTime;
+    });
   }
 
   String _fmt(DateTime d) => d.toIso8601String().split('T')[0];
@@ -114,7 +121,10 @@ class _IncrementalBackupDialogBodyState
   Future<void> _rerunAnalysis() async {
     final analyzer = widget.analyzer;
     if (analyzer == null) return;
-    setState(() => _analyzing = true);
+    setState(() {
+      _analyzing = true;
+      _scope = null;
+    });
     final gen = ++_gen;
     try {
       final scope = await analyzer(
@@ -383,7 +393,10 @@ class _IncrementalBackupDialogBodyState
                   icon: Lucide.RefreshCw,
                   size: 18,
                   minSize: 36,
-                  onTap: () => setState(() => _since = widget.lastBackupTime!),
+                  onTap: () {
+                    setState(() => _since = widget.lastBackupTime!);
+                    _rerunAnalysis();
+                  },
                   semanticLabel: l10n.backupPageIncrementalLastBackup,
                 ),
               ),


### PR DESCRIPTION
- Call setState + mount check in _loadPersistence so UI reflects persisted includeSettings/updateBackupTime toggles
- Clear _scope on re-analysis so preview card shows loading state
- Add missing _rerunAnalysis to reset-date button
- Add success SnackBar for mobile WebDAV/S3 incremental backup
- Remove duplicate backupReminderSectionTitle key in app_zh.arb