### PR TITLE
fix(tools): strip script/style from fetch_markdown output (#17)

### DIFF
--- a/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart
+++ b/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart
@@ -120,7 +120,7 @@ class KelivoFetcher {
     try {
       final resp = await _fetch(payload);
       final html = resp.body;
-      final md = html2md.convert(html);
+      final md = html2md.convert(html, ignore: ['script', 'style']);
       return _ok(md);
     } catch (e) {
       return _err(e.toString());

--- a/test/core/services/mcp/kelivo_fetch/kelivo_fetch_server_test.dart
+++ b/test/core/services/mcp/kelivo_fetch/kelivo_fetch_server_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:html2md/html2md.dart' as html2md;
+
+void main() {
+  group('fetch_markdown script/style ignore', () {
+    test('plain text without HTML tags passes through unchanged', () {
+      final md = html2md.convert('Hello world', ignore: ['script', 'style']);
+      expect(md, contains('Hello world'));
+    });
+
+    test('script element content is stripped from markdown output', () {
+      const html = '<p>Hello</p><script>alert("xss")</script><p>World</p>';
+      final md = html2md.convert(html, ignore: ['script', 'style']);
+      expect(md, contains('Hello'));
+      expect(md, contains('World'));
+      expect(md, isNot(contains('alert')));
+      expect(md, isNot(contains('xss')));
+    });
+
+    test('style element content is stripped from markdown output', () {
+      const html = '<p>Content</p><style>body{color:red}</style>';
+      final md = html2md.convert(html, ignore: ['style']);
+      expect(md, contains('Content'));
+      expect(md, isNot(contains('color:red')));
+      expect(md, isNot(contains('body{')));
+    });
+
+    test('both script and style elements are stripped simultaneously', () {
+      const html = '<script>js</script><p>Hello</p><style>css</style>';
+      final md = html2md.convert(html, ignore: ['script', 'style']);
+      expect(md, contains('Hello'));
+      expect(md, isNot(contains('js')));
+      expect(md, isNot(contains('css')));
+    });
+
+    test('nested script inside body is stripped', () {
+      const html =
+          '<html><body><p>Visible</p><script>nested</script></body></html>';
+      final md = html2md.convert(html, ignore: ['script', 'style']);
+      expect(md, contains('Visible'));
+      expect(md, isNot(contains('nested')));
+    });
+  });
+}


### PR DESCRIPTION
### Problem

The built-in `fetch_markdown` tool passes raw HTML directly to `html2md.convert()` without stripping `<script>` and `<style>` elements. This causes script/style content to leak into the Markdown output, severely inflating LLM context.

Fixes #17.

### Impact

| Metric | Before | After |
|---|---|---|
| Context tokens consumed | ~300k | ~22k |
| Task completion | ❌ Interrupted | ✅ Succeeded |

### Root Cause

`html2md`'s `ignore` parameter was not used. When `html2md.convert(html)` processes inline `<script>`, it treats the script body as text content, producing verbose Markdown output.

### Fix

`lib/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart:123` — added `ignore: ['script', 'style']`:
