### PR TITLE
fix: replace regex with indexOf scanning to prevent stack overflow on large base64 images

### DIFF
--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -278,16 +278,33 @@ List<_ImageRef> _extractOpenAIImageRefs(dynamic content) {
   final raw = (content ?? '').toString();
   if (raw.isEmpty) return const <_ImageRef>[];
   final refs = <_ImageRef>[];
-  final markdownImage = RegExp(r'!\[[^\]]*\]\(([^)]+)\)');
-  final customImage = RegExp(r'\[image:(.+?)\]');
-  for (final match in markdownImage.allMatches(raw)) {
-    final source = (match.group(1) ?? '').trim();
+
+  int searchFrom = 0;
+  while (true) {
+    final imgStart = raw.indexOf('![', searchFrom);
+    if (imgStart < 0) break;
+    final altEnd = raw.indexOf('](', imgStart + 2);
+    if (altEnd < 0) break;
+    final srcStart = altEnd + 2;
+    final srcEnd = raw.indexOf(')', srcStart);
+    if (srcEnd < 0) break;
+    final source = raw.substring(srcStart, srcEnd).trim();
     if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+    searchFrom = srcEnd + 1;
   }
-  for (final match in customImage.allMatches(raw)) {
-    final source = (match.group(1) ?? '').trim();
+
+  searchFrom = 0;
+  while (true) {
+    final tagStart = raw.indexOf('[image:', searchFrom);
+    if (tagStart < 0) break;
+    final srcStart = tagStart + 7;
+    final srcEnd = raw.indexOf(']', srcStart);
+    if (srcEnd < 0) break;
+    final source = raw.substring(srcStart, srcEnd).trim();
     if (source.isNotEmpty) refs.add(_imageRefFromSource(source));
+    searchFrom = srcEnd + 1;
   }
+
   return refs;
 }
 

--- a/lib/utils/markdown_media_sanitizer.dart
+++ b/lib/utils/markdown_media_sanitizer.dart
@@ -84,19 +84,25 @@ class MarkdownMediaSanitizer {
   // Replace Markdown image links pointing to local file paths with inline base64 data URLs.
   // Example: "![image](/data/user/0/.../images/xxx.png)" -> "![image](data:image/png;base64,...)"
   static Future<String> inlineLocalImagesToBase64(String markdown) async {
-    // Quick check: contains a Markdown image and looks like a local path
     if (!(markdown.contains('![') && markdown.contains(']('))) return markdown;
-
-    final re = RegExp(r'!\[[^\]]*\]\(([^)]+)\)', multiLine: true);
-    final matches = re.allMatches(markdown).toList();
-    if (matches.isEmpty) return markdown;
 
     final sb = StringBuffer();
     int last = 0;
-    for (final m in matches) {
-      sb.write(markdown.substring(last, m.start));
-      final url = (m.group(1) ?? '').trim();
-      // Only convert local file paths; skip http(s) and existing data URLs
+    int searchFrom = 0;
+
+    while (true) {
+      final imgStart = markdown.indexOf('![', searchFrom);
+      if (imgStart < 0) break;
+      final altEnd = markdown.indexOf('](', imgStart + 2);
+      if (altEnd < 0) break;
+      final srcStart = altEnd + 2;
+      final srcEnd = markdown.indexOf(')', srcStart);
+      if (srcEnd < 0) break;
+      final matchEnd = srcEnd + 1;
+
+      sb.write(markdown.substring(last, imgStart));
+      final url = markdown.substring(srcStart, srcEnd).trim();
+
       final isRemote = url.startsWith('http://') || url.startsWith('https://');
       final isData = url.startsWith('data:');
       final isFileUri = url.startsWith('file://');
@@ -105,26 +111,23 @@ class MarkdownMediaSanitizer {
           (isFileUri || url.startsWith('/') || url.contains(':'));
 
       if (!isLikelyLocalPath) {
-        // Keep original
-        sb.write(markdown.substring(m.start, m.end));
-        last = m.end;
+        sb.write(markdown.substring(imgStart, matchEnd));
+        last = matchEnd;
+        searchFrom = matchEnd;
         continue;
       }
 
       try {
-        // Normalize file path
         var path = url;
         if (isFileUri) {
           path = url.replaceFirst('file://', '');
         }
-        // Read bytes and encode
-        final fixed =
-            path; // Caller may already pass sandbox-fixed paths; avoid depending on Flutter layer here
+        final fixed = path;
         final f = File(fixed);
         if (!f.existsSync()) {
-          // Fallback to original if missing
-          sb.write(markdown.substring(m.start, m.end));
-          last = m.end;
+          sb.write(markdown.substring(imgStart, matchEnd));
+          last = matchEnd;
+          searchFrom = matchEnd;
           continue;
         }
         final bytes = await f.readAsBytes();
@@ -132,15 +135,16 @@ class MarkdownMediaSanitizer {
         final mime = _guessMimeFromPath(fixed);
         final dataUrl = 'data:$mime;base64,$b64';
         final replaced = markdown
-            .substring(m.start, m.end)
+            .substring(imgStart, matchEnd)
             .replaceFirst(url, dataUrl);
         sb.write(replaced);
       } catch (_) {
-        // On failure, keep original
-        sb.write(markdown.substring(m.start, m.end));
+        sb.write(markdown.substring(imgStart, matchEnd));
       }
-      last = m.end;
+      last = matchEnd;
+      searchFrom = matchEnd;
     }
+
     sb.write(markdown.substring(last));
     return sb.toString();
   }

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -796,5 +796,54 @@ void main() {
       expect(await File(imagePath).readAsBytes(), const [1, 2, 3, 4]);
       expect(chunks.last.isDone, isTrue);
     });
+
+    test(
+      'does not stack overflow when assistant image is a large base64 data URL',
+      () async {
+        late Uri requestUri;
+        late String contentType;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          requestUri = request.uri;
+          contentType = request.headers.contentType?.mimeType ?? '';
+          await request.drain<void>();
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'data': [
+                {'url': 'https://example.com/large-edit.png'},
+              ],
+            }),
+          );
+          await request.response.close();
+        });
+
+        final largeB64 = base64Encode(List.filled(2 * 1024 * 1024, 65));
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _openAiConfig(_baseUrl(server)),
+          modelId: 'gpt-image-2',
+          messages: [
+            {'role': 'user', 'content': 'draw a cat'},
+            {
+              'role': 'assistant',
+              'content': '![image](data:image/png;base64,$largeB64)',
+            },
+            {'role': 'user', 'content': 'make it bigger'},
+          ],
+        ).toList();
+
+        expect(requestUri.path, '/v1/images/edits');
+        expect(contentType, 'multipart/form-data');
+        expect(
+          chunks.single.content,
+          '![image](https://example.com/large-edit.png)',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
`_extractOpenAIImageRefs` and `inlineLocalImagesToBase64` used `RegExp(r'!\[[^\]]*\]\(([^)]+)\)')` which causes stack overflow when scanning multi-MB base64 data URLs inlined into assistant messages.

Replace with O(1)-stack indexOf-based scanning that is safe for arbitrary string lengths.

Closes #48.
