### PR TITLE
fix: multi-AI retry matrix — context truncation, version selection timing, and guard toasts

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -835,55 +835,69 @@ class HomePageController extends ChangeNotifier {
   }) async {
     if (currentConversation == null) return;
 
-    // Restrict retry ability when multi-AI rounds are active.
-    if (!_isRetryableInMultiAI(message)) return;
+    final l10n = AppLocalizations.of(_context)!;
 
-    // Multi-AI active but no rounds started yet: convert regenerate of a
-    // legacy assistant message into a startRoundFromHistory call.
+    if (!multiAIEngine.isActive &&
+        _chatController.subgroupActiveGroupIds.isNotEmpty) {
+      showAppSnackBar(
+        _context,
+        message: l10n.multiAIRetryBlockedUnresolvedComparison,
+        type: NotificationType.warning,
+      );
+      return;
+    }
+
+    if (!_isRetryableInMultiAI(message)) {
+      showAppSnackBar(
+        _context,
+        message: l10n.multiAIRetryBlockedUnresolvedComparison,
+        type: NotificationType.warning,
+      );
+      return;
+    }
+
     if (multiAIEngine.isActive &&
         _chatController.subgroupActiveGroupIds.isEmpty &&
         message.role == 'assistant') {
       _tagTriggerMessageForMultiAI(message);
       final settings = _context.read<SettingsProvider>();
       final assistant = _context.read<AssistantProvider>().currentAssistant;
-      final anchorId = await multiAIEngine.startRoundFromHistory(
+      await multiAIEngine.startRoundFromHistory(
         triggerMessage: message,
         conversation: currentConversation!,
         settings: settings,
         assistant: assistant,
       );
-      if (anchorId.isNotEmpty) {
-        // startRoundFromHistory already creates N placeholder messages
-      }
       notifyListeners();
       return;
     }
 
-    // User message retry, multi-AI active but no rounds yet: delegate to
-    // the next assistant message so it triggers a startRoundFromHistory
-    // call with all pre-selected models.
     if (message.role == 'user' &&
         multiAIEngine.isActive &&
         _chatController.subgroupActiveGroupIds.isEmpty) {
       final nextAssistant = _findNextAssistantAfter(message);
+      final settings = _context.read<SettingsProvider>();
+      final assistant = _context.read<AssistantProvider>().currentAssistant;
       if (nextAssistant != null) {
         _tagTriggerMessageForMultiAI(nextAssistant);
-        final settings = _context.read<SettingsProvider>();
-        final assistant = _context.read<AssistantProvider>().currentAssistant;
         await multiAIEngine.startRoundFromHistory(
           triggerMessage: nextAssistant,
           conversation: currentConversation!,
           settings: settings,
           assistant: assistant,
         );
-        notifyListeners();
-        return;
+      } else {
+        await multiAIEngine.startRoundFromUserMessage(
+          userMessage: message,
+          conversation: currentConversation!,
+          settings: settings,
+          assistant: assistant,
+        );
       }
-      // No assistant below → fall through to normal single-model regenerate
+      notifyListeners();
+      return;
     }
 
-    // User message retry in multi-select mode: create version+1 for every
-    // thread in the following round.
     if (message.role == 'user' &&
         multiAIEngine.isActive &&
         _chatController.subgroupActiveGroupIds.isNotEmpty) {

--- a/lib/features/home/services/multi_ai_engine.dart
+++ b/lib/features/home/services/multi_ai_engine.dart
@@ -329,7 +329,7 @@ class MultiAIEngine extends ChangeNotifier {
     return userMessage.id;
   }
 
-  /// Start a round from an existing assistant message ("也让其他AI回答").
+  /// Start a round from an existing assistant message.
   /// Finds the preceding user message as anchor, creates N new threads.
   Future<String> startRoundFromHistory({
     required ChatMessage triggerMessage,
@@ -341,9 +341,8 @@ class MultiAIEngine extends ChangeNotifier {
   }) async {
     if (_models.length < 2 || _threadIds.isEmpty) return '';
 
-    final roundGroupId = const Uuid().v4();
+    final roundGroupId = triggerMessage.groupId ?? triggerMessage.id;
 
-    // Find preceding user message (walk backwards from trigger)
     final triggerIdx = _chatController.messages.indexWhere(
       (m) => m.id == triggerMessage.id,
     );
@@ -361,6 +360,45 @@ class MultiAIEngine extends ChangeNotifier {
     final completeMessages = _chatController.messagesForCompleteHistoryContext(
       conversation,
     );
+    final anchorIdx = completeMessages.indexWhere(
+      (m) => m.id == precedingUserId,
+    );
+    final truncated = anchorIdx >= 0
+        ? completeMessages.sublist(0, anchorIdx + 1)
+        : completeMessages;
+
+    await _executeThreads(
+      conversation: conversation,
+      settings: settings,
+      assistant: assistant,
+      approvalService: approvalService,
+      askUserService: askUserService,
+      completeMessages: truncated,
+      roundGroupId: roundGroupId,
+    );
+
+    _chatController.notifyListeners();
+    return precedingUserId;
+  }
+
+  /// Start a round anchored on an existing user message that has no assistant
+  /// response yet (e.g. send was cancelled). Creates N threads directly.
+  Future<String> startRoundFromUserMessage({
+    required ChatMessage userMessage,
+    required Conversation conversation,
+    required SettingsProvider settings,
+    required Assistant? assistant,
+    ToolApprovalService? approvalService,
+    AskUserInteractionService? askUserService,
+  }) async {
+    if (_models.length < 2 || _threadIds.isEmpty) return '';
+    if (userMessage.role != 'user') return '';
+
+    final roundGroupId = const Uuid().v4();
+
+    final completeMessages = _chatController.messagesForCompleteHistoryContext(
+      conversation,
+    );
 
     await _executeThreads(
       conversation: conversation,
@@ -373,7 +411,7 @@ class MultiAIEngine extends ChangeNotifier {
     );
 
     _chatController.notifyListeners();
-    return precedingUserId;
+    return userMessage.id;
   }
 
   // ============================================================================
@@ -483,6 +521,9 @@ class MultiAIEngine extends ChangeNotifier {
     if (insertAfterIdx < 0) return;
     _chatController.messages.insert(insertAfterIdx + 1, newMessage);
 
+    final gid = newMessage.groupId ?? newMessage.id;
+    _chatController.versionSelections[gid] = newMessage.version;
+
     _streamController.markStreamingStarted(newMessage.id);
     _chatController.notifyListeners();
     _streamController.toolParts.remove(newMessage.id);
@@ -573,10 +614,13 @@ class MultiAIEngine extends ChangeNotifier {
 
     if (newMessages.isEmpty) return;
 
+    for (final newMsg in newMessages) {
+      final gid = newMsg.groupId ?? newMsg.id;
+      _chatController.versionSelections[gid] = newMsg.version;
+    }
+
     _chatController.notifyListeners();
 
-    // Execute streams for all new messages — iterate by _threadIds to ensure
-    // model/thread association is consistent regardless of Map iteration order.
     for (int i = 0; i < _threadIds.length; i++) {
       final threadId = _threadIds[i];
       final newMsg = newMsgByThread[threadId];
@@ -603,13 +647,6 @@ class MultiAIEngine extends ChangeNotifier {
         allowImagesApiRouting: true,
         generateTitleOnFinish: false,
       );
-    }
-
-    // Point versionSelections to the new versions so collapseVersions
-    // picks them for API context on subsequent rounds.
-    for (final newMsg in newMessages) {
-      final gid = newMsg.groupId ?? newMsg.id;
-      _chatController.versionSelections[gid] = newMsg.version;
     }
 
     _chatController.notifyListeners();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2615,5 +2615,9 @@
   "multiAISynthesizeCommentPrompt": "Please comment on the different opinions across models.",
   "@multiAISynthesizeCommentPrompt": {
     "description": "Default prompt for the comment synthesis task"
+  },
+  "multiAIRetryBlockedUnresolvedComparison": "Please adopt or drop the comparison results before retrying.",
+  "@multiAIRetryBlockedUnresolvedComparison": {
+    "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10627,6 +10627,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Please comment on the different opinions across models.'**
   String get multiAISynthesizeCommentPrompt;
+
+  /// Toast shown when retry is blocked due to active or unresolved multi-AI comparison state
+  ///
+  /// In en, this message translates to:
+  /// **'Please adopt or drop the comparison results before retrying.'**
+  String get multiAIRetryBlockedUnresolvedComparison;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5791,4 +5791,8 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get multiAISynthesizeCommentPrompt =>
       'Please comment on the different opinions across models.';
+
+  @override
+  String get multiAIRetryBlockedUnresolvedComparison =>
+      'Please adopt or drop the comparison results before retrying.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5559,6 +5559,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get multiAISynthesizeCommentPrompt => '请点评各模型的不同观点。';
+
+  @override
+  String get multiAIRetryBlockedUnresolvedComparison => '请先采纳或丢弃对比结果，再进行重试。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -11116,6 +11119,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get multiAISynthesizeCommentPrompt => '请点评各模型的不同观点。';
+
+  @override
+  String get multiAIRetryBlockedUnresolvedComparison => '请先采纳或丢弃对比结果，再进行重试。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -16673,4 +16679,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get multiAISynthesizeCommentPrompt => '請點評各模型的不同觀點。';
+
+  @override
+  String get multiAIRetryBlockedUnresolvedComparison => '請先採納或丟棄對比結果，再進行重試。';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2162,5 +2162,9 @@
   "multiAISynthesizeCommentPrompt": "请点评各模型的不同观点。",
   "@multiAISynthesizeCommentPrompt": {
     "description": "点评合成任务的默认提示词"
+  },
+  "multiAIRetryBlockedUnresolvedComparison": "请先采纳或丢弃对比结果，再进行重试。",
+  "@multiAIRetryBlockedUnresolvedComparison": {
+    "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
   }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2162,5 +2162,9 @@
   "multiAISynthesizeCommentPrompt": "请点评各模型的不同观点。",
   "@multiAISynthesizeCommentPrompt": {
     "description": "点评合成任务的默认提示词"
+  },
+  "multiAIRetryBlockedUnresolvedComparison": "请先采纳或丢弃对比结果，再进行重试。",
+  "@multiAIRetryBlockedUnresolvedComparison": {
+    "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
   }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2162,5 +2162,9 @@
   "multiAISynthesizeCommentPrompt": "請點評各模型的不同觀點。",
   "@multiAISynthesizeCommentPrompt": {
     "description": "點評合成任務的默認提示詞"
+  },
+  "multiAIRetryBlockedUnresolvedComparison": "請先採納或丟棄對比結果，再進行重試。",
+  "@multiAIRetryBlockedUnresolvedComparison": {
+    "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
   }
 }


### PR DESCRIPTION
Part 2/3 of #36.

- startRoundFromHistory: truncate context at anchor user message to prevent trailing assistant in API request body
- startRoundFromHistory: reuse trigger's groupId as roundGroupId so resolveThread correctly collapses adopted thread as a version sibling
- retryThread/retryRound: update versionSelections BEFORE executing streams so collapseVersions picks the placeholder (empty → skipped) instead of the old assistant response
- Add startRoundFromUserMessage for M+C0+U+no-assistant case
- Block all retry with toast when single-model + unresolved subgroup messages exist
- Show toast when _isRetryableInMultiAI blocks earlier rounds
- l10n: add multiAIRetryBlockedUnresolvedComparison (4 ARB files)