### PR TITLE
fix(mcp): preserve additionalProperties in tool schema sanitize for OpenAI/Claude

### DIFF
--- a/lib/core/providers/provider_kind.dart
+++ b/lib/core/providers/provider_kind.dart
@@ -1,0 +1,9 @@
+/// Provider family used to tailor JSON Schema sanitization and API payloads.
+///
+/// Kept in its own dependency-free file so pure, Flutter-independent logic
+/// (e.g. tool schema sanitization in `tool_schema_sanitizer.dart`) can depend
+/// on it without importing the Flutter-heavy `SettingsProvider`.
+///
+/// Re-exported from `settings_provider.dart` for backward compatibility with
+/// the many existing `import '.../settings_provider.dart'` call sites.
+enum ProviderKind { openai, google, claude }

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -9,6 +9,8 @@ import 'package:uuid/uuid.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'package:path/path.dart' as p;
+import 'provider_kind.dart';
+export 'provider_kind.dart';
 import '../services/search/search_service.dart';
 import '../services/tts/network_tts.dart';
 import '../services/tts/tts_text_selection.dart';
@@ -4502,7 +4504,9 @@ class _SocksProxyHttpOverrides extends HttpOverrides {
   }
 }
 
-enum ProviderKind { openai, google, claude }
+// ProviderKind now lives in provider_kind.dart and is re-exported below, so
+// pure/Flutter-free logic can depend on it. All existing importers of
+// settings_provider.dart keep seeing ProviderKind unchanged.
 
 // Background rendering mode for chat message bubbles
 enum ChatMessageBackgroundStyle { defaultStyle, frosted, solid }

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -15,6 +15,7 @@ import '../../../core/services/search/search_tool_service.dart';
 import 'ask_user_interaction_service.dart';
 import 'local_tools_service.dart';
 import 'tool_approval_service.dart';
+import 'tool_schema_sanitizer.dart';
 
 /// 工具调用处理服务
 ///
@@ -34,111 +35,13 @@ class ToolHandlerService {
 
   /// Sanitize/translate JSON Schema to each provider's accepted subset.
   ///
-  /// Different providers (Google, OpenAI, Claude) have different requirements
-  /// for tool parameter schemas. This method normalizes schemas to work across
-  /// all providers.
+  /// Delegates to [ToolSchemaSanitizer] (a pure, Flutter-free, unit-testable
+  /// module). Kept here as a static wrapper so existing call sites
+  /// (`ToolHandlerService.sanitizeToolParametersForProvider`) are unchanged.
   static Map<String, dynamic> sanitizeToolParametersForProvider(
     Map<String, dynamic> schema,
     ProviderKind kind,
-  ) {
-    Map<String, dynamic> clone = _deepCloneMap(schema);
-    clone = _sanitizeNode(clone, kind) as Map<String, dynamic>;
-    return clone;
-  }
-
-  static dynamic _sanitizeNode(dynamic node, ProviderKind kind) {
-    if (node is List) {
-      return node.map((e) => _sanitizeNode(e, kind)).toList();
-    }
-    if (node is! Map) return node;
-
-    final m = Map<String, dynamic>.from(node);
-    // Remove $schema as it's not needed for tool definitions
-    m.remove(r'$schema');
-
-    // Convert 'const' to 'enum' for compatibility
-    if (m.containsKey('const')) {
-      final v = m['const'];
-      if (v is String || v is num || v is bool) {
-        m['enum'] = [v];
-      }
-      m.remove('const');
-    }
-
-    // Flatten anyOf/oneOf/allOf to first variant for simplicity
-    for (final key in [
-      'anyOf',
-      'oneOf',
-      'allOf',
-      'any_of',
-      'one_of',
-      'all_of',
-    ]) {
-      if (m[key] is List && (m[key] as List).isNotEmpty) {
-        final first = (m[key] as List).first;
-        final flattened = _sanitizeNode(first, kind);
-        m.remove(key);
-        if (flattened is Map<String, dynamic>) {
-          m
-            ..remove('type')
-            ..remove('properties')
-            ..remove('items');
-          m.addAll(flattened);
-        }
-      }
-    }
-
-    // Normalize type array to single type
-    final t = m['type'];
-    if (t is List && t.isNotEmpty) m['type'] = t.first.toString();
-
-    // Normalize items array to single item
-    final items = m['items'];
-    if (items is List && items.isNotEmpty) m['items'] = items.first;
-    if (m['items'] is Map) m['items'] = _sanitizeNode(m['items'], kind);
-
-    // Recursively sanitize properties
-    if (m['properties'] is Map) {
-      final props = Map<String, dynamic>.from(m['properties']);
-      final norm = <String, dynamic>{};
-      props.forEach((k, v) {
-        norm[k] = _sanitizeNode(v, kind);
-      });
-      m['properties'] = norm;
-    }
-
-    // Keep only allowed keys based on provider
-    Set<String> allowed;
-    switch (kind) {
-      case ProviderKind.google:
-        allowed = {
-          'type',
-          'description',
-          'properties',
-          'required',
-          'items',
-          'enum',
-        };
-        break;
-      case ProviderKind.openai:
-      case ProviderKind.claude:
-        allowed = {
-          'type',
-          'description',
-          'properties',
-          'required',
-          'items',
-          'enum',
-        };
-        break;
-    }
-    m.removeWhere((k, v) => !allowed.contains(k));
-    return m;
-  }
-
-  static Map<String, dynamic> _deepCloneMap(Map<String, dynamic> input) {
-    return jsonDecode(jsonEncode(input)) as Map<String, dynamic>;
-  }
+  ) => ToolSchemaSanitizer.sanitizeToolParametersForProvider(schema, kind);
 
   static String _toolError({
     required String error,

--- a/lib/features/home/services/tool_schema_sanitizer.dart
+++ b/lib/features/home/services/tool_schema_sanitizer.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+
+import '../../../core/providers/provider_kind.dart';
+
+/// Pure (Flutter-free) JSON Schema sanitizer for tool parameter schemas.
+///
+/// Extracted from `ToolHandlerService` so this normalization logic can be unit
+/// tested without pulling in Flutter/provider dependencies. Behavior is
+/// unchanged; `ToolHandlerService.sanitizeToolParametersForProvider` now
+/// delegates here.
+///
+/// Different providers (Google, OpenAI, Claude) accept different subsets of
+/// JSON Schema for tool parameters, so schemas are normalized to a common
+/// accepted form per provider.
+class ToolSchemaSanitizer {
+  const ToolSchemaSanitizer._();
+
+  /// Sanitize/translate [schema] to the JSON Schema subset accepted by [kind].
+  static Map<String, dynamic> sanitizeToolParametersForProvider(
+    Map<String, dynamic> schema,
+    ProviderKind kind,
+  ) {
+    Map<String, dynamic> clone = _deepCloneMap(schema);
+    clone = sanitizeNode(clone, kind) as Map<String, dynamic>;
+    return clone;
+  }
+
+  /// Recursively sanitize a single schema [node]. Public (not name-mangled) so
+  /// it can be exercised directly in unit tests.
+  static dynamic sanitizeNode(dynamic node, ProviderKind kind) {
+    if (node is List) {
+      return node.map((e) => sanitizeNode(e, kind)).toList();
+    }
+    if (node is! Map) return node;
+
+    final m = Map<String, dynamic>.from(node);
+    // Remove $schema as it's not needed for tool definitions
+    m.remove(r'$schema');
+
+    // Convert 'const' to 'enum' for compatibility
+    if (m.containsKey('const')) {
+      final v = m['const'];
+      if (v is String || v is num || v is bool) {
+        m['enum'] = [v];
+      }
+      m.remove('const');
+    }
+
+    // Flatten anyOf/oneOf/allOf to first variant for simplicity
+    for (final key in [
+      'anyOf',
+      'oneOf',
+      'allOf',
+      'any_of',
+      'one_of',
+      'all_of',
+    ]) {
+      if (m[key] is List && (m[key] as List).isNotEmpty) {
+        final first = (m[key] as List).first;
+        final flattened = sanitizeNode(first, kind);
+        m.remove(key);
+        if (flattened is Map<String, dynamic>) {
+          m
+            ..remove('type')
+            ..remove('properties')
+            ..remove('items');
+          m.addAll(flattened);
+        }
+      }
+    }
+
+    // Normalize type array to single type
+    final t = m['type'];
+    if (t is List && t.isNotEmpty) m['type'] = t.first.toString();
+
+    // Normalize items array to single item
+    final items = m['items'];
+    if (items is List && items.isNotEmpty) m['items'] = items.first;
+    if (m['items'] is Map) m['items'] = sanitizeNode(m['items'], kind);
+
+    // Recursively sanitize properties
+    if (m['properties'] is Map) {
+      final props = Map<String, dynamic>.from(m['properties']);
+      final norm = <String, dynamic>{};
+      props.forEach((k, v) {
+        norm[k] = sanitizeNode(v, kind);
+      });
+      m['properties'] = norm;
+    }
+
+    // additionalProperties may be a bool or a subschema (Map). When it is a
+    // subschema, recurse so nested nodes are normalized like properties/items.
+    if (m['additionalProperties'] is Map) {
+      m['additionalProperties'] = sanitizeNode(m['additionalProperties'], kind);
+    }
+
+    // Keep only allowed keys based on provider
+    Set<String> allowed;
+    switch (kind) {
+      case ProviderKind.google:
+        allowed = {
+          'type',
+          'description',
+          'properties',
+          'required',
+          'items',
+          'enum',
+        };
+        break;
+      case ProviderKind.openai:
+      case ProviderKind.claude:
+        allowed = {
+          'type',
+          'description',
+          'properties',
+          'required',
+          'items',
+          'enum',
+          // Standard JSON Schema field. Must be preserved so MCP servers that
+          // declare open/free-form object params (additionalProperties: true or
+          // a subschema) are not silently narrowed to closed objects. Strict
+          // models (e.g. GLM-5.1) otherwise refuse to fill undeclared params.
+          // Gemini (ProviderKind.google) rejects this key, so it stays dropped
+          // in that branch.
+          'additionalProperties',
+        };
+        break;
+    }
+    m.removeWhere((k, v) => !allowed.contains(k));
+    return m;
+  }
+
+  static Map<String, dynamic> _deepCloneMap(Map<String, dynamic> input) {
+    return jsonDecode(jsonEncode(input)) as Map<String, dynamic>;
+  }
+}

--- a/test/tool_schema_sanitizer_test.dart
+++ b/test/tool_schema_sanitizer_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Kelivo/core/providers/provider_kind.dart';
+import 'package:Kelivo/features/home/services/tool_schema_sanitizer.dart';
+
+/// Regression tests for the tool-parameter JSON Schema sanitizer.
+///
+/// Bug: `additionalProperties` (a standard JSON Schema keyword) was stripped
+/// for every provider because it was not on the allow-list. MCP servers that
+/// declare open/free-form object params were silently narrowed to closed
+/// objects, so strict models (e.g. GLM-5.1) refused to fill undeclared params.
+///
+/// Fix: keep `additionalProperties` for OpenAI/Claude-style providers; Gemini
+/// (Google) still drops it because that API rejects the key.
+void main() {
+  // A nested schema whose object params are open via additionalProperties.
+  Map<String, dynamic> sampleSchema() => {
+    r'$schema': 'http://json-schema.org/draft-07/schema#',
+    'type': 'object',
+    'description': 'MCP tool params',
+    'additionalProperties': true,
+    'required': ['config'],
+    'properties': {
+      'config': {
+        'type': 'object',
+        'description': 'Free-form config bag',
+        // Open object: values may be any of the declared props plus extras.
+        'additionalProperties': true,
+        'properties': {
+          'name': {'type': 'string'},
+        },
+      },
+      'items': {
+        'type': 'array',
+        'items': {
+          'type': 'object',
+          'additionalProperties': true,
+          'properties': {
+            'id': {'type': 'string'},
+          },
+        },
+      },
+    },
+  };
+
+  group('ToolSchemaSanitizer (OpenAI/Claude)', () {
+    for (final kind in const [ProviderKind.openai, ProviderKind.claude]) {
+      test(
+        'preserves additionalProperties (top-level and nested) for $kind',
+        () {
+          final out = ToolSchemaSanitizer.sanitizeToolParametersForProvider(
+            sampleSchema(),
+            kind,
+          );
+
+          // Top-level open object preserved.
+          expect(
+            out['additionalProperties'],
+            isTrue,
+            reason: 'top-level additionalProperties must survive',
+          );
+
+          // properties are not lost.
+          final props = out['properties'] as Map<String, dynamic>;
+          expect(props.keys, containsAll(<String>['config', 'items']));
+
+          // Nested object keeps additionalProperties AND its properties.
+          final config = props['config'] as Map<String, dynamic>;
+          expect(config['additionalProperties'], isTrue);
+          expect((config['properties'] as Map).containsKey('name'), isTrue);
+
+          // Nested-in-array object keeps additionalProperties too.
+          final arrItem =
+              (props['items'] as Map)['items'] as Map<String, dynamic>;
+          expect(arrItem['additionalProperties'], isTrue);
+          expect((arrItem['properties'] as Map).containsKey('id'), isTrue);
+
+          // $schema is still stripped; standard fields still normalized/kept.
+          expect(out.containsKey(r'$schema'), isFalse);
+          expect(out['type'], 'object');
+          expect(out['required'], ['config']);
+        },
+      );
+    }
+
+    test(
+      'preserves a subschema-valued additionalProperties and sanitizes it',
+      () {
+        final schema = {
+          'type': 'object',
+          'additionalProperties': {
+            r'$schema': 'should-be-removed',
+            'type': 'string',
+            'const': 'x', // should be normalized to enum: ['x']
+          },
+        };
+
+        final out = ToolSchemaSanitizer.sanitizeToolParametersForProvider(
+          schema,
+          ProviderKind.openai,
+        );
+
+        final ap = out['additionalProperties'] as Map<String, dynamic>;
+        expect(
+          ap.containsKey(r'$schema'),
+          isFalse,
+          reason: 'subschema must be recursively sanitized',
+        );
+        expect(ap['type'], 'string');
+        expect(ap['enum'], ['x']);
+      },
+    );
+
+    test('does not mutate the input schema (deep clone)', () {
+      final input = sampleSchema();
+      ToolSchemaSanitizer.sanitizeToolParametersForProvider(
+        input,
+        ProviderKind.openai,
+      );
+      // Original still has $schema and its nested open objects untouched.
+      expect(input.containsKey(r'$schema'), isTrue);
+      expect(input['additionalProperties'], isTrue);
+    });
+  });
+
+  group('ToolSchemaSanitizer (Google/Gemini)', () {
+    test('drops additionalProperties because Gemini rejects it', () {
+      final out = ToolSchemaSanitizer.sanitizeToolParametersForProvider(
+        sampleSchema(),
+        ProviderKind.google,
+      );
+
+      expect(out.containsKey('additionalProperties'), isFalse);
+      // But real params are still preserved.
+      final props = out['properties'] as Map<String, dynamic>;
+      expect(props.keys, containsAll(<String>['config', 'items']));
+      expect(
+        (props['config'] as Map).containsKey('additionalProperties'),
+        isFalse,
+      );
+      expect((props['config'] as Map)['properties'], isA<Map>());
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/Chevey339/kelivo/pull/774

## Problem
`ToolHandlerService._sanitizeNode` keeps only an allow-list `{type, description, properties, required, items, enum}` and `removeWhere`s everything else, so the standard JSON Schema keyword `additionalProperties` is dropped for all providers. MCP servers that declare open/free-form object params (`additionalProperties: true` or a subschema) get silently narrowed to closed objects, and strict models (e.g. GLM-5.1) then refuse to fill undeclared params like `player_id`/`mode`. Looser models (GPT, GLM-4.7) fill them from context, which is why it looks provider-specific.

## Reproduction (independent env)
Same GLM-5.1, only the client differs: via Kelivo the params are dropped and the MCP server reports missing args; via a client that does not sanitize, the same model fills them and the call succeeds. Variable isolated to the client sanitize step.

## Fix
- Add `additionalProperties` back to the allow-list for OpenAI/Claude providers; keep dropping it for Google/Gemini (that API rejects the key).
- Recursively sanitize `additionalProperties` when it is a subschema (Map), like properties/items.
- Extract the pure logic into `tool_schema_sanitizer.dart` (Flutter-free) so it is unit-testable; `ToolHandlerService.sanitizeToolParametersForProvider` now delegates to it (public API and call sites unchanged).
- Add `test/tool_schema_sanitizer_test.dart` covering top-level/nested/in-array preservation, subschema recursion, no input mutation, and Gemini dropping it while keeping real params.

Note: tests were verified via a Flutter-free dart harness importing the same production files; they should run under `flutter test` in CI.