### PR TITLE
feat: add SVG code block preview for svg markdown fences

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -27,6 +27,7 @@ import 'mermaid_bridge.dart';
 import 'export_capture_scope.dart';
 import 'mermaid_image_cache.dart';
 import 'plantuml_block.dart';
+import 'svg_preview_block.dart';
 import 'tabbed_preview_block.dart';
 import 'package:path/path.dart' as p;
 import 'package:Cuplivo/l10n/app_localizations.dart';
@@ -486,6 +487,8 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
           );
         } else if (lang.toLowerCase() == 'plantuml') {
           return PlantUMLBlock(code: restoredCode);
+        } else if (lang.toLowerCase() == 'svg') {
+          return SvgPreviewBlock(code: restoredCode);
         }
         return _CollapsibleCodeBlock(
           language: lang,
@@ -4296,6 +4299,8 @@ class FencedCodeBlockMd extends BlockMd {
       return _MermaidBlock(code: code, streaming: isStreamingFence);
     } else if (langLower == 'plantuml') {
       return PlantUMLBlock(code: code);
+    } else if (langLower == 'svg') {
+      return SvgPreviewBlock(code: code);
     }
     return _CollapsibleCodeBlock(
       language: lang,

--- a/lib/shared/widgets/svg_preview_block.dart
+++ b/lib/shared/widgets/svg_preview_block.dart
@@ -1,0 +1,273 @@
+import 'dart:io';
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:path/path.dart' as p;
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../icons/lucide_adapter.dart';
+import 'export_capture_scope.dart';
+import 'snackbar.dart';
+import 'tabbed_preview_block.dart';
+
+enum _SvgTab { image, code }
+
+class SvgPreviewBlock extends StatefulWidget {
+  const SvgPreviewBlock({super.key, required this.code});
+
+  final String code;
+
+  @override
+  State<SvgPreviewBlock> createState() => _SvgPreviewBlockState();
+}
+
+class _SvgPreviewBlockState extends State<SvgPreviewBlock> {
+  static const double _previewHeight = 406;
+
+  _SvgTab _selectedTab = _SvgTab.image;
+  late final ScrollController _codeScrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _codeScrollController = ScrollController();
+  }
+
+  @override
+  void didUpdateWidget(covariant SvgPreviewBlock oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.code != widget.code) {
+      _selectedTab = _SvgTab.image;
+    }
+  }
+
+  @override
+  void dispose() {
+    _codeScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final l10n = AppLocalizations.of(context)!;
+    final exporting = ExportCaptureScope.of(context);
+    final colors = PreviewBlockColors.resolve(isDark);
+
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      decoration: BoxDecoration(
+        color: colors.body,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      clipBehavior: Clip.antiAlias,
+      foregroundDecoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: colors.header,
+              border: Border(
+                bottom: BorderSide(color: colors.border, width: 1),
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(vertical: 5),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.only(
+                      start: 16,
+                      end: 10,
+                    ),
+                    child: Align(
+                      alignment: AlignmentDirectional.centerStart,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: colors.tabTrack,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(2),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              PreviewTabButton(
+                                label: l10n.mermaidImageTab,
+                                selected: _selectedTab == _SvgTab.image,
+                                colors: colors,
+                                onTap: () {
+                                  setState(() => _selectedTab = _SvgTab.image);
+                                },
+                              ),
+                              PreviewTabButton(
+                                label: l10n.mermaidCodeTab,
+                                selected: _selectedTab == _SvgTab.code,
+                                colors: colors,
+                                onTap: () {
+                                  setState(() => _selectedTab = _SvgTab.code);
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                if (!exporting)
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(end: 10),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        PreviewTextAction(
+                          icon: Lucide.Copy,
+                          label: l10n.shareProviderSheetCopyButton,
+                          colors: colors,
+                          onTap: () => _copySvgCode(context),
+                        ),
+                        const SizedBox(width: 4),
+                        PreviewTextAction(
+                          icon: Lucide.Link,
+                          label: l10n.mermaidPreviewOpen,
+                          colors: colors,
+                          onTap: () => _openInBrowser(context),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          SizedBox(
+            key: const ValueKey('svg-preview-body'),
+            width: double.infinity,
+            height: _previewHeight,
+            child: ColoredBox(
+              color: colors.body,
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 180),
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeInCubic,
+                layoutBuilder: (currentChild, previousChildren) {
+                  return currentChild ?? const SizedBox.shrink();
+                },
+                child: _selectedTab == _SvgTab.code
+                    ? _buildCodeView(context, colors)
+                    : _buildImageView(colors),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImageView(PreviewBlockColors colors) {
+    final trimmed = widget.code.trim();
+    final isValid = trimmed.startsWith('<svg') || trimmed.startsWith('<?xml');
+
+    if (!isValid) {
+      return Padding(
+        key: const ValueKey('svg-image-error'),
+        padding: const EdgeInsets.all(8),
+        child: PreviewErrorView(colors: colors),
+      );
+    }
+
+    return Padding(
+      key: const ValueKey('svg-image-body'),
+      padding: const EdgeInsets.all(8),
+      child: SvgPicture.string(
+        widget.code,
+        fit: BoxFit.contain,
+        placeholderBuilder: (context) => PreviewLoadingView(colors: colors),
+      ),
+    );
+  }
+
+  Widget _buildCodeView(BuildContext context, PreviewBlockColors colors) {
+    return Padding(
+      key: const ValueKey('svg-code-body'),
+      padding: const EdgeInsets.all(12),
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(
+          dragDevices: {
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.stylus,
+            PointerDeviceKind.unknown,
+          },
+        ),
+        child: Scrollbar(
+          controller: _codeScrollController,
+          thumbVisibility: true,
+          interactive: true,
+          notificationPredicate: (notif) => notif.metrics.axis == Axis.vertical,
+          child: SingleChildScrollView(
+            controller: _codeScrollController,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SelectableText(
+                widget.code,
+                style: TextStyle(
+                  color: colors.textPrimary,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _copySvgCode(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    await Clipboard.setData(ClipboardData(text: widget.code));
+    if (!context.mounted) return;
+    showAppSnackBar(
+      context,
+      message: l10n.chatMessageWidgetCopiedToClipboard,
+      type: NotificationType.success,
+    );
+  }
+
+  Future<void> _openInBrowser(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final dir = Directory.systemTemp;
+    final file = File(
+      p.join(
+        dir.path,
+        'svg_preview_${DateTime.now().millisecondsSinceEpoch}.svg',
+      ),
+    );
+    try {
+      await file.writeAsString(widget.code, flush: true);
+      final ok = await launchUrl(
+        Uri.file(file.path),
+        mode: LaunchMode.externalApplication,
+      );
+      if (ok || !context.mounted) return;
+    } catch (_) {
+      if (!context.mounted) return;
+    }
+    showAppSnackBar(
+      context,
+      message: l10n.mermaidPreviewOpenFailed,
+      type: NotificationType.error,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Add live SVG preview for `svg` code blocks in chat messages, matching the existing preview pattern for Mermaid and PlantUML.

## Preview

https://github.com/user-attachments/assets/4be9b958-0df4-4125-ad5d-6bacbb610aa9
