### PR TITLE
feat(multi-ai): add synthesize mode — fork + XML

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -38,6 +38,9 @@ import 'home_view_model.dart';
 import '../services/message_builder_service.dart';
 import '../services/message_generation_service.dart';
 import '../services/multi_ai_engine.dart';
+import '../widgets/synthesize_task_selector.dart'
+    show showSynthesizeTaskSelector;
+import '../models/synthesize_task.dart' show synthesizeTasks;
 import '../services/message_pipeline.dart';
 import '../services/ask_user_interaction_service.dart';
 import '../services/ocr_service.dart';
@@ -677,7 +680,10 @@ class HomePageController extends ChangeNotifier {
     }
 
     ChatInputSubmissionResult result;
-    if (multiAIEngine.isActive) {
+    if (multiAIEngine.isActive &&
+        multiAIEngine.mode == MultiAIMode.synthesize) {
+      result = await _sendSynthesize(input);
+    } else if (multiAIEngine.isActive) {
       if (!_context.mounted) return ChatInputSubmissionResult.rejected;
       final settings = _context.read<SettingsProvider>();
       final assistant = _context.read<AssistantProvider>().currentAssistant;
@@ -694,6 +700,48 @@ class HomePageController extends ChangeNotifier {
       result = await _viewModel.sendMessage(input);
     }
     if (result != ChatInputSubmissionResult.rejected) {
+      notifyListeners();
+    }
+    return result;
+  }
+
+  Future<ChatInputSubmissionResult> _sendSynthesize(ChatInputData input) async {
+    if (currentConversation == null) return ChatInputSubmissionResult.rejected;
+
+    final allMsgs = _chatController.allMessagesForCurrentConversationContext();
+    final contextMsgs = MultiAIEngine.selectMessagesBeforeMultiAI(allMsgs);
+
+    // Fork new conversation with messages before first multi-AI anchor
+    final newConvo = await _chatService.forkConversation(
+      title: _titleForLocale(_context),
+      assistantId: currentConversation!.assistantId,
+      sourceMessages: contextMsgs,
+    );
+
+    // Switch to new conversation
+    _chatService.setCurrentConversation(newConvo.id);
+    _chatController.setCurrentConversation(newConvo);
+    _viewModel.restoreMessageUiState();
+
+    // Generate XML from all messages with current version selections
+    final xml = multiAIEngine.multiRoundsToXML(
+      allMsgs,
+      multiAIEngine.selectedVersionByThread,
+    );
+    final fullContent = '${input.text}\n\n$xml';
+
+    // Send as normal single-model message
+    final syntheticInput = ChatInputData(
+      text: fullContent,
+      imagePaths: input.imagePaths,
+      documents: input.documents,
+      allowImagesApiRouting: input.allowImagesApiRouting,
+    );
+    final result = await _viewModel.sendMessage(syntheticInput);
+    if (result != ChatInputSubmissionResult.rejected) {
+      // Reset engine to continue mode so the original conversation's
+      // mode switch row shows "继续" as active when user switches back.
+      await multiAIEngine.setMode(MultiAIMode.continue_);
       notifyListeners();
     }
     return result;
@@ -789,6 +837,50 @@ class HomePageController extends ChangeNotifier {
 
     // Restrict retry ability when multi-AI rounds are active.
     if (!_isRetryableInMultiAI(message)) return;
+
+    // Multi-AI active but no rounds started yet: convert regenerate of a
+    // legacy assistant message into a startRoundFromHistory call.
+    if (multiAIEngine.isActive &&
+        _chatController.subgroupActiveGroupIds.isEmpty &&
+        message.role == 'assistant') {
+      _tagTriggerMessageForMultiAI(message);
+      final settings = _context.read<SettingsProvider>();
+      final assistant = _context.read<AssistantProvider>().currentAssistant;
+      final anchorId = await multiAIEngine.startRoundFromHistory(
+        triggerMessage: message,
+        conversation: currentConversation!,
+        settings: settings,
+        assistant: assistant,
+      );
+      if (anchorId.isNotEmpty) {
+        // startRoundFromHistory already creates N placeholder messages
+      }
+      notifyListeners();
+      return;
+    }
+
+    // User message retry, multi-AI active but no rounds yet: delegate to
+    // the next assistant message so it triggers a startRoundFromHistory
+    // call with all pre-selected models.
+    if (message.role == 'user' &&
+        multiAIEngine.isActive &&
+        _chatController.subgroupActiveGroupIds.isEmpty) {
+      final nextAssistant = _findNextAssistantAfter(message);
+      if (nextAssistant != null) {
+        _tagTriggerMessageForMultiAI(nextAssistant);
+        final settings = _context.read<SettingsProvider>();
+        final assistant = _context.read<AssistantProvider>().currentAssistant;
+        await multiAIEngine.startRoundFromHistory(
+          triggerMessage: nextAssistant,
+          conversation: currentConversation!,
+          settings: settings,
+          assistant: assistant,
+        );
+        notifyListeners();
+        return;
+      }
+      // No assistant below → fall through to normal single-model regenerate
+    }
 
     // User message retry in multi-select mode: create version+1 for every
     // thread in the following round.
@@ -1714,6 +1806,50 @@ class HomePageController extends ChangeNotifier {
   /// Get current multi-AI model selections for input bar badge.
   List<ModelSelection> get multiAIModelSelections => multiAIEngine.models;
 
+  /// Whether the "启动对比" action should be visible on the message more sheet.
+  bool get canStartMultiAIComparison =>
+      multiAIEngine.isActive &&
+      multiAIEngine.models.length >= 2 &&
+      _chatController.subgroupActiveGroupIds.isEmpty;
+
+  /// Tag a trigger assistant message with its matching subgroupId from the
+  /// engine's model list. If the trigger's model matches a pre-selected model,
+  /// the message gets tagged so it becomes part of the multi-AI round.
+  /// Otherwise it's left untouched (stays as a regular assistant message).
+  Future<void> _tagTriggerMessageForMultiAI(ChatMessage triggerMessage) async {
+    final threadIds = multiAIEngine.threadIds.toList();
+    final triggerKey = '${triggerMessage.providerId}|${triggerMessage.modelId}';
+    final modelIdx = multiAIEngine.models.indexWhere(
+      (m) => '${m.providerKey}|${m.modelId}' == triggerKey,
+    );
+    if (modelIdx < 0) return;
+    final tid = threadIds[modelIdx];
+    final idx = _chatController.messages.indexWhere(
+      (m) => m.id == triggerMessage.id,
+    );
+    if (idx == -1) return;
+    final updated = triggerMessage.copyWith(subgroupId: tid);
+    _chatController.messages[idx] = updated;
+    await _chatService.updateMessage(
+      triggerMessage.id,
+      subgroupId: tid,
+      content: updated.content,
+      totalTokens: updated.totalTokens,
+      isStreaming: updated.isStreaming,
+    );
+  }
+
+  /// Find the first assistant message immediately after [target].
+  ChatMessage? _findNextAssistantAfter(ChatMessage target) {
+    final msgs = _chatController.messages;
+    int idx = msgs.indexWhere((m) => m.id == target.id);
+    if (idx < 0) return null;
+    for (int i = idx + 1; i < msgs.length; i++) {
+      if (msgs[i].role == 'assistant') return msgs[i];
+    }
+    return null;
+  }
+
   /// Handle "启动对比" (Start Comparison) action from assistant message more
   /// sheet. Requires multi-select mode already active with ≥2 models and zero
   /// existing subgroup messages in the conversation.
@@ -1724,33 +1860,7 @@ class HomePageController extends ChangeNotifier {
     // Prevent starting comparison after multi-AI rounds have begun.
     if (_chatController.subgroupActiveGroupIds.isNotEmpty) return;
 
-    final threadIds = multiAIEngine.threadIds.toList();
-    final triggerKey = '${triggerMessage.providerId}|${triggerMessage.modelId}';
-    final modelIdx = multiAIEngine.models.indexWhere(
-      (m) => '${m.providerKey}|${m.modelId}' == triggerKey,
-    );
-
-    if (modelIdx >= 0) {
-      // Reuse the trigger message: its AI is in the pre-selected model list.
-      final tid = threadIds[modelIdx];
-      final idx = _chatController.messages.indexWhere(
-        (m) => m.id == triggerMessage.id,
-      );
-      if (idx != -1) {
-        final updated = triggerMessage.copyWith(subgroupId: tid);
-        _chatController.messages[idx] = updated;
-        await _chatService.updateMessage(
-          triggerMessage.id,
-          subgroupId: tid,
-          content: updated.content,
-          totalTokens: updated.totalTokens,
-          isStreaming: updated.isStreaming,
-        );
-      }
-    }
-    // If trigger message's model is NOT in the pre-selected list, leave it
-    // untouched (no subgroupId). The message stays as a regular assistant
-    // message.
+    await _tagTriggerMessageForMultiAI(triggerMessage);
 
     _chatController.invalidateCache();
     notifyListeners();
@@ -1770,6 +1880,46 @@ class HomePageController extends ChangeNotifier {
             notifyListeners();
           }),
     );
+  }
+
+  /// Switch the multi-AI engine to synthesize mode.
+  ///
+  /// Shows a task type selector (bottom sheet / dialog), switches to
+  /// single-select on the model selector, pre-fills the chat input with the
+  /// chosen prompt, and calls [MultiAIEngine.setMode].
+  Future<void> switchToSynthesizeMode() async {
+    final engine = multiAIEngine;
+    if (engine.mode == MultiAIMode.synthesize) return;
+
+    // Show task type selector
+    final taskType = await showSynthesizeTaskSelector(_context);
+    if (taskType == null) return; // user cancelled
+
+    // Switch engine mode
+    await engine.setMode(MultiAIMode.synthesize);
+
+    // Pre-fill prompt
+    if (!_context.mounted) return;
+    final l10n = AppLocalizations.of(_context)!;
+    final task = synthesizeTasks.firstWhere((t) => t.type == taskType);
+    final prompt = _resolveSynthesizePrompt(l10n, task.defaultPromptKey);
+    _inputController.text = prompt;
+    _inputController.selection = TextSelection.collapsed(offset: prompt.length);
+
+    notifyListeners();
+  }
+
+  String _resolveSynthesizePrompt(AppLocalizations l10n, String key) {
+    switch (key) {
+      case 'multiAISynthesizeSummarizePrompt':
+        return l10n.multiAISynthesizeSummarizePrompt;
+      case 'multiAISynthesizeFusePrompt':
+        return l10n.multiAISynthesizeFusePrompt;
+      case 'multiAISynthesizeCommentPrompt':
+        return l10n.multiAISynthesizeCommentPrompt;
+      default:
+        return key;
+    }
   }
 
   /// Enter multi-AI mode with pre-selected models (from model selector multi-select).

--- a/lib/features/home/models/synthesize_task.dart
+++ b/lib/features/home/models/synthesize_task.dart
@@ -1,0 +1,42 @@
+/// Synthesize task types for multi-AI conversation synthesis.
+enum SynthesizeTaskType { summarize, fuse, comment }
+
+/// A synthesis task descriptor.
+///
+/// [labelKey], [descriptionKey], and [defaultPromptKey] are ARB keys
+/// resolved at the UI layer via [AppLocalizations].
+class SynthesizeTask {
+  final SynthesizeTaskType type;
+  final String labelKey;
+  final String descriptionKey;
+  final String defaultPromptKey;
+
+  const SynthesizeTask({
+    required this.type,
+    required this.labelKey,
+    required this.descriptionKey,
+    required this.defaultPromptKey,
+  });
+}
+
+/// All available synthesis tasks.
+const synthesizeTasks = [
+  SynthesizeTask(
+    type: SynthesizeTaskType.summarize,
+    labelKey: 'multiAISynthesizeTaskSummarize',
+    descriptionKey: 'multiAISynthesizeTaskSummarizeDesc',
+    defaultPromptKey: 'multiAISynthesizeSummarizePrompt',
+  ),
+  SynthesizeTask(
+    type: SynthesizeTaskType.fuse,
+    labelKey: 'multiAISynthesizeTaskFuse',
+    descriptionKey: 'multiAISynthesizeTaskFuseDesc',
+    defaultPromptKey: 'multiAISynthesizeFusePrompt',
+  ),
+  SynthesizeTask(
+    type: SynthesizeTaskType.comment,
+    labelKey: 'multiAISynthesizeTaskComment',
+    descriptionKey: 'multiAISynthesizeTaskCommentDesc',
+    defaultPromptKey: 'multiAISynthesizeCommentPrompt',
+  ),
+];

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -35,6 +35,7 @@ import '../../../desktop/world_book_popover.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../chat/widgets/bottom_tools_sheet.dart';
 import '../../chat/widgets/context_management_sheet.dart';
+import '../../chat/widgets/message_more_sheet.dart';
 import '../../chat/widgets/reasoning_budget_sheet.dart';
 import '../../search/widgets/search_settings_sheet.dart';
 import '../../model/widgets/model_select_sheet.dart';
@@ -51,6 +52,7 @@ import '../widgets/learning_prompt_sheet.dart';
 import '../widgets/scroll_nav_buttons.dart';
 import '../widgets/message_list_view.dart';
 import '../widgets/multi_ai_comparison_view.dart';
+import '../services/multi_ai_engine.dart' show MultiAIMode;
 import '../widgets/chat_input_section.dart';
 import '../widgets/chat_input_overlay_layout.dart';
 import '../widgets/chat_selection_app_bar.dart';
@@ -1179,6 +1181,13 @@ class _HomePageState extends State<HomePage>
       onLoadMoreBefore: _controller.loadMoreBefore,
       hasMoreAfter: _controller.chatController.hasMoreAfter,
       onLoadMoreAfter: _controller.loadMoreAfter,
+      hideMoreActions: () {
+        final hide = <MessageMoreAction>{};
+        if (!_controller.canStartMultiAIComparison) {
+          hide.add(MessageMoreAction.multiAI);
+        }
+        return hide;
+      },
       onVersionChange: (groupId, version) async {
         await _controller.setSelectedVersion(groupId, version);
       },
@@ -1246,7 +1255,10 @@ class _HomePageState extends State<HomePage>
       onMore: _toggleTools,
       onSelectModel: () => showModelSelectSheet(
         context,
-        onMultiSelectConfirm: _controller.enterMultiAIMode,
+        onMultiSelectConfirm:
+            _controller.multiAIEngine.mode == MultiAIMode.synthesize
+            ? null
+            : _controller.enterMultiAIMode,
       ),
       onLongPressSelectModel: () {
         Navigator.of(
@@ -1322,7 +1334,9 @@ class _HomePageState extends State<HomePage>
       onClearContext: _controller.clearContext,
       onCompressContext: _handleDesktopCompressContext,
       backgroundImageActive: _assistantBackgroundActive(context),
-      multiAIModelCount: _controller.multiAIEngine.isActive
+      multiAIModelCount:
+          _controller.multiAIEngine.isActive &&
+              _controller.multiAIEngine.mode == MultiAIMode.continue_
           ? _controller.multiAIEngine.models.length
           : null,
       onExitMultiAI:

--- a/lib/features/home/services/multi_ai_engine.dart
+++ b/lib/features/home/services/multi_ai_engine.dart
@@ -26,6 +26,15 @@ import '../services/tool_approval_service.dart';
 ///     tracked in _anchorThreads — a runtime-only map, not stored on messages.
 // ignore_for_file: prefer_initializing_formals
 
+/// Mode for multi-AI conversation.
+enum MultiAIMode {
+  /// Each model continues independently with its own thread context.
+  continue_,
+
+  /// Synthesize all rounds into a single response via one model.
+  synthesize,
+}
+
 class MultiAIEngine extends ChangeNotifier {
   MultiAIEngine({
     required ChatService chatService,
@@ -48,6 +57,8 @@ class MultiAIEngine extends ChangeNotifier {
   bool _isActive = false;
   List<ModelSelection> _models = [];
   List<String> _threadIds = [];
+  MultiAIMode _mode = MultiAIMode.continue_;
+  final Map<String, int> _selectedVersionByThread = {};
 
   // ============================================================================
   // Getters — all round/anchorship is computed from message list order
@@ -56,6 +67,27 @@ class MultiAIEngine extends ChangeNotifier {
   bool get isActive => _isActive;
   List<ModelSelection> get models => List<ModelSelection>.unmodifiable(_models);
   Set<String> get threadIds => Set<String>.unmodifiable(_threadIds);
+  MultiAIMode get mode => _mode;
+
+  /// The currently displayed version index per thread (card view state).
+  Map<String, int> get selectedVersionByThread => _selectedVersionByThread;
+
+  /// Get the selected version for a thread, falling back to [maxVersion].
+  int getSelectedVersion(String threadId, int maxVersion) {
+    final v = _selectedVersionByThread[threadId];
+    if (v != null && v >= 0 && v <= maxVersion) return v;
+    return maxVersion;
+  }
+
+  /// Set the selected version for a thread (called from card UI).
+  void setSelectedVersion(String threadId, int version) {
+    _selectedVersionByThread[threadId] = version;
+  }
+
+  /// Clear all version selections.
+  void clearSelectedVersions() {
+    _selectedVersionByThread.clear();
+  }
 
   Set<String> get subgroupActiveGroupIds =>
       _chatController.subgroupActiveGroupIds;
@@ -123,6 +155,7 @@ class MultiAIEngine extends ChangeNotifier {
     _threadIds =
         existingThreadIds ??
         List<String>.generate(models.length, (_) => const Uuid().v4());
+    _mode = MultiAIMode.continue_;
     notifyListeners();
   }
 
@@ -130,6 +163,7 @@ class MultiAIEngine extends ChangeNotifier {
     _isActive = false;
     _models = [];
     _threadIds = [];
+    _selectedVersionByThread.clear();
     _chatController.invalidateCache();
     notifyListeners();
   }
@@ -532,10 +566,7 @@ class MultiAIEngine extends ChangeNotifier {
         (m) => m.id == latest.id,
       );
       if (insertAfterIdx < 0) continue;
-      _chatController.messages.insert(
-        insertAfterIdx + 1 + newMessages.length,
-        newMsg,
-      );
+      _chatController.messages.insert(insertAfterIdx + 1, newMsg);
       newMessages.add(newMsg);
       newMsgByThread[threadId] = newMsg;
     }
@@ -572,6 +603,13 @@ class MultiAIEngine extends ChangeNotifier {
         allowImagesApiRouting: true,
         generateTitleOnFinish: false,
       );
+    }
+
+    // Point versionSelections to the new versions so collapseVersions
+    // picks them for API context on subsequent rounds.
+    for (final newMsg in newMessages) {
+      final gid = newMsg.groupId ?? newMsg.id;
+      _chatController.versionSelections[gid] = newMsg.version;
     }
 
     _chatController.notifyListeners();
@@ -735,6 +773,122 @@ class MultiAIEngine extends ChangeNotifier {
       exit();
     } else {
       _chatController.invalidateCache();
+      notifyListeners();
+    }
+  }
+
+  // ============================================================================
+  // Synthesize mode
+  // ============================================================================
+
+  /// Serialize multi-AI conversation rounds to XML.
+  ///
+  /// Linear scan over [messages]: when a user message is followed by
+  /// subgroup messages, emit a `<user>` / `<assistants>` pair.
+  /// Each thread takes its currently displayed version from
+  /// [selectedVersionByThread].
+  ///
+  /// Model labels: "Model 1", "Model 2", ... per [_models] order.
+  String multiRoundsToXML(
+    List<ChatMessage> messages,
+    Map<String, int> selectedVersionByThread,
+  ) {
+    final buf = StringBuffer();
+    buf.writeln('<rounds>');
+
+    String? currentUserContent;
+    final assistants = <String, ChatMessage>{};
+
+    for (final m in messages) {
+      if (m.role == 'user') {
+        _flushRound(buf, currentUserContent, assistants);
+        currentUserContent = m.content;
+        assistants.clear();
+      } else if (m.subgroupId != null) {
+        final threadId = m.subgroupId!;
+        final selectedVer = selectedVersionByThread[threadId];
+        if (selectedVer != null && m.version == selectedVer) {
+          assistants[threadId] = m;
+        } else if (!assistants.containsKey(threadId)) {
+          assistants[threadId] = m;
+        }
+      }
+    }
+    _flushRound(buf, currentUserContent, assistants);
+
+    buf.write('</rounds>');
+    return buf.toString();
+  }
+
+  void _flushRound(
+    StringBuffer buf,
+    String? userContent,
+    Map<String, ChatMessage> assistants,
+  ) {
+    if (userContent == null || assistants.isEmpty) return;
+    buf.writeln('  <user>${_xmlEscape(userContent)}</user>');
+    buf.writeln('  <assistants>');
+    var idx = 0;
+    for (final tid in _threadIds) {
+      final msg = assistants[tid];
+      if (msg == null) continue;
+      idx++;
+      final model = _models.length >= idx ? _models[idx - 1] : null;
+      buf.writeln(
+        '    <model name="Model $idx"'
+        ' provider="${_xmlEscape(model?.providerKey ?? '')}"'
+        ' id="${_xmlEscape(model?.modelId ?? '')}">',
+      );
+      buf.writeln(_xmlEscape(msg.content));
+      buf.writeln('    </model>');
+    }
+    buf.writeln('  </assistants>');
+  }
+
+  static String _xmlEscape(String s) {
+    return s
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;');
+  }
+
+  /// Select messages before the first multi-AI anchor.
+  ///
+  /// Returns all messages up to (but not including) the first user message
+  /// that has ≥2 subgroup responses following it.
+  static List<ChatMessage> selectMessagesBeforeMultiAI(
+    List<ChatMessage> messages,
+  ) {
+    final anchors = _computeAnchors(messages);
+    if (anchors.isEmpty) return List.of(messages);
+
+    final firstAnchorId = anchors.keys.first;
+    final result = <ChatMessage>[];
+    for (final m in messages) {
+      if (m.id == firstAnchorId) break;
+      if (m.subgroupId != null) continue;
+      result.add(m);
+    }
+    return result;
+  }
+
+  /// Switch the engine's conversation mode.
+  ///
+  /// continue_ → synthesize: caller must handle model selector restriction
+  ///   and task type selection beforehand.
+  ///
+  /// synthesize → continue_: recovers engine state from persisted subgroup
+  ///   messages via [recoverFromMessages].
+  Future<void> setMode(MultiAIMode newMode) async {
+    if (newMode == _mode) return;
+
+    if (newMode == MultiAIMode.synthesize) {
+      _mode = newMode;
+      notifyListeners();
+    } else {
+      _mode = newMode;
+      recoverFromMessages(_chatController.messages);
       notifyListeners();
     }
   }

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -133,6 +133,7 @@ class MessageListView extends StatefulWidget {
     this.onLoadMoreBefore,
     this.hasMoreAfter = false,
     this.onLoadMoreAfter,
+    this.hideMoreActions,
   });
 
   final ScrollController scrollController;
@@ -189,10 +190,6 @@ class MessageListView extends StatefulWidget {
   final OnShareMessage? onShareMessage;
   final OnSelectMessages? onSelectMessages;
   final OnSpeakMessage? onSpeakMessage;
-  final List<String> suggestions;
-
-  /// Inline widgets rendered after specific message items (e.g. Multi-AI card groups).
-  final Map<String, Widget>? afterMessageWidgets;
   final OnSuggestionTap? onSuggestionTap;
   final OnRecoveredAskUserAnswer? onRecoveredAskUserAnswer;
   final void Function(String messageId, bool selected)? onToggleSelection;
@@ -200,6 +197,15 @@ class MessageListView extends StatefulWidget {
   final void Function(String messageId)? onToggleTranslation;
   final void Function(String messageId, int segmentIndex)?
   onToggleReasoningSegment;
+
+  /// Actions to hide from the message more sheet, computed by caller.
+  final Set<MessageMoreAction> Function()? hideMoreActions;
+
+  final List<String> suggestions;
+
+  /// Inline widgets rendered after specific message items (e.g. Multi-AI card groups).
+  final Map<String, Widget>? afterMessageWidgets;
+
   final Widget Function()? buildPinnedStreamingIndicator;
   final bool hasMoreBefore;
   final bool Function()? onLoadMoreBefore;
@@ -834,10 +840,12 @@ class _MessageListViewState extends State<MessageListView> {
           ? () => widget.onDeleteMessage?.call(message, widget.byGroup)
           : null,
       onMore: () async {
+        final hide = widget.hideMoreActions?.call();
         final action = await showMessageMoreSheet(
           context,
           message,
           canDeleteAllVersions: total > 1,
+          hideActions: hide,
         );
         if (action == MessageMoreAction.deleteCurrentVersion) {
           await widget.onDeleteMessage?.call(message, widget.byGroup);

--- a/lib/features/home/widgets/multi_ai_comparison_view.dart
+++ b/lib/features/home/widgets/multi_ai_comparison_view.dart
@@ -8,7 +8,7 @@ import '../../chat/widgets/chat_message_widget.dart'
     show ChatMessageWidget, ReasoningSegment;
 import '../../chat/widgets/message_more_sheet.dart'
     show showMessageMoreSheet, MessageMoreAction;
-
+import '../services/multi_ai_engine.dart' show MultiAIMode;
 import '../controllers/home_page_controller.dart';
 
 /// Card container for a single multi-AI round (anchor).
@@ -42,9 +42,6 @@ class _MultiAICardGroupState extends State<MultiAICardGroup> {
 
   @override
   void dispose() {
-    for (final sgId in widget.subgroupedMessages.keys) {
-      _SingleModelCardState.clearSelection(sgId);
-    }
     _pageCtrl.dispose();
     super.dispose();
   }
@@ -62,17 +59,64 @@ class _MultiAICardGroupState extends State<MultiAICardGroup> {
         ? (subgroups.length / 2).ceil()
         : subgroups.length;
 
-    return SizedBox(
-      height: MediaQuery.sizeOf(context).height * 0.65,
-      child: PageView.builder(
-        controller: _pageCtrl,
-        itemCount: pageCount,
-        itemBuilder: (context, pageIndex) {
-          if (_isDesktop) {
-            return _buildDesktopPage(subgroups, pageIndex);
-          }
-          return _buildMobileCard(subgroups, pageIndex);
-        },
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          height: MediaQuery.sizeOf(context).height * 0.65,
+          child: PageView.builder(
+            controller: _pageCtrl,
+            itemCount: pageCount,
+            itemBuilder: (context, pageIndex) {
+              if (_isDesktop) {
+                return _buildDesktopPage(subgroups, pageIndex);
+              }
+              return _buildMobileCard(subgroups, pageIndex);
+            },
+          ),
+        ),
+        if (widget.isLatestRound) _buildModeSwitchRow(context),
+      ],
+    );
+  }
+
+  Widget _buildModeSwitchRow(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final engine = widget.controller.multiAIEngine;
+    final isContinue = engine.mode == MultiAIMode.continue_;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
+      child: Row(
+        children: [
+          Text(
+            l10n.multiAIConversationMode,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: AppFontWeights.medium,
+              color: cs.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          const Spacer(),
+          _ModeButton(
+            label: l10n.multiAIContinue,
+            tooltip: l10n.multiAIContinueHint,
+            active: isContinue,
+            onTap: () {
+              engine.setMode(MultiAIMode.continue_);
+            },
+          ),
+          const SizedBox(width: 8),
+          _ModeButton(
+            label: l10n.multiAISynthesize,
+            tooltip: l10n.multiAISynthesizeHint,
+            active: !isContinue,
+            onTap: () {
+              widget.controller.switchToSynthesizeMode();
+            },
+          ),
+        ],
       ),
     );
   }
@@ -146,26 +190,22 @@ class _SingleModelCard extends StatefulWidget {
 }
 
 class _SingleModelCardState extends State<_SingleModelCard> {
-  static final Map<String, int> _selectedIdxByThread = {};
-
   int get _selectedIdx {
-    final stored = _selectedIdxByThread[widget.subgroupId];
-    if (stored != null && stored >= 0 && stored < widget.versions.length) {
-      return stored;
-    }
-    return widget.versions.length - 1;
+    final engine = widget.controller.multiAIEngine;
+    final versions = widget.versions;
+    final stored = engine.getSelectedVersion(
+      widget.subgroupId,
+      versions.length - 1,
+    );
+    return stored;
   }
 
   ChatMessage get _currentMessage => widget.versions[_selectedIdx];
 
   void _selectVersion(int idx) {
     if (idx < 0 || idx >= widget.versions.length) return;
-    _selectedIdxByThread[widget.subgroupId] = idx;
+    widget.controller.multiAIEngine.setSelectedVersion(widget.subgroupId, idx);
     setState(() {});
-  }
-
-  static void clearSelection(String subgroupId) {
-    _selectedIdxByThread.remove(subgroupId);
   }
 
   @override
@@ -174,16 +214,17 @@ class _SingleModelCardState extends State<_SingleModelCard> {
     final oldLen = oldWidget.versions.length;
     final newLen = widget.versions.length;
     final subgId = widget.subgroupId;
+    final engine = widget.controller.multiAIEngine;
 
     if (newLen > oldLen) {
-      _selectedIdxByThread[subgId] = newLen - 1;
+      engine.setSelectedVersion(subgId, newLen - 1);
       setState(() {});
     } else if (newLen < oldLen) {
       final stillExists = widget.versions.any(
         (v) => v.id == oldWidget.versions[_selectedIdx].id,
       );
       if (!stillExists) {
-        _selectedIdxByThread[subgId] = newLen - 1;
+        engine.setSelectedVersion(subgId, newLen - 1);
         setState(() {});
       }
     }
@@ -397,6 +438,78 @@ class _SingleModelCardState extends State<_SingleModelCard> {
           ),
         );
       },
+    );
+  }
+}
+
+class _ModeButton extends StatefulWidget {
+  const _ModeButton({
+    required this.label,
+    required this.tooltip,
+    required this.active,
+    required this.onTap,
+  });
+
+  final String label;
+  final String tooltip;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  State<_ModeButton> createState() => _ModeButtonState();
+}
+
+class _ModeButtonState extends State<_ModeButton> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Tooltip(
+      message: widget.tooltip,
+      child: GestureDetector(
+        onTapDown: (_) => setState(() => _pressed = true),
+        onTapUp: (_) => setState(() => _pressed = false),
+        onTapCancel: () => setState(() => _pressed = false),
+        onTap: widget.onTap,
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedScale(
+          scale: _pressed ? 0.97 : 1.0,
+          duration: const Duration(milliseconds: 120),
+          curve: Curves.easeOutCubic,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 180),
+            curve: Curves.easeOutCubic,
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+            decoration: BoxDecoration(
+              color: widget.active
+                  ? cs.primary.withValues(alpha: isDark ? 0.22 : 0.12)
+                  : (isDark ? Colors.white10 : const Color(0xFFF2F3F5)),
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: widget.active
+                    ? cs.primary.withValues(alpha: isDark ? 0.4 : 0.25)
+                    : cs.outlineVariant.withValues(alpha: 0.2),
+                width: widget.active ? 1.2 : 0.6,
+              ),
+            ),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: widget.active
+                    ? AppFontWeights.semibold
+                    : AppFontWeights.regular,
+                color: widget.active
+                    ? cs.primary
+                    : cs.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/widgets/synthesize_task_selector.dart
+++ b/lib/features/home/widgets/synthesize_task_selector.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_tactile.dart';
+import '../../../theme/app_font_weights.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../home/models/synthesize_task.dart';
+
+/// Show a bottom sheet (mobile) or dialog (desktop) for selecting a
+/// synthesize task type.
+///
+/// Returns the selected [SynthesizeTaskType], or null if cancelled.
+Future<SynthesizeTaskType?> showSynthesizeTaskSelector(
+  BuildContext context,
+) async {
+  final isDesktop =
+      defaultTargetPlatform == TargetPlatform.macOS ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.linux;
+
+  if (isDesktop) {
+    return showDialog<SynthesizeTaskType>(
+      context: context,
+      builder: (_) => _SynthesizeTaskDialog(),
+    );
+  }
+  return showModalBottomSheet<SynthesizeTaskType>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Theme.of(context).colorScheme.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (_) => const _SynthesizeTaskSheet(),
+  );
+}
+
+class _SynthesizeTaskSheet extends StatelessWidget {
+  const _SynthesizeTaskSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return _buildContent(context);
+  }
+}
+
+class _SynthesizeTaskDialog extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return AlertDialog(
+      backgroundColor: cs.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      contentPadding: const EdgeInsets.fromLTRB(4, 16, 4, 4),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: _buildContent(context),
+      ),
+    );
+  }
+}
+
+Widget _buildContent(BuildContext context) {
+  final l10n = AppLocalizations.of(context)!;
+  final cs = Theme.of(context).colorScheme;
+
+  Widget buildTaskRow(SynthesizeTask task, IconData icon) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: SizedBox(
+        height: 56,
+        child: IosCardPress(
+          borderRadius: BorderRadius.circular(14),
+          baseColor: cs.surface,
+          duration: const Duration(milliseconds: 260),
+          onTap: () => Navigator.of(context).pop(task.type),
+          padding: const EdgeInsets.symmetric(horizontal: 14),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: cs.primaryContainer.withValues(alpha: 0.6),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(icon, size: 18, color: cs.onPrimaryContainer),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _resolve(l10n, task.labelKey),
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: AppFontWeights.semibold,
+                        color: cs.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      _resolve(l10n, task.descriptionKey),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: cs.onSurface.withValues(alpha: 0.55),
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  return SafeArea(
+    top: false,
+    child: ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * 0.6,
+      ),
+      child: SingleChildScrollView(
+        physics: const BouncingScrollPhysics(),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 6, bottom: 6),
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: cs.onSurface.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  buildTaskRow(synthesizeTasks[0], Lucide.FileText),
+                  buildTaskRow(synthesizeTasks[1], Lucide.Shuffle),
+                  buildTaskRow(synthesizeTasks[2], Lucide.MessageCircle),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+String _resolve(AppLocalizations l10n, String key) {
+  // Resolve ARB key via generated accessors.
+  switch (key) {
+    case 'multiAISynthesizeTaskSummarize':
+      return l10n.multiAISynthesizeTaskSummarize;
+    case 'multiAISynthesizeTaskSummarizeDesc':
+      return l10n.multiAISynthesizeTaskSummarizeDesc;
+    case 'multiAISynthesizeSummarizePrompt':
+      return l10n.multiAISynthesizeSummarizePrompt;
+    case 'multiAISynthesizeTaskFuse':
+      return l10n.multiAISynthesizeTaskFuse;
+    case 'multiAISynthesizeTaskFuseDesc':
+      return l10n.multiAISynthesizeTaskFuseDesc;
+    case 'multiAISynthesizeFusePrompt':
+      return l10n.multiAISynthesizeFusePrompt;
+    case 'multiAISynthesizeTaskComment':
+      return l10n.multiAISynthesizeTaskComment;
+    case 'multiAISynthesizeTaskCommentDesc':
+      return l10n.multiAISynthesizeTaskCommentDesc;
+    case 'multiAISynthesizeCommentPrompt':
+      return l10n.multiAISynthesizeCommentPrompt;
+    default:
+      return key;
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2559,5 +2559,61 @@
   "multiAIDropThread": "Drop",
   "@multiAIDropThread": {
     "description": "Tooltip for the button that removes a model thread from multi-AI comparison"
+  },
+  "multiAIConversationMode": "Conversation Mode",
+  "@multiAIConversationMode": {
+    "description": "Label for the conversation mode switch row in multi-AI card group"
+  },
+  "multiAIContinue": "Continue",
+  "@multiAIContinue": {
+    "description": "Button label for continue mode in multi-AI conversation"
+  },
+  "multiAIContinueHint": "Continue multi-model conversation, each model inherits its own context",
+  "@multiAIContinueHint": {
+    "description": "Tooltip for continue mode button"
+  },
+  "multiAISynthesize": "Synthesize",
+  "@multiAISynthesize": {
+    "description": "Button label for synthesize mode in multi-AI conversation"
+  },
+  "multiAISynthesizeHint": "Synthesize multi-model conversation into a single response",
+  "@multiAISynthesizeHint": {
+    "description": "Tooltip for synthesize mode button"
+  },
+  "multiAISynthesizeTaskSummarize": "Summarize",
+  "@multiAISynthesizeTaskSummarize": {
+    "description": "Label for the summarize synthesis task"
+  },
+  "multiAISynthesizeTaskSummarizeDesc": "Summarize the conversation, focusing on similarities and differences between model responses",
+  "@multiAISynthesizeTaskSummarizeDesc": {
+    "description": "Description for the summarize synthesis task"
+  },
+  "multiAISynthesizeTaskFuse": "Fuse",
+  "@multiAISynthesizeTaskFuse": {
+    "description": "Label for the fuse synthesis task"
+  },
+  "multiAISynthesizeTaskFuseDesc": "Combine all model perspectives into a single best response",
+  "@multiAISynthesizeTaskFuseDesc": {
+    "description": "Description for the fuse synthesis task"
+  },
+  "multiAISynthesizeTaskComment": "Comment",
+  "@multiAISynthesizeTaskComment": {
+    "description": "Label for the comment synthesis task"
+  },
+  "multiAISynthesizeTaskCommentDesc": "Comment on the different opinions across models",
+  "@multiAISynthesizeTaskCommentDesc": {
+    "description": "Description for the comment synthesis task"
+  },
+  "multiAISynthesizeSummarizePrompt": "Please summarize the conversation, focused on the similarities and differences of the responses of assistants.",
+  "@multiAISynthesizeSummarizePrompt": {
+    "description": "Default prompt for the summarize synthesis task"
+  },
+  "multiAISynthesizeFusePrompt": "Please summarize the conversation and then provide a single response that fits the user's prompt based on previous responses.",
+  "@multiAISynthesizeFusePrompt": {
+    "description": "Default prompt for the fuse synthesis task"
+  },
+  "multiAISynthesizeCommentPrompt": "Please comment on the different opinions across models.",
+  "@multiAISynthesizeCommentPrompt": {
+    "description": "Default prompt for the comment synthesis task"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10543,6 +10543,90 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Drop'**
   String get multiAIDropThread;
+
+  /// Label for the conversation mode switch row in multi-AI card group
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation Mode'**
+  String get multiAIConversationMode;
+
+  /// Button label for continue mode in multi-AI conversation
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get multiAIContinue;
+
+  /// Tooltip for continue mode button
+  ///
+  /// In en, this message translates to:
+  /// **'Continue multi-model conversation, each model inherits its own context'**
+  String get multiAIContinueHint;
+
+  /// Button label for synthesize mode in multi-AI conversation
+  ///
+  /// In en, this message translates to:
+  /// **'Synthesize'**
+  String get multiAISynthesize;
+
+  /// Tooltip for synthesize mode button
+  ///
+  /// In en, this message translates to:
+  /// **'Synthesize multi-model conversation into a single response'**
+  String get multiAISynthesizeHint;
+
+  /// Label for the summarize synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Summarize'**
+  String get multiAISynthesizeTaskSummarize;
+
+  /// Description for the summarize synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Summarize the conversation, focusing on similarities and differences between model responses'**
+  String get multiAISynthesizeTaskSummarizeDesc;
+
+  /// Label for the fuse synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Fuse'**
+  String get multiAISynthesizeTaskFuse;
+
+  /// Description for the fuse synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Combine all model perspectives into a single best response'**
+  String get multiAISynthesizeTaskFuseDesc;
+
+  /// Label for the comment synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Comment'**
+  String get multiAISynthesizeTaskComment;
+
+  /// Description for the comment synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Comment on the different opinions across models'**
+  String get multiAISynthesizeTaskCommentDesc;
+
+  /// Default prompt for the summarize synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Please summarize the conversation, focused on the similarities and differences of the responses of assistants.'**
+  String get multiAISynthesizeSummarizePrompt;
+
+  /// Default prompt for the fuse synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Please summarize the conversation and then provide a single response that fits the user\'s prompt based on previous responses.'**
+  String get multiAISynthesizeFusePrompt;
+
+  /// Default prompt for the comment synthesis task
+  ///
+  /// In en, this message translates to:
+  /// **'Please comment on the different opinions across models.'**
+  String get multiAISynthesizeCommentPrompt;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5741,4 +5741,54 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get multiAIDropThread => 'Drop';
+
+  @override
+  String get multiAIConversationMode => 'Conversation Mode';
+
+  @override
+  String get multiAIContinue => 'Continue';
+
+  @override
+  String get multiAIContinueHint =>
+      'Continue multi-model conversation, each model inherits its own context';
+
+  @override
+  String get multiAISynthesize => 'Synthesize';
+
+  @override
+  String get multiAISynthesizeHint =>
+      'Synthesize multi-model conversation into a single response';
+
+  @override
+  String get multiAISynthesizeTaskSummarize => 'Summarize';
+
+  @override
+  String get multiAISynthesizeTaskSummarizeDesc =>
+      'Summarize the conversation, focusing on similarities and differences between model responses';
+
+  @override
+  String get multiAISynthesizeTaskFuse => 'Fuse';
+
+  @override
+  String get multiAISynthesizeTaskFuseDesc =>
+      'Combine all model perspectives into a single best response';
+
+  @override
+  String get multiAISynthesizeTaskComment => 'Comment';
+
+  @override
+  String get multiAISynthesizeTaskCommentDesc =>
+      'Comment on the different opinions across models';
+
+  @override
+  String get multiAISynthesizeSummarizePrompt =>
+      'Please summarize the conversation, focused on the similarities and differences of the responses of assistants.';
+
+  @override
+  String get multiAISynthesizeFusePrompt =>
+      'Please summarize the conversation and then provide a single response that fits the user\'s prompt based on previous responses.';
+
+  @override
+  String get multiAISynthesizeCommentPrompt =>
+      'Please comment on the different opinions across models.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5517,6 +5517,48 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get multiAIDropThread => '移除';
+
+  @override
+  String get multiAIConversationMode => '对话模式';
+
+  @override
+  String get multiAIContinue => '继续';
+
+  @override
+  String get multiAIContinueHint => '继续多模型对话，每个模型继承原有上下文';
+
+  @override
+  String get multiAISynthesize => '合成';
+
+  @override
+  String get multiAISynthesizeHint => '将多模型对话合成为一个回复';
+
+  @override
+  String get multiAISynthesizeTaskSummarize => '总结';
+
+  @override
+  String get multiAISynthesizeTaskSummarizeDesc => '总结对话，聚焦各模型回复的异同';
+
+  @override
+  String get multiAISynthesizeTaskFuse => '融合';
+
+  @override
+  String get multiAISynthesizeTaskFuseDesc => '综合各模型观点，给出一个最佳回复';
+
+  @override
+  String get multiAISynthesizeTaskComment => '点评';
+
+  @override
+  String get multiAISynthesizeTaskCommentDesc => '点评不同模型的观点分歧';
+
+  @override
+  String get multiAISynthesizeSummarizePrompt => '请总结以下对话，聚焦各助手回复的异同之处。';
+
+  @override
+  String get multiAISynthesizeFusePrompt => '请总结以下对话，并基于各方回复给出一个综合性的回答。';
+
+  @override
+  String get multiAISynthesizeCommentPrompt => '请点评各模型的不同观点。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -11032,6 +11074,48 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get multiAIDropThread => '移除';
+
+  @override
+  String get multiAIConversationMode => '对话模式';
+
+  @override
+  String get multiAIContinue => '继续';
+
+  @override
+  String get multiAIContinueHint => '继续多模型对话，每个模型继承原有上下文';
+
+  @override
+  String get multiAISynthesize => '合成';
+
+  @override
+  String get multiAISynthesizeHint => '将多模型对话合成为一个回复';
+
+  @override
+  String get multiAISynthesizeTaskSummarize => '总结';
+
+  @override
+  String get multiAISynthesizeTaskSummarizeDesc => '总结对话，聚焦各模型回复的异同';
+
+  @override
+  String get multiAISynthesizeTaskFuse => '融合';
+
+  @override
+  String get multiAISynthesizeTaskFuseDesc => '综合各模型观点，给出一个最佳回复';
+
+  @override
+  String get multiAISynthesizeTaskComment => '点评';
+
+  @override
+  String get multiAISynthesizeTaskCommentDesc => '点评不同模型的观点分歧';
+
+  @override
+  String get multiAISynthesizeSummarizePrompt => '请总结以下对话，聚焦各助手回复的异同之处。';
+
+  @override
+  String get multiAISynthesizeFusePrompt => '请总结以下对话，并基于各方回复给出一个综合性的回答。';
+
+  @override
+  String get multiAISynthesizeCommentPrompt => '请点评各模型的不同观点。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -16547,4 +16631,46 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get multiAIDropThread => '移除';
+
+  @override
+  String get multiAIConversationMode => '對話模式';
+
+  @override
+  String get multiAIContinue => '繼續';
+
+  @override
+  String get multiAIContinueHint => '繼續多模型對話，每個模型繼承原有上下文';
+
+  @override
+  String get multiAISynthesize => '合成';
+
+  @override
+  String get multiAISynthesizeHint => '將多模型對話合成為一個回覆';
+
+  @override
+  String get multiAISynthesizeTaskSummarize => '總結';
+
+  @override
+  String get multiAISynthesizeTaskSummarizeDesc => '總結對話，聚焦各模型回覆的異同';
+
+  @override
+  String get multiAISynthesizeTaskFuse => '融合';
+
+  @override
+  String get multiAISynthesizeTaskFuseDesc => '綜合各模型觀點，給出一個最佳回覆';
+
+  @override
+  String get multiAISynthesizeTaskComment => '點評';
+
+  @override
+  String get multiAISynthesizeTaskCommentDesc => '點評不同模型的觀點分歧';
+
+  @override
+  String get multiAISynthesizeSummarizePrompt => '請總結以下對話，聚焦各助手回覆的異同之處。';
+
+  @override
+  String get multiAISynthesizeFusePrompt => '請總結以下對話，並基於各方回覆給出一個綜合性的回答。';
+
+  @override
+  String get multiAISynthesizeCommentPrompt => '請點評各模型的不同觀點。';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2106,5 +2106,61 @@
   "multiAIDropThread": "移除",
   "@multiAIDropThread": {
     "description": "在多 AI 对比中移除某个模型回复的按钮提示"
+  },
+  "multiAIConversationMode": "对话模式",
+  "@multiAIConversationMode": {
+    "description": "多 AI 卡片组中的对话模式切换行标签"
+  },
+  "multiAIContinue": "继续",
+  "@multiAIContinue": {
+    "description": "多 AI 对话中继续模式的按钮标签"
+  },
+  "multiAIContinueHint": "继续多模型对话，每个模型继承原有上下文",
+  "@multiAIContinueHint": {
+    "description": "继续模式按钮的提示"
+  },
+  "multiAISynthesize": "合成",
+  "@multiAISynthesize": {
+    "description": "多 AI 对话中合成模式的按钮标签"
+  },
+  "multiAISynthesizeHint": "将多模型对话合成为一个回复",
+  "@multiAISynthesizeHint": {
+    "description": "合成模式按钮的提示"
+  },
+  "multiAISynthesizeTaskSummarize": "总结",
+  "@multiAISynthesizeTaskSummarize": {
+    "description": "总结合成任务标签"
+  },
+  "multiAISynthesizeTaskSummarizeDesc": "总结对话，聚焦各模型回复的异同",
+  "@multiAISynthesizeTaskSummarizeDesc": {
+    "description": "总结合成任务描述"
+  },
+  "multiAISynthesizeTaskFuse": "融合",
+  "@multiAISynthesizeTaskFuse": {
+    "description": "融合合成任务标签"
+  },
+  "multiAISynthesizeTaskFuseDesc": "综合各模型观点，给出一个最佳回复",
+  "@multiAISynthesizeTaskFuseDesc": {
+    "description": "融合合成任务描述"
+  },
+  "multiAISynthesizeTaskComment": "点评",
+  "@multiAISynthesizeTaskComment": {
+    "description": "点评合成任务标签"
+  },
+  "multiAISynthesizeTaskCommentDesc": "点评不同模型的观点分歧",
+  "@multiAISynthesizeTaskCommentDesc": {
+    "description": "点评合成任务描述"
+  },
+  "multiAISynthesizeSummarizePrompt": "请总结以下对话，聚焦各助手回复的异同之处。",
+  "@multiAISynthesizeSummarizePrompt": {
+    "description": "总结合成任务的默认提示词"
+  },
+  "multiAISynthesizeFusePrompt": "请总结以下对话，并基于各方回复给出一个综合性的回答。",
+  "@multiAISynthesizeFusePrompt": {
+    "description": "融合合成任务的默认提示词"
+  },
+  "multiAISynthesizeCommentPrompt": "请点评各模型的不同观点。",
+  "@multiAISynthesizeCommentPrompt": {
+    "description": "点评合成任务的默认提示词"
   }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2106,5 +2106,61 @@
   "multiAIDropThread": "移除",
   "@multiAIDropThread": {
     "description": "在多 AI 对比中移除某个模型回复的按钮提示"
+  },
+  "multiAIConversationMode": "对话模式",
+  "@multiAIConversationMode": {
+    "description": "多 AI 卡片组中的对话模式切换行标签"
+  },
+  "multiAIContinue": "继续",
+  "@multiAIContinue": {
+    "description": "多 AI 对话中继续模式的按钮标签"
+  },
+  "multiAIContinueHint": "继续多模型对话，每个模型继承原有上下文",
+  "@multiAIContinueHint": {
+    "description": "继续模式按钮的提示"
+  },
+  "multiAISynthesize": "合成",
+  "@multiAISynthesize": {
+    "description": "多 AI 对话中合成模式的按钮标签"
+  },
+  "multiAISynthesizeHint": "将多模型对话合成为一个回复",
+  "@multiAISynthesizeHint": {
+    "description": "合成模式按钮的提示"
+  },
+  "multiAISynthesizeTaskSummarize": "总结",
+  "@multiAISynthesizeTaskSummarize": {
+    "description": "总结合成任务标签"
+  },
+  "multiAISynthesizeTaskSummarizeDesc": "总结对话，聚焦各模型回复的异同",
+  "@multiAISynthesizeTaskSummarizeDesc": {
+    "description": "总结合成任务描述"
+  },
+  "multiAISynthesizeTaskFuse": "融合",
+  "@multiAISynthesizeTaskFuse": {
+    "description": "融合合成任务标签"
+  },
+  "multiAISynthesizeTaskFuseDesc": "综合各模型观点，给出一个最佳回复",
+  "@multiAISynthesizeTaskFuseDesc": {
+    "description": "融合合成任务描述"
+  },
+  "multiAISynthesizeTaskComment": "点评",
+  "@multiAISynthesizeTaskComment": {
+    "description": "点评合成任务标签"
+  },
+  "multiAISynthesizeTaskCommentDesc": "点评不同模型的观点分歧",
+  "@multiAISynthesizeTaskCommentDesc": {
+    "description": "点评合成任务描述"
+  },
+  "multiAISynthesizeSummarizePrompt": "请总结以下对话，聚焦各助手回复的异同之处。",
+  "@multiAISynthesizeSummarizePrompt": {
+    "description": "总结合成任务的默认提示词"
+  },
+  "multiAISynthesizeFusePrompt": "请总结以下对话，并基于各方回复给出一个综合性的回答。",
+  "@multiAISynthesizeFusePrompt": {
+    "description": "融合合成任务的默认提示词"
+  },
+  "multiAISynthesizeCommentPrompt": "请点评各模型的不同观点。",
+  "@multiAISynthesizeCommentPrompt": {
+    "description": "点评合成任务的默认提示词"
   }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2106,5 +2106,61 @@
   "multiAIDropThread": "移除",
   "@multiAIDropThread": {
     "description": "在多 AI 對比中移除某個模型回覆的按鈕提示"
+  },
+  "multiAIConversationMode": "對話模式",
+  "@multiAIConversationMode": {
+    "description": "多 AI 卡片組中的對話模式切換行標籤"
+  },
+  "multiAIContinue": "繼續",
+  "@multiAIContinue": {
+    "description": "多 AI 對話中繼續模式的按鈕標籤"
+  },
+  "multiAIContinueHint": "繼續多模型對話，每個模型繼承原有上下文",
+  "@multiAIContinueHint": {
+    "description": "繼續模式按鈕的提示"
+  },
+  "multiAISynthesize": "合成",
+  "@multiAISynthesize": {
+    "description": "多 AI 對話中合成模式的按鈕標籤"
+  },
+  "multiAISynthesizeHint": "將多模型對話合成為一個回覆",
+  "@multiAISynthesizeHint": {
+    "description": "合成模式按鈕的提示"
+  },
+  "multiAISynthesizeTaskSummarize": "總結",
+  "@multiAISynthesizeTaskSummarize": {
+    "description": "總結合成任務標籤"
+  },
+  "multiAISynthesizeTaskSummarizeDesc": "總結對話，聚焦各模型回覆的異同",
+  "@multiAISynthesizeTaskSummarizeDesc": {
+    "description": "總結合成任務描述"
+  },
+  "multiAISynthesizeTaskFuse": "融合",
+  "@multiAISynthesizeTaskFuse": {
+    "description": "融合合成任務標籤"
+  },
+  "multiAISynthesizeTaskFuseDesc": "綜合各模型觀點，給出一個最佳回覆",
+  "@multiAISynthesizeTaskFuseDesc": {
+    "description": "融合合成任務描述"
+  },
+  "multiAISynthesizeTaskComment": "點評",
+  "@multiAISynthesizeTaskComment": {
+    "description": "點評合成任務標籤"
+  },
+  "multiAISynthesizeTaskCommentDesc": "點評不同模型的觀點分歧",
+  "@multiAISynthesizeTaskCommentDesc": {
+    "description": "點評合成任務描述"
+  },
+  "multiAISynthesizeSummarizePrompt": "請總結以下對話，聚焦各助手回覆的異同之處。",
+  "@multiAISynthesizeSummarizePrompt": {
+    "description": "總結合成任務的默認提示詞"
+  },
+  "multiAISynthesizeFusePrompt": "請總結以下對話，並基於各方回覆給出一個綜合性的回答。",
+  "@multiAISynthesizeFusePrompt": {
+    "description": "融合合成任務的默認提示詞"
+  },
+  "multiAISynthesizeCommentPrompt": "請點評各模型的不同觀點。",
+  "@multiAISynthesizeCommentPrompt": {
+    "description": "點評合成任務的默認提示詞"
   }
 }


### PR DESCRIPTION
- Add MultiAIMode enum (continue_ / synthesize) to MultiAIEngine with setMode(), multiRoundsToXML(), selectMessagesBeforeMultiAI()
- Lift selectedVersionByThread from static map to engine state for XML
- Add synthesize task selector (bottom sheet / dialog) with 3 tasks: summarise, fuse, comment — each with l10n'd default prompt
- Mode switch row in MultiAICardGroup footer (isLatestRound gate), styled per _ModeOption convention with AnimatedContainer
- sendMessage dispatches synthesize → fork + switch conversation + send prompt+XML; auto-reset to continue mode after send
- Model selector: hide multi-AI badge + disable multi-select toggle when in synthesize mode

Bug fixes:
- Regenerate of legacy assistant messages now routes to startRoundFromHistory when multi-AI engine is active, with proper trigger-message subgroupId tagging
- retryRound: update versionSelections so collapseVersions picks latest versions for API context after regeneration
- User message retry with no multi-AI rounds delegates to next assistant message for startRoundFromHistory
- "Start Comparison" action now hidden when engine inactive or subgroups already exist (moved guard from controller to UI layer)

Part of #36.