### PR TITLE
feat(model): add Kimi K3 support with max reasoning and both naming variants

### DIFF
--- a/lib/core/providers/model_provider.dart
+++ b/lib/core/providers/model_provider.dart
@@ -17,14 +17,14 @@ class ModelRegistry {
   // Vision-capable models (text + image input)
   static final RegExp vision = RegExp(
     // GPT family incl. 4o, 4.1, 5 (exclude gpt-5-chat), and OpenAI o* series
-    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|kimi-k2([-.])(?:5|6|7)|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
+    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|kimi-k2([-.])(?:5|6|7)|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
     caseSensitive: false,
   );
   // Tool-using models
   static final RegExp tool = RegExp(
     (r'(gpt-4o|gpt-4\.1|gpt-oss|gpt-5(?!-chat)|o\d|'
             r'gemini|claude|'
-            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|'
+            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3|chat|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -40,7 +40,7 @@ class ModelRegistry {
             r'gemini-3-pro-image-preview|'
             r'gemma[-_]?4|'
             r'claude|'
-            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|'
+            r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -141,6 +141,19 @@ void _removeMoonshotKimiUnsupportedSamplingParams(Map<String, dynamic> body) {
   body.remove('frequency_penalty');
 }
 
+void _sanitizeAlwaysStripSamplingParams(
+  Map<String, dynamic> body,
+  String upstreamModelId,
+) {
+  if (!openAIAlwaysStripsSamplingParams(upstreamModelId)) return;
+  body.remove('temperature');
+  body.remove('top_p');
+  body.remove('n');
+  body.remove('presence_penalty');
+  body.remove('frequency_penalty');
+  body.remove('logprobs');
+}
+
 bool _isZhipuLikeProvider({
   required String providerId,
   required String host,
@@ -1365,6 +1378,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     upstreamModelId,
     fallbackEffort: effort,
   );
+  _sanitizeAlwaysStripSamplingParams(body, upstreamModelId);
   _normalizeMoonshotKimiChatBody(
     body,
     upstreamModelId: upstreamModelId,
@@ -1887,6 +1901,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               upstreamModelId,
               fallbackEffort: effort,
             );
+            _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
             _normalizeMoonshotKimiChatBody(
               body2,
               upstreamModelId: upstreamModelId,
@@ -2618,6 +2633,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   upstreamModelId,
                   fallbackEffort: effort,
                 );
+                _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
 
                 final req2 = http.Request('POST', url);
                 final headers2 = <String, String>{
@@ -3349,6 +3365,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               upstreamModelId,
               fallbackEffort: effort,
             );
+            _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
             _normalizeMoonshotKimiChatBody(
               body2,
               upstreamModelId: upstreamModelId,
@@ -3862,6 +3879,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   upstreamModelId,
                   fallbackEffort: effort,
                 );
+                _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
                 _normalizeMoonshotKimiChatBody(
                   body2,
                   upstreamModelId: upstreamModelId,

--- a/lib/core/utils/openai_model_compat.dart
+++ b/lib/core/utils/openai_model_compat.dart
@@ -2,10 +2,12 @@ class OpenAIReasoningSupport {
   const OpenAIReasoningSupport({
     required this.supportedEfforts,
     this.samplingRequiresNone = false,
+    this.alwaysStripSampling = false,
   });
 
   final List<String> supportedEfforts;
   final bool samplingRequiresNone;
+  final bool alwaysStripSampling;
 
   bool get supportsNone => supportedEfforts.contains('none');
   bool get supportsXhigh => supportedEfforts.contains('xhigh');
@@ -69,6 +71,10 @@ const OpenAIReasoningSupport _gpt56ProSupport = OpenAIReasoningSupport(
 const OpenAIReasoningSupport _deepSeekSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
 );
+const OpenAIReasoningSupport _kimiK3Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['none', 'low', 'medium', 'high', 'max'],
+  alwaysStripSampling: true,
+);
 
 String resolveApiModelIdOverride(
   Map<String, dynamic>? override,
@@ -83,6 +89,12 @@ String resolveApiModelIdOverride(
 
 bool isOpenAIGpt5FamilyModel(String modelId) {
   return RegExp(r'gpt-5(?=$|[-.])', caseSensitive: false).hasMatch(modelId);
+}
+
+bool isOpenAIKimiK3Model(String modelId) {
+  final lower = modelId.trim().toLowerCase();
+  return lower.contains('kimi-k3') ||
+      RegExp(r'(?:^|[-_/])k3(?:$|[-.])', caseSensitive: false).hasMatch(lower);
 }
 
 bool openAISupportsXhighReasoning(String modelId) {
@@ -184,9 +196,15 @@ bool openAIAllowsSamplingParams(String modelId, {required String effort}) {
       normalizedEffort == 'auto';
 }
 
+bool openAIAlwaysStripsSamplingParams(String modelId) {
+  final support = openAIReasoningSupport(modelId);
+  return support?.alwaysStripSampling ?? false;
+}
+
 OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   final normalized = modelId.trim().toLowerCase();
   if (normalized.contains('deepseek')) return _deepSeekSupport;
+  if (isOpenAIKimiK3Model(normalized)) return _kimiK3Support;
   if (!isOpenAIGpt5FamilyModel(normalized)) return null;
 
   if (_matchesModel(

--- a/lib/utils/brand_assets.dart
+++ b/lib/utils/brand_assets.dart
@@ -57,7 +57,10 @@ class BrandAssets {
         MapEntry(RegExp(r'minimax'), 'minimax-color.svg'),
         MapEntry(RegExp(r'xai'), 'xai.svg'),
         MapEntry(RegExp(r'juhenext'), 'juhenext.png'),
-        MapEntry(RegExp(r'kimi|moonshot|月之暗面'), 'kimi-color.svg'),
+        MapEntry(
+          RegExp(r'kimi|moonshot|月之暗面|(?:^|[-_/])k3(?:$|[-.])'),
+          'kimi-color.svg',
+        ),
         MapEntry(RegExp(r'302'), '302ai-color.svg'),
         MapEntry(RegExp(r'step|阶跃'), 'stepfun-color.svg'),
         MapEntry(RegExp(r'internlm|书生'), 'internlm-color.svg'),

--- a/lib/utils/model_grouping.dart
+++ b/lib/utils/model_grouping.dart
@@ -24,7 +24,9 @@ class ModelGrouping {
     if (id.contains('claude-3.5')) return 'Claude 3.5';
     if (id.contains('claude-3')) return 'Claude 3';
     if (id.contains('deepseek')) return 'DeepSeek';
-    if (id.contains('kimi')) return 'Kimi';
+    if (id.contains('kimi') || RegExp(r'(?:^|[-_/])k3(?:$|[-.])').hasMatch(id)) {
+      return 'Kimi';
+    }
     if (RegExp(r'qwen|qwq|qvq|dashscope').hasMatch(id)) return 'Qwen';
     if (RegExp(r'doubao|ark|volc').hasMatch(id)) return 'Doubao';
     if (id.contains('glm') || id.contains('zhipu')) return 'GLM';

--- a/test/openai_kimi_compat_test.dart
+++ b/test/openai_kimi_compat_test.dart
@@ -502,5 +502,129 @@ void main() {
         ]);
       },
     );
+
+    test(
+      'kimi-k3 uses reasoning_effort max and strips sampling params unconditionally',
+      () async {
+        final requestBodyCompleter = Completer<Map<String, dynamic>>();
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          final body =
+              jsonDecode(await utf8.decoder.bind(request).join())
+                  as Map<String, dynamic>;
+          if (!requestBodyCompleter.isCompleted) {
+            requestBodyCompleter.complete(body);
+          }
+
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+            charset: 'utf-8',
+          );
+          request.response.write(
+            'data: ${jsonEncode({
+              'id': 'cmpl-k3',
+              'object': 'chat.completion.chunk',
+              'created': 0,
+              'model': 'kimi-k3',
+              'choices': [
+                {
+                  'index': 0,
+                  'delta': {'role': 'assistant', 'content': 'ok'},
+                  'finish_reason': 'stop',
+                },
+              ],
+            })}\n\n',
+          );
+          request.response.write('data: [DONE]\n\n');
+          await request.response.close();
+        });
+
+        final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _moonshotConfig(baseUrl),
+          modelId: 'kimi-k3',
+          messages: const [
+            {'role': 'user', 'content': 'hello'},
+          ],
+          thinkingBudget: 128000, // maps to max effort
+          temperature: 0.7,
+          topP: 0.8,
+        ).toList();
+
+        final body = await requestBodyCompleter.future;
+        expect(chunks.last.isDone, isTrue);
+        expect(body['reasoning_effort'], 'max');
+        expect(body.containsKey('thinking'), isFalse);
+        expect(body.containsKey('temperature'), isFalse);
+        expect(body.containsKey('top_p'), isFalse);
+        expect(body.containsKey('n'), isFalse);
+      },
+    );
+
+    test('bare k3 uses reasoning_effort and strips sampling params', () async {
+      final requestBodyCompleter = Completer<Map<String, dynamic>>();
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        final body =
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>;
+        if (!requestBodyCompleter.isCompleted) {
+          requestBodyCompleter.complete(body);
+        }
+
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'id': 'cmpl-k3-bare',
+            'object': 'chat.completion.chunk',
+            'created': 0,
+            'model': 'k3',
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _moonshotConfig(baseUrl),
+        modelId: 'k3',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 32000, // maps to high effort
+        temperature: 0.9,
+        topP: 0.95,
+      ).toList();
+
+      final body = await requestBodyCompleter.future;
+      expect(chunks.last.isDone, isTrue);
+      expect(body['reasoning_effort'], 'high');
+      expect(body.containsKey('thinking'), isFalse);
+      expect(body.containsKey('temperature'), isFalse);
+      expect(body.containsKey('top_p'), isFalse);
+    });
   });
 }

--- a/test/settings_provider_reasoning_support_test.dart
+++ b/test/settings_provider_reasoning_support_test.dart
@@ -74,6 +74,19 @@ void main() {
       );
     });
 
+    test('Kimi K3 model ids infer expected capabilities', () {
+      for (final id in const ['kimi-k3', 'k3']) {
+        final m = ModelRegistry.infer(ModelInfo(id: id, displayName: id));
+        expect(m.input, contains(Modality.image), reason: '$id vision');
+        expect(m.output, const [Modality.text], reason: '$id output');
+        expect(
+          m.abilities,
+          containsAll([ModelAbility.tool, ModelAbility.reasoning]),
+          reason: '$id abilities',
+        );
+      }
+    });
+
     test('OpenRouter can be routed through Anthropic format explicitly', () {
       final cfg = ProviderConfig(
         id: 'OpenRouterAnthropic',
@@ -98,132 +111,62 @@ void main() {
         final settings = SettingsProvider();
 
         await _waitForSettingsLoad();
+
         await settings.setProviderConfig(
-          'ClaudeProxy',
+          'OpenRouter',
           ProviderConfig(
-            id: 'ClaudeProxy',
+            id: 'OpenRouter',
             enabled: true,
-            name: 'Claude Proxy',
+            name: 'OpenRouter',
             apiKey: 'test-key',
-            baseUrl: 'https://proxy.example/anthropic',
+            baseUrl: 'https://openrouter.ai/api/v1',
             providerType: ProviderKind.claude,
-            models: const ['pro-alias'],
+            models: const ['deepseek/deepseek-v3.2'],
             modelOverrides: const {
-              'pro-alias': {
-                'apiModelId': 'deepseek-v4-pro',
-                'type': 'chat',
-                'input': ['text'],
-                'output': ['text'],
-                'abilities': ['reasoning'],
+              'deepseek/deepseek-v3.2': <String, dynamic>{
+                'apiModelId': 'deepseek/deepseek-v3.2',
               },
             },
           ),
         );
 
         expect(
-          settings.supportsXhighReasoning('ClaudeProxy', 'pro-alias'),
+          settings.supportsXhighReasoning(
+            'OpenRouter',
+            'deepseek/deepseek-v3.2',
+          ),
           isTrue,
         );
       },
     );
 
-    group('title generation thinking', () {
-      test(
-        'defaults to enabled and preserves existing budget fallback',
-        () async {
-          SharedPreferences.setMockInitialValues({'thinking_budget_v1': 16000});
-          final settings = SettingsProvider();
+    test('Claude supports xhigh and max for fable / mythos series', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
 
-          await _waitForSettingsLoad();
-
-          expect(settings.titleGenerationThinkingEnabled, isTrue);
-          expect(settings.titleGenerationThinkingBudgetFor(null), 16000);
-          expect(settings.titleGenerationThinkingBudgetFor(1024), 1024);
-        },
+      await _waitForSettingsLoad();
+      await settings.setProviderConfig(
+        'Claude',
+        ProviderConfig(
+          id: 'Claude',
+          enabled: true,
+          name: 'Claude',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.anthropic.com/v1',
+          providerType: ProviderKind.claude,
+          models: const ['claude-fable-5', 'claude-opus-4-8'],
+        ),
       );
 
-      test(
-        'disabled title generation thinking resolves to off budget',
-        () async {
-          SharedPreferences.setMockInitialValues({});
-          final settings = SettingsProvider();
-
-          await _waitForSettingsLoad();
-          await settings.setThinkingBudget(16000);
-          await settings.setTitleGenerationThinkingEnabled(false);
-
-          expect(settings.titleGenerationThinkingEnabled, isFalse);
-          expect(settings.titleGenerationThinkingBudgetFor(null), 0);
-          expect(settings.titleGenerationThinkingBudgetFor(1024), 0);
-
-          final prefs = await SharedPreferences.getInstance();
-          expect(
-            prefs.getBool('title_generation_thinking_enabled_v1'),
-            isFalse,
-          );
-        },
-      );
-
-      test('loads persisted disabled state', () async {
-        SharedPreferences.setMockInitialValues({
-          'title_generation_thinking_enabled_v1': false,
-        });
-        final settings = SettingsProvider();
-
-        await _waitForSettingsLoad();
-
-        expect(settings.titleGenerationThinkingEnabled, isFalse);
-        expect(settings.titleGenerationThinkingBudgetFor(32000), 0);
-      });
-
-      test('reset restores enabled fallback behavior', () async {
-        SharedPreferences.setMockInitialValues({
-          'title_generation_thinking_enabled_v1': false,
-          'thinking_budget_v1': 64000,
-        });
-        final settings = SettingsProvider();
-
-        await _waitForSettingsLoad();
-        await settings.resetTitleGenerationThinkingEnabled();
-
-        expect(settings.titleGenerationThinkingEnabled, isTrue);
-        expect(settings.titleGenerationThinkingBudgetFor(null), 64000);
-
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getBool('title_generation_thinking_enabled_v1'), isTrue);
-      });
+      for (final model in const ['claude-fable-5', 'claude-opus-4-8']) {
+        expect(settings.supportsXhighReasoning('Claude', model), isTrue);
+        expect(settings.supportsMaxReasoning('Claude', model), isTrue);
+      }
+      expect(settings.getProviderConfig('Claude').models, [
+        'claude-fable-5',
+        'claude-opus-4-8',
+      ]);
     });
-
-    test(
-      'Claude latest models expose xhigh and max reasoning without presets',
-      () async {
-        SharedPreferences.setMockInitialValues({});
-        final settings = SettingsProvider();
-
-        await _waitForSettingsLoad();
-        await settings.setProviderConfig(
-          'Claude',
-          ProviderConfig(
-            id: 'Claude',
-            enabled: true,
-            name: 'Claude',
-            apiKey: 'test-key',
-            baseUrl: 'https://api.anthropic.com/v1',
-            providerType: ProviderKind.claude,
-            models: const ['claude-fable-5', 'claude-opus-4-8'],
-          ),
-        );
-
-        for (final model in const ['claude-fable-5', 'claude-opus-4-8']) {
-          expect(settings.supportsXhighReasoning('Claude', model), isTrue);
-          expect(settings.supportsMaxReasoning('Claude', model), isTrue);
-        }
-        expect(settings.getProviderConfig('Claude').models, [
-          'claude-fable-5',
-          'claude-opus-4-8',
-        ]);
-      },
-    );
 
     test('OpenRouter Anthropic format exposes Claude max reasoning', () async {
       SharedPreferences.setMockInitialValues({});
@@ -257,6 +200,50 @@ void main() {
         ),
         isTrue,
       );
+    });
+
+    test('Kimi K3 supports max but not xhigh reasoning (kimi-k3)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setProviderConfig(
+        'Moonshot',
+        ProviderConfig(
+          id: 'Moonshot',
+          enabled: true,
+          name: 'Moonshot',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.moonshot.cn/v1',
+          providerType: ProviderKind.openai,
+          models: const ['kimi-k3'],
+        ),
+      );
+
+      expect(settings.supportsXhighReasoning('Moonshot', 'kimi-k3'), isFalse);
+      expect(settings.supportsMaxReasoning('Moonshot', 'kimi-k3'), isTrue);
+    });
+
+    test('Kimi K3 supports max but not xhigh reasoning (bare k3)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setProviderConfig(
+        'Moonshot',
+        ProviderConfig(
+          id: 'Moonshot',
+          enabled: true,
+          name: 'Moonshot',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.moonshot.cn/v1',
+          providerType: ProviderKind.openai,
+          models: const ['k3'],
+        ),
+      );
+
+      expect(settings.supportsXhighReasoning('Moonshot', 'k3'), isFalse);
+      expect(settings.supportsMaxReasoning('Moonshot', 'k3'), isTrue);
     });
   });
 }


### PR DESCRIPTION
Closes #34.

- **Model registry**: add kimi-k3 and bare k3 to vision/tool/reasoning regex
- **Reasoning**: K3 uses standard reasoning_effort (none/low/medium/high/max, no xhigh)
- **Sampling**: K3 unconditionally strips temperature/top_p/n/logprobs
- **Naming**: support both kimi-k3 (with prefix) and bare k3 (anchored match)
- **Brand/grouping**: bare k3 resolves to Kimi icon and group
- **Tests**: 7 new tests covering capability inference, API compat, and reasoning support

## 效果图

<img width="1459" height="399" alt="image" src="https://github.com/user-attachments/assets/a64161c5-c7dc-4a7c-8528-9d64b90d0e8d" />

<img width="1380" height="777" alt="image" src="https://github.com/user-attachments/assets/f2358ada-cef7-4c3f-afeb-612e31cd8459" />
