### PR TITLE
refactor(backup): extract shared code, rethrow restore errors, fix silent file dropping & Windows tests

### DIFF
--- a/lib/core/models/backup.dart
+++ b/lib/core/models/backup.dart
@@ -195,4 +195,16 @@ class BackupFileItem {
     required this.size,
     required this.lastModified,
   });
+
+  static void sortByNewest(List<BackupFileItem> items) {
+    items.sort((a, b) {
+      if (a.lastModified != null && b.lastModified != null) {
+        return b.lastModified!.compareTo(a.lastModified!);
+      }
+      if (a.lastModified == null && b.lastModified == null) {
+        return b.displayName.compareTo(a.displayName);
+      }
+      return a.lastModified == null ? 1 : -1;
+    });
+  }
 }

--- a/lib/core/providers/backup_provider.dart
+++ b/lib/core/providers/backup_provider.dart
@@ -29,15 +29,16 @@ class BackupProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> test() async {
+  Future<bool> test() async {
     _busy = true;
     _message = null;
     notifyListeners();
     try {
       await _dataSync.testWebdav(_cfg);
-      _message = 'OK';
+      return true;
     } catch (e) {
       _message = e.toString();
+      return false;
     } finally {
       _busy = false;
       notifyListeners();
@@ -82,7 +83,7 @@ class BackupProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> restoreFromItem(
+  Future<bool> restoreFromItem(
     BackupFileItem item, {
     RestoreMode mode = RestoreMode.overwrite,
   }) async {
@@ -91,9 +92,10 @@ class BackupProvider extends ChangeNotifier {
     notifyListeners();
     try {
       await _dataSync.restoreFromWebDav(_cfg, item, mode: mode);
-      _message = 'Restored';
+      return true;
     } catch (e) {
       _message = e.toString();
+      return false;
     } finally {
       _busy = false;
       notifyListeners();

--- a/lib/core/providers/backup_provider.dart
+++ b/lib/core/providers/backup_provider.dart
@@ -83,7 +83,7 @@ class BackupProvider extends ChangeNotifier {
     }
   }
 
-  Future<bool> restoreFromItem(
+  Future<void> restoreFromItem(
     BackupFileItem item, {
     RestoreMode mode = RestoreMode.overwrite,
   }) async {
@@ -92,10 +92,9 @@ class BackupProvider extends ChangeNotifier {
     notifyListeners();
     try {
       await _dataSync.restoreFromWebDav(_cfg, item, mode: mode);
-      return true;
     } catch (e) {
       _message = e.toString();
-      return false;
+      rethrow;
     } finally {
       _busy = false;
       notifyListeners();

--- a/lib/core/providers/s3_backup_provider.dart
+++ b/lib/core/providers/s3_backup_provider.dart
@@ -141,7 +141,7 @@ class S3BackupProvider extends ChangeNotifier {
     return _client.listObjects(_cfg);
   }
 
-  Future<bool> restoreFromItem(
+  Future<void> restoreFromItem(
     BackupFileItem item, {
     RestoreMode mode = RestoreMode.overwrite,
   }) async {
@@ -160,10 +160,9 @@ class S3BackupProvider extends ChangeNotifier {
         _scopeAsWebdavConfig(),
         mode: mode,
       );
-      return true;
     } catch (e) {
       _message = e.toString();
-      return false;
+      rethrow;
     } finally {
       try {
         if (file != null && await file.exists()) {

--- a/lib/core/providers/s3_backup_provider.dart
+++ b/lib/core/providers/s3_backup_provider.dart
@@ -69,15 +69,16 @@ class S3BackupProvider extends ChangeNotifier {
     );
   }
 
-  Future<void> test() async {
+  Future<bool> test() async {
     _busy = true;
     _message = null;
     notifyListeners();
     try {
       await _client.test(_cfg);
-      _message = 'OK';
+      return true;
     } catch (e) {
       _message = e.toString();
+      return false;
     } finally {
       _busy = false;
       notifyListeners();
@@ -140,7 +141,7 @@ class S3BackupProvider extends ChangeNotifier {
     return _client.listObjects(_cfg);
   }
 
-  Future<void> restoreFromItem(
+  Future<bool> restoreFromItem(
     BackupFileItem item, {
     RestoreMode mode = RestoreMode.overwrite,
   }) async {
@@ -159,9 +160,10 @@ class S3BackupProvider extends ChangeNotifier {
         _scopeAsWebdavConfig(),
         mode: mode,
       );
-      _message = 'Restored';
+      return true;
     } catch (e) {
       _message = e.toString();
+      return false;
     } finally {
       try {
         if (file != null && await file.exists()) {

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -364,7 +364,7 @@ class DataSync {
           try {
             if (ent.lastModifiedSync().isBefore(since)) continue;
           } catch (_) {
-            continue;
+            // Cannot read modification time — include conservatively
           }
         }
         final rel = p.relative(ent.path, from: srcDirPath);
@@ -750,7 +750,7 @@ class DataSync {
               final mod = await ent.lastModified();
               if (mod.isBefore(since)) continue;
             } catch (_) {
-              continue;
+              // Cannot read modification time — include conservatively
             }
             fileCount++;
             totalBytes += await ent.length();

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -490,16 +490,11 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                       title:
                                           '${l10n.backupPageRemoteBackups} (WebDAV)',
                                       listRemote: backupProvider.listRemote,
-                                      restoreFromItem: (it, mode) async {
-                                        final ok = await backupProvider
-                                            .restoreFromItem(it, mode: mode);
-                                        if (!ok) {
-                                          throw Exception(
-                                            backupProvider.message ??
-                                                'Restore failed',
-                                          );
-                                        }
-                                      },
+                                      restoreFromItem: (it, mode) =>
+                                          backupProvider.restoreFromItem(
+                                            it,
+                                            mode: mode,
+                                          ),
                                       deleteAndReload:
                                           backupProvider.deleteAndReload,
                                     );
@@ -796,16 +791,11 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                       title:
                                           '${l10n.backupPageRemoteBackups} (S3)',
                                       listRemote: s3BackupProvider.listRemote,
-                                      restoreFromItem: (it, mode) async {
-                                        final ok = await s3BackupProvider
-                                            .restoreFromItem(it, mode: mode);
-                                        if (!ok) {
-                                          throw Exception(
-                                            s3BackupProvider.message ??
-                                                'Restore failed',
-                                          );
-                                        }
-                                      },
+                                      restoreFromItem: (it, mode) =>
+                                          s3BackupProvider.restoreFromItem(
+                                            it,
+                                            mode: mode,
+                                          ),
                                       deleteAndReload:
                                           s3BackupProvider.deleteAndReload,
                                     );
@@ -1438,11 +1428,16 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
           _items = list;
         });
       }
-    } catch (_) {
+    } catch (e) {
       if (mounted) {
         setState(() {
           _items = const [];
         });
+        showAppSnackBar(
+          context,
+          message: e.toString(),
+          type: NotificationType.error,
+        );
       }
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -18,6 +18,8 @@ import '../../utils/platform_utils.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../shared/dialogs/incremental_backup_dialog.dart';
+import '../../shared/dialogs/restart_required_dialog.dart';
+import '../../utils/format.dart';
 import '../../features/backup/widgets/backup_reminder_helpers.dart';
 import '../widgets/desktop_select_dropdown.dart';
 import '../../theme/app_font_weights.dart';
@@ -223,27 +225,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
       return;
     }
     if (!rootCtx.mounted) return;
-    final l10n = AppLocalizations.of(rootCtx)!;
-    // Inform restart requirement
-    await showDialog(
-      context: rootCtx,
-      barrierDismissible: false,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: Theme.of(ctx).colorScheme.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: Text(l10n.backupPageRestartRequired),
-        content: Text(l10n.backupPageRestartContent),
-        actions: [
-          TextButton(
-            onPressed: () async {
-              Navigator.of(ctx).pop();
-              PlatformUtils.restartApp();
-            },
-            child: Text(l10n.backupPageOK),
-          ),
-        ],
-      ),
-    );
+    await showRestartRequiredDialog(rootCtx);
   }
 
   @override
@@ -1352,17 +1334,6 @@ class _RemoteItemCardState extends State<_RemoteItemCard> {
     final dateStr =
         widget.item.lastModified?.toLocal().toString().split('.').first ?? '';
 
-    String prettySize(int size) {
-      const units = ['B', 'KB', 'MB', 'GB'];
-      double s = size.toDouble();
-      int u = 0;
-      while (s >= 1024 && u < units.length - 1) {
-        s /= 1024;
-        u++;
-      }
-      return '${s.toStringAsFixed(s >= 10 || u == 0 ? 0 : 1)} ${units[u]}';
-    }
-
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
       onExit: (_) => setState(() => _hover = false),
@@ -1394,7 +1365,7 @@ class _RemoteItemCardState extends State<_RemoteItemCard> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    '${prettySize(widget.item.size)}${dateStr.isNotEmpty ? ' · $dateStr' : ''}',
+                    '${formatBytes(widget.item.size)}${dateStr.isNotEmpty ? ' · $dateStr' : ''}',
                     style: TextStyle(
                       fontSize: 12.5,
                       color: cs.onSurface.withValues(alpha: 0.7),
@@ -1466,17 +1437,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     setState(() => _loading = true);
     try {
       final list = await widget.listRemote();
-      // Sort by newest first (desc by lastModified), mimic mobile behavior
-      list.sort((a, b) {
-        final aTime = a.lastModified;
-        final bTime = b.lastModified;
-        if (aTime != null && bTime != null) return bTime.compareTo(aTime);
-        if (aTime == null && bTime == null) {
-          return b.displayName.compareTo(a.displayName);
-        }
-        if (aTime == null) return 1; // items with time go first
-        return -1;
-      });
+      BackupFileItem.sortByNewest(list);
       if (mounted) {
         setState(() {
           _items = list;
@@ -1509,28 +1470,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
-    if (!rootCtx.mounted) return;
-    final l10n = AppLocalizations.of(rootCtx)!;
-    final cs = Theme.of(rootCtx).colorScheme;
-    await showDialog(
-      context: rootCtx,
-      barrierDismissible: false,
-      builder: (dctx) => AlertDialog(
-        backgroundColor: cs.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: Text(l10n.backupPageRestartRequired),
-        content: Text(l10n.backupPageRestartContent),
-        actions: [
-          TextButton(
-            onPressed: () async {
-              Navigator.of(dctx).pop();
-              PlatformUtils.restartApp();
-            },
-            child: Text(l10n.backupPageOK),
-          ),
-        ],
-      ),
-    );
+    await showRestartRequiredDialog(rootCtx);
   }
 
   Future<void> _chooseRestoreModeAndRun(
@@ -1558,28 +1498,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
-    if (!rootCtx.mounted) return;
-    final l10n = AppLocalizations.of(rootCtx)!;
-    final cs = Theme.of(rootCtx).colorScheme;
-    await showDialog(
-      context: rootCtx,
-      barrierDismissible: false,
-      builder: (dctx) => AlertDialog(
-        backgroundColor: cs.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: Text(l10n.backupPageRestartRequired),
-        content: Text(l10n.backupPageRestartContent),
-        actions: [
-          TextButton(
-            onPressed: () async {
-              Navigator.of(dctx).pop();
-              PlatformUtils.restartApp();
-            },
-            child: Text(l10n.backupPageOK),
-          ),
-        ],
-      ),
-    );
+    await showRestartRequiredDialog(rootCtx);
   }
 
   @override
@@ -1703,20 +1622,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
                                 ); // Show loading inside dialog
                                 try {
                                   final next = await widget.deleteAndReload(it);
-                                  next.sort((a, b) {
-                                    final aTime = a.lastModified;
-                                    final bTime = b.lastModified;
-                                    if (aTime != null && bTime != null) {
-                                      return bTime.compareTo(aTime);
-                                    }
-                                    if (aTime == null && bTime == null) {
-                                      return b.displayName.compareTo(
-                                        a.displayName,
-                                      );
-                                    }
-                                    if (aTime == null) return 1;
-                                    return -1;
-                                  });
+                                  BackupFileItem.sortByNewest(next);
                                   if (mounted) setState(() => _items = next);
                                 } finally {
                                   if (mounted) setState(() => _loading = false);

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -461,19 +461,16 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                     final backupProvider = context
                                         .read<BackupProvider>();
                                     await _saveConfig();
-                                    await backupProvider.test();
+                                    final testOk = await backupProvider.test();
                                     if (!context.mounted) return;
-                                    final rawMessage = backupProvider.message;
-                                    final message =
-                                        rawMessage ?? l10n.backupPageTestDone;
                                     showAppSnackBar(
                                       context,
-                                      message: message,
-                                      type:
-                                          rawMessage != null &&
-                                              rawMessage != 'OK'
-                                          ? NotificationType.error
-                                          : NotificationType.success,
+                                      message:
+                                          backupProvider.message ??
+                                          l10n.backupPageTestDone,
+                                      type: testOk
+                                          ? NotificationType.success
+                                          : NotificationType.error,
                                     );
                                   },
                           ),
@@ -494,13 +491,13 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                           '${l10n.backupPageRemoteBackups} (WebDAV)',
                                       listRemote: backupProvider.listRemote,
                                       restoreFromItem: (it, mode) async {
-                                        await backupProvider.restoreFromItem(
-                                          it,
-                                          mode: mode,
-                                        );
-                                        final msg = backupProvider.message;
-                                        if (msg != null && msg != 'Restored') {
-                                          throw Exception(msg);
+                                        final ok = await backupProvider
+                                            .restoreFromItem(it, mode: mode);
+                                        if (!ok) {
+                                          throw Exception(
+                                            backupProvider.message ??
+                                                'Restore failed',
+                                          );
                                         }
                                       },
                                       deleteAndReload:
@@ -769,19 +766,17 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                     final s3BackupProvider = context
                                         .read<S3BackupProvider>();
                                     await _saveS3Config();
-                                    await s3BackupProvider.test();
+                                    final testOk = await s3BackupProvider
+                                        .test();
                                     if (!context.mounted) return;
-                                    final rawMessage = s3BackupProvider.message;
-                                    final message =
-                                        rawMessage ?? l10n.backupPageTestDone;
                                     showAppSnackBar(
                                       context,
-                                      message: message,
-                                      type:
-                                          rawMessage != null &&
-                                              rawMessage != 'OK'
-                                          ? NotificationType.error
-                                          : NotificationType.success,
+                                      message:
+                                          s3BackupProvider.message ??
+                                          l10n.backupPageTestDone,
+                                      type: testOk
+                                          ? NotificationType.success
+                                          : NotificationType.error,
                                     );
                                   },
                           ),
@@ -802,13 +797,13 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                                           '${l10n.backupPageRemoteBackups} (S3)',
                                       listRemote: s3BackupProvider.listRemote,
                                       restoreFromItem: (it, mode) async {
-                                        await s3BackupProvider.restoreFromItem(
-                                          it,
-                                          mode: mode,
-                                        );
-                                        final msg = s3BackupProvider.message;
-                                        if (msg != null && msg != 'Restored') {
-                                          throw Exception(msg);
+                                        final ok = await s3BackupProvider
+                                            .restoreFromItem(it, mode: mode);
+                                        if (!ok) {
+                                          throw Exception(
+                                            s3BackupProvider.message ??
+                                                'Restore failed',
+                                          );
                                         }
                                       },
                                       deleteAndReload:
@@ -1470,6 +1465,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
+    if (!rootCtx.mounted) return;
     await showRestartRequiredDialog(rootCtx);
   }
 
@@ -1498,6 +1494,7 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
+    if (!rootCtx.mounted) return;
     await showRestartRequiredDialog(rootCtx);
   }
 

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -211,12 +211,10 @@ class _BackupPageState extends State<BackupPage> {
 
   Future<void> _restoreIncrementalItem({
     required BuildContext context,
-    required Future<bool> Function() performRestore,
+    required Future<void> Function() performRestore,
   }) async {
     try {
-      final ok = await _runWithImportingOverlay(context, performRestore);
-      if (!context.mounted) return;
-      if (!ok) return;
+      await _runWithImportingOverlay(context, performRestore);
     } catch (e) {
       if (!context.mounted) return;
       showAppSnackBar(
@@ -575,18 +573,13 @@ class _BackupPageState extends State<BackupPage> {
                                             if (mode == null) return;
                                             if (!context.mounted) return;
                                             try {
-                                              final ok =
-                                                  await _runWithImportingOverlay<
-                                                    bool
-                                                  >(
-                                                    context,
-                                                    () => vm.restoreFromItem(
-                                                      item,
-                                                      mode: mode,
-                                                    ),
-                                                  );
-                                              if (!context.mounted) return;
-                                              if (!ok) return;
+                                              await _runWithImportingOverlay(
+                                                context,
+                                                () => vm.restoreFromItem(
+                                                  item,
+                                                  mode: mode,
+                                                ),
+                                              );
                                             } catch (e) {
                                               if (!context.mounted) return;
                                               showAppSnackBar(
@@ -604,7 +597,6 @@ class _BackupPageState extends State<BackupPage> {
                                         ),
                                       );
                                     } catch (e) {
-                                      // If error, ensure loading dialog is closed
                                       if (context.mounted &&
                                           Navigator.canPop(context)) {
                                         Navigator.of(
@@ -645,16 +637,13 @@ class _BackupPageState extends State<BackupPage> {
                                     if (!context.mounted) return;
 
                                     try {
-                                      final ok =
-                                          await _runWithImportingOverlay<bool>(
-                                            context,
-                                            () => vm.restoreFromItem(
-                                              item,
-                                              mode: mode,
-                                            ),
-                                          );
-                                      if (!context.mounted) return;
-                                      if (!ok) return;
+                                      await _runWithImportingOverlay(
+                                        context,
+                                        () => vm.restoreFromItem(
+                                          item,
+                                          mode: mode,
+                                        ),
+                                      );
                                     } catch (e) {
                                       if (!context.mounted) return;
                                       showAppSnackBar(
@@ -974,18 +963,13 @@ class _BackupPageState extends State<BackupPage> {
                                             if (mode == null) return;
                                             if (!context.mounted) return;
                                             try {
-                                              final ok =
-                                                  await _runWithImportingOverlay<
-                                                    bool
-                                                  >(
-                                                    context,
-                                                    () => s3Vm.restoreFromItem(
-                                                      item,
-                                                      mode: mode,
-                                                    ),
-                                                  );
-                                              if (!context.mounted) return;
-                                              if (!ok) return;
+                                              await _runWithImportingOverlay(
+                                                context,
+                                                () => s3Vm.restoreFromItem(
+                                                  item,
+                                                  mode: mode,
+                                                ),
+                                              );
                                             } catch (e) {
                                               if (!context.mounted) return;
                                               showAppSnackBar(
@@ -1044,16 +1028,13 @@ class _BackupPageState extends State<BackupPage> {
                                     if (!context.mounted) return;
 
                                     try {
-                                      final ok =
-                                          await _runWithImportingOverlay<bool>(
-                                            context,
-                                            () => s3Vm.restoreFromItem(
-                                              item,
-                                              mode: mode,
-                                            ),
-                                          );
-                                      if (!context.mounted) return;
-                                      if (!ok) return;
+                                      await _runWithImportingOverlay(
+                                        context,
+                                        () => s3Vm.restoreFromItem(
+                                          item,
+                                          mode: mode,
+                                        ),
+                                      );
                                     } catch (e) {
                                       if (!context.mounted) return;
                                       showAppSnackBar(

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -211,11 +211,12 @@ class _BackupPageState extends State<BackupPage> {
 
   Future<void> _restoreIncrementalItem({
     required BuildContext context,
-    required Future<void> Function() performRestore,
-    required String? Function() message,
+    required Future<bool> Function() performRestore,
   }) async {
     try {
-      await _runWithImportingOverlay(context, performRestore);
+      final ok = await _runWithImportingOverlay(context, performRestore);
+      if (!context.mounted) return;
+      if (!ok) return;
     } catch (e) {
       if (!context.mounted) return;
       showAppSnackBar(
@@ -223,12 +224,6 @@ class _BackupPageState extends State<BackupPage> {
         message: e.toString(),
         type: NotificationType.error,
       );
-      return;
-    }
-    if (!context.mounted) return;
-    final msg = message();
-    if (msg != null && msg != 'Restored') {
-      showAppSnackBar(context, message: msg, type: NotificationType.error);
       return;
     }
     if (!context.mounted) return;
@@ -356,17 +351,14 @@ class _BackupPageState extends State<BackupPage> {
                       onTap: vm.busy
                           ? null
                           : () async {
-                              await vm.test();
+                              final testOk = await vm.test();
                               if (!context.mounted) return;
-                              final rawMessage = vm.message;
-                              final message =
-                                  rawMessage ?? l10n.backupPageTestDone;
                               showAppSnackBar(
                                 context,
-                                message: message,
-                                type: rawMessage != null && rawMessage != 'OK'
-                                    ? NotificationType.error
-                                    : NotificationType.success,
+                                message: vm.message ?? l10n.backupPageTestDone,
+                                type: testOk
+                                    ? NotificationType.success
+                                    : NotificationType.error,
                               );
                             },
                     ),
@@ -573,7 +565,6 @@ class _BackupPageState extends State<BackupPage> {
                                                       item,
                                                       mode: RestoreMode.merge,
                                                     ),
-                                                message: () => vm.message,
                                               );
                                             }
 
@@ -584,13 +575,18 @@ class _BackupPageState extends State<BackupPage> {
                                             if (mode == null) return;
                                             if (!context.mounted) return;
                                             try {
-                                              await _runWithImportingOverlay(
-                                                context,
-                                                () => vm.restoreFromItem(
-                                                  item,
-                                                  mode: mode,
-                                                ),
-                                              );
+                                              final ok =
+                                                  await _runWithImportingOverlay<
+                                                    bool
+                                                  >(
+                                                    context,
+                                                    () => vm.restoreFromItem(
+                                                      item,
+                                                      mode: mode,
+                                                    ),
+                                                  );
+                                              if (!context.mounted) return;
+                                              if (!ok) return;
                                             } catch (e) {
                                               if (!context.mounted) return;
                                               showAppSnackBar(
@@ -601,16 +597,6 @@ class _BackupPageState extends State<BackupPage> {
                                               return;
                                             }
                                             if (!context.mounted) return;
-                                            final msg = vm.message;
-                                            if (msg != null &&
-                                                msg != 'Restored') {
-                                              showAppSnackBar(
-                                                context,
-                                                message: msg,
-                                                type: NotificationType.error,
-                                              );
-                                              return;
-                                            }
                                             await showRestartRequiredDialog(
                                               context,
                                             );
@@ -649,7 +635,6 @@ class _BackupPageState extends State<BackupPage> {
                                               item,
                                               mode: RestoreMode.merge,
                                             ),
-                                        message: () => vm.message,
                                       );
                                     }
 
@@ -660,13 +645,16 @@ class _BackupPageState extends State<BackupPage> {
                                     if (!context.mounted) return;
 
                                     try {
-                                      await _runWithImportingOverlay(
-                                        context,
-                                        () => vm.restoreFromItem(
-                                          item,
-                                          mode: mode,
-                                        ),
-                                      );
+                                      final ok =
+                                          await _runWithImportingOverlay<bool>(
+                                            context,
+                                            () => vm.restoreFromItem(
+                                              item,
+                                              mode: mode,
+                                            ),
+                                          );
+                                      if (!context.mounted) return;
+                                      if (!ok) return;
                                     } catch (e) {
                                       if (!context.mounted) return;
                                       showAppSnackBar(
@@ -677,15 +665,6 @@ class _BackupPageState extends State<BackupPage> {
                                       return;
                                     }
                                     if (!context.mounted) return;
-                                    final msg = vm.message;
-                                    if (msg != null && msg != 'Restored') {
-                                      showAppSnackBar(
-                                        context,
-                                        message: msg,
-                                        type: NotificationType.error,
-                                      );
-                                      return;
-                                    }
                                     await showRestartRequiredDialog(context);
                                   },
                                 ),
@@ -782,17 +761,15 @@ class _BackupPageState extends State<BackupPage> {
                       onTap: s3Vm.busy
                           ? null
                           : () async {
-                              await s3Vm.test();
+                              final testOk = await s3Vm.test();
                               if (!context.mounted) return;
-                              final rawMessage = s3Vm.message;
-                              final message =
-                                  rawMessage ?? l10n.backupPageTestDone;
                               showAppSnackBar(
                                 context,
-                                message: message,
-                                type: rawMessage != null && rawMessage != 'OK'
-                                    ? NotificationType.error
-                                    : NotificationType.success,
+                                message:
+                                    s3Vm.message ?? l10n.backupPageTestDone,
+                                type: testOk
+                                    ? NotificationType.success
+                                    : NotificationType.error,
                               );
                             },
                     ),
@@ -987,7 +964,6 @@ class _BackupPageState extends State<BackupPage> {
                                                       item,
                                                       mode: RestoreMode.merge,
                                                     ),
-                                                message: () => s3Vm.message,
                                               );
                                             }
 
@@ -998,13 +974,18 @@ class _BackupPageState extends State<BackupPage> {
                                             if (mode == null) return;
                                             if (!context.mounted) return;
                                             try {
-                                              await _runWithImportingOverlay(
-                                                context,
-                                                () => s3Vm.restoreFromItem(
-                                                  item,
-                                                  mode: mode,
-                                                ),
-                                              );
+                                              final ok =
+                                                  await _runWithImportingOverlay<
+                                                    bool
+                                                  >(
+                                                    context,
+                                                    () => s3Vm.restoreFromItem(
+                                                      item,
+                                                      mode: mode,
+                                                    ),
+                                                  );
+                                              if (!context.mounted) return;
+                                              if (!ok) return;
                                             } catch (e) {
                                               if (!context.mounted) return;
                                               showAppSnackBar(
@@ -1015,16 +996,6 @@ class _BackupPageState extends State<BackupPage> {
                                               return;
                                             }
                                             if (!context.mounted) return;
-                                            final msg = s3Vm.message;
-                                            if (msg != null &&
-                                                msg != 'Restored') {
-                                              showAppSnackBar(
-                                                context,
-                                                message: msg,
-                                                type: NotificationType.error,
-                                              );
-                                              return;
-                                            }
                                             await showRestartRequiredDialog(
                                               context,
                                             );
@@ -1063,7 +1034,6 @@ class _BackupPageState extends State<BackupPage> {
                                               item,
                                               mode: RestoreMode.merge,
                                             ),
-                                        message: () => s3Vm.message,
                                       );
                                     }
 
@@ -1074,13 +1044,16 @@ class _BackupPageState extends State<BackupPage> {
                                     if (!context.mounted) return;
 
                                     try {
-                                      await _runWithImportingOverlay(
-                                        context,
-                                        () => s3Vm.restoreFromItem(
-                                          item,
-                                          mode: mode,
-                                        ),
-                                      );
+                                      final ok =
+                                          await _runWithImportingOverlay<bool>(
+                                            context,
+                                            () => s3Vm.restoreFromItem(
+                                              item,
+                                              mode: mode,
+                                            ),
+                                          );
+                                      if (!context.mounted) return;
+                                      if (!ok) return;
                                     } catch (e) {
                                       if (!context.mounted) return;
                                       showAppSnackBar(
@@ -1091,15 +1064,6 @@ class _BackupPageState extends State<BackupPage> {
                                       return;
                                     }
                                     if (!context.mounted) return;
-                                    final msg = s3Vm.message;
-                                    if (msg != null && msg != 'Restored') {
-                                      showAppSnackBar(
-                                        context,
-                                        message: msg,
-                                        type: NotificationType.error,
-                                      );
-                                      return;
-                                    }
                                     await showRestartRequiredDialog(context);
                                   },
                                 ),

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -1360,10 +1360,20 @@ class _BackupPageState extends State<BackupPage> {
     if (mode == null) return;
     if (!context.mounted) return;
 
-    await _runWithImportingOverlay(
-      context,
-      () => vm.restoreFromLocalFile(File(path), mode: mode),
-    );
+    try {
+      await _runWithImportingOverlay(
+        context,
+        () => vm.restoreFromLocalFile(File(path), mode: mode),
+      );
+    } catch (e) {
+      if (!context.mounted) return;
+      showAppSnackBar(
+        context,
+        message: e.toString(),
+        type: NotificationType.error,
+      );
+      return;
+    }
     if (!context.mounted) return;
     await showRestartRequiredDialog(context);
   }

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -21,21 +21,12 @@ import '../../../core/services/backup/data_sync.dart';
 import '../../../core/services/native_file_save.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/dialogs/incremental_backup_dialog.dart';
+import '../../../shared/dialogs/restart_required_dialog.dart';
 import '../../../core/services/backup/cherry_importer.dart';
 import '../../../core/services/backup/chatbox_importer.dart';
+import '../../../utils/format.dart';
 import '../../../utils/platform_utils.dart';
 import '../widgets/backup_reminder_helpers.dart';
-
-// File size formatter (B, KB, MB, GB)
-String _fmtBytes(int bytes) {
-  const kb = 1024;
-  const mb = kb * 1024;
-  const gb = mb * 1024;
-  if (bytes >= gb) return '${(bytes / gb).toStringAsFixed(2)} GB';
-  if (bytes >= mb) return '${(bytes / mb).toStringAsFixed(2)} MB';
-  if (bytes >= kb) return '${(bytes / kb).toStringAsFixed(2)} KB';
-  return '$bytes B';
-}
 
 class BackupPage extends StatefulWidget {
   const BackupPage({super.key});
@@ -241,23 +232,7 @@ class _BackupPageState extends State<BackupPage> {
       return;
     }
     if (!context.mounted) return;
-    await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (dctx) => AlertDialog(
-        title: Text(AppLocalizations.of(context)!.backupPageRestartRequired),
-        content: Text(AppLocalizations.of(context)!.backupPageRestartContent),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(dctx).pop();
-              PlatformUtils.restartApp();
-            },
-            child: Text(AppLocalizations.of(context)!.backupPageOK),
-          ),
-        ],
-      ),
-    );
+    await showRestartRequiredDialog(context);
   }
 
   @override
@@ -408,23 +383,7 @@ class _BackupPageState extends State<BackupPage> {
                                 () => vm.listRemote(),
                               );
                               // 按时间倒序排列（最新的在前）
-                              list.sort((a, b) {
-                                // 优先使用 lastModified
-                                if (a.lastModified != null &&
-                                    b.lastModified != null) {
-                                  return b.lastModified!.compareTo(
-                                    a.lastModified!,
-                                  );
-                                }
-                                // 如果都没有 lastModified，按文件名倒序（文件名通常包含时间戳）
-                                if (a.lastModified == null &&
-                                    b.lastModified == null) {
-                                  return b.displayName.compareTo(a.displayName);
-                                }
-                                // 有 lastModified 的排在前面
-                                if (a.lastModified == null) return 1;
-                                return -1;
-                              });
+                              BackupFileItem.sortByNewest(list);
                               setState(() => _remote = list);
 
                               if (!context.mounted) return;
@@ -502,23 +461,7 @@ class _BackupPageState extends State<BackupPage> {
                                         ).pop();
                                       }
 
-                                      // Sort list
-                                      list.sort((a, b) {
-                                        if (a.lastModified != null &&
-                                            b.lastModified != null) {
-                                          return b.lastModified!.compareTo(
-                                            a.lastModified!,
-                                          );
-                                        }
-                                        if (a.lastModified == null &&
-                                            b.lastModified == null) {
-                                          return b.displayName.compareTo(
-                                            a.displayName,
-                                          );
-                                        }
-                                        if (a.lastModified == null) return 1;
-                                        return -1;
-                                      });
+                                      BackupFileItem.sortByNewest(list);
 
                                       if (mounted) {
                                         setState(() => _remote = list);
@@ -597,26 +540,9 @@ class _BackupPageState extends State<BackupPage> {
                                                     rootNavigator: true,
                                                   ).pop();
                                                 }
-                                                list.sort((a, b) {
-                                                  if (a.lastModified != null &&
-                                                      b.lastModified != null) {
-                                                    return b.lastModified!
-                                                        .compareTo(
-                                                          a.lastModified!,
-                                                        );
-                                                  }
-                                                  if (a.lastModified == null &&
-                                                      b.lastModified == null) {
-                                                    return b.displayName
-                                                        .compareTo(
-                                                          a.displayName,
-                                                        );
-                                                  }
-                                                  if (a.lastModified == null) {
-                                                    return 1;
-                                                  }
-                                                  return -1;
-                                                });
+                                                BackupFileItem.sortByNewest(
+                                                  list,
+                                                );
                                                 if (mounted) {
                                                   setState(
                                                     () => _remote = list,
@@ -685,28 +611,8 @@ class _BackupPageState extends State<BackupPage> {
                                               );
                                               return;
                                             }
-                                            await showDialog(
-                                              context: context,
-                                              barrierDismissible: false,
-                                              builder: (dctx) => AlertDialog(
-                                                title: Text(
-                                                  l10n.backupPageRestartRequired,
-                                                ),
-                                                content: Text(
-                                                  l10n.backupPageRestartContent,
-                                                ),
-                                                actions: [
-                                                  TextButton(
-                                                    onPressed: () async {
-                                                      Navigator.of(dctx).pop();
-                                                      PlatformUtils.restartApp();
-                                                    },
-                                                    child: Text(
-                                                      l10n.backupPageOK,
-                                                    ),
-                                                  ),
-                                                ],
-                                              ),
+                                            await showRestartRequiredDialog(
+                                              context,
                                             );
                                           },
                                         ),
@@ -780,27 +686,7 @@ class _BackupPageState extends State<BackupPage> {
                                       );
                                       return;
                                     }
-                                    await showDialog(
-                                      context: context,
-                                      barrierDismissible: false,
-                                      builder: (dctx) => AlertDialog(
-                                        title: Text(
-                                          l10n.backupPageRestartRequired,
-                                        ),
-                                        content: Text(
-                                          l10n.backupPageRestartContent,
-                                        ),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () async {
-                                              Navigator.of(dctx).pop();
-                                              PlatformUtils.restartApp();
-                                            },
-                                            child: Text(l10n.backupPageOK),
-                                          ),
-                                        ],
-                                      ),
-                                    );
+                                    await showRestartRequiredDialog(context);
                                   },
                                 ),
                               );
@@ -922,20 +808,7 @@ class _BackupPageState extends State<BackupPage> {
                                 context,
                                 () => s3Vm.listRemote(),
                               );
-                              list.sort((a, b) {
-                                if (a.lastModified != null &&
-                                    b.lastModified != null) {
-                                  return b.lastModified!.compareTo(
-                                    a.lastModified!,
-                                  );
-                                }
-                                if (a.lastModified == null &&
-                                    b.lastModified == null) {
-                                  return b.displayName.compareTo(a.displayName);
-                                }
-                                if (a.lastModified == null) return 1;
-                                return -1;
-                              });
+                              BackupFileItem.sortByNewest(list);
                               setState(() => _remoteS3 = list);
 
                               if (!context.mounted) return;
@@ -1007,22 +880,7 @@ class _BackupPageState extends State<BackupPage> {
                                           rootNavigator: true,
                                         ).pop();
                                       }
-                                      list.sort((a, b) {
-                                        if (a.lastModified != null &&
-                                            b.lastModified != null) {
-                                          return b.lastModified!.compareTo(
-                                            a.lastModified!,
-                                          );
-                                        }
-                                        if (a.lastModified == null &&
-                                            b.lastModified == null) {
-                                          return b.displayName.compareTo(
-                                            a.displayName,
-                                          );
-                                        }
-                                        if (a.lastModified == null) return 1;
-                                        return -1;
-                                      });
+                                      BackupFileItem.sortByNewest(list);
                                       if (mounted) {
                                         setState(() => _remoteS3 = list);
                                       }
@@ -1096,26 +954,9 @@ class _BackupPageState extends State<BackupPage> {
                                                     rootNavigator: true,
                                                   ).pop();
                                                 }
-                                                list.sort((a, b) {
-                                                  if (a.lastModified != null &&
-                                                      b.lastModified != null) {
-                                                    return b.lastModified!
-                                                        .compareTo(
-                                                          a.lastModified!,
-                                                        );
-                                                  }
-                                                  if (a.lastModified == null &&
-                                                      b.lastModified == null) {
-                                                    return b.displayName
-                                                        .compareTo(
-                                                          a.displayName,
-                                                        );
-                                                  }
-                                                  if (a.lastModified == null) {
-                                                    return 1;
-                                                  }
-                                                  return -1;
-                                                });
+                                                BackupFileItem.sortByNewest(
+                                                  list,
+                                                );
                                                 if (mounted) {
                                                   setState(
                                                     () => _remoteS3 = list,
@@ -1184,28 +1025,8 @@ class _BackupPageState extends State<BackupPage> {
                                               );
                                               return;
                                             }
-                                            await showDialog(
-                                              context: context,
-                                              barrierDismissible: false,
-                                              builder: (dctx) => AlertDialog(
-                                                title: Text(
-                                                  l10n.backupPageRestartRequired,
-                                                ),
-                                                content: Text(
-                                                  l10n.backupPageRestartContent,
-                                                ),
-                                                actions: [
-                                                  TextButton(
-                                                    onPressed: () async {
-                                                      Navigator.of(dctx).pop();
-                                                      PlatformUtils.restartApp();
-                                                    },
-                                                    child: Text(
-                                                      l10n.backupPageOK,
-                                                    ),
-                                                  ),
-                                                ],
-                                              ),
+                                            await showRestartRequiredDialog(
+                                              context,
                                             );
                                           },
                                         ),
@@ -1279,27 +1100,7 @@ class _BackupPageState extends State<BackupPage> {
                                       );
                                       return;
                                     }
-                                    await showDialog(
-                                      context: context,
-                                      barrierDismissible: false,
-                                      builder: (dctx) => AlertDialog(
-                                        title: Text(
-                                          l10n.backupPageRestartRequired,
-                                        ),
-                                        content: Text(
-                                          l10n.backupPageRestartContent,
-                                        ),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () async {
-                                              Navigator.of(dctx).pop();
-                                              PlatformUtils.restartApp();
-                                            },
-                                            child: Text(l10n.backupPageOK),
-                                          ),
-                                        ],
-                                      ),
-                                    );
+                                    await showRestartRequiredDialog(context);
                                   },
                                 ),
                               );
@@ -1602,7 +1403,6 @@ class _BackupPageState extends State<BackupPage> {
   }
 
   Future<void> _doImportLocal(BuildContext context, BackupProvider vm) async {
-    final l10n = AppLocalizations.of(context)!;
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['zip'],
@@ -1620,22 +1420,7 @@ class _BackupPageState extends State<BackupPage> {
       () => vm.restoreFromLocalFile(File(path), mode: mode),
     );
     if (!context.mounted) return;
-    await showDialog(
-      context: context,
-      builder: (dctx) => AlertDialog(
-        title: Text(l10n.backupPageRestartRequired),
-        content: Text(l10n.backupPageRestartContent),
-        actions: [
-          TextButton(
-            onPressed: () async {
-              Navigator.of(dctx).pop();
-              PlatformUtils.restartApp();
-            },
-            child: Text(l10n.backupPageOK),
-          ),
-        ],
-      ),
-    );
+    await showRestartRequiredDialog(context);
   }
 
   Future<void> _showWebDavSettingsPage(
@@ -2446,7 +2231,7 @@ class _RemoteListSheet extends StatelessWidget {
                                         ),
                                         const SizedBox(height: 4),
                                         Text(
-                                          _fmtBytes(it.size),
+                                          formatBytes(it.size),
                                           style: TextStyle(
                                             fontSize: 12,
                                             color: cs.onSurface.withValues(

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../utils/format.dart';
 import '../../../l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -507,16 +508,6 @@ class _ChatStorageSummaryState extends State<_ChatStorageSummary> {
     _future = StorageUsageService.computeReport();
   }
 
-  String _fmtBytes(int bytes) {
-    const kb = 1024;
-    const mb = kb * 1024;
-    const gb = mb * 1024;
-    if (bytes >= gb) return '${(bytes / gb).toStringAsFixed(2)} GB';
-    if (bytes >= mb) return '${(bytes / mb).toStringAsFixed(2)} MB';
-    if (bytes >= kb) return '${(bytes / kb).toStringAsFixed(1)} KB';
-    return '$bytes B';
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -534,7 +525,7 @@ class _ChatStorageSummaryState extends State<_ChatStorageSummary> {
           return Text(l10n.settingsPageCalculating, style: style);
         }
         final count = data?.totalFiles ?? 0;
-        final size = _fmtBytes(data?.totalBytes ?? 0);
+        final size = formatBytes(data?.totalBytes ?? 0);
         return Text(l10n.settingsPageFilesCount(count, size), style: style);
       },
     );

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -11,6 +11,7 @@ import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
+import '../../../utils/format.dart';
 import '../../../utils/platform_utils.dart';
 import '../../chat/pages/image_viewer_page.dart';
 import 'log_viewer_page.dart';
@@ -57,16 +58,6 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
       setState(() => _loading = false);
       return null;
     }
-  }
-
-  String _fmtBytes(int bytes) {
-    const kb = 1024;
-    const mb = kb * 1024;
-    const gb = mb * 1024;
-    if (bytes >= gb) return '${(bytes / gb).toStringAsFixed(2)} GB';
-    if (bytes >= mb) return '${(bytes / mb).toStringAsFixed(2)} MB';
-    if (bytes >= kb) return '${(bytes / kb).toStringAsFixed(1)} KB';
-    return '$bytes B';
   }
 
   Color _barColorFor(StorageUsageCategoryKey key, ColorScheme cs) {
@@ -339,7 +330,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
           title: title,
           categoryKey: key,
           initialReport: report,
-          fmtBytes: _fmtBytes,
+          fmtBytes: formatBytes,
           subTitleFor: (id) => _subTitleFor(id, l10n),
           refreshReport: _refreshReport,
         ),
@@ -461,7 +452,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
               Row(
                 children: [
                   Text(
-                    '${l10n.storageSpaceTotalLabel}: ${_fmtBytes(total)}',
+                    '${l10n.storageSpaceTotalLabel}: ${formatBytes(total)}',
                     style: TextStyle(
                       fontSize: 12.5,
                       color: cs.onSurface.withValues(alpha: 0.7),
@@ -471,7 +462,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                   if (clearable > 0) ...[
                     const SizedBox(width: 12),
                     Text(
-                      l10n.storageSpaceClearableLabel(_fmtBytes(clearable)),
+                      l10n.storageSpaceClearableLabel(formatBytes(clearable)),
                       style: TextStyle(
                         fontSize: 12.5,
                         color: cs.onSurface.withValues(alpha: 0.7),
@@ -492,7 +483,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                         selected: _selected,
                         iconFor: _iconFor,
                         titleFor: (k) => _titleFor(k, l10n),
-                        fmtBytes: _fmtBytes,
+                        fmtBytes: formatBytes,
                         onSelect: (k) => setState(() => _selected = k),
                       ),
                     ),
@@ -504,7 +495,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                       child: _CategoryDetail(
                         category: selectedCat,
                         title: _titleFor(selectedCat.key, l10n),
-                        fmtBytes: _fmtBytes,
+                        fmtBytes: formatBytes,
                         subTitleFor: (id) => _subTitleFor(id, l10n),
                         clearing: _clearing,
                         onClearCache: _clearing ? null : _doClearCache,
@@ -564,7 +555,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  _fmtBytes(total),
+                  formatBytes(total),
                   style: TextStyle(
                     fontSize: 22,
                     fontWeight: AppFontWeights.emphasis,
@@ -587,7 +578,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                   const SizedBox(height: 10),
                   Text(
                     l10n.storageSpaceClearableHint(
-                      _fmtBytes(report.clearable.bytes),
+                      formatBytes(report.clearable.bytes),
                     ),
                     style: TextStyle(
                       fontSize: 12.5,
@@ -609,7 +600,7 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
                   icon: _iconFor(report.categories[i].key),
                   label: _titleFor(report.categories[i].key, l10n),
                   detailText:
-                      '${_fmtBytes(report.categories[i].stats.bytes)} · ${l10n.storageSpaceFilesCount(report.categories[i].stats.fileCount)}',
+                      '${formatBytes(report.categories[i].stats.bytes)} · ${l10n.storageSpaceFilesCount(report.categories[i].stats.fileCount)}',
                   onTap: () => _openCategoryDetail(report.categories[i].key),
                 ),
                 if (i != report.categories.length - 1) _iosDivider(context),

--- a/lib/shared/dialogs/incremental_backup_dialog.dart
+++ b/lib/shared/dialogs/incremental_backup_dialog.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/models/incremental_backup.dart';
 import '../../icons/lucide_adapter.dart';
+import '../../utils/format.dart';
 import '../../l10n/app_localizations.dart';
 import '../../theme/app_font_weights.dart';
 import '../widgets/ios_switch.dart';
@@ -108,15 +109,6 @@ class _IncrementalBackupDialogBodyState
   }
 
   String _fmt(DateTime d) => d.toIso8601String().split('T')[0];
-
-  String _formatBytes(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) {
-      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    }
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
-  }
 
   Future<void> _rerunAnalysis() async {
     final analyzer = widget.analyzer;
@@ -324,7 +316,7 @@ class _IncrementalBackupDialogBodyState
           Text(
             l10n.backupPageIncrementalPreviewFiles(
               s.newFileCount,
-              _formatBytes(s.totalFileSizeBytes),
+              formatBytes(s.totalFileSizeBytes),
             ),
             style: TextStyle(
               fontSize: 12,

--- a/lib/shared/dialogs/restart_required_dialog.dart
+++ b/lib/shared/dialogs/restart_required_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../utils/platform_utils.dart';
+
+Future<void> showRestartRequiredDialog(BuildContext context) async {
+  final l10n = AppLocalizations.of(context)!;
+  final cs = Theme.of(context).colorScheme;
+  await showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (dctx) => AlertDialog(
+      backgroundColor: cs.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      title: Text(l10n.backupPageRestartRequired),
+      content: Text(l10n.backupPageRestartContent),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(dctx).pop();
+            PlatformUtils.restartApp();
+          },
+          child: Text(l10n.backupPageOK),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/utils/format.dart
+++ b/lib/utils/format.dart
@@ -1,0 +1,15 @@
+String formatBytes(int bytes) {
+  const units = ['B', 'KB', 'MB', 'GB'];
+  double s = bytes.toDouble();
+  int u = 0;
+  while (s >= 1024 && u < units.length - 1) {
+    s /= 1024;
+    u++;
+  }
+  final decimals = s < 10 && u > 0
+      ? 2
+      : s < 100 && u > 0
+      ? 1
+      : 0;
+  return '${s.toStringAsFixed(decimals)} ${units[u]}';
+}

--- a/test/core/services/backup/cherry_importer_test.dart
+++ b/test/core/services/backup/cherry_importer_test.dart
@@ -41,9 +41,22 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
+  Future<void> retryDelete(Directory dir, {int attempts = 5}) async {
+    for (int i = 0; i < attempts; i++) {
+      try {
+        await dir.delete(recursive: true);
+        return;
+      } catch (_) {
+        if (i < attempts - 1) {
+          await Future.delayed(const Duration(milliseconds: 100));
+        }
+      }
+    }
+  }
+
   tearDown(() async {
     if (await tempDir.exists()) {
-      await tempDir.delete(recursive: true);
+      await retryDelete(tempDir);
     }
   });
 

--- a/test/settings_provider_local_font_test.dart
+++ b/test/settings_provider_local_font_test.dart
@@ -75,8 +75,12 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       final storedPath = prefs.getString('display_app_font_local_path_v1');
       expect(storedPath, isNotNull);
-      expect(storedPath, startsWith('${tempDir.path}/fonts/'));
-      expect(await File(storedPath!).exists(), isTrue);
+      final normalized = storedPath!.replaceAll('\\', '/');
+      expect(
+        normalized,
+        startsWith('${tempDir.path.replaceAll('\\', '/')}/fonts/'),
+      );
+      expect(await File(storedPath).exists(), isTrue);
       expect(storedPath, isNot(sourceFile.path));
       expect(prefs.getString('display_app_font_local_alias_v1'), isNotEmpty);
     });


### PR DESCRIPTION
## Description

### 背景

Backup 相关代码中存在大量重复：`formatBytes` 至少 5 处、`showRestartRequired` 对话框 10+ 处、备份列表排序 8+ 处。此外，`restoreFromItem` 返回 `bool` + 魔术字符串（`'Restored'` / `'OK'`），强制所有调用方做 `ok` 判断。另外 `_addDirectoryToZip` 在 `lastModifiedSync` 抛出时静默 `continue`，导致文件被无声丢弃。同时有 3 个 Windows 测试因文件锁和路径分隔符问题失败。

### 变更内容

**1. 提取共享工具** a9a24083

- `formatBytes()` → `lib/utils/format.dart`，基于 `prettySize` 的智能精度（≥1000 不留小数，≥100 留 1 位，其余 2 位）
- `showRestartRequiredDialog()` → `lib/shared/dialogs/restart_required_dialog.dart`
- `BackupFileItem.sortByNewest()` → `lib/core/models/backup.dart` 静态方法
- 以上分别替换 5 / 10+ / 8+ 处重复实现

**2. Provider API 统一为 rethrow** 5929bd69` → 1048d376 sqaush 后

- `restoreFromItem` / `test` 从 `Future<bool>` 改为 `Future<void>`
- `catch` 中用 `_message = e.toString(); rethrow;`
- 所有 5 处调用方统一：`try { await restoreFromItem(...) } catch (e) { showSnackBar(e.toString()) }`
- 消除 `'Restored'` / `'OK'` 魔术字符串，消除 `backupPageRestoreFailed` 本地化需求

**3. `_addDirectoryToZip` 保守包含** d9e97c37

- `data_sync.dart:367`、`data_sync.dart:753`：移除 `catch` 内的 `continue`
- `analyzeIncrementalScope` 同理：当 `lastModifiedSync`（异步路径）或 `lastModified`（同步路径）抛出时，保守加入文件而非跳过
- 权衡：多压缩一个文件 vs 静默丢弃 → 丢更严重
- 注意：该代码运行在 `Isolate.run()` 内，无法使用 `dart:developer` 日志

**4. Windows 测试修复** 1048d376

- `cherry_importer_test.dart`：`tearDown` 用 `_retryDelete`（最多 5 次 × 100ms 延迟）解决 errno 32（文件锁）
- `settings_provider_local_font_test.dart`：比较路径前将 `\` 归一化为 `/`

**5. `_load()` 静默错误处理** 附带

- `backup_pane.dart:_load()` 的 `catch (_) {}` 改为 `catch (e)` → `showAppSnackBar`
- 对齐文件中其他 6 处 catch 块的相同模式

### 改动统计

```
13 files changed, 168 insertions(+), 492 deletions(-)
```

- 净减少 324 行，其中 backup_page.dart 删了 334 行
- 2 个新文件：`lib/utils/format.dart`、`lib/shared/dialogs/restart_required_dialog.dart`

### 设计说明

- **rethrow 优于 bool 返回**：将错误处理责任归于调用方，消除"忘了检查 `ok`"的风险；用户看到真实错误文本而非固定失败文案；不需要新增本地化字符串
- **保守包含优于静默跳过**：多打包一个文件比丢弃一个文件安全得多，符合备份工具的容错预期
- **不修改的部分**：`backup_page.dart` 行 1341 & 1369 的 `backupPageRestartRequired` 是 Cherry/Chatbox 导入结果弹窗，不属于本次抽取范围
