### PR TITLE
feat: show 2 columns per page on desktop comparison view

### DIFF
--- a/lib/features/home/services/multi_ai_engine.dart
+++ b/lib/features/home/services/multi_ai_engine.dart
@@ -681,6 +681,14 @@ class MultiAIEngine extends ChangeNotifier {
 
   /// Drop a thread: clear subgroupId on ALL its messages across all rounds.
   Future<void> dropThread(String threadId) async {
+    // Capture anchor info BEFORE clearing messages — _computeAnchors filters
+    // out anchors with < 2 threads, so after clearing one thread's messages
+    // the anchor becomes invisible and auto-adopt would fail.
+    final capturedAnchor = latestAnchorId;
+    final capturedAnchorMsgs = capturedAnchor != null
+        ? getMessagesForAnchor(capturedAnchor)
+        : null;
+
     var matchCount = 0;
     final totalSubgroup = _chatController.messages
         .where((m) => m.subgroupId != null)
@@ -708,16 +716,14 @@ class MultiAIEngine extends ChangeNotifier {
     if (remaining == 1) {
       // Auto-adopt: resolve the remaining thread.
       final remainingTid = _threadIds[0];
-      final anchor = latestAnchorId;
       debugPrint(
-        '[MultiAI][dropThread] auto-adopt remainingTid=$remainingTid anchor=$anchor',
+        '[MultiAI][dropThread] auto-adopt remainingTid=$remainingTid anchor=$capturedAnchor',
       );
-      if (anchor != null) {
-        final msgs = getMessagesForAnchor(anchor);
-        final threadMsgs = msgs[remainingTid] ?? [];
+      if (capturedAnchor != null && capturedAnchorMsgs != null) {
+        final threadMsgs = capturedAnchorMsgs[remainingTid] ?? [];
         if (threadMsgs.isNotEmpty) {
           await resolveThread(
-            anchorId: anchor,
+            anchorId: capturedAnchor,
             threadId: remainingTid,
             version: threadMsgs.last.version,
           );

--- a/lib/features/home/widgets/multi_ai_comparison_view.dart
+++ b/lib/features/home/widgets/multi_ai_comparison_view.dart
@@ -32,60 +32,91 @@ class MultiAICardGroup extends StatefulWidget {
 
 class _MultiAICardGroupState extends State<MultiAICardGroup> {
   late PageController _pageCtrl;
-  int _activePage = 0;
 
   @override
   void initState() {
     super.initState();
-    _pageCtrl = PageController(viewportFraction: _viewportFraction)
-      ..addListener(_onPageChanged);
+    _pageCtrl = PageController(viewportFraction: _viewportFraction);
   }
 
   @override
   void dispose() {
-    _pageCtrl.removeListener(_onPageChanged);
     _pageCtrl.dispose();
     super.dispose();
   }
 
-  void _onPageChanged() {
-    final page = _pageCtrl.page?.round() ?? 0;
-    if (page != _activePage) setState(() => _activePage = page);
-  }
+  bool get _isDesktop => PlatformUtils.isDesktop;
 
-  double get _viewportFraction => PlatformUtils.isDesktop ? 0.5 : 0.85;
+  double get _viewportFraction => _isDesktop ? 1.0 : 0.85;
 
   @override
   Widget build(BuildContext context) {
     final subgroups = widget.subgroupedMessages.keys.toList();
     if (subgroups.isEmpty) return const SizedBox.shrink();
 
+    final pageCount = _isDesktop
+        ? (subgroups.length / 2).ceil()
+        : subgroups.length;
+
     return SizedBox(
       height: MediaQuery.sizeOf(context).height * 0.65,
       child: PageView.builder(
         controller: _pageCtrl,
-        itemCount: subgroups.length,
-        itemBuilder: (context, index) {
-          final sgId = subgroups[index];
-          final versions = widget.subgroupedMessages[sgId] ?? [];
-          final latest = versions.isNotEmpty ? versions.last : null;
-          if (latest == null) return const SizedBox.shrink();
-
-          return Padding(
-            padding: EdgeInsets.only(
-              right: index < subgroups.length - 1 ? 8 : 0,
-              left: index > 0 ? 8 : 0,
-            ),
-            child: _SingleModelCard(
-              message: latest,
-              anchorUserMessageId: widget.anchorUserMessageId,
-              controller: widget.controller,
-              showActions: widget.isLatestRound,
-              subgroupId: sgId,
-            ),
-          );
+        itemCount: pageCount,
+        itemBuilder: (context, pageIndex) {
+          if (_isDesktop) {
+            return _buildDesktopPage(subgroups, pageIndex);
+          }
+          return _buildMobileCard(subgroups, pageIndex);
         },
       ),
+    );
+  }
+
+  Widget _buildDesktopPage(List<String> subgroups, int pageIndex) {
+    final i1 = pageIndex * 2;
+    final i2 = i1 + 1;
+    final hasSecond = i2 < subgroups.length;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        children: [
+          Expanded(child: _buildCardForSubgroup(subgroups[i1])),
+          if (hasSecond) ...[
+            const SizedBox(width: 8),
+            Expanded(child: _buildCardForSubgroup(subgroups[i2])),
+          ] else
+            const Spacer(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMobileCard(List<String> subgroups, int index) {
+    final sgId = subgroups[index];
+    final card = _buildCardForSubgroup(sgId);
+
+    return Padding(
+      padding: EdgeInsets.only(
+        right: index < subgroups.length - 1 ? 8 : 0,
+        left: index > 0 ? 8 : 0,
+      ),
+      child: card,
+    );
+  }
+
+  Widget _buildCardForSubgroup(String sgId) {
+    final versions = widget.subgroupedMessages[sgId] ?? [];
+    final latest = versions.isNotEmpty ? versions.last : null;
+    if (latest == null) return const SizedBox.shrink();
+
+    return _SingleModelCard(
+      message: latest,
+      anchorUserMessageId: widget.anchorUserMessageId,
+      controller: widget.controller,
+      showActions: widget.isLatestRound,
+      subgroupId: sgId,
     );
   }
 }


### PR DESCRIPTION
## Summary

Desktop multi-AI comparison mode now displays 2 model cards side-by-side per page instead of a single centered card, matching the expected large-screen layout.

**Changes:**
- `multi_ai_comparison_view.dart`: Set `viewportFraction` to 1.0 on desktop, render card pairs in a two-column `Row` layout per page. Removed unused `_activePage` state and listener.
- `multi_ai_engine.dart`: Fixed anchor capture timing in `dropThread` to prevent auto-adopt failure when clearing the last remaining thread's messages.

Closes #37.