### PR TITLE
fix: make conversation messageIds lists mutable to prevent send crash after restart

### DIFF
--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -871,9 +871,9 @@ class ChatDatabaseRepository {
       title: row.title,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
-      messageIds: messageRows.map((m) => m.id).toList(growable: false),
+      messageIds: messageRows.map((m) => m.id).toList(),
       isPinned: row.isPinned,
-      mcpServerIds: mcpRows.map((m) => m.serverId).toList(growable: false),
+      mcpServerIds: mcpRows.map((m) => m.serverId).toList(),
       assistantId: row.assistantId,
       truncateIndex: row.truncateIndex,
       versionSelections: _decodeStringIntMap(row.versionSelectionsJson),
@@ -907,14 +907,10 @@ class ChatDatabaseRepository {
       createdAt: _dateTimeFromSqlite(row['created_at']),
       updatedAt: _dateTimeFromSqlite(row['updated_at']),
       messageIds:
-          messageRows?.map((m) => m['id'] as String).toList(growable: false) ??
-          const <String>[],
+          messageRows?.map((m) => m['id'] as String).toList() ?? <String>[],
       isPinned: row['is_pinned'] == 1,
       mcpServerIds:
-          mcpRows
-              ?.map((m) => m['server_id'] as String)
-              .toList(growable: false) ??
-          const <String>[],
+          mcpRows?.map((m) => m['server_id'] as String).toList() ?? <String>[],
       assistantId: row['assistant_id'] as String?,
       truncateIndex: row['truncate_index'] as int? ?? -1,
       versionSelections: _decodeStringIntMap(

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -116,11 +116,10 @@ class Conversation {
       title: json['title'] as String,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
-      messageIds:
-          (json['messageIds'] as List?)?.cast<String>() ?? const <String>[],
+      messageIds: (json['messageIds'] as List?)?.cast<String>() ?? <String>[],
       isPinned: json['isPinned'] as bool? ?? false,
       mcpServerIds:
-          (json['mcpServerIds'] as List?)?.cast<String>() ?? const <String>[],
+          (json['mcpServerIds'] as List?)?.cast<String>() ?? <String>[],
       assistantId: json['assistantId'] as String?,
       truncateIndex: json['truncateIndex'] as int? ?? -1,
       versionSelections:
@@ -132,8 +131,7 @@ class Conversation {
       lastSummarizedMessageCount:
           json['lastSummarizedMessageCount'] as int? ?? 0,
       chatSuggestions:
-          (json['chatSuggestions'] as List?)?.cast<String>() ??
-          const <String>[],
+          (json['chatSuggestions'] as List?)?.cast<String>() ?? <String>[],
     );
   }
 }

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -592,6 +592,9 @@ class ChatActions {
     } catch (e) {
       // Ensure file processing indicator is cleared on error
       onFileProcessingFinished?.call();
+      _setConversationLoading(conversation.id, false);
+      streamController.markStreamingEnded(assistantMessage.id);
+      streamController.cleanupTimers(assistantMessage.id);
       return ChatActionResult.error(e.toString());
     }
   }


### PR DESCRIPTION
https://[github.com/Chevey339/kelivo/issues/785](https://github.com/Chevey339/kelivo/issues/785)

The root cause is a mismatch between Conversation's field declarations (which permit mutation via `.add()`/`.remove()`) and the values assigned during deserialization (which were immutable `const <String>[]` or fixed-length `toList(growable: false))`.

When ChatService._loadConversationsCache loads conversations via `getAllConversationsSync(includeMessageIds: false)`, `messageRows` is `null`, causing `_conversationFromSqliteRow` to fall back to `const <String>[]` — a shared, unmodifiable empty list.  Any subsequent sendMessage → addMessage → conversation.messageIds.add(message.id) then crashes with 'Cannot add to an unmodifiable list'.

Changes:
- lib/core/models/conversation.dart (3 lines): fromJson fallbacks: const <String>[] → <String>[]
- lib/core/database/chat_database_repository.dart (4 lines): toList(growable: false) → toList() for messageIds and mcpServerIds; const <String>[] → <String>[] for the sync SQLite fallback
- lib/features/home/controllers/chat_actions.dart (1 block): sendMessage catch now calls _setConversationLoading(false), markStreamingEnded, and cleanupTimers to prevent permanently stuck conversations when an exception does escape.