### PR TITLE
feat: 新增主动关怀「Ta的来信」功能

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,11 @@
     <uses-permission android:name="android.permission.VIBRATE"/>
     <!-- Foreground service + notifications for background execution (Android only) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Proactive care: exact alarms to wake the app at scheduled times -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <application
@@ -46,6 +51,22 @@
             android:name="de.julianassmann.flutter_background.IsolateHolderService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <!-- Proactive care: alarm receiver (android_alarm_manager_plus) -->
+        <receiver
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmBroadcastReceiver"
+            android:exported="false" />
+        <receiver
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <service
+            android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:screenOrientation="portrait"

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -111,6 +111,15 @@ class AssistantRows extends Table {
   TextColumn get localToolIdsJson => text().withDefault(const Constant('[]'))();
   TextColumn get regexRulesJson => text().withDefault(const Constant('[]'))();
 
+  // --- Proactive Care ("Ta的来信") ---
+  BoolColumn get enableProactiveCare =>
+      boolean().withDefault(const Constant(false))();
+  DateTimeColumn get proactiveCareNextMessageAt => dateTime().nullable()();
+  TextColumn get proactiveCarePrompt =>
+      text().withDefault(const Constant(''))();
+  TextColumn get proactiveCareDecisionPrompt =>
+      text().withDefault(const Constant(''))();
+
   // --- Memory ---
   BoolColumn get enableMemory => boolean().withDefault(const Constant(false))();
   TextColumn get memoryMode =>
@@ -228,7 +237,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -266,6 +275,32 @@ class AppDatabase extends _$AppDatabase {
           await migrator.addColumn(
             assistantRows,
             assistantRows.otherOfficeMode,
+          );
+        } catch (_) {}
+      }
+      if (from < 6) {
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.enableProactiveCare,
+          );
+        } catch (_) {}
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.proactiveCareNextMessageAt,
+          );
+        } catch (_) {}
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.proactiveCarePrompt,
+          );
+        } catch (_) {}
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.proactiveCareDecisionPrompt,
           );
         } catch (_) {}
       }

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -2279,6 +2279,55 @@ class $AssistantRowsTable extends AssistantRows
     requiredDuringInsert: false,
     defaultValue: const Constant('[]'),
   );
+  static const VerificationMeta _enableProactiveCareMeta =
+      const VerificationMeta('enableProactiveCare');
+  @override
+  late final GeneratedColumn<bool> enableProactiveCare = GeneratedColumn<bool>(
+    'enable_proactive_care',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("enable_proactive_care" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _proactiveCareNextMessageAtMeta =
+      const VerificationMeta('proactiveCareNextMessageAt');
+  @override
+  late final GeneratedColumn<DateTime> proactiveCareNextMessageAt =
+      GeneratedColumn<DateTime>(
+        'proactive_care_next_message_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _proactiveCarePromptMeta =
+      const VerificationMeta('proactiveCarePrompt');
+  @override
+  late final GeneratedColumn<String> proactiveCarePrompt =
+      GeneratedColumn<String>(
+        'proactive_care_prompt',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant(''),
+      );
+  static const VerificationMeta _proactiveCareDecisionPromptMeta =
+      const VerificationMeta('proactiveCareDecisionPrompt');
+  @override
+  late final GeneratedColumn<String> proactiveCareDecisionPrompt =
+      GeneratedColumn<String>(
+        'proactive_care_decision_prompt',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant(''),
+      );
   static const VerificationMeta _enableMemoryMeta = const VerificationMeta(
     'enableMemory',
   );
@@ -2440,6 +2489,10 @@ class $AssistantRowsTable extends AssistantRows
     mcpServerIdsJson,
     localToolIdsJson,
     regexRulesJson,
+    enableProactiveCare,
+    proactiveCareNextMessageAt,
+    proactiveCarePrompt,
+    proactiveCareDecisionPrompt,
     enableMemory,
     memoryMode,
     enableRecentChatsReference,
@@ -2663,6 +2716,42 @@ class $AssistantRowsTable extends AssistantRows
         ),
       );
     }
+    if (data.containsKey('enable_proactive_care')) {
+      context.handle(
+        _enableProactiveCareMeta,
+        enableProactiveCare.isAcceptableOrUnknown(
+          data['enable_proactive_care']!,
+          _enableProactiveCareMeta,
+        ),
+      );
+    }
+    if (data.containsKey('proactive_care_next_message_at')) {
+      context.handle(
+        _proactiveCareNextMessageAtMeta,
+        proactiveCareNextMessageAt.isAcceptableOrUnknown(
+          data['proactive_care_next_message_at']!,
+          _proactiveCareNextMessageAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('proactive_care_prompt')) {
+      context.handle(
+        _proactiveCarePromptMeta,
+        proactiveCarePrompt.isAcceptableOrUnknown(
+          data['proactive_care_prompt']!,
+          _proactiveCarePromptMeta,
+        ),
+      );
+    }
+    if (data.containsKey('proactive_care_decision_prompt')) {
+      context.handle(
+        _proactiveCareDecisionPromptMeta,
+        proactiveCareDecisionPrompt.isAcceptableOrUnknown(
+          data['proactive_care_decision_prompt']!,
+          _proactiveCareDecisionPromptMeta,
+        ),
+      );
+    }
     if (data.containsKey('enable_memory')) {
       context.handle(
         _enableMemoryMeta,
@@ -2855,6 +2944,22 @@ class $AssistantRowsTable extends AssistantRows
         DriftSqlType.string,
         data['${effectivePrefix}regex_rules_json'],
       )!,
+      enableProactiveCare: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}enable_proactive_care'],
+      )!,
+      proactiveCareNextMessageAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}proactive_care_next_message_at'],
+      ),
+      proactiveCarePrompt: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}proactive_care_prompt'],
+      )!,
+      proactiveCareDecisionPrompt: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}proactive_care_decision_prompt'],
+      )!,
       enableMemory: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}enable_memory'],
@@ -2933,6 +3038,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
   final String mcpServerIdsJson;
   final String localToolIdsJson;
   final String regexRulesJson;
+  final bool enableProactiveCare;
+  final DateTime? proactiveCareNextMessageAt;
+  final String proactiveCarePrompt;
+  final String proactiveCareDecisionPrompt;
   final bool enableMemory;
   final String memoryMode;
   final bool enableRecentChatsReference;
@@ -2969,6 +3078,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     required this.mcpServerIdsJson,
     required this.localToolIdsJson,
     required this.regexRulesJson,
+    required this.enableProactiveCare,
+    this.proactiveCareNextMessageAt,
+    required this.proactiveCarePrompt,
+    required this.proactiveCareDecisionPrompt,
     required this.enableMemory,
     required this.memoryMode,
     required this.enableRecentChatsReference,
@@ -3024,6 +3137,16 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     map['mcp_server_ids_json'] = Variable<String>(mcpServerIdsJson);
     map['local_tool_ids_json'] = Variable<String>(localToolIdsJson);
     map['regex_rules_json'] = Variable<String>(regexRulesJson);
+    map['enable_proactive_care'] = Variable<bool>(enableProactiveCare);
+    if (!nullToAbsent || proactiveCareNextMessageAt != null) {
+      map['proactive_care_next_message_at'] = Variable<DateTime>(
+        proactiveCareNextMessageAt,
+      );
+    }
+    map['proactive_care_prompt'] = Variable<String>(proactiveCarePrompt);
+    map['proactive_care_decision_prompt'] = Variable<String>(
+      proactiveCareDecisionPrompt,
+    );
     map['enable_memory'] = Variable<bool>(enableMemory);
     map['memory_mode'] = Variable<String>(memoryMode);
     map['enable_recent_chats_reference'] = Variable<bool>(
@@ -3082,6 +3205,13 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       mcpServerIdsJson: Value(mcpServerIdsJson),
       localToolIdsJson: Value(localToolIdsJson),
       regexRulesJson: Value(regexRulesJson),
+      enableProactiveCare: Value(enableProactiveCare),
+      proactiveCareNextMessageAt:
+          proactiveCareNextMessageAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(proactiveCareNextMessageAt),
+      proactiveCarePrompt: Value(proactiveCarePrompt),
+      proactiveCareDecisionPrompt: Value(proactiveCareDecisionPrompt),
       enableMemory: Value(enableMemory),
       memoryMode: Value(memoryMode),
       enableRecentChatsReference: Value(enableRecentChatsReference),
@@ -3132,6 +3262,18 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       mcpServerIdsJson: serializer.fromJson<String>(json['mcpServerIdsJson']),
       localToolIdsJson: serializer.fromJson<String>(json['localToolIdsJson']),
       regexRulesJson: serializer.fromJson<String>(json['regexRulesJson']),
+      enableProactiveCare: serializer.fromJson<bool>(
+        json['enableProactiveCare'],
+      ),
+      proactiveCareNextMessageAt: serializer.fromJson<DateTime?>(
+        json['proactiveCareNextMessageAt'],
+      ),
+      proactiveCarePrompt: serializer.fromJson<String>(
+        json['proactiveCarePrompt'],
+      ),
+      proactiveCareDecisionPrompt: serializer.fromJson<String>(
+        json['proactiveCareDecisionPrompt'],
+      ),
       enableMemory: serializer.fromJson<bool>(json['enableMemory']),
       memoryMode: serializer.fromJson<String>(json['memoryMode']),
       enableRecentChatsReference: serializer.fromJson<bool>(
@@ -3179,6 +3321,14 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       'mcpServerIdsJson': serializer.toJson<String>(mcpServerIdsJson),
       'localToolIdsJson': serializer.toJson<String>(localToolIdsJson),
       'regexRulesJson': serializer.toJson<String>(regexRulesJson),
+      'enableProactiveCare': serializer.toJson<bool>(enableProactiveCare),
+      'proactiveCareNextMessageAt': serializer.toJson<DateTime?>(
+        proactiveCareNextMessageAt,
+      ),
+      'proactiveCarePrompt': serializer.toJson<String>(proactiveCarePrompt),
+      'proactiveCareDecisionPrompt': serializer.toJson<String>(
+        proactiveCareDecisionPrompt,
+      ),
       'enableMemory': serializer.toJson<bool>(enableMemory),
       'memoryMode': serializer.toJson<String>(memoryMode),
       'enableRecentChatsReference': serializer.toJson<bool>(
@@ -3222,6 +3372,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     String? mcpServerIdsJson,
     String? localToolIdsJson,
     String? regexRulesJson,
+    bool? enableProactiveCare,
+    Value<DateTime?> proactiveCareNextMessageAt = const Value.absent(),
+    String? proactiveCarePrompt,
+    String? proactiveCareDecisionPrompt,
     bool? enableMemory,
     String? memoryMode,
     bool? enableRecentChatsReference,
@@ -3262,6 +3416,13 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     mcpServerIdsJson: mcpServerIdsJson ?? this.mcpServerIdsJson,
     localToolIdsJson: localToolIdsJson ?? this.localToolIdsJson,
     regexRulesJson: regexRulesJson ?? this.regexRulesJson,
+    enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
+    proactiveCareNextMessageAt: proactiveCareNextMessageAt.present
+        ? proactiveCareNextMessageAt.value
+        : this.proactiveCareNextMessageAt,
+    proactiveCarePrompt: proactiveCarePrompt ?? this.proactiveCarePrompt,
+    proactiveCareDecisionPrompt:
+        proactiveCareDecisionPrompt ?? this.proactiveCareDecisionPrompt,
     enableMemory: enableMemory ?? this.enableMemory,
     memoryMode: memoryMode ?? this.memoryMode,
     enableRecentChatsReference:
@@ -3340,6 +3501,18 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       regexRulesJson: data.regexRulesJson.present
           ? data.regexRulesJson.value
           : this.regexRulesJson,
+      enableProactiveCare: data.enableProactiveCare.present
+          ? data.enableProactiveCare.value
+          : this.enableProactiveCare,
+      proactiveCareNextMessageAt: data.proactiveCareNextMessageAt.present
+          ? data.proactiveCareNextMessageAt.value
+          : this.proactiveCareNextMessageAt,
+      proactiveCarePrompt: data.proactiveCarePrompt.present
+          ? data.proactiveCarePrompt.value
+          : this.proactiveCarePrompt,
+      proactiveCareDecisionPrompt: data.proactiveCareDecisionPrompt.present
+          ? data.proactiveCareDecisionPrompt.value
+          : this.proactiveCareDecisionPrompt,
       enableMemory: data.enableMemory.present
           ? data.enableMemory.value
           : this.enableMemory,
@@ -3394,6 +3567,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           ..write('mcpServerIdsJson: $mcpServerIdsJson, ')
           ..write('localToolIdsJson: $localToolIdsJson, ')
           ..write('regexRulesJson: $regexRulesJson, ')
+          ..write('enableProactiveCare: $enableProactiveCare, ')
+          ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
+          ..write('proactiveCarePrompt: $proactiveCarePrompt, ')
+          ..write('proactiveCareDecisionPrompt: $proactiveCareDecisionPrompt, ')
           ..write('enableMemory: $enableMemory, ')
           ..write('memoryMode: $memoryMode, ')
           ..write('enableRecentChatsReference: $enableRecentChatsReference, ')
@@ -3437,6 +3614,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     mcpServerIdsJson,
     localToolIdsJson,
     regexRulesJson,
+    enableProactiveCare,
+    proactiveCareNextMessageAt,
+    proactiveCarePrompt,
+    proactiveCareDecisionPrompt,
     enableMemory,
     memoryMode,
     enableRecentChatsReference,
@@ -3477,6 +3658,11 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           other.mcpServerIdsJson == this.mcpServerIdsJson &&
           other.localToolIdsJson == this.localToolIdsJson &&
           other.regexRulesJson == this.regexRulesJson &&
+          other.enableProactiveCare == this.enableProactiveCare &&
+          other.proactiveCareNextMessageAt == this.proactiveCareNextMessageAt &&
+          other.proactiveCarePrompt == this.proactiveCarePrompt &&
+          other.proactiveCareDecisionPrompt ==
+              this.proactiveCareDecisionPrompt &&
           other.enableMemory == this.enableMemory &&
           other.memoryMode == this.memoryMode &&
           other.enableRecentChatsReference == this.enableRecentChatsReference &&
@@ -3516,6 +3702,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
   final Value<String> mcpServerIdsJson;
   final Value<String> localToolIdsJson;
   final Value<String> regexRulesJson;
+  final Value<bool> enableProactiveCare;
+  final Value<DateTime?> proactiveCareNextMessageAt;
+  final Value<String> proactiveCarePrompt;
+  final Value<String> proactiveCareDecisionPrompt;
   final Value<bool> enableMemory;
   final Value<String> memoryMode;
   final Value<bool> enableRecentChatsReference;
@@ -3553,6 +3743,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.mcpServerIdsJson = const Value.absent(),
     this.localToolIdsJson = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
+    this.enableProactiveCare = const Value.absent(),
+    this.proactiveCareNextMessageAt = const Value.absent(),
+    this.proactiveCarePrompt = const Value.absent(),
+    this.proactiveCareDecisionPrompt = const Value.absent(),
     this.enableMemory = const Value.absent(),
     this.memoryMode = const Value.absent(),
     this.enableRecentChatsReference = const Value.absent(),
@@ -3591,6 +3785,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.mcpServerIdsJson = const Value.absent(),
     this.localToolIdsJson = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
+    this.enableProactiveCare = const Value.absent(),
+    this.proactiveCareNextMessageAt = const Value.absent(),
+    this.proactiveCarePrompt = const Value.absent(),
+    this.proactiveCareDecisionPrompt = const Value.absent(),
     this.enableMemory = const Value.absent(),
     this.memoryMode = const Value.absent(),
     this.enableRecentChatsReference = const Value.absent(),
@@ -3633,6 +3831,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Expression<String>? mcpServerIdsJson,
     Expression<String>? localToolIdsJson,
     Expression<String>? regexRulesJson,
+    Expression<bool>? enableProactiveCare,
+    Expression<DateTime>? proactiveCareNextMessageAt,
+    Expression<String>? proactiveCarePrompt,
+    Expression<String>? proactiveCareDecisionPrompt,
     Expression<bool>? enableMemory,
     Expression<String>? memoryMode,
     Expression<bool>? enableRecentChatsReference,
@@ -3675,6 +3877,14 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       if (mcpServerIdsJson != null) 'mcp_server_ids_json': mcpServerIdsJson,
       if (localToolIdsJson != null) 'local_tool_ids_json': localToolIdsJson,
       if (regexRulesJson != null) 'regex_rules_json': regexRulesJson,
+      if (enableProactiveCare != null)
+        'enable_proactive_care': enableProactiveCare,
+      if (proactiveCareNextMessageAt != null)
+        'proactive_care_next_message_at': proactiveCareNextMessageAt,
+      if (proactiveCarePrompt != null)
+        'proactive_care_prompt': proactiveCarePrompt,
+      if (proactiveCareDecisionPrompt != null)
+        'proactive_care_decision_prompt': proactiveCareDecisionPrompt,
       if (enableMemory != null) 'enable_memory': enableMemory,
       if (memoryMode != null) 'memory_mode': memoryMode,
       if (enableRecentChatsReference != null)
@@ -3718,6 +3928,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Value<String>? mcpServerIdsJson,
     Value<String>? localToolIdsJson,
     Value<String>? regexRulesJson,
+    Value<bool>? enableProactiveCare,
+    Value<DateTime?>? proactiveCareNextMessageAt,
+    Value<String>? proactiveCarePrompt,
+    Value<String>? proactiveCareDecisionPrompt,
     Value<bool>? enableMemory,
     Value<String>? memoryMode,
     Value<bool>? enableRecentChatsReference,
@@ -3756,6 +3970,12 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       mcpServerIdsJson: mcpServerIdsJson ?? this.mcpServerIdsJson,
       localToolIdsJson: localToolIdsJson ?? this.localToolIdsJson,
       regexRulesJson: regexRulesJson ?? this.regexRulesJson,
+      enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
+      proactiveCareNextMessageAt:
+          proactiveCareNextMessageAt ?? this.proactiveCareNextMessageAt,
+      proactiveCarePrompt: proactiveCarePrompt ?? this.proactiveCarePrompt,
+      proactiveCareDecisionPrompt:
+          proactiveCareDecisionPrompt ?? this.proactiveCareDecisionPrompt,
       enableMemory: enableMemory ?? this.enableMemory,
       memoryMode: memoryMode ?? this.memoryMode,
       enableRecentChatsReference:
@@ -3850,6 +4070,24 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     if (regexRulesJson.present) {
       map['regex_rules_json'] = Variable<String>(regexRulesJson.value);
     }
+    if (enableProactiveCare.present) {
+      map['enable_proactive_care'] = Variable<bool>(enableProactiveCare.value);
+    }
+    if (proactiveCareNextMessageAt.present) {
+      map['proactive_care_next_message_at'] = Variable<DateTime>(
+        proactiveCareNextMessageAt.value,
+      );
+    }
+    if (proactiveCarePrompt.present) {
+      map['proactive_care_prompt'] = Variable<String>(
+        proactiveCarePrompt.value,
+      );
+    }
+    if (proactiveCareDecisionPrompt.present) {
+      map['proactive_care_decision_prompt'] = Variable<String>(
+        proactiveCareDecisionPrompt.value,
+      );
+    }
     if (enableMemory.present) {
       map['enable_memory'] = Variable<bool>(enableMemory.value);
     }
@@ -3920,6 +4158,10 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
           ..write('mcpServerIdsJson: $mcpServerIdsJson, ')
           ..write('localToolIdsJson: $localToolIdsJson, ')
           ..write('regexRulesJson: $regexRulesJson, ')
+          ..write('enableProactiveCare: $enableProactiveCare, ')
+          ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
+          ..write('proactiveCarePrompt: $proactiveCarePrompt, ')
+          ..write('proactiveCareDecisionPrompt: $proactiveCareDecisionPrompt, ')
           ..write('enableMemory: $enableMemory, ')
           ..write('memoryMode: $memoryMode, ')
           ..write('enableRecentChatsReference: $enableRecentChatsReference, ')
@@ -6750,6 +6992,10 @@ typedef $$AssistantRowsTableCreateCompanionBuilder =
       Value<String> mcpServerIdsJson,
       Value<String> localToolIdsJson,
       Value<String> regexRulesJson,
+      Value<bool> enableProactiveCare,
+      Value<DateTime?> proactiveCareNextMessageAt,
+      Value<String> proactiveCarePrompt,
+      Value<String> proactiveCareDecisionPrompt,
       Value<bool> enableMemory,
       Value<String> memoryMode,
       Value<bool> enableRecentChatsReference,
@@ -6789,6 +7035,10 @@ typedef $$AssistantRowsTableUpdateCompanionBuilder =
       Value<String> mcpServerIdsJson,
       Value<String> localToolIdsJson,
       Value<String> regexRulesJson,
+      Value<bool> enableProactiveCare,
+      Value<DateTime?> proactiveCareNextMessageAt,
+      Value<String> proactiveCarePrompt,
+      Value<String> proactiveCareDecisionPrompt,
       Value<bool> enableMemory,
       Value<String> memoryMode,
       Value<bool> enableRecentChatsReference,
@@ -6929,6 +7179,26 @@ class $$AssistantRowsTableFilterComposer
 
   ColumnFilters<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get enableProactiveCare => $composableBuilder(
+    column: $table.enableProactiveCare,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get proactiveCareNextMessageAt => $composableBuilder(
+    column: $table.proactiveCareNextMessageAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get proactiveCarePrompt => $composableBuilder(
+    column: $table.proactiveCarePrompt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get proactiveCareDecisionPrompt => $composableBuilder(
+    column: $table.proactiveCareDecisionPrompt,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7117,6 +7387,27 @@ class $$AssistantRowsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get enableProactiveCare => $composableBuilder(
+    column: $table.enableProactiveCare,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get proactiveCareNextMessageAt =>
+      $composableBuilder(
+        column: $table.proactiveCareNextMessageAt,
+        builder: (column) => ColumnOrderings(column),
+      );
+
+  ColumnOrderings<String> get proactiveCarePrompt => $composableBuilder(
+    column: $table.proactiveCarePrompt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get proactiveCareDecisionPrompt => $composableBuilder(
+    column: $table.proactiveCareDecisionPrompt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get enableMemory => $composableBuilder(
     column: $table.enableMemory,
     builder: (column) => ColumnOrderings(column),
@@ -7292,6 +7583,27 @@ class $$AssistantRowsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get enableProactiveCare => $composableBuilder(
+    column: $table.enableProactiveCare,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get proactiveCareNextMessageAt =>
+      $composableBuilder(
+        column: $table.proactiveCareNextMessageAt,
+        builder: (column) => column,
+      );
+
+  GeneratedColumn<String> get proactiveCarePrompt => $composableBuilder(
+    column: $table.proactiveCarePrompt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get proactiveCareDecisionPrompt => $composableBuilder(
+    column: $table.proactiveCareDecisionPrompt,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get enableMemory => $composableBuilder(
     column: $table.enableMemory,
     builder: (column) => column,
@@ -7393,6 +7705,12 @@ class $$AssistantRowsTableTableManager
                 Value<String> mcpServerIdsJson = const Value.absent(),
                 Value<String> localToolIdsJson = const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
+                Value<bool> enableProactiveCare = const Value.absent(),
+                Value<DateTime?> proactiveCareNextMessageAt =
+                    const Value.absent(),
+                Value<String> proactiveCarePrompt = const Value.absent(),
+                Value<String> proactiveCareDecisionPrompt =
+                    const Value.absent(),
                 Value<bool> enableMemory = const Value.absent(),
                 Value<String> memoryMode = const Value.absent(),
                 Value<bool> enableRecentChatsReference = const Value.absent(),
@@ -7431,6 +7749,10 @@ class $$AssistantRowsTableTableManager
                 mcpServerIdsJson: mcpServerIdsJson,
                 localToolIdsJson: localToolIdsJson,
                 regexRulesJson: regexRulesJson,
+                enableProactiveCare: enableProactiveCare,
+                proactiveCareNextMessageAt: proactiveCareNextMessageAt,
+                proactiveCarePrompt: proactiveCarePrompt,
+                proactiveCareDecisionPrompt: proactiveCareDecisionPrompt,
                 enableMemory: enableMemory,
                 memoryMode: memoryMode,
                 enableRecentChatsReference: enableRecentChatsReference,
@@ -7470,6 +7792,12 @@ class $$AssistantRowsTableTableManager
                 Value<String> mcpServerIdsJson = const Value.absent(),
                 Value<String> localToolIdsJson = const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
+                Value<bool> enableProactiveCare = const Value.absent(),
+                Value<DateTime?> proactiveCareNextMessageAt =
+                    const Value.absent(),
+                Value<String> proactiveCarePrompt = const Value.absent(),
+                Value<String> proactiveCareDecisionPrompt =
+                    const Value.absent(),
                 Value<bool> enableMemory = const Value.absent(),
                 Value<String> memoryMode = const Value.absent(),
                 Value<bool> enableRecentChatsReference = const Value.absent(),
@@ -7508,6 +7836,10 @@ class $$AssistantRowsTableTableManager
                 mcpServerIdsJson: mcpServerIdsJson,
                 localToolIdsJson: localToolIdsJson,
                 regexRulesJson: regexRulesJson,
+                enableProactiveCare: enableProactiveCare,
+                proactiveCareNextMessageAt: proactiveCareNextMessageAt,
+                proactiveCarePrompt: proactiveCarePrompt,
+                proactiveCareDecisionPrompt: proactiveCareDecisionPrompt,
                 enableMemory: enableMemory,
                 memoryMode: memoryMode,
                 enableRecentChatsReference: enableRecentChatsReference,

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -970,6 +970,11 @@ class ChatDatabaseRepository {
       'otherOfficeMode': row.otherOfficeMode,
       'presetMessages': jsonDecode(row.presetMessagesJson),
       'regexRules': jsonDecode(row.regexRulesJson),
+      'enableProactiveCare': row.enableProactiveCare,
+      'proactiveCareNextMessageAt': row.proactiveCareNextMessageAt
+          ?.toIso8601String(),
+      'proactiveCarePrompt': row.proactiveCarePrompt,
+      'proactiveCareDecisionPrompt': row.proactiveCareDecisionPrompt,
       'createdAt': row.createdAt.toIso8601String(),
       'updatedAt': row.updatedAt.toIso8601String(),
     });
@@ -1013,6 +1018,10 @@ class ChatDatabaseRepository {
       regexRulesJson: Value(
         jsonEncode(a.regexRules.map((e) => e.toJson()).toList()),
       ),
+      enableProactiveCare: Value(a.enableProactiveCare),
+      proactiveCareNextMessageAt: Value(a.proactiveCareNextMessageAt),
+      proactiveCarePrompt: Value(a.proactiveCarePrompt),
+      proactiveCareDecisionPrompt: Value(a.proactiveCareDecisionPrompt),
       sortOrder: sortOrder,
       createdAt: a.createdAt,
       updatedAt: a.updatedAt,

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -75,6 +75,11 @@ Do **not** store sensitive information, including:
   final List<PresetMessage> presetMessages;
   // Regex replacement rules
   final List<AssistantRegex> regexRules;
+  // Proactive care ("Ta的来信")
+  final bool enableProactiveCare;
+  final DateTime? proactiveCareNextMessageAt;
+  final String proactiveCarePrompt;
+  final String proactiveCareDecisionPrompt;
   // File processing configuration (per assistant)
   // Values: 'extract' (parse locally / OCR), 'direct' (upload raw file), 'discard'
   final String docxMode;
@@ -113,6 +118,10 @@ Do **not** store sensitive information, including:
     this.memoryRecordPrompt = defaultMemoryRecordPrompt,
     this.presetMessages = const <PresetMessage>[],
     this.regexRules = const <AssistantRegex>[],
+    this.enableProactiveCare = false,
+    this.proactiveCareNextMessageAt,
+    this.proactiveCarePrompt = '',
+    this.proactiveCareDecisionPrompt = '',
     this.docxMode = 'extract',
     this.pdfMode = 'extract',
     this.otherOfficeMode = 'direct',
@@ -151,6 +160,11 @@ Do **not** store sensitive information, including:
     String? memoryRecordPrompt,
     List<PresetMessage>? presetMessages,
     List<AssistantRegex>? regexRules,
+    bool? enableProactiveCare,
+    DateTime? proactiveCareNextMessageAt,
+    String? proactiveCarePrompt,
+    String? proactiveCareDecisionPrompt,
+    bool clearProactiveCareNextMessageAt = false,
     String? docxMode,
     String? pdfMode,
     String? otherOfficeMode,
@@ -200,6 +214,13 @@ Do **not** store sensitive information, including:
       memoryRecordPrompt: memoryRecordPrompt ?? this.memoryRecordPrompt,
       presetMessages: presetMessages ?? this.presetMessages,
       regexRules: regexRules ?? this.regexRules,
+      enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
+      proactiveCareNextMessageAt: clearProactiveCareNextMessageAt
+          ? null
+          : (proactiveCareNextMessageAt ?? this.proactiveCareNextMessageAt),
+      proactiveCarePrompt: proactiveCarePrompt ?? this.proactiveCarePrompt,
+      proactiveCareDecisionPrompt:
+          proactiveCareDecisionPrompt ?? this.proactiveCareDecisionPrompt,
       docxMode: docxMode ?? this.docxMode,
       pdfMode: pdfMode ?? this.pdfMode,
       otherOfficeMode: otherOfficeMode ?? this.otherOfficeMode,
@@ -238,6 +259,10 @@ Do **not** store sensitive information, including:
     'memoryRecordPrompt': memoryRecordPrompt,
     'presetMessages': PresetMessage.encodeList(presetMessages),
     'regexRules': regexRules.map((e) => e.toJson()).toList(),
+    'enableProactiveCare': enableProactiveCare,
+    'proactiveCareNextMessageAt': proactiveCareNextMessageAt?.toIso8601String(),
+    'proactiveCarePrompt': proactiveCarePrompt,
+    'proactiveCareDecisionPrompt': proactiveCareDecisionPrompt,
     'docxMode': docxMode,
     'pdfMode': pdfMode,
     'otherOfficeMode': otherOfficeMode,
@@ -328,6 +353,15 @@ Do **not** store sensitive information, including:
       }
       return const <AssistantRegex>[];
     })(),
+    enableProactiveCare: json['enableProactiveCare'] as bool? ?? false,
+    proactiveCareNextMessageAt: (() {
+      final raw = json['proactiveCareNextMessageAt'];
+      if (raw is! String || raw.isEmpty) return null;
+      return DateTime.tryParse(raw);
+    })(),
+    proactiveCarePrompt: (json['proactiveCarePrompt'] as String?) ?? '',
+    proactiveCareDecisionPrompt:
+        (json['proactiveCareDecisionPrompt'] as String?) ?? '',
     docxMode: (json['docxMode'] as String?) ?? 'extract',
     pdfMode: (json['pdfMode'] as String?) ?? 'extract',
     otherOfficeMode: (json['otherOfficeMode'] as String?) ?? 'direct',

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -572,11 +572,11 @@ class AssistantProvider extends ChangeNotifier {
     final timeChanged =
         prev.proactiveCareNextMessageAt != next.proactiveCareNextMessageAt;
     if (!isEnabled && wasEnabled) {
-      ProactiveCareAlarmService.cancelAlarm(next.id);
+      ProactiveCareAlarmService.cancelFor(next.id);
     } else if (isEnabled && (!wasEnabled || timeChanged)) {
       final at = next.proactiveCareNextMessageAt;
       if (at != null) {
-        ProactiveCareAlarmService.scheduleAlarm(next.id, at);
+        ProactiveCareAlarmService.sync(next);
       }
     }
   }
@@ -614,7 +614,7 @@ class AssistantProvider extends ChangeNotifier {
     await chatService?.deleteConversationsForAssistant(id);
     // Cancel any pending proactive care alarm for this assistant.
     if (Platform.isAndroid && ProactiveCareAlarmService.isSupported) {
-      ProactiveCareAlarmService.cancelAlarm(id);
+      ProactiveCareAlarmService.cancelFor(id);
     }
 
     final removingCurrent = _assistants[idx].id == _currentAssistantId;

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -490,10 +490,10 @@ class AssistantProvider extends ChangeNotifier {
     final idx = _assistants.indexWhere((a) => a.id == updated.id);
     if (idx == -1) return;
 
+    final prev = _assistants[idx];
     var next = updated;
 
     try {
-      final prev = _assistants[idx];
       final raw = (updated.avatar ?? '').trim();
       final prevRaw = (prev.avatar ?? '').trim();
       final changed = raw != prevRaw;
@@ -561,7 +561,7 @@ class AssistantProvider extends ChangeNotifier {
     _assistants[idx] = next;
     await _persistSingle(next, sortOrder: idx);
     notifyListeners();
-    _syncProactiveCareAlarm(updated, next);
+    _syncProactiveCareAlarm(prev, next);
   }
 
   /// Schedule or cancel the proactive care alarm when relevant fields change.

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -17,7 +17,7 @@ import '../../utils/app_directories.dart';
 import '../services/proactive_care_alarm_service.dart';
 
 class AssistantProvider extends ChangeNotifier {
-  static const String assistantsPrefsKey = 'assistants_v1';
+  static const String _assistantsKey = 'assistants_v1';
   static const String _currentAssistantKey = 'current_assistant_id_v1';
   static const String _legacySearchEnabledKey = 'search_enabled_v1';
 
@@ -56,7 +56,7 @@ class AssistantProvider extends ChangeNotifier {
   Future<void> loadFromPrefs() async {
     if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(assistantsPrefsKey);
+    final raw = prefs.getString(_assistantsKey);
     if (raw != null && raw.isNotEmpty) {
       final legacySearchEnabled = prefs.getBool(_legacySearchEnabledKey);
       final migrated = _decodeAssistantsWithLegacySearch(
@@ -101,7 +101,7 @@ class AssistantProvider extends ChangeNotifier {
     SharedPreferences prefs,
     ChatDatabaseRepository? repo,
   ) async {
-    final raw = prefs.getString(assistantsPrefsKey);
+    final raw = prefs.getString(_assistantsKey);
     if (raw == null || raw.isEmpty) return;
 
     final legacySearchEnabled = prefs.getBool(_legacySearchEnabledKey);
@@ -148,11 +148,11 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       try {
         await repo.putAssistants(_assistants);
-        await prefs.remove(assistantsPrefsKey);
+        await prefs.remove(_assistantsKey);
         await prefs.remove(_legacySearchEnabledKey);
       } catch (_) {}
     } else if (changed) {
-      await prefs.setString(assistantsPrefsKey, Assistant.encodeList(_assistants));
+      await prefs.setString(_assistantsKey, Assistant.encodeList(_assistants));
     }
   }
 
@@ -352,10 +352,10 @@ class AssistantProvider extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     if (repo != null) {
       await repo.putAssistants(_assistants);
-      await prefs.remove(assistantsPrefsKey);
+      await prefs.remove(_assistantsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
-      await prefs.setString(assistantsPrefsKey, Assistant.encodeList(_assistants));
+      await prefs.setString(_assistantsKey, Assistant.encodeList(_assistants));
     }
   }
 
@@ -364,7 +364,7 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       await repo.putAssistant(a, sortOrder: sortOrder);
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(assistantsPrefsKey);
+      await prefs.remove(_assistantsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
       await _persist();
@@ -376,7 +376,7 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       await repo.deleteAssistant(id);
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(assistantsPrefsKey);
+      await prefs.remove(_assistantsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
       await _persist();

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -14,9 +14,10 @@ import '../models/preset_message.dart';
 import '../../l10n/app_localizations.dart';
 import '../../utils/avatar_cache.dart';
 import '../../utils/app_directories.dart';
+import '../services/proactive_care_alarm_service.dart';
 
 class AssistantProvider extends ChangeNotifier {
-  static const String _assistantsKey = 'assistants_v1';
+  static const String assistantsPrefsKey = 'assistants_v1';
   static const String _currentAssistantKey = 'current_assistant_id_v1';
   static const String _legacySearchEnabledKey = 'search_enabled_v1';
 
@@ -55,7 +56,7 @@ class AssistantProvider extends ChangeNotifier {
   Future<void> loadFromPrefs() async {
     if (_loaded) return;
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_assistantsKey);
+    final raw = prefs.getString(assistantsPrefsKey);
     if (raw != null && raw.isNotEmpty) {
       final legacySearchEnabled = prefs.getBool(_legacySearchEnabledKey);
       final migrated = _decodeAssistantsWithLegacySearch(
@@ -100,7 +101,7 @@ class AssistantProvider extends ChangeNotifier {
     SharedPreferences prefs,
     ChatDatabaseRepository? repo,
   ) async {
-    final raw = prefs.getString(_assistantsKey);
+    final raw = prefs.getString(assistantsPrefsKey);
     if (raw == null || raw.isEmpty) return;
 
     final legacySearchEnabled = prefs.getBool(_legacySearchEnabledKey);
@@ -147,11 +148,11 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       try {
         await repo.putAssistants(_assistants);
-        await prefs.remove(_assistantsKey);
+        await prefs.remove(assistantsPrefsKey);
         await prefs.remove(_legacySearchEnabledKey);
       } catch (_) {}
     } else if (changed) {
-      await prefs.setString(_assistantsKey, Assistant.encodeList(_assistants));
+      await prefs.setString(assistantsPrefsKey, Assistant.encodeList(_assistants));
     }
   }
 
@@ -351,10 +352,10 @@ class AssistantProvider extends ChangeNotifier {
     final prefs = await SharedPreferences.getInstance();
     if (repo != null) {
       await repo.putAssistants(_assistants);
-      await prefs.remove(_assistantsKey);
+      await prefs.remove(assistantsPrefsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
-      await prefs.setString(_assistantsKey, Assistant.encodeList(_assistants));
+      await prefs.setString(assistantsPrefsKey, Assistant.encodeList(_assistants));
     }
   }
 
@@ -363,7 +364,7 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       await repo.putAssistant(a, sortOrder: sortOrder);
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_assistantsKey);
+      await prefs.remove(assistantsPrefsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
       await _persist();
@@ -375,7 +376,7 @@ class AssistantProvider extends ChangeNotifier {
     if (repo != null) {
       await repo.deleteAssistant(id);
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_assistantsKey);
+      await prefs.remove(assistantsPrefsKey);
       await prefs.remove(_legacySearchEnabledKey);
     } else {
       await _persist();
@@ -560,6 +561,24 @@ class AssistantProvider extends ChangeNotifier {
     _assistants[idx] = next;
     await _persistSingle(next, sortOrder: idx);
     notifyListeners();
+    _syncProactiveCareAlarm(updated, next);
+  }
+
+  /// Schedule or cancel the proactive care alarm when relevant fields change.
+  void _syncProactiveCareAlarm(Assistant prev, Assistant next) {
+    if (!Platform.isAndroid || !ProactiveCareAlarmService.isSupported) return;
+    final wasEnabled = prev.enableProactiveCare;
+    final isEnabled = next.enableProactiveCare;
+    final timeChanged =
+        prev.proactiveCareNextMessageAt != next.proactiveCareNextMessageAt;
+    if (!isEnabled && wasEnabled) {
+      ProactiveCareAlarmService.cancelAlarm(next.id);
+    } else if (isEnabled && (!wasEnabled || timeChanged)) {
+      final at = next.proactiveCareNextMessageAt;
+      if (at != null) {
+        ProactiveCareAlarmService.scheduleAlarm(next.id, at);
+      }
+    }
   }
 
   Future<void> setSearchEnabledForCurrentAssistant(bool enabled) async {
@@ -593,6 +612,10 @@ class AssistantProvider extends ChangeNotifier {
     if (_assistants.length <= 1) return false;
 
     await chatService?.deleteConversationsForAssistant(id);
+    // Cancel any pending proactive care alarm for this assistant.
+    if (Platform.isAndroid && ProactiveCareAlarmService.isSupported) {
+      ProactiveCareAlarmService.cancelAlarm(id);
+    }
 
     final removingCurrent = _assistants[idx].id == _currentAssistantId;
     _assistants.removeAt(idx);

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -100,6 +100,7 @@ class SettingsProvider extends ChangeNotifier {
   static const String _suggestionInsertOnTapOnlyKey =
       'suggestion_insert_on_tap_only_v1';
   static const String _compressModelKey = 'compress_model_v1';
+  static const String _proactiveCareDecisionModelKey = 'proactive_care_decision_model_v1';
   static const String _compressPromptKey = 'compress_prompt_v1';
   static const String _themePaletteKey = 'theme_palette_v1';
   static const String _useDynamicColorKey = 'use_dynamic_color_v1';
@@ -907,6 +908,17 @@ class SettingsProvider extends ChangeNotifier {
     _compressPrompt = (compressp == null || compressp.trim().isEmpty)
         ? defaultCompressPrompt
         : compressp;
+    // load proactive care decision model
+    final proactiveCareDecisionSel =
+        prefs.getString(_proactiveCareDecisionModelKey);
+    if (proactiveCareDecisionSel != null &&
+        proactiveCareDecisionSel.contains('::')) {
+      final parts = proactiveCareDecisionSel.split('::');
+      if (parts.length >= 2) {
+        _proactiveCareDecisionModelProvider = parts[0];
+        _proactiveCareDecisionModelId = parts.sublist(1).join('::');
+      }
+    }
     // learning mode
     _learningModeEnabled = prefs.getBool(_learningModeEnabledKey) ?? false;
     final lmp = prefs.getString(_learningModePromptKey);
@@ -2679,6 +2691,12 @@ class SettingsProvider extends ChangeNotifier {
       await prefs.remove(_compressModelKey);
       changed = true;
     }
+    if (_proactiveCareDecisionModelProvider == providerKey) {
+      _proactiveCareDecisionModelProvider = null;
+      _proactiveCareDecisionModelId = null;
+      await prefs.remove(_proactiveCareDecisionModelKey);
+      changed = true;
+    }
     if (changed) notifyListeners();
   }
 
@@ -2734,6 +2752,13 @@ class SettingsProvider extends ChangeNotifier {
       _compressModelProvider = null;
       _compressModelId = null;
       await prefs.remove(_compressModelKey);
+      changed = true;
+    }
+    if (_proactiveCareDecisionModelProvider == providerKey &&
+        _proactiveCareDecisionModelId == modelId) {
+      _proactiveCareDecisionModelProvider = null;
+      _proactiveCareDecisionModelId = null;
+      await prefs.remove(_proactiveCareDecisionModelKey);
       changed = true;
     }
     // Also remove from pinned if applicable
@@ -2793,6 +2818,11 @@ class SettingsProvider extends ChangeNotifier {
       _compressModelProvider = null;
       _compressModelId = null;
       await prefs.remove(_compressModelKey);
+    }
+    if (_proactiveCareDecisionModelProvider == key) {
+      _proactiveCareDecisionModelProvider = null;
+      _proactiveCareDecisionModelId = null;
+      await prefs.remove(_proactiveCareDecisionModelKey);
     }
 
     // Remove pinned models for this provider
@@ -3220,6 +3250,43 @@ Requirements:
 
   Future<void> resetCompressPrompt() async =>
       setCompressPrompt(defaultCompressPrompt);
+
+  // ============================================================================
+  // Proactive Care Decision Model
+  // ============================================================================
+
+  String? _proactiveCareDecisionModelProvider;
+  String? _proactiveCareDecisionModelId;
+  String? get proactiveCareDecisionModelProvider =>
+      _proactiveCareDecisionModelProvider;
+  String? get proactiveCareDecisionModelId => _proactiveCareDecisionModelId;
+  String? get proactiveCareDecisionModelKey =>
+      (_proactiveCareDecisionModelProvider != null &&
+          _proactiveCareDecisionModelId != null)
+      ? '${_proactiveCareDecisionModelProvider!}::${_proactiveCareDecisionModelId!}'
+      : null;
+
+  Future<void> setProactiveCareDecisionModel(
+    String providerKey,
+    String modelId,
+  ) async {
+    _proactiveCareDecisionModelProvider = providerKey;
+    _proactiveCareDecisionModelId = modelId;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _proactiveCareDecisionModelKey,
+      '$providerKey::$modelId',
+    );
+  }
+
+  Future<void> resetProactiveCareDecisionModel() async {
+    _proactiveCareDecisionModelProvider = null;
+    _proactiveCareDecisionModelId = null;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_proactiveCareDecisionModelKey);
+  }
 
   // Learning Mode
   bool _learningModeEnabled = false;
@@ -4219,6 +4286,9 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     copy._compressModelProvider = _compressModelProvider;
     copy._compressModelId = _compressModelId;
     copy._compressPrompt = _compressPrompt;
+    copy._proactiveCareDecisionModelProvider =
+        _proactiveCareDecisionModelProvider;
+    copy._proactiveCareDecisionModelId = _proactiveCareDecisionModelId;
     copy._translateModelProvider = _translateModelProvider;
     copy._translateModelId = _translateModelId;
     copy._translatePrompt = _translatePrompt;

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -6,12 +6,20 @@ class NotificationService {
       FlutterLocalNotificationsPlugin();
   static bool _inited = false;
   static const AndroidNotificationChannel _channel = AndroidNotificationChannel(
-    'kelivo_bg_chat_v2',
+    'cuplivo_bg_chat_v2',
     'Chat Background',
     description: 'Notifications for chat generation status',
     importance: Importance.high,
     playSound: true,
   );
+  static const AndroidNotificationChannel _proactiveCareChannel =
+      AndroidNotificationChannel(
+        'cuplivo_proactive_care',
+        'Proactive Care',
+        description: 'Proactive care messages from assistants',
+        importance: Importance.high,
+        playSound: true,
+      );
 
   static Future<void> ensureInitialized() async {
     if (!Platform.isAndroid) return;
@@ -25,14 +33,14 @@ class NotificationService {
     );
     await _plugin.initialize(init);
 
-    // Create channel
+    // Create channels
     final android = _plugin
         .resolvePlatformSpecificImplementation<
           AndroidFlutterLocalNotificationsPlugin
         >();
     if (android != null) {
       await android.createNotificationChannel(_channel);
-      // Runtime notification permission (Android 13+) should be requested by app UI if needed
+      await android.createNotificationChannel(_proactiveCareChannel);
     }
     _inited = true;
   }
@@ -57,6 +65,46 @@ class NotificationService {
     }
   }
 
+  /// Shows a proactive care notification on behalf of an assistant.
+  ///
+  /// [id] should be stable per assistant (e.g. derived from the assistant id)
+  /// so a newer notification replaces the previous one instead of piling up.
+  /// [title] is the assistant name, [body] the message text (the LLM reply),
+  /// and [largeIconPath] an optional local image file shown as the
+  /// notification's large icon.
+  static Future<void> showProactiveCare({
+    required int id,
+    required String title,
+    required String body,
+    String? largeIconPath,
+  }) async {
+    if (!Platform.isAndroid) return;
+    await ensureInitialized();
+    await _plugin.show(
+      id,
+      title,
+      body,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          _proactiveCareChannel.id,
+          _proactiveCareChannel.name,
+          channelDescription: _proactiveCareChannel.description,
+          importance: Importance.max,
+          priority: Priority.max,
+          playSound: true,
+          enableVibration: true,
+          category: AndroidNotificationCategory.message,
+          visibility: NotificationVisibility.public,
+          ticker: 'Cuplivo',
+          largeIcon: largeIconPath == null
+              ? null
+              : FilePathAndroidBitmap(largeIconPath),
+          styleInformation: BigTextStyleInformation(body),
+        ),
+      ),
+    );
+  }
+
   static Future<void> showChatCompleted({String? title, String? body}) async {
     if (!Platform.isAndroid) return;
     await ensureInitialized();
@@ -75,7 +123,7 @@ class NotificationService {
           enableVibration: true,
           category: AndroidNotificationCategory.message,
           visibility: NotificationVisibility.public,
-          ticker: 'Kelivo',
+          ticker: 'Cuplivo',
           styleInformation: const DefaultStyleInformation(true, true),
         ),
       ),

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -46,7 +46,7 @@ Future<void> proactiveCareAlarmCallback(
   // pipeline.
   if (_forwardToMainIsolate(assistantId)) return;
 
-  final assistant = await ProactiveCareMessageFlow.loadAssistantFromPrefs(
+  final assistant = await ProactiveCareMessageFlow.loadAssistantFromDb(
     assistantId,
   );
   if (assistant == null) {
@@ -167,7 +167,7 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
         );
         if (newTime != null) {
           final persisted =
-              await ProactiveCareMessageFlow.updateAssistantNextCareTimeInPrefs(
+              await ProactiveCareMessageFlow.updateAssistantNextCareTimeInDb(
                 assistant.id,
                 newTime,
               );

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -96,6 +96,9 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
     // running: re-check the main port right before touching the database.
     if (_forwardToMainIsolate(assistant.id)) return;
 
+    final fallbackThinkingBudget =
+        await ProactiveCareMessageFlow.loadThinkingBudgetFromPrefs();
+
     final recent =
         await ProactiveCareHeadlessChatStore.loadRecentConversationFor(
           assistant.id,
@@ -124,6 +127,7 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
       modelId: modelCfg.modelId,
       assistant: assistant,
       apiMessages: apiMessages,
+      fallbackThinkingBudget: fallbackThinkingBudget,
     );
     if (reply.isEmpty) {
       throw StateError('model returned an empty proactive care reply');
@@ -164,6 +168,7 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
             {'role': 'assistant', 'content': reply},
           ],
           decisionPrompt: decisionPrompt,
+          fallbackThinkingBudget: fallbackThinkingBudget,
         );
         if (newTime != null) {
           final persisted =

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -1,0 +1,418 @@
+import 'dart:io' show File, Platform;
+import 'dart:math' as math;
+import 'dart:ui' show IsolateNameServer;
+
+import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
+import 'package:image/image.dart' as img;
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../utils/app_directories.dart';
+import '../../utils/avatar_cache.dart';
+import '../../utils/sandbox_path_resolver.dart';
+import '../models/assistant.dart';
+import 'logging/flutter_logger.dart';
+import 'notification_service.dart';
+import 'proactive_care_message_flow.dart';
+
+/// Name of the main-isolate port that handles proactive care triggers while
+/// the app process is alive. Registered by HomePageController on Android;
+/// the alarm background isolate forwards the assistantId to it.
+const String proactiveCareMainPortName = 'cuplivo_proactive_care_main_port';
+
+// User-visible only in the first-run edge where no l10n snapshot was saved
+// yet (the snapshot is written on every app start, before any alarm can be
+// scheduled through the UI).
+const String _failureBodyFallback =
+    'Failed to generate the proactive care message. Open Cuplivo for details.';
+const String _conversationTitleFallback = 'New Chat';
+
+/// Background entrypoint invoked by android_alarm_manager_plus when a
+/// proactive care alarm fires. It runs in a dedicated background isolate and
+/// wakes the app whether it is in foreground, background, or killed.
+@pragma('vm:entry-point')
+Future<void> proactiveCareAlarmCallback(
+  int id,
+  Map<String, dynamic> params,
+) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final assistantId = params['assistantId'] as String?;
+  debugPrint('[ProactiveCare] Alarm fired (id=$id, assistantId=$assistantId)');
+  if (assistantId == null || assistantId.isEmpty) return;
+
+  // App alive (foreground or background): the main isolate owns the database
+  // and the provider stack, so hand the trigger over and let it run the full
+  // pipeline.
+  if (_forwardToMainIsolate(assistantId)) return;
+
+  final assistant = await ProactiveCareMessageFlow.loadAssistantFromPrefs(
+    assistantId,
+  );
+  if (assistant == null) {
+    debugPrint('[ProactiveCare] Assistant $assistantId not found, skipping');
+    return;
+  }
+  // The alarm and the toggle live in different processes, so a stale alarm
+  // may still fire after the feature was switched off. Re-check here.
+  if (!assistant.enableProactiveCare) {
+    debugPrint(
+      '[ProactiveCare] Proactive care disabled for $assistantId, skipping',
+    );
+    return;
+  }
+
+  await _runHeadlessCareFlow(assistant, id);
+}
+
+bool _forwardToMainIsolate(String assistantId) {
+  final port = IsolateNameServer.lookupPortByName(proactiveCareMainPortName);
+  if (port == null) return false;
+  debugPrint('[ProactiveCare] App alive, forwarding $assistantId to main');
+  port.send(assistantId);
+  return true;
+}
+
+/// Killed-process path: builds the full context from SharedPreferences and
+/// SQLite, requests the care reply, appends it to the assistant's most recent
+/// conversation, shows the notification, and asks the model for the next
+/// care time to re-schedule the alarm.
+Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
+  final snapshot = await ProactiveCareL10nSnapshot.load();
+  final failureBody = (snapshot?.failureNotificationBody.isNotEmpty ?? false)
+      ? snapshot!.failureNotificationBody
+      : _failureBodyFallback;
+
+  String body;
+  try {
+    final modelCfg = await ProactiveCareMessageFlow.loadModelConfigFromPrefs(
+      assistant,
+    );
+    if (modelCfg == null) {
+      throw StateError('no chat model configured');
+    }
+
+    // Narrow the race where the user launches the app while this isolate is
+    // running: re-check the main port right before touching the database.
+    if (_forwardToMainIsolate(assistant.id)) return;
+
+    final recent =
+        await ProactiveCareHeadlessChatStore.loadRecentConversationFor(
+          assistant.id,
+        );
+    final history = recent.conversation == null
+        ? const <Map<String, dynamic>>[]
+        : ProactiveCareMessageFlow.buildHistory(
+            conversation: recent.conversation!,
+            messages: recent.messages,
+          );
+
+    final carePrompt = assistant.proactiveCarePrompt.trim().isNotEmpty
+        ? assistant.proactiveCarePrompt
+        : (snapshot?.carePromptDefault ?? '');
+    final apiMessages = await ProactiveCareMessageFlow.buildCareApiMessages(
+      assistant: assistant,
+      userNickname: await ProactiveCareMessageFlow.loadUserNicknameFromPrefs(),
+      modelId: modelCfg.modelId,
+      history: history,
+      carePrompt: carePrompt,
+      now: DateTime.now(),
+    );
+
+    final reply = await ProactiveCareMessageFlow.requestCareReply(
+      config: modelCfg.config,
+      modelId: modelCfg.modelId,
+      assistant: assistant,
+      apiMessages: apiMessages,
+    );
+    if (reply.isEmpty) {
+      throw StateError('model returned an empty proactive care reply');
+    }
+
+    await ProactiveCareHeadlessChatStore.appendAssistantReply(
+      assistantId: assistant.id,
+      conversation: recent.conversation,
+      content: reply,
+      fallbackTitle: (snapshot?.defaultConversationTitle.isNotEmpty ?? false)
+          ? snapshot!.defaultConversationTitle
+          : _conversationTitleFallback,
+      modelId: modelCfg.modelId,
+      providerId: modelCfg.providerKey,
+    );
+    body = reply;
+
+    // Ask the decision model for the next care time (continuous care). A
+    // failure here must not hide the reply that was already produced.
+    try {
+      final decisionCfg =
+          await ProactiveCareMessageFlow.loadDecisionModelConfigFromPrefs(
+            assistant,
+          );
+      if (decisionCfg != null) {
+        final decisionPrompt =
+            assistant.proactiveCareDecisionPrompt.trim().isNotEmpty
+            ? assistant.proactiveCareDecisionPrompt
+            : (snapshot?.decisionPromptDefault ?? '');
+        final newTime = await ProactiveCareMessageFlow.decideNextCareTime(
+          config: decisionCfg.config,
+          modelId: decisionCfg.modelId,
+          assistant: assistant,
+          userNickname:
+              await ProactiveCareMessageFlow.loadUserNicknameFromPrefs(),
+          history: <Map<String, dynamic>>[
+            ...history,
+            {'role': 'assistant', 'content': reply},
+          ],
+          decisionPrompt: decisionPrompt,
+        );
+        if (newTime != null) {
+          final persisted =
+              await ProactiveCareMessageFlow.updateAssistantNextCareTimeInPrefs(
+                assistant.id,
+                newTime,
+              );
+          if (persisted) {
+            await ProactiveCareAlarmService.initialize();
+            await ProactiveCareAlarmService.sync(
+              assistant.copyWith(proactiveCareNextMessageAt: newTime),
+            );
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[ProactiveCare] Next-time decision failed: $e');
+    }
+  } catch (e) {
+    debugPrint('[ProactiveCare] Headless care flow failed: $e');
+    body = failureBody;
+  } finally {
+    await ProactiveCareHeadlessChatStore.close();
+  }
+
+  final iconPath = await resolveProactiveCareNotificationIconPath(
+    assistant,
+    alarmId,
+  );
+  try {
+    await NotificationService.showProactiveCare(
+      id: alarmId,
+      title: assistant.name,
+      body: body,
+      largeIconPath: iconPath,
+    );
+    debugPrint(
+      '[ProactiveCare] Notification shown for ${assistant.id} '
+      '(icon=${iconPath ?? 'none'})',
+    );
+  } catch (e) {
+    debugPrint('[ProactiveCare] Failed to show notification: $e');
+  }
+}
+
+/// Resolves the assistant avatar to a local PNG usable as the notification
+/// large icon. Returns null for emoji/initial avatars or on failure (the
+/// notification then falls back to the app's default icon).
+Future<String?> resolveProactiveCareNotificationIconPath(
+  Assistant assistant,
+  int alarmId,
+) async {
+  final avatar = assistant.avatar?.trim() ?? '';
+  if (avatar.isEmpty) return null;
+
+  String? sourcePath;
+  try {
+    if (avatar.startsWith('http://') || avatar.startsWith('https://')) {
+      sourcePath = await AvatarCache.getPath(avatar);
+    } else if (avatar.startsWith('/') || avatar.contains(':')) {
+      await SandboxPathResolver.init();
+      final fixed = SandboxPathResolver.fix(avatar);
+      if (File(fixed).existsSync()) sourcePath = fixed;
+    } else {
+      // Emoji or initial-letter avatar: no bitmap to show.
+      return null;
+    }
+  } catch (e) {
+    debugPrint('[ProactiveCare] Avatar resolve failed: $e');
+    return null;
+  }
+  if (sourcePath == null) {
+    debugPrint('[ProactiveCare] Avatar file unavailable for $avatar');
+    return null;
+  }
+
+  try {
+    final bytes = await File(sourcePath).readAsBytes();
+    final png = cropAvatarForNotification(bytes);
+    if (png == null) {
+      debugPrint('[ProactiveCare] Avatar decode failed for $sourcePath');
+      return null;
+    }
+    final dir = await AppDirectories.getCacheDirectory();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    final out = File('${dir.path}/proactive_care_icon_$alarmId.png');
+    await out.writeAsBytes(png, flush: true);
+    return out.path;
+  } catch (e) {
+    debugPrint('[ProactiveCare] Avatar crop failed: $e');
+    return null;
+  }
+}
+
+/// Center-crops [bytes] to a square (no stretching), resizes it down to at
+/// most [maxSize] px, applies a circular mask, and returns the PNG bytes.
+/// Returns null when the input cannot be decoded as an image.
+@visibleForTesting
+Uint8List? cropAvatarForNotification(Uint8List bytes, {int maxSize = 256}) {
+  img.Image? decoded;
+  try {
+    decoded = img.decodeImage(bytes);
+  } catch (_) {
+    return null;
+  }
+  if (decoded == null) return null;
+  final side = math.min(decoded.width, decoded.height);
+  var square = img.copyCrop(
+    decoded,
+    x: (decoded.width - side) ~/ 2,
+    y: (decoded.height - side) ~/ 2,
+    width: side,
+    height: side,
+  );
+  if (side > maxSize) {
+    square = img.copyResize(
+      square,
+      width: maxSize,
+      height: maxSize,
+      interpolation: img.Interpolation.average,
+    );
+  }
+  final circled = img.copyCropCircle(square.convert(numChannels: 4));
+  return img.encodePng(circled);
+}
+
+/// Result of the proactive care permission check on Android.
+typedef ProactiveCarePermissions = ({bool exactAlarm, bool notifications});
+
+/// Schedules Android exact alarms ("setExactAndAllowWhileIdle") that wake the
+/// app when an assistant's proactive care time arrives.
+///
+/// All methods are no-ops on non-Android platforms.
+class ProactiveCareAlarmService {
+  const ProactiveCareAlarmService._();
+
+  static const String _logTag = 'ProactiveCareAlarm';
+
+  /// Whether proactive care (exact alarms + wake-up) is available on this device.
+  static bool get isSupported => !kIsWeb && Platform.isAndroid;
+
+  static bool get _isAndroid => isSupported;
+
+  /// Starts the AlarmManager service. Must be called once before scheduling
+  /// alarms (done in `main()` before `runApp`).
+  static Future<void> initialize() async {
+    if (!_isAndroid) return;
+    try {
+      final ok = await AndroidAlarmManager.initialize();
+      if (!ok) {
+        FlutterLogger.log(
+          'AndroidAlarmManager.initialize returned false',
+          tag: _logTag,
+        );
+      }
+    } catch (e) {
+      FlutterLogger.log('AlarmManager initialize failed: $e', tag: _logTag);
+    }
+  }
+
+  /// Derives a stable 31-bit positive alarm id from [assistantId] using
+  /// FNV-1a. `String.hashCode` is not guaranteed to be stable across runs,
+  /// while the id must stay identical to cancel/replace a pending alarm.
+  static int alarmIdFor(String assistantId) {
+    const int fnvPrime = 0x01000193;
+    int hash = 0x811c9dc5; // FNV offset basis
+    for (final unit in assistantId.codeUnits) {
+      hash ^= unit;
+      hash = (hash * fnvPrime) & 0xFFFFFFFF;
+    }
+    return hash & 0x7FFFFFFF;
+  }
+
+  /// Schedules or cancels the exact alarm so it matches the assistant's
+  /// proactive care settings.
+  static Future<void> sync(Assistant assistant) async {
+    if (!_isAndroid) return;
+    final at = assistant.proactiveCareNextMessageAt;
+    final id = alarmIdFor(assistant.id);
+    try {
+      if (!assistant.enableProactiveCare ||
+          at == null ||
+          !at.isAfter(DateTime.now())) {
+        await AndroidAlarmManager.cancel(id);
+        return;
+      }
+      final ok = await AndroidAlarmManager.oneShotAt(
+        at,
+        id,
+        proactiveCareAlarmCallback,
+        exact: true,
+        wakeup: true,
+        allowWhileIdle: true,
+        rescheduleOnReboot: true,
+        params: <String, dynamic>{'assistantId': assistant.id},
+      );
+      FlutterLogger.log(
+        'Alarm ${ok ? 'scheduled' : 'schedule FAILED'} for assistant '
+        '${assistant.id} at ${at.toIso8601String()} (id=$id)',
+        tag: _logTag,
+      );
+    } catch (e) {
+      FlutterLogger.log(
+        'Alarm sync failed for assistant ${assistant.id}: $e',
+        tag: _logTag,
+      );
+    }
+  }
+
+  /// Cancels the pending alarm for [assistantId], if any.
+  static Future<void> cancelFor(String assistantId) async {
+    if (!_isAndroid) return;
+    try {
+      await AndroidAlarmManager.cancel(alarmIdFor(assistantId));
+    } catch (e) {
+      FlutterLogger.log(
+        'Alarm cancel failed for assistant $assistantId: $e',
+        tag: _logTag,
+      );
+    }
+  }
+
+  /// Ensures the exact alarm permission (Android 12+) and the notification
+  /// permission (Android 13+) are granted, requesting them when missing.
+  /// Requesting the exact alarm permission opens the system
+  /// "Alarms & reminders" settings page.
+  static Future<ProactiveCarePermissions> ensurePermissions() async {
+    if (!_isAndroid) return (exactAlarm: true, notifications: true);
+
+    bool exactAlarm;
+    try {
+      var status = await Permission.scheduleExactAlarm.status;
+      if (!status.isGranted) {
+        status = await Permission.scheduleExactAlarm.request();
+      }
+      exactAlarm = status.isGranted;
+    } catch (e) {
+      FlutterLogger.log(
+        'Exact alarm permission request failed: $e',
+        tag: _logTag,
+      );
+      exactAlarm = false;
+    }
+
+    final notifications =
+        await NotificationService.ensureAndroidNotificationsPermission();
+
+    return (exactAlarm: exactAlarm, notifications: notifications);
+  }
+}

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -388,6 +388,23 @@ class ProactiveCareAlarmService {
     }
   }
 
+  /// Re-schedules alarms for all assistants that have proactive care enabled
+  /// and a future [proactiveCareNextMessageAt]. Call this on app startup to
+  /// recover alarms lost after force-stop or process death.
+  static Future<void> rescheduleAll(List<Assistant> assistants) async {
+    if (!_isAndroid) return;
+    for (final a in assistants) {
+      if (!a.enableProactiveCare) continue;
+      final at = a.proactiveCareNextMessageAt;
+      if (at == null || !at.isAfter(DateTime.now())) continue;
+      try {
+        await sync(a);
+      } catch (e) {
+        FlutterLogger.log('rescheduleAll failed for ${a.id}: $e', tag: _logTag);
+      }
+    }
+  }
+
   /// Ensures the exact alarm permission (Android 12+) and the notification
   /// permission (Android 13+) are granted, requesting them when missing.
   /// Requesting the exact alarm permission opens the system

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -1,0 +1,692 @@
+import 'dart:convert';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+import '../../utils/app_directories.dart';
+import '../models/assistant.dart';
+import '../models/chat_message.dart';
+import '../models/conversation.dart';
+import '../providers/assistant_provider.dart';
+import '../providers/settings_provider.dart';
+import 'api/chat_api_service.dart';
+import 'chat/prompt_transformer.dart';
+import 'instruction_injection_store.dart';
+import 'logging/flutter_logger.dart';
+import 'memory_store.dart';
+import 'proactive_care_service.dart';
+
+const String _logTag = 'ProactiveCareFlow';
+
+/// Snapshot of localized strings needed by the proactive care background
+/// isolate, which has no BuildContext / AppLocalizations. The main isolate
+/// saves it on every app start (see main.dart), so by the time an alarm can
+/// fire the snapshot reflects the user's UI language.
+class ProactiveCareL10nSnapshot {
+  const ProactiveCareL10nSnapshot({
+    required this.defaultConversationTitle,
+    required this.carePromptDefault,
+    required this.decisionPromptDefault,
+    required this.failureNotificationBody,
+  });
+
+  static const String _prefsKey = 'proactive_care_l10n_v1';
+
+  final String defaultConversationTitle;
+  final String carePromptDefault;
+  final String decisionPromptDefault;
+  final String failureNotificationBody;
+
+  static Future<void> save({
+    required String defaultConversationTitle,
+    required String carePromptDefault,
+    required String decisionPromptDefault,
+    required String failureNotificationBody,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode(<String, String>{
+        'defaultConversationTitle': defaultConversationTitle,
+        'carePromptDefault': carePromptDefault,
+        'decisionPromptDefault': decisionPromptDefault,
+        'failureNotificationBody': failureNotificationBody,
+      }),
+    );
+  }
+
+  static Future<ProactiveCareL10nSnapshot?> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      if (raw == null || raw.isEmpty) return null;
+      final map = (jsonDecode(raw) as Map).cast<String, dynamic>();
+      return ProactiveCareL10nSnapshot(
+        defaultConversationTitle:
+            (map['defaultConversationTitle'] as String?) ?? '',
+        carePromptDefault: (map['carePromptDefault'] as String?) ?? '',
+        decisionPromptDefault: (map['decisionPromptDefault'] as String?) ?? '',
+        failureNotificationBody:
+            (map['failureNotificationBody'] as String?) ?? '',
+      );
+    } catch (e) {
+      FlutterLogger.log('L10n snapshot load failed: $e', tag: _logTag);
+      return null;
+    }
+  }
+}
+
+/// Resolved provider/model for a proactive care request.
+class ProactiveCareModelConfig {
+  const ProactiveCareModelConfig({
+    required this.config,
+    required this.providerKey,
+    required this.modelId,
+  });
+
+  final ProviderConfig config;
+  final String providerKey;
+  final String modelId;
+}
+
+/// Shared logic for the proactive care message ("Ta的来信") sent when the
+/// scheduled care time arrives.
+///
+/// Everything here is headless (no BuildContext): the same code path runs in
+/// the main isolate (app alive) and in the alarm background isolate (app
+/// killed). Only data loading and persistence differ between the two paths:
+/// the main isolate uses providers + ChatService, the background isolate uses
+/// SharedPreferences + [ProactiveCareHeadlessChatStore].
+class ProactiveCareMessageFlow {
+  const ProactiveCareMessageFlow._();
+
+  // SharedPreferences keys owned by other classes that keep them private.
+  // They are stable v1 keys; keep in sync with SettingsProvider.
+  static const String _selectedModelPrefsKey = 'selected_model_v1';
+  static const String _providerConfigsPrefsKey = 'provider_configs_v1';
+  // Keep in sync with UserProvider.
+  static const String _userNamePrefsKey = 'user_name';
+
+  /// Loads [assistantId] from the persisted assistant list (background path).
+  static Future<Assistant?> loadAssistantFromPrefs(String assistantId) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(AssistantProvider.assistantsPrefsKey);
+      if (raw == null || raw.isEmpty) return null;
+      for (final a in Assistant.decodeList(raw)) {
+        if (a.id == assistantId) return a;
+      }
+    } catch (e) {
+      FlutterLogger.log('Load assistant failed: $e', tag: _logTag);
+    }
+    return null;
+  }
+
+  /// Persists a new next-care time for [assistantId] (background path; the
+  /// app process is dead, so there is no concurrent writer).
+  static Future<bool> updateAssistantNextCareTimeInPrefs(
+    String assistantId,
+    DateTime nextCareTime,
+  ) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(AssistantProvider.assistantsPrefsKey);
+      if (raw == null || raw.isEmpty) return false;
+      final assistants = Assistant.decodeList(raw);
+      final idx = assistants.indexWhere((a) => a.id == assistantId);
+      if (idx == -1) return false;
+      assistants[idx] = assistants[idx].copyWith(
+        proactiveCareNextMessageAt: nextCareTime,
+      );
+      await prefs.setString(
+        AssistantProvider.assistantsPrefsKey,
+        Assistant.encodeList(assistants),
+      );
+      return true;
+    } catch (e) {
+      FlutterLogger.log('Persist next care time failed: $e', tag: _logTag);
+      return false;
+    }
+  }
+
+  /// Resolves the chat model for [assistant] from SharedPreferences:
+  /// assistant-specific model first, then the globally selected model
+  /// (mirrors the decision flow in HomeViewModel).
+  static Future<ProactiveCareModelConfig?> loadModelConfigFromPrefs(
+    Assistant assistant,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    String? provKey = assistant.chatModelProvider;
+    String? modelId = assistant.chatModelId;
+    if (provKey == null || modelId == null) {
+      final sel = prefs.getString(_selectedModelPrefsKey);
+      if (sel != null && sel.contains('::')) {
+        final parts = sel.split('::');
+        if (parts.length >= 2) {
+          provKey ??= parts[0];
+          modelId ??= parts.sublist(1).join('::');
+        }
+      }
+    }
+    if (provKey == null || modelId == null) return null;
+
+    ProviderConfig? cfg;
+    try {
+      final cfgStr = prefs.getString(_providerConfigsPrefsKey);
+      if (cfgStr != null && cfgStr.isNotEmpty) {
+        final raw = jsonDecode(cfgStr) as Map<String, dynamic>;
+        final entry = raw[provKey];
+        if (entry is Map) {
+          cfg = ProviderConfig.fromJson(entry.cast<String, dynamic>());
+        }
+      }
+    } catch (e) {
+      FlutterLogger.log('Provider configs decode failed: $e', tag: _logTag);
+    }
+    cfg ??= ProviderConfig.defaultsFor(provKey);
+    return ProactiveCareModelConfig(
+      config: cfg,
+      providerKey: provKey,
+      modelId: modelId,
+    );
+  }
+
+  /// Resolves the proactive care decision model from SharedPreferences.
+  /// Falls back to the chat model if no dedicated decision model is set.
+  static Future<ProactiveCareModelConfig?> loadDecisionModelConfigFromPrefs(
+    Assistant assistant,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    final sel = prefs.getString('proactive_care_decision_model_v1');
+    if (sel != null && sel.contains('::')) {
+      final parts = sel.split('::');
+      if (parts.length >= 2) {
+        final provKey = parts[0];
+        final modelId = parts.sublist(1).join('::');
+        ProviderConfig? cfg;
+        try {
+          final cfgStr = prefs.getString(_providerConfigsPrefsKey);
+          if (cfgStr != null && cfgStr.isNotEmpty) {
+            final raw = jsonDecode(cfgStr) as Map<String, dynamic>;
+            final entry = raw[provKey];
+            if (entry is Map) {
+              cfg = ProviderConfig.fromJson(entry.cast<String, dynamic>());
+            }
+          }
+        } catch (_) {}
+        cfg ??= ProviderConfig.defaultsFor(provKey);
+        return ProactiveCareModelConfig(
+          config: cfg,
+          providerKey: provKey,
+          modelId: modelId,
+        );
+      }
+    }
+    // Fallback to chat model
+    return loadModelConfigFromPrefs(assistant);
+  }
+
+  /// Loads the user nickname for system prompt placeholders (background
+  /// path). 'User' mirrors UserProvider's built-in default.
+  static Future<String> loadUserNicknameFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final n = prefs.getString(_userNamePrefsKey);
+      if (n != null && n.isNotEmpty) return n;
+    } catch (_) {}
+    return 'User';
+  }
+
+  /// Collapses message versions, keeping the selected (or latest) version per
+  /// group. Same semantics as MessageBuilderService.collapseVersions.
+  @visibleForTesting
+  static List<ChatMessage> collapseMessageVersions(
+    List<ChatMessage> items,
+    Map<String, int> versionSelections,
+  ) {
+    final Map<String, List<ChatMessage>> byGroup =
+        <String, List<ChatMessage>>{};
+    final List<String> order = <String>[];
+
+    for (final m in items) {
+      final gid = (m.groupId ?? m.id);
+      final list = byGroup.putIfAbsent(gid, () {
+        order.add(gid);
+        return <ChatMessage>[];
+      });
+      list.add(m);
+    }
+
+    for (final e in byGroup.entries) {
+      e.value.sort((a, b) => a.version.compareTo(b.version));
+    }
+
+    final out = <ChatMessage>[];
+    for (final gid in order) {
+      final vers = byGroup[gid]!;
+      final sel = versionSelections[gid];
+      final idx = (sel != null && sel >= 0 && sel < vers.length)
+          ? sel
+          : (vers.length - 1);
+      out.add(vers[idx]);
+    }
+    return out;
+  }
+
+  /// Builds the plain-text LLM history for [conversation]: collapsed
+  /// versions, truncateIndex applied, only completed non-empty user/assistant
+  /// turns (mirrors the decision flow in HomeViewModel).
+  static List<Map<String, dynamic>> buildHistory({
+    required Conversation conversation,
+    required List<ChatMessage> messages,
+  }) {
+    final collapsed = collapseMessageVersions(
+      messages,
+      conversation.versionSelections,
+    );
+    final tIndex = conversation.truncateIndex;
+    final effective = (tIndex >= 0 && tIndex <= collapsed.length)
+        ? collapsed.sublist(tIndex)
+        : collapsed;
+    return <Map<String, dynamic>>[
+      for (final m in effective)
+        if ((m.role == 'user' || m.role == 'assistant') &&
+            !m.isStreaming &&
+            m.content.trim().isNotEmpty)
+          {'role': m.role, 'content': m.content},
+    ];
+  }
+
+  /// System prompt placeholders without a BuildContext: locale comes from
+  /// Platform.localeName instead of Localizations (otherwise mirrors
+  /// PromptTransformer.buildPlaceholders).
+  @visibleForTesting
+  static Map<String, String> buildHeadlessPlaceholders({
+    required Assistant assistant,
+    required String modelId,
+    required String userNickname,
+    required DateTime now,
+  }) {
+    final date =
+        '${now.year.toString().padLeft(4, '0')}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+    final time =
+        '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
+    final os = Platform.operatingSystem;
+    final osv = Platform.operatingSystemVersion;
+    return <String, String>{
+      '{cur_date}': date,
+      '{cur_time}': time,
+      '{cur_datetime}': '$date $time',
+      '{model_id}': modelId,
+      '{model_name}': modelId,
+      '{locale}': Platform.localeName,
+      '{timezone}': now.timeZoneName,
+      '{system_version}': '$os $osv',
+      '{device_info}': os,
+      '{battery_level}': 'unknown',
+      '{nickname}': userNickname,
+      '{assistant_name}': assistant.name,
+    };
+  }
+
+  /// Assembles the full silent care request (Pipeline ②):
+  /// system prompt (placeholders replaced) + memories + instruction
+  /// injections + conversation history + the care prompt with the current
+  /// system time as the final user turn.
+  static Future<List<Map<String, dynamic>>> buildCareApiMessages({
+    required Assistant assistant,
+    required String userNickname,
+    required String modelId,
+    required List<Map<String, dynamic>> history,
+    required String carePrompt,
+    required DateTime now,
+  }) async {
+    final apiMessages = <Map<String, dynamic>>[
+      for (final m in history) Map<String, dynamic>.of(m),
+    ];
+
+    // The care prompt is the final user turn so the model replies to it.
+    apiMessages.add({
+      'role': 'user',
+      'content': ProactiveCareService.buildCareUserMessage(
+        carePrompt: carePrompt,
+        now: now,
+      ),
+    });
+
+    if (assistant.systemPrompt.trim().isNotEmpty) {
+      final vars = buildHeadlessPlaceholders(
+        assistant: assistant,
+        modelId: modelId,
+        userNickname: userNickname,
+        now: now,
+      );
+      apiMessages.insert(0, {
+        'role': 'system',
+        'content': PromptTransformer.replacePlaceholders(
+          assistant.systemPrompt,
+          vars,
+        ),
+      });
+    }
+
+    // Memory records.
+    if (assistant.enableMemory) {
+      try {
+        final block = ProactiveCareService.buildMemoriesBlock(
+          await MemoryStore.getForAssistant(assistant.id),
+        );
+        if (block.isNotEmpty) {
+          _appendToSystemMessage(apiMessages, block);
+        }
+      } catch (e) {
+        FlutterLogger.log('Memory injection failed: $e', tag: _logTag);
+      }
+    }
+
+    // Instruction injections.
+    try {
+      final actives = await InstructionInjectionStore.getActives(
+        assistantId: assistant.id,
+      );
+      final prompts = actives
+          .map((e) => e.prompt.trim())
+          .where((p) => p.isNotEmpty)
+          .toList(growable: false);
+      if (prompts.isNotEmpty) {
+        _appendToSystemMessage(apiMessages, prompts.join('\n\n'));
+      }
+    } catch (e) {
+      FlutterLogger.log('Instruction injection failed: $e', tag: _logTag);
+    }
+
+    return apiMessages;
+  }
+
+  static void _appendToSystemMessage(
+    List<Map<String, dynamic>> apiMessages,
+    String content,
+  ) {
+    if (apiMessages.isNotEmpty && apiMessages.first['role'] == 'system') {
+      apiMessages[0]['content'] =
+          '${(apiMessages[0]['content'] ?? '') as String}\n\n$content';
+    } else {
+      apiMessages.insert(0, {'role': 'system', 'content': content});
+    }
+  }
+
+  /// Sends the silent care request and returns the aggregated reply text.
+  static Future<String> requestCareReply({
+    required ProviderConfig config,
+    required String modelId,
+    required Assistant assistant,
+    required List<Map<String, dynamic>> apiMessages,
+    int? fallbackThinkingBudget,
+  }) async {
+    final buf = StringBuffer();
+    await for (final chunk in ChatApiService.sendMessageStream(
+      config: config,
+      modelId: modelId,
+      messages: apiMessages,
+      thinkingBudget: assistant.thinkingBudget ?? fallbackThinkingBudget,
+      temperature: assistant.temperature,
+      topP: assistant.topP,
+      maxTokens: assistant.maxTokens,
+      stream: false,
+    )) {
+      buf.write(chunk.content);
+    }
+    return buf.toString().trim();
+  }
+
+  /// Silently asks the decision model for the next proactive care time
+  /// (Pipeline ①). Returns null when the model declines, fails, or returns
+  /// an invalid/past time.
+  static Future<DateTime?> decideNextCareTime({
+    required ProviderConfig config,
+    required String modelId,
+    required Assistant assistant,
+    required String userNickname,
+    required List<Map<String, dynamic>> history,
+    required String decisionPrompt,
+    int? fallbackThinkingBudget,
+  }) async {
+    if (history.isEmpty) return null;
+    final now = DateTime.now();
+
+    String personaPrompt = '';
+    if (assistant.systemPrompt.trim().isNotEmpty) {
+      final vars = buildHeadlessPlaceholders(
+        assistant: assistant,
+        modelId: modelId,
+        userNickname: userNickname,
+        now: now,
+      );
+      personaPrompt = PromptTransformer.replacePlaceholders(
+        assistant.systemPrompt,
+        vars,
+      );
+    }
+    String memoriesBlock = '';
+    if (assistant.enableMemory) {
+      try {
+        memoriesBlock = ProactiveCareService.buildMemoriesBlock(
+          await MemoryStore.getForAssistant(assistant.id),
+        );
+      } catch (e) {
+        FlutterLogger.log('Decision memories load failed: $e', tag: _logTag);
+      }
+    }
+
+    final apiMessages = ProactiveCareService.buildDecisionApiMessages(
+      decisionPrompt: decisionPrompt,
+      currentNextCareTime: assistant.proactiveCareNextMessageAt,
+      now: now,
+      history: history,
+      personaPrompt: personaPrompt,
+      memoriesBlock: memoriesBlock,
+    );
+
+    try {
+      final buf = StringBuffer();
+      await for (final chunk in ChatApiService.sendMessageStream(
+        config: config,
+        modelId: modelId,
+        messages: apiMessages,
+        thinkingBudget: assistant.thinkingBudget ?? fallbackThinkingBudget,
+        temperature: assistant.temperature,
+        topP: assistant.topP,
+        maxTokens: assistant.maxTokens,
+        stream: false,
+      )) {
+        buf.write(chunk.content);
+      }
+      return ProactiveCareService.parseDecision(
+        buf.toString(),
+        now: DateTime.now(),
+      );
+    } catch (e) {
+      FlutterLogger.log('Decision request failed: $e', tag: _logTag);
+      return null;
+    }
+  }
+}
+
+/// Direct SQLite access used ONLY by the proactive care background isolate
+/// when the app process is dead, so no ChatService instance has the database
+/// open. Never call this from the main isolate: SQLite WAL mode does not
+/// support concurrent multi-isolate writes to the same database file.
+class ProactiveCareHeadlessChatStore {
+  const ProactiveCareHeadlessChatStore._();
+
+  /// Overridable for tests, where path_provider is unavailable.
+  @visibleForTesting
+  static Future<String> Function() dataDirPathProvider = () async =>
+      (await AppDirectories.getAppDataDirectory()).path;
+
+  static sqlite.Database? _db;
+
+  static Future<sqlite.Database> _ensureDb() async {
+    if (_db != null) return _db!;
+    final dirPath = await dataDirPathProvider();
+    final dbPath = '$dirPath/kelivo.sqlite';
+    _db = sqlite.sqlite3.open(dbPath);
+    _db!.execute('PRAGMA journal_mode = WAL;');
+    _db!.execute('PRAGMA foreign_keys = ON;');
+    _db!.execute('PRAGMA busy_timeout = 5000;');
+    return _db!;
+  }
+
+  /// Returns the most recently active conversation of [assistantId] and its
+  /// messages, or a null conversation when the assistant has none.
+  static Future<({Conversation? conversation, List<ChatMessage> messages})>
+  loadRecentConversationFor(String assistantId) async {
+    final db = await _ensureDb();
+
+    // Find the most recent conversation for this assistant
+    final convRows = db.select(
+      'SELECT * FROM conversation_rows WHERE assistant_id = ? ORDER BY updated_at DESC LIMIT 1',
+      [assistantId],
+    );
+    if (convRows.isEmpty) {
+      return (conversation: null, messages: const <ChatMessage>[]);
+    }
+
+    final row = convRows.first;
+    final conversation = Conversation(
+      id: row['id'] as String,
+      title: row['title'] as String,
+      createdAt: DateTime.parse(row['created_at'] as String),
+      updatedAt: DateTime.parse(row['updated_at'] as String),
+      isPinned: (row['is_pinned'] as int) != 0,
+      assistantId: row['assistant_id'] as String?,
+      truncateIndex: row['truncate_index'] as int? ?? -1,
+      versionSelections: _parseVersionSelections(
+        row['version_selections_json'] as String?,
+      ),
+    );
+
+    // Load messages for this conversation
+    final msgRows = db.select(
+      'SELECT * FROM message_rows WHERE conversation_id = ? ORDER BY message_order ASC',
+      [conversation.id],
+    );
+    final messages = <ChatMessage>[];
+    for (final mRow in msgRows) {
+      messages.add(ChatMessage(
+        id: mRow['id'] as String,
+        role: mRow['role'] as String,
+        content: mRow['content'] as String,
+        timestamp: DateTime.parse(mRow['timestamp'] as String),
+        modelId: mRow['model_id'] as String?,
+        providerId: mRow['provider_id'] as String?,
+        totalTokens: mRow['total_tokens'] as int?,
+        conversationId: mRow['conversation_id'] as String,
+        isStreaming: (mRow['is_streaming'] as int? ?? 0) != 0,
+        groupId: mRow['group_id'] as String?,
+        subgroupId: mRow['subgroup_id'] as String?,
+        version: mRow['version'] as int? ?? 0,
+      ));
+    }
+
+    return (conversation: conversation, messages: messages);
+  }
+
+  /// Appends an assistant reply to [conversation], creating a new
+  /// conversation titled [fallbackTitle] when null.
+  static Future<({Conversation conversation, ChatMessage message})>
+  appendAssistantReply({
+    required String assistantId,
+    required Conversation? conversation,
+    required String content,
+    required String fallbackTitle,
+    String? modelId,
+    String? providerId,
+  }) async {
+    final db = await _ensureDb();
+
+    final convo =
+        conversation ??
+        Conversation(title: fallbackTitle, assistantId: assistantId);
+
+    final message = ChatMessage(
+      role: 'assistant',
+      content: content,
+      conversationId: convo.id,
+      modelId: modelId,
+      providerId: providerId,
+    );
+
+    // Insert message
+    final msgCount = (db.select(
+      'SELECT COUNT(*) as cnt FROM message_rows WHERE conversation_id = ?',
+      [convo.id],
+    ).first['cnt'] as int);
+
+    db.execute(
+      '''INSERT OR REPLACE INTO message_rows
+         (id, conversation_id, role, content, timestamp, model_id, provider_id,
+          total_tokens, is_streaming, group_id, subgroup_id, version, message_order)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+      [
+        message.id,
+        convo.id,
+        message.role,
+        message.content,
+        message.timestamp.toIso8601String(),
+        message.modelId,
+        message.providerId,
+        message.totalTokens,
+        0,
+        message.groupId,
+        message.subgroupId,
+        message.version,
+        msgCount,
+      ],
+    );
+
+    // Update conversation
+    convo.updatedAt = DateTime.now();
+    db.execute(
+      '''INSERT OR REPLACE INTO conversation_rows
+         (id, title, created_at, updated_at, is_pinned, assistant_id,
+          truncate_index, version_selections_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+      [
+        convo.id,
+        convo.title,
+        convo.createdAt.toIso8601String(),
+        convo.updatedAt.toIso8601String(),
+        convo.isPinned ? 1 : 0,
+        convo.assistantId,
+        convo.truncateIndex,
+        jsonEncode(convo.versionSelections),
+      ],
+    );
+
+    return (conversation: convo, message: message);
+  }
+
+  /// Flushes and closes the database so all writes hit disk before the
+  /// background isolate is torn down.
+  static Future<void> close() async {
+    try {
+      _db?.dispose();
+      _db = null;
+    } catch (e) {
+      FlutterLogger.log('DB close failed: $e', tag: _logTag);
+    }
+  }
+
+  static Map<String, int> _parseVersionSelections(String? json) {
+    if (json == null || json.isEmpty) return <String, int>{};
+    try {
+      final map = jsonDecode(json) as Map<String, dynamic>;
+      return map.map((k, v) => MapEntry(k, v as int));
+    } catch (_) {
+      return <String, int>{};
+    }
+  }
+}

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -673,7 +673,7 @@ class ProactiveCareHeadlessChatStore {
   /// background isolate is torn down.
   static Future<void> close() async {
     try {
-      _db?.dispose();
+      _db?.close();
       _db = null;
     } catch (e) {
       FlutterLogger.log('DB close failed: $e', tag: _logTag);

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -227,6 +227,16 @@ class ProactiveCareMessageFlow {
     return 'User';
   }
 
+  /// Loads the global thinking budget from SharedPreferences for use in
+  /// background isolates where SettingsProvider is unavailable.
+  static Future<int?> loadThinkingBudgetFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getInt('thinking_budget_v1');
+    } catch (_) {}
+    return null;
+  }
+
   /// Collapses message versions, keeping the selected (or latest) version per
   /// group. Same semantics as MessageBuilderService.collapseVersions.
   @visibleForTesting

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -9,7 +9,6 @@ import '../../utils/app_directories.dart';
 import '../models/assistant.dart';
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
-import '../providers/assistant_provider.dart';
 import '../providers/settings_provider.dart';
 import 'api/chat_api_service.dart';
 import 'chat/prompt_transformer.dart';
@@ -98,7 +97,7 @@ class ProactiveCareModelConfig {
 /// the main isolate (app alive) and in the alarm background isolate (app
 /// killed). Only data loading and persistence differ between the two paths:
 /// the main isolate uses providers + ChatService, the background isolate uses
-/// SharedPreferences + [ProactiveCareHeadlessChatStore].
+/// SQLite via [ProactiveCareHeadlessChatStore].
 class ProactiveCareMessageFlow {
   const ProactiveCareMessageFlow._();
 
@@ -109,44 +108,33 @@ class ProactiveCareMessageFlow {
   // Keep in sync with UserProvider.
   static const String _userNamePrefsKey = 'user_name';
 
-  /// Loads [assistantId] from the persisted assistant list (background path).
-  static Future<Assistant?> loadAssistantFromPrefs(String assistantId) async {
+  /// Loads [assistantId] from SQLite (background isolate path).
+  static Future<Assistant?> loadAssistantFromDb(String assistantId) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(AssistantProvider.assistantsPrefsKey);
-      if (raw == null || raw.isEmpty) return null;
-      for (final a in Assistant.decodeList(raw)) {
-        if (a.id == assistantId) return a;
-      }
+      return await ProactiveCareHeadlessChatStore.loadAssistantFor(assistantId);
     } catch (e) {
-      FlutterLogger.log('Load assistant failed: $e', tag: _logTag);
+      FlutterLogger.log('Load assistant from DB failed: $e', tag: _logTag);
     }
     return null;
   }
 
-  /// Persists a new next-care time for [assistantId] (background path; the
-  /// app process is dead, so there is no concurrent writer).
-  static Future<bool> updateAssistantNextCareTimeInPrefs(
+  /// Persists a new next-care time for [assistantId] in SQLite (background
+  /// isolate path; the app process is dead, so there is no concurrent writer).
+  static Future<bool> updateAssistantNextCareTimeInDb(
     String assistantId,
     DateTime nextCareTime,
   ) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(AssistantProvider.assistantsPrefsKey);
-      if (raw == null || raw.isEmpty) return false;
-      final assistants = Assistant.decodeList(raw);
-      final idx = assistants.indexWhere((a) => a.id == assistantId);
-      if (idx == -1) return false;
-      assistants[idx] = assistants[idx].copyWith(
-        proactiveCareNextMessageAt: nextCareTime,
-      );
-      await prefs.setString(
-        AssistantProvider.assistantsPrefsKey,
-        Assistant.encodeList(assistants),
+      await ProactiveCareHeadlessChatStore.updateNextCareTime(
+        assistantId,
+        nextCareTime,
       );
       return true;
     } catch (e) {
-      FlutterLogger.log('Persist next care time failed: $e', tag: _logTag);
+      FlutterLogger.log(
+        'Persist next care time to DB failed: $e',
+        tag: _logTag,
+      );
       return false;
     }
   }
@@ -539,6 +527,79 @@ class ProactiveCareHeadlessChatStore {
     return _db!;
   }
 
+  /// Loads a single assistant by id from the `assistant_rows` table.
+  static Future<Assistant?> loadAssistantFor(String assistantId) async {
+    final db = await _ensureDb();
+    final rows = db.select('SELECT * FROM assistant_rows WHERE id = ?', [
+      assistantId,
+    ]);
+    if (rows.isEmpty) return null;
+    return _assistantFromRow(rows.first);
+  }
+
+  /// Updates the proactive care next-message time for [assistantId].
+  static Future<void> updateNextCareTime(
+    String assistantId,
+    DateTime nextCareTime,
+  ) async {
+    final db = await _ensureDb();
+    db.execute(
+      'UPDATE assistant_rows SET proactive_care_next_message_at = ? WHERE id = ?',
+      [nextCareTime.toIso8601String(), assistantId],
+    );
+  }
+
+  /// Maps a raw sqlite3 row to an [Assistant] via its JSON constructor,
+  /// mirroring `ChatDatabaseRepository._assistantFromRow`.
+  static Assistant _assistantFromRow(sqlite.Row row) {
+    return Assistant.fromJson({
+      'id': row['id'] as String,
+      'name': row['name'] as String,
+      'avatar': row['avatar'] as String?,
+      'useAssistantAvatar': (row['use_assistant_avatar'] as int) != 0,
+      'useAssistantName': (row['use_assistant_name'] as int) != 0,
+      'background': row['background'] as String?,
+      'chatModelProvider': row['chat_model_provider'] as String?,
+      'chatModelId': row['chat_model_id'] as String?,
+      'temperature': row['temperature'] as double?,
+      'topP': row['top_p'] as double?,
+      'contextMessageSize': row['context_message_size'] as int,
+      'limitContextMessages': (row['limit_context_messages'] as int) != 0,
+      'streamOutput': (row['stream_output'] as int) != 0,
+      'thinkingBudget': row['thinking_budget'] as int?,
+      'maxTokens': row['max_tokens'] as int?,
+      'systemPrompt': row['system_prompt'] as String,
+      'messageTemplate': row['message_template'] as String,
+      'searchEnabled': (row['search_enabled'] as int) != 0,
+      'mcpServerIds': (jsonDecode(row['mcp_server_ids_json'] as String) as List)
+          .cast<String>(),
+      'localToolIds': (jsonDecode(row['local_tool_ids_json'] as String) as List)
+          .cast<String>(),
+      'customHeaders': jsonDecode(row['custom_headers_json'] as String),
+      'customBody': jsonDecode(row['custom_body_json'] as String),
+      'enableMemory': (row['enable_memory'] as int) != 0,
+      'memoryMode': row['memory_mode'] as String,
+      'enableRecentChatsReference':
+          (row['enable_recent_chats_reference'] as int) != 0,
+      'recentChatsSummaryMessageCount':
+          row['recent_chats_summary_message_count'] as int,
+      'memoryRecordPrompt': row['memory_record_prompt'] as String,
+      'docxMode': row['docx_mode'] as String,
+      'pdfMode': row['pdf_mode'] as String,
+      'otherOfficeMode': row['other_office_mode'] as String,
+      'presetMessages': jsonDecode(row['preset_messages_json'] as String),
+      'regexRules': jsonDecode(row['regex_rules_json'] as String),
+      'enableProactiveCare': (row['enable_proactive_care'] as int) != 0,
+      'proactiveCareNextMessageAt':
+          row['proactive_care_next_message_at'] as String?,
+      'proactiveCarePrompt': row['proactive_care_prompt'] as String,
+      'proactiveCareDecisionPrompt':
+          row['proactive_care_decision_prompt'] as String,
+      'createdAt': row['created_at'] as String,
+      'updatedAt': row['updated_at'] as String,
+    });
+  }
+
   /// Returns the most recently active conversation of [assistantId] and its
   /// messages, or a null conversation when the assistant has none.
   static Future<({Conversation? conversation, List<ChatMessage> messages})>
@@ -575,20 +636,22 @@ class ProactiveCareHeadlessChatStore {
     );
     final messages = <ChatMessage>[];
     for (final mRow in msgRows) {
-      messages.add(ChatMessage(
-        id: mRow['id'] as String,
-        role: mRow['role'] as String,
-        content: mRow['content'] as String,
-        timestamp: DateTime.parse(mRow['timestamp'] as String),
-        modelId: mRow['model_id'] as String?,
-        providerId: mRow['provider_id'] as String?,
-        totalTokens: mRow['total_tokens'] as int?,
-        conversationId: mRow['conversation_id'] as String,
-        isStreaming: (mRow['is_streaming'] as int? ?? 0) != 0,
-        groupId: mRow['group_id'] as String?,
-        subgroupId: mRow['subgroup_id'] as String?,
-        version: mRow['version'] as int? ?? 0,
-      ));
+      messages.add(
+        ChatMessage(
+          id: mRow['id'] as String,
+          role: mRow['role'] as String,
+          content: mRow['content'] as String,
+          timestamp: DateTime.parse(mRow['timestamp'] as String),
+          modelId: mRow['model_id'] as String?,
+          providerId: mRow['provider_id'] as String?,
+          totalTokens: mRow['total_tokens'] as int?,
+          conversationId: mRow['conversation_id'] as String,
+          isStreaming: (mRow['is_streaming'] as int? ?? 0) != 0,
+          groupId: mRow['group_id'] as String?,
+          subgroupId: mRow['subgroup_id'] as String?,
+          version: mRow['version'] as int? ?? 0,
+        ),
+      );
     }
 
     return (conversation: conversation, messages: messages);
@@ -620,10 +683,12 @@ class ProactiveCareHeadlessChatStore {
     );
 
     // Insert message
-    final msgCount = (db.select(
-      'SELECT COUNT(*) as cnt FROM message_rows WHERE conversation_id = ?',
-      [convo.id],
-    ).first['cnt'] as int);
+    final msgCount =
+        (db.select(
+              'SELECT COUNT(*) as cnt FROM message_rows WHERE conversation_id = ?',
+              [convo.id],
+            ).first['cnt']
+            as int);
 
     db.execute(
       '''INSERT OR REPLACE INTO message_rows

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -527,6 +527,25 @@ class ProactiveCareHeadlessChatStore {
     return _db!;
   }
 
+  /// Converts a raw SQLite value to [DateTime].
+  /// Drift 2.x stores DateTime as unix timestamp (seconds, INTEGER) by
+  /// default (`store_date_time_values_as_text` is false without build.yaml).
+  static DateTime _dateTimeFromSql(Object? value) {
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value * 1000);
+    }
+    // Fallback for ISO-8601 text (should not happen with default drift config)
+    return DateTime.parse(value as String);
+  }
+
+  static DateTime? _dateTimeFromSqlNullable(Object? value) {
+    if (value == null) return null;
+    return _dateTimeFromSql(value);
+  }
+
+  /// Converts [DateTime] to unix timestamp seconds for drift compatibility.
+  static int _dateTimeToSql(DateTime dt) => dt.millisecondsSinceEpoch ~/ 1000;
+
   /// Loads a single assistant by id from the `assistant_rows` table.
   static Future<Assistant?> loadAssistantFor(String assistantId) async {
     final db = await _ensureDb();
@@ -545,7 +564,7 @@ class ProactiveCareHeadlessChatStore {
     final db = await _ensureDb();
     db.execute(
       'UPDATE assistant_rows SET proactive_care_next_message_at = ? WHERE id = ?',
-      [nextCareTime.toIso8601String(), assistantId],
+      [_dateTimeToSql(nextCareTime), assistantId],
     );
   }
 
@@ -590,13 +609,14 @@ class ProactiveCareHeadlessChatStore {
       'presetMessages': jsonDecode(row['preset_messages_json'] as String),
       'regexRules': jsonDecode(row['regex_rules_json'] as String),
       'enableProactiveCare': (row['enable_proactive_care'] as int) != 0,
-      'proactiveCareNextMessageAt':
-          row['proactive_care_next_message_at'] as String?,
+      'proactiveCareNextMessageAt': _dateTimeFromSqlNullable(
+        row['proactive_care_next_message_at'],
+      )?.toIso8601String(),
       'proactiveCarePrompt': row['proactive_care_prompt'] as String,
       'proactiveCareDecisionPrompt':
           row['proactive_care_decision_prompt'] as String,
-      'createdAt': row['created_at'] as String,
-      'updatedAt': row['updated_at'] as String,
+      'createdAt': _dateTimeFromSql(row['created_at']).toIso8601String(),
+      'updatedAt': _dateTimeFromSql(row['updated_at']).toIso8601String(),
     });
   }
 
@@ -619,8 +639,8 @@ class ProactiveCareHeadlessChatStore {
     final conversation = Conversation(
       id: row['id'] as String,
       title: row['title'] as String,
-      createdAt: DateTime.parse(row['created_at'] as String),
-      updatedAt: DateTime.parse(row['updated_at'] as String),
+      createdAt: _dateTimeFromSql(row['created_at']),
+      updatedAt: _dateTimeFromSql(row['updated_at']),
       isPinned: (row['is_pinned'] as int) != 0,
       assistantId: row['assistant_id'] as String?,
       truncateIndex: row['truncate_index'] as int? ?? -1,
@@ -641,7 +661,7 @@ class ProactiveCareHeadlessChatStore {
           id: mRow['id'] as String,
           role: mRow['role'] as String,
           content: mRow['content'] as String,
-          timestamp: DateTime.parse(mRow['timestamp'] as String),
+          timestamp: _dateTimeFromSql(mRow['timestamp']),
           modelId: mRow['model_id'] as String?,
           providerId: mRow['provider_id'] as String?,
           totalTokens: mRow['total_tokens'] as int?,
@@ -682,7 +702,7 @@ class ProactiveCareHeadlessChatStore {
       providerId: providerId,
     );
 
-    // Insert message
+    // Insert message (id is always a fresh UUID, plain INSERT is safe)
     final msgCount =
         (db.select(
               'SELECT COUNT(*) as cnt FROM message_rows WHERE conversation_id = ?',
@@ -691,7 +711,7 @@ class ProactiveCareHeadlessChatStore {
             as int);
 
     db.execute(
-      '''INSERT OR REPLACE INTO message_rows
+      '''INSERT INTO message_rows
          (id, conversation_id, role, content, timestamp, model_id, provider_id,
           total_tokens, is_streaming, group_id, subgroup_id, version, message_order)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
@@ -700,7 +720,7 @@ class ProactiveCareHeadlessChatStore {
         convo.id,
         message.role,
         message.content,
-        message.timestamp.toIso8601String(),
+        _dateTimeToSql(message.timestamp),
         message.modelId,
         message.providerId,
         message.totalTokens,
@@ -712,24 +732,34 @@ class ProactiveCareHeadlessChatStore {
       ],
     );
 
-    // Update conversation
+    // Update conversation — use UPDATE for existing conversations to avoid
+    // INSERT OR REPLACE triggering ON DELETE CASCADE on message_rows.
     convo.updatedAt = DateTime.now();
-    db.execute(
-      '''INSERT OR REPLACE INTO conversation_rows
-         (id, title, created_at, updated_at, is_pinned, assistant_id,
-          truncate_index, version_selections_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
-      [
+    if (conversation != null) {
+      // Existing conversation: only touch updated_at.
+      db.execute('UPDATE conversation_rows SET updated_at = ? WHERE id = ?', [
+        _dateTimeToSql(convo.updatedAt),
         convo.id,
-        convo.title,
-        convo.createdAt.toIso8601String(),
-        convo.updatedAt.toIso8601String(),
-        convo.isPinned ? 1 : 0,
-        convo.assistantId,
-        convo.truncateIndex,
-        jsonEncode(convo.versionSelections),
-      ],
-    );
+      ]);
+    } else {
+      // Brand-new conversation: safe to INSERT.
+      db.execute(
+        '''INSERT INTO conversation_rows
+           (id, title, created_at, updated_at, is_pinned, assistant_id,
+            truncate_index, version_selections_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+        [
+          convo.id,
+          convo.title,
+          _dateTimeToSql(convo.createdAt),
+          _dateTimeToSql(convo.updatedAt),
+          convo.isPinned ? 1 : 0,
+          convo.assistantId,
+          convo.truncateIndex,
+          jsonEncode(convo.versionSelections),
+        ],
+      );
+    }
 
     return (conversation: convo, message: message);
   }

--- a/lib/core/services/proactive_care_service.dart
+++ b/lib/core/services/proactive_care_service.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+
+import '../models/assistant_memory.dart';
+
+/// Pure logic for the proactive care ("Ta的来信") decision flow.
+///
+/// After each completed assistant reply, the full conversation context plus
+/// the decision prompt built here is sent silently to the decision model.
+/// The model answers with a JSON decision that may update the assistant's
+/// next proactive message time.
+class ProactiveCareService {
+  /// Built-in JSON output rules for the decision request (LLM only).
+  ///
+  /// Time fields are appended separately via [buildDecisionTimeFooter] after
+  /// the chat history.
+  static const String builtinDecisionJsonRules = '''
+【输出要求】
+你必须严格以 JSON 格式输出，不要包含任何额外文字：
+{
+  "should_update": true或false,
+  "next_care_time": "ISO 8601格式的时间字符串，如2026-06-12T10:00:00"
+}''';
+
+  /// Prefix before the assistant persona in the decision request (LLM only).
+  static const String personaReferencePrefix = '以下是供你参考的助手人设';
+
+  /// Prefix before the memory block in the decision request (LLM only).
+  static const String memoriesReferencePrefix = '以下是供你参考的助手记忆';
+
+  /// Prefix inserted as a separate user message before chat history (LLM only).
+  static const String chatHistoryPrefix = '以下是用户与助手的聊天记录';
+
+  /// Built-in suffix appended to the user-configured care prompt when the
+  /// proactive care time arrives (LLM only, never shown in UI).
+  static const String builtinCareTimePrompt = '当前系统时间：{current_system_time}';
+
+  /// Builds the time footer placed after chat history in the decision request.
+  static String buildDecisionTimeFooter({
+    required DateTime now,
+    required DateTime? currentNextCareTime,
+  }) {
+    return '''
+当前已设定的下次主动关怀时间：${currentNextCareTime?.toIso8601String() ?? '未设定'}
+当前系统时间：${now.toIso8601String()}'''
+        .trim();
+  }
+
+  /// Assembles the full silent decision API message list (Pipeline ①):
+  ///
+  /// 1. `system`: user decision prompt + JSON output rules (no times)
+  /// 2. `user` (optional): persona reference prefix + assistant system prompt
+  /// 3. `user` (optional): memories reference prefix + memory block
+  /// 4. `user`: chat history header (when [history] is non-empty)
+  /// 5. ...[history] (user/assistant turns, unchanged)
+  /// 6. `user`: next care time + current system time (always last)
+  static List<Map<String, dynamic>> buildDecisionApiMessages({
+    required String decisionPrompt,
+    required DateTime? currentNextCareTime,
+    required DateTime now,
+    required List<Map<String, dynamic>> history,
+    String personaPrompt = '',
+    String memoriesBlock = '',
+  }) {
+    final messages = <Map<String, dynamic>>[];
+
+    final systemParts = <String>[
+      if (decisionPrompt.trim().isNotEmpty) decisionPrompt.trim(),
+      builtinDecisionJsonRules.trim(),
+    ];
+    messages.add({'role': 'system', 'content': systemParts.join('\n\n')});
+
+    final persona = personaPrompt.trim();
+    if (persona.isNotEmpty) {
+      messages.add({
+        'role': 'user',
+        'content': '$personaReferencePrefix\n\n$persona',
+      });
+    }
+
+    final memories = memoriesBlock.trim();
+    if (memories.isNotEmpty) {
+      messages.add({
+        'role': 'user',
+        'content': '$memoriesReferencePrefix\n\n$memories',
+      });
+    }
+
+    if (history.isNotEmpty) {
+      messages.add({'role': 'user', 'content': chatHistoryPrefix});
+      messages.addAll(history);
+    }
+
+    messages.add({
+      'role': 'user',
+      'content': buildDecisionTimeFooter(
+        now: now,
+        currentNextCareTime: currentNextCareTime,
+      ),
+    });
+
+    return messages;
+  }
+
+  /// Formats assistant memories the same way as the normal send pipeline's
+  /// `<memories>` block, but without the memory tool instructions (the
+  /// silent requests carry no tools). Returns an empty string when there are
+  /// no memories.
+  static String buildMemoriesBlock(List<AssistantMemory> mems) {
+    if (mems.isEmpty) return '';
+    final buf = StringBuffer();
+    buf.writeln('## Memories');
+    buf.writeln(
+      'These are memories that you can reference in the future conversations.',
+    );
+    buf.writeln('<memories>');
+    for (final m in mems) {
+      buf.writeln('<record>');
+      buf.writeln('<id>${m.id}</id>');
+      buf.writeln('<content>${m.content}</content>');
+      buf.writeln('</record>');
+    }
+    buf.writeln('</memories>');
+    return buf.toString().trim();
+  }
+
+  /// Builds the silent user-role message sent when the proactive care time
+  /// arrives: the user-configured care prompt plus the current system time.
+  static String buildCareUserMessage({
+    required String carePrompt,
+    required DateTime now,
+  }) {
+    final time = builtinCareTimePrompt.replaceAll(
+      '{current_system_time}',
+      now.toIso8601String(),
+    );
+    final head = carePrompt.trim();
+    if (head.isEmpty) return time;
+    return '$head\n\n$time';
+  }
+
+  /// Parses the LLM decision reply.
+  ///
+  /// Returns the new next-care time only when `should_update` is true and
+  /// `next_care_time` parses to a time later than [now] (mirroring the date
+  /// picker constraint that past times are not allowed). Returns null in all
+  /// other cases (invalid JSON, should_update=false, past/invalid time).
+  static DateTime? parseDecision(String raw, {required DateTime now}) {
+    final jsonText = _extractJsonObject(raw);
+    if (jsonText == null) return null;
+
+    Object? decoded;
+    try {
+      decoded = jsonDecode(jsonText);
+    } catch (_) {
+      return null;
+    }
+    if (decoded is! Map) return null;
+
+    if (decoded['should_update'] != true) return null;
+    final rawTime = decoded['next_care_time'];
+    if (rawTime is! String || rawTime.trim().isEmpty) return null;
+    final parsed = DateTime.tryParse(rawTime.trim());
+    if (parsed == null) return null;
+
+    final local = parsed.isUtc ? parsed.toLocal() : parsed;
+    if (!local.isAfter(now)) return null;
+    return local;
+  }
+
+  /// Extracts the first balanced top-level `{...}` block, tolerating
+  /// markdown code fences and surrounding prose.
+  static String? _extractJsonObject(String raw) {
+    final start = raw.indexOf('{');
+    final end = raw.lastIndexOf('}');
+    if (start < 0 || end <= start) return null;
+    return raw.substring(start, end + 1);
+  }
+}

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' show File;
+import 'dart:io' show File, Platform;
 import 'dart:math' as math;
 import 'dart:ui';
 
@@ -48,7 +48,9 @@ import '../../../theme/design_tokens.dart';
 import '../../../utils/avatar_cache.dart';
 import '../../../utils/brand_assets.dart';
 import '../../../utils/sandbox_path_resolver.dart';
+import '../../../core/services/proactive_care_alarm_service.dart';
 import '../utils/assistant_edit_tab_layout.dart';
+import '../widgets/proactive_care_datetime_picker.dart';
 import 'assistant_regex_tab.dart';
 
 part 'assistant_settings_edit_basic_tab.dart';
@@ -58,6 +60,7 @@ part 'assistant_settings_edit_local_tools_tab.dart';
 part 'assistant_settings_edit_mcp_tab.dart';
 part 'assistant_settings_edit_quick_phrase_tab.dart';
 part 'assistant_settings_edit_custom_request_tab.dart';
+part 'assistant_settings_edit_proactive_letter_tab.dart';
 
 const int _contextMessageMin = Assistant.minContextMessageSize;
 const int _contextMessageMax = Assistant.maxContextMessageSize;
@@ -130,6 +133,13 @@ List<_AssistantEditTabSpec> _assistantEditTabSpecs(
       icon: Lucide.CaseSensitive,
       child: AssistantRegexTab(assistantId: assistantId),
     ),
+    if (Platform.isAndroid)
+      _AssistantEditTabSpec(
+        id: assistantEditTabProactiveLetter,
+        label: l10n.assistantEditPageProactiveLetterTab,
+        icon: Lucide.HeartPulse,
+        child: _ProactiveLetterTab(assistantId: assistantId),
+      ),
   ];
 }
 
@@ -140,6 +150,9 @@ List<_AssistantEditTabSpec> _orderedAssistantEditTabs(
   final byId = {for (final tab in tabs) tab.id: tab};
   return orderAssistantEditTabIds(
     savedOrder: order,
+    defaultOrder: defaultAssistantEditTabIdsFor(
+      includeProactiveCare: Platform.isAndroid,
+    ),
   ).map((id) => byId[id]).nonNulls.toList();
 }
 
@@ -155,6 +168,9 @@ List<_AssistantEditTabSpec> _visibleAssistantEditTabs(
   return visibleAssistantEditTabIds(
     savedOrder: settings.mobileAssistantEditTabOrder,
     hiddenIds: settings.hiddenMobileAssistantEditTabs,
+    defaultOrder: defaultAssistantEditTabIdsFor(
+      includeProactiveCare: Platform.isAndroid,
+    ),
   ).map((id) => byId[id]).nonNulls.toList();
 }
 

--- a/lib/features/assistant/pages/assistant_settings_edit_proactive_letter_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_proactive_letter_tab.dart
@@ -1,0 +1,232 @@
+part of 'assistant_settings_edit_page.dart';
+
+class _ProactiveLetterTab extends StatefulWidget {
+  const _ProactiveLetterTab({required this.assistantId});
+
+  final String assistantId;
+
+  @override
+  State<_ProactiveLetterTab> createState() => _ProactiveLetterTabState();
+}
+
+class _ProactiveLetterTabState extends State<_ProactiveLetterTab> {
+  late final TextEditingController _carePromptCtrl;
+  late final TextEditingController _decisionPromptCtrl;
+  String? _boundAssistantId;
+
+  @override
+  void initState() {
+    super.initState();
+    _carePromptCtrl = TextEditingController();
+    _decisionPromptCtrl = TextEditingController();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncControllers();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ProactiveLetterTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.assistantId != widget.assistantId) {
+      _boundAssistantId = null;
+      _syncControllers(force: true);
+    }
+  }
+
+  void _syncControllers({bool force = false}) {
+    final a = context.read<AssistantProvider>().getById(widget.assistantId);
+    if (a == null) return;
+    if (!force && _boundAssistantId == a.id) return;
+    _boundAssistantId = a.id;
+
+    final l10n = AppLocalizations.of(context)!;
+    final defaultDecision =
+        l10n.assistantEditProactiveCareDecisionPromptDefault;
+
+    final careText = a.proactiveCarePrompt.isEmpty
+        ? l10n.assistantEditProactiveCarePromptDefault
+        : a.proactiveCarePrompt;
+    if (_carePromptCtrl.text != careText) {
+      _carePromptCtrl.text = careText;
+    }
+    final decisionText = a.proactiveCareDecisionPrompt.isEmpty
+        ? defaultDecision
+        : a.proactiveCareDecisionPrompt;
+    if (_decisionPromptCtrl.text != decisionText) {
+      _decisionPromptCtrl.text = decisionText;
+    }
+  }
+
+  @override
+  void dispose() {
+    _carePromptCtrl.dispose();
+    _decisionPromptCtrl.dispose();
+    super.dispose();
+  }
+
+  InputDecoration _promptDecoration(BuildContext context, {String? hint}) {
+    final cs = Theme.of(context).colorScheme;
+    return InputDecoration(
+      hintText: hint,
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(
+          color: cs.outlineVariant.withValues(alpha: 0.35),
+        ),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: cs.primary.withValues(alpha: 0.5)),
+      ),
+      contentPadding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+    );
+  }
+
+  Future<void> _pickNextMessageTime(Assistant a) async {
+    final picked = await showProactiveCareDateTimePicker(
+      context,
+      initial: a.proactiveCareNextMessageAt,
+    );
+    if (!mounted || picked == null) return;
+    await context.read<AssistantProvider>().updateAssistant(
+      a.copyWith(proactiveCareNextMessageAt: picked),
+    );
+  }
+
+  Future<void> _onProactiveCareChanged(Assistant a, bool enabled) async {
+    if (enabled) {
+      // Auto-request the exact alarm + notification permissions needed to
+      // wake the app and notify the user at the scheduled care time.
+      final perms = await ProactiveCareAlarmService.ensurePermissions();
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      if (!perms.exactAlarm) {
+        showAppSnackBar(
+          context,
+          message: l10n.assistantEditProactiveCareExactAlarmPermissionDenied,
+          type: NotificationType.warning,
+        );
+      } else if (!perms.notifications) {
+        showAppSnackBar(
+          context,
+          message: l10n.assistantEditProactiveCareNotificationPermissionDenied,
+          type: NotificationType.warning,
+        );
+      }
+    }
+    if (enabled && a.proactiveCareNextMessageAt == null) {
+      await context.read<AssistantProvider>().updateAssistant(
+        a.copyWith(
+          enableProactiveCare: true,
+          proactiveCareNextMessageAt: DateTime.now().add(
+            const Duration(hours: 24),
+          ),
+        ),
+      );
+      return;
+    }
+    await context.read<AssistantProvider>().updateAssistant(
+      a.copyWith(enableProactiveCare: enabled),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final a = context.watch<AssistantProvider>().getById(widget.assistantId);
+    if (a == null) {
+      return const SizedBox.shrink();
+    }
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+      children: [
+        _iosSectionCard(
+          children: [
+            _iosSwitchRow(
+              context,
+              icon: Lucide.HeartPulse,
+              label: l10n.assistantEditProactiveCareEnableTitle,
+              value: a.enableProactiveCare,
+              onChanged: (v) => _onProactiveCareChanged(a, v),
+            ),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 180),
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.topCenter,
+              child: a.enableProactiveCare
+                  ? Column(
+                      children: [
+                        _iosDivider(context),
+                        _iosNavRow(
+                          context,
+                          icon: Lucide.clock,
+                          label: l10n
+                              .assistantEditProactiveCareNextMessageTimeTitle,
+                          detailText: proactiveCareNextMessageLabel(
+                            context,
+                            a.proactiveCareNextMessageAt,
+                          ),
+                          onTap: () => _pickNextMessageTime(a),
+                        ),
+                      ],
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ],
+        ),
+        if (a.enableProactiveCare) ...[
+          const SizedBox(height: 16),
+          Text(
+            l10n.assistantEditProactiveCarePromptTitle,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: AppFontWeights.emphasis,
+              color: cs.onSurface.withValues(alpha: 0.92),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _carePromptCtrl,
+            onChanged: (v) => context.read<AssistantProvider>().updateAssistant(
+              a.copyWith(proactiveCarePrompt: v),
+            ),
+            maxLines: 8,
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.newline,
+            decoration: _promptDecoration(
+              context,
+              hint: l10n.assistantEditProactiveCarePromptHint,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            l10n.assistantEditProactiveCareDecisionPromptTitle,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: AppFontWeights.emphasis,
+              color: cs.onSurface.withValues(alpha: 0.92),
+            ),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _decisionPromptCtrl,
+            onChanged: (v) => context.read<AssistantProvider>().updateAssistant(
+              a.copyWith(proactiveCareDecisionPrompt: v),
+            ),
+            maxLines: null,
+            minLines: 8,
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.newline,
+            decoration: _promptDecoration(context),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/assistant/utils/assistant_edit_tab_layout.dart
+++ b/lib/features/assistant/utils/assistant_edit_tab_layout.dart
@@ -1,13 +1,15 @@
 const String assistantEditTabBasic = 'basic';
 const String assistantEditTabPrompts = 'prompts';
 const String assistantEditTabMemory = 'memory';
+const String assistantEditTabProactiveLetter = 'proactiveLetter';
 const String assistantEditTabMcp = 'mcp';
 const String assistantEditTabLocalTools = 'localTools';
 const String assistantEditTabQuickPhrase = 'quickPhrase';
 const String assistantEditTabCustom = 'custom';
 const String assistantEditTabRegex = 'regex';
 
-const List<String> defaultAssistantEditTabIds = [
+/// Default assistant edit tabs without proactive care (non-Android).
+const List<String> defaultAssistantEditTabIdsBase = [
   assistantEditTabBasic,
   assistantEditTabPrompts,
   assistantEditTabMemory,
@@ -17,6 +19,28 @@ const List<String> defaultAssistantEditTabIds = [
   assistantEditTabLocalTools,
   assistantEditTabMcp,
 ];
+
+/// Default assistant edit tabs when proactive care is supported (Android).
+const List<String> defaultAssistantEditTabIdsWithProactiveCare = [
+  assistantEditTabBasic,
+  assistantEditTabPrompts,
+  assistantEditTabMemory,
+  assistantEditTabProactiveLetter,
+  assistantEditTabQuickPhrase,
+  assistantEditTabCustom,
+  assistantEditTabRegex,
+  assistantEditTabLocalTools,
+  assistantEditTabMcp,
+];
+
+List<String> defaultAssistantEditTabIdsFor({
+  required bool includeProactiveCare,
+}) => includeProactiveCare
+    ? defaultAssistantEditTabIdsWithProactiveCare
+    : defaultAssistantEditTabIdsBase;
+
+/// Back-compat alias for callers/tests that expect the base tab set.
+const List<String> defaultAssistantEditTabIds = defaultAssistantEditTabIdsBase;
 
 List<String> orderAssistantEditTabIds({
   required List<String> savedOrder,

--- a/lib/features/assistant/widgets/proactive_care_datetime_picker.dart
+++ b/lib/features/assistant/widgets/proactive_care_datetime_picker.dart
@@ -1,0 +1,392 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_tactile.dart';
+import '../../../theme/app_font_weights.dart';
+
+String proactiveCareNextMessageLabel(BuildContext context, DateTime? value) {
+  final l10n = AppLocalizations.of(context)!;
+  if (value == null) return l10n.assistantEditProactiveCareNextMessageTimeUnset;
+  final local = value.toLocal();
+  final material = MaterialLocalizations.of(context);
+  return '${material.formatMediumDate(local)} ${TimeOfDay.fromDateTime(local).format(context)}';
+}
+
+Future<DateTime?> showProactiveCareDateTimePicker(
+  BuildContext context, {
+  DateTime? initial,
+}) {
+  final resolved = _resolveInitialDateTime(initial);
+  return showModalBottomSheet<DateTime>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (ctx) {
+      return _ProactiveCareDateTimePanel(
+        initial: resolved,
+        onCancel: () => Navigator.of(ctx).pop(),
+        onSave: (value) => Navigator.of(ctx).pop(value),
+      );
+    },
+  );
+}
+
+DateTime _resolveInitialDateTime(DateTime? initial) {
+  final now = DateTime.now();
+  final candidate = initial ?? now.add(const Duration(hours: 24));
+  if (candidate.isBefore(now)) {
+    return now.add(const Duration(hours: 24));
+  }
+  return candidate;
+}
+
+class _ProactiveCareDateTimePanel extends StatefulWidget {
+  const _ProactiveCareDateTimePanel({
+    required this.initial,
+    required this.onCancel,
+    required this.onSave,
+  });
+
+  final DateTime initial;
+  final VoidCallback onCancel;
+  final ValueChanged<DateTime> onSave;
+
+  @override
+  State<_ProactiveCareDateTimePanel> createState() =>
+      _ProactiveCareDateTimePanelState();
+}
+
+class _ProactiveCareDateTimePanelState
+    extends State<_ProactiveCareDateTimePanel> {
+  static const double _itemExtent = 42;
+  static const double _timePickerHeight = 160;
+  static const double _datePickerHeight = 180;
+
+  late DateTime _selectedDate;
+  late int _selectedHour;
+  late int _selectedMinute;
+  late final FixedExtentScrollController _hourController;
+  late final FixedExtentScrollController _minuteController;
+
+  @override
+  void initState() {
+    super.initState();
+    final local = widget.initial.toLocal();
+    _selectedDate = DateTime(local.year, local.month, local.day);
+    _selectedHour = local.hour;
+    _selectedMinute = local.minute;
+    _hourController = FixedExtentScrollController(initialItem: _selectedHour);
+    _minuteController = FixedExtentScrollController(
+      initialItem: _selectedMinute,
+    );
+  }
+
+  @override
+  void dispose() {
+    _hourController.dispose();
+    _minuteController.dispose();
+    super.dispose();
+  }
+
+  DateTime get _selectedDateTime => DateTime(
+    _selectedDate.year,
+    _selectedDate.month,
+    _selectedDate.day,
+    _selectedHour,
+    _selectedMinute,
+  );
+
+  void _save() {
+    final selected = _selectedDateTime;
+    final now = DateTime.now();
+    if (selected.isBefore(now)) {
+      widget.onSave(now.add(const Duration(minutes: 1)));
+      return;
+    }
+    widget.onSave(selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    const radius = BorderRadius.all(Radius.circular(22));
+    final panelColor = isDark
+        ? const Color(0xFF1F2023)
+        : const Color(0xFFF8F9FA);
+    final preview = proactiveCareNextMessageLabel(context, _selectedDateTime);
+
+    return SafeArea(
+      top: false,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: double.infinity,
+          margin: EdgeInsets.only(
+            left: 12,
+            right: 12,
+            bottom: 12 + bottomInset,
+          ),
+          decoration: BoxDecoration(color: panelColor, borderRadius: radius),
+          child: ClipRRect(
+            borderRadius: radius,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 14, 16, 0),
+                  child: Center(
+                    child: Text(
+                      l10n.assistantEditProactiveCareDateTimePickerTitle,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 17,
+                        fontWeight: AppFontWeights.emphasis,
+                        color: cs.onSurface.withValues(alpha: 0.92),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 8, 18, 10),
+                  child: Column(
+                    children: [
+                      Text(
+                        preview,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: AppFontWeights.emphasis,
+                          color: cs.primary,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        height: _datePickerHeight,
+                        child: CupertinoTheme(
+                          data: CupertinoTheme.of(context).copyWith(
+                            textTheme: CupertinoTheme.of(context).textTheme
+                                .copyWith(
+                                  dateTimePickerTextStyle: TextStyle(
+                                    color: cs.onSurface,
+                                    fontSize: 18,
+                                    fontWeight: AppFontWeights.semibold,
+                                  ),
+                                ),
+                          ),
+                          child: CupertinoDatePicker(
+                            mode: CupertinoDatePickerMode.date,
+                            initialDateTime: _selectedDate,
+                            minimumDate: DateTime(
+                              DateTime.now().year,
+                              DateTime.now().month,
+                              DateTime.now().day,
+                            ),
+                            maximumDate: DateTime.now().add(
+                              const Duration(days: 365 * 2),
+                            ),
+                            onDateTimeChanged: (value) {
+                              setState(() {
+                                _selectedDate = DateTime(
+                                  value.year,
+                                  value.month,
+                                  value.day,
+                                );
+                              });
+                            },
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      _buildTimeWheels(context, cs, isDark),
+                    ],
+                  ),
+                ),
+                _buildActions(context, l10n, cs, isDark),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimeWheels(BuildContext context, ColorScheme cs, bool isDark) {
+    final selectionColor = Color.alphaBlend(
+      cs.primary.withValues(alpha: isDark ? 0.18 : 0.10),
+      cs.surface,
+    );
+    final selectionBorder = cs.primary.withValues(alpha: isDark ? 0.30 : 0.18);
+
+    return SizedBox(
+      height: _timePickerHeight,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Container(
+            height: _itemExtent,
+            decoration: BoxDecoration(
+              color: selectionColor,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: selectionBorder),
+            ),
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: _buildWheel(
+                  controller: _hourController,
+                  itemCount: 24,
+                  selectedIndex: _selectedHour,
+                  cs: cs,
+                  onSelected: (value) {
+                    setState(() => _selectedHour = value);
+                  },
+                ),
+              ),
+              SizedBox(
+                width: 28,
+                child: Center(
+                  child: Text(
+                    ':',
+                    style: TextStyle(
+                      fontSize: 24,
+                      height: 1,
+                      fontWeight: AppFontWeights.emphasis,
+                      color: cs.onSurface.withValues(alpha: 0.62),
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: _buildWheel(
+                  controller: _minuteController,
+                  itemCount: 60,
+                  selectedIndex: _selectedMinute,
+                  cs: cs,
+                  onSelected: (value) {
+                    setState(() => _selectedMinute = value);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildWheel({
+    required FixedExtentScrollController controller,
+    required int itemCount,
+    required int selectedIndex,
+    required ColorScheme cs,
+    required ValueChanged<int> onSelected,
+  }) {
+    return CupertinoTheme(
+      data: CupertinoTheme.of(context).copyWith(
+        scaffoldBackgroundColor: Colors.transparent,
+        textTheme: CupertinoTheme.of(context).textTheme.copyWith(
+          pickerTextStyle: TextStyle(
+            color: cs.onSurface,
+            fontSize: 22,
+            fontWeight: AppFontWeights.semibold,
+            letterSpacing: 0,
+          ),
+        ),
+      ),
+      child: CupertinoPicker(
+        scrollController: controller,
+        itemExtent: _itemExtent,
+        diameterRatio: 1.35,
+        squeeze: 1.08,
+        useMagnifier: true,
+        magnification: 1.04,
+        backgroundColor: Colors.transparent,
+        selectionOverlay: const SizedBox.shrink(),
+        looping: true,
+        onSelectedItemChanged: onSelected,
+        children: List.generate(itemCount, (index) {
+          final selected = index == selectedIndex;
+          return Center(
+            child: Text(
+              index.toString().padLeft(2, '0'),
+              style: TextStyle(
+                fontSize: selected ? 23 : 21,
+                fontWeight: selected
+                    ? AppFontWeights.emphasis
+                    : AppFontWeights.medium,
+                color: selected
+                    ? cs.primary
+                    : cs.onSurface.withValues(alpha: 0.72),
+                letterSpacing: 0,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildActions(
+    BuildContext context,
+    AppLocalizations l10n,
+    ColorScheme cs,
+    bool isDark,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: IosCardPress(
+              onTap: widget.onCancel,
+              haptics: false,
+              borderRadius: BorderRadius.circular(13),
+              baseColor: isDark
+                  ? Colors.white.withValues(alpha: 0.08)
+                  : const Color(0xFFE7E9EC),
+              padding: const EdgeInsets.symmetric(vertical: 11),
+              child: Center(
+                child: Text(
+                  l10n.backupPageCancel,
+                  style: TextStyle(
+                    color: cs.onSurface.withValues(alpha: 0.74),
+                    fontSize: 13,
+                    fontWeight: AppFontWeights.emphasis,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: IosCardPress(
+              onTap: _save,
+              haptics: false,
+              borderRadius: BorderRadius.circular(13),
+              baseColor: isDark
+                  ? Colors.white.withValues(alpha: 0.16)
+                  : const Color(0xFFDADDE2),
+              padding: const EdgeInsets.symmetric(vertical: 11),
+              child: Center(
+                child: Text(
+                  l10n.backupPageSave,
+                  style: TextStyle(
+                    color: cs.onSurface.withValues(alpha: 0.9),
+                    fontSize: 13,
+                    fontWeight: AppFontWeights.heavy,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -114,6 +114,9 @@ class ChatActions {
   /// Called when a successful assistant reply is finalized.
   void Function(ChatMessage message)? onAssistantMessageFinished;
 
+  /// Called after an assistant reply to maybe update proactive care timing.
+  void Function(String conversationId)? onMaybeUpdateProactiveCare;
+
   /// Called when file processing starts.
   VoidCallback? onFileProcessingStarted;
 
@@ -1561,6 +1564,7 @@ class ChatActions {
 
     _setConversationLoading(conversationId, false);
     onAssistantMessageFinished?.call(finalizedMessage);
+    onMaybeUpdateProactiveCare?.call(conversationId);
 
     // Use unified reasoning completion method
     await streamController.finishReasoningAndPersist(

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
-import 'dart:ui' show IsolateNameServer, ReceivePort;
+import 'dart:isolate' show ReceivePort;
+import 'dart:ui' show IsolateNameServer;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:io' show Platform;
+import 'dart:ui' show IsolateNameServer, ReceivePort;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -19,6 +21,7 @@ import '../../../core/providers/memory_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/tts/tts_text_selection.dart';
 import '../../../core/services/haptics.dart';
+import '../../../core/services/proactive_care_alarm_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/platform_utils.dart';
@@ -143,6 +146,7 @@ class HomePageController extends ChangeNotifier {
 
   McpProvider? _mcpProvider;
   StreamSubscription<ChatAction>? _chatActionSub;
+  ReceivePort? _proactiveCarePort;
 
   // ============================================================================
   // Animation Controllers
@@ -315,6 +319,23 @@ class HomePageController extends ChangeNotifier {
     _initializeProviders();
     _setupKeyboardListeners();
     _setupDesktopFeatures();
+    _registerProactiveCarePort();
+  }
+
+  /// Register the main-isolate port so the alarm background isolate can
+  /// forward proactive care triggers to [HomeViewModel.handleProactiveCareTrigger].
+  void _registerProactiveCarePort() {
+    if (!Platform.isAndroid || !ProactiveCareAlarmService.isSupported) return;
+    _proactiveCarePort = ReceivePort();
+    IsolateNameServer.registerPortWithName(
+      _proactiveCarePort!.sendPort,
+      proactiveCareMainPortName,
+    );
+    _proactiveCarePort!.listen((dynamic data) {
+      final assistantId = data as String?;
+      if (assistantId == null || assistantId.isEmpty) return;
+      _viewModel.handleProactiveCareTrigger(assistantId);
+    });
   }
 
   void _initializeAnimations() {
@@ -2430,6 +2451,8 @@ class HomePageController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _proactiveCarePort?.close();
+    IsolateNameServer.removePortNameMapping(proactiveCareMainPortName);
     _convoFadeController.dispose();
     _mcpProvider?.removeListener(_onMcpChanged);
     _scrollCtrl.dispose();

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/models/chat_input_data.dart';
@@ -10,6 +11,11 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/logging/flutter_logger.dart';
+import '../../../core/services/notification_service.dart';
+import '../../../core/services/proactive_care_alarm_service.dart';
+import '../../../core/services/proactive_care_message_flow.dart';
+import '../../../core/providers/user_provider.dart';
+import '../../../utils/avatar_cache.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../chat/widgets/chat_message_widget.dart' show ToolUIPart;
 import '../../chat/utils/thinking_tag_parser.dart';
@@ -196,6 +202,7 @@ class HomeViewModel extends ChangeNotifier {
     _chatActions.onMaybeGenerateSuggestions = _onMaybeGenerateSuggestions;
     _chatActions.onStreamFinished = _onStreamFinished;
     _chatActions.onAssistantMessageFinished = _onAssistantMessageFinished;
+    _chatActions.onMaybeUpdateProactiveCare = _onMaybeUpdateProactiveCare;
     _chatActions.onFileProcessingStarted = _onFileProcessingStarted;
     _chatActions.onFileProcessingFinished = _onFileProcessingFinished;
   }
@@ -360,6 +367,10 @@ class HomeViewModel extends ChangeNotifier {
 
   void _onAssistantMessageFinished(ChatMessage message) {
     onAssistantMessageFinished?.call(message);
+  }
+
+  void _onMaybeUpdateProactiveCare(String conversationId) {
+    _maybeUpdateProactiveCareFor(conversationId);
   }
 
   void _onFileProcessingStarted() {
@@ -1508,6 +1519,181 @@ class HomeViewModel extends ChangeNotifier {
 
   bool isReasoningEnabled(int? budget) {
     return _generationController.isReasoningEnabled(budget);
+  }
+
+
+  // ============================================================================
+  // Proactive Care
+  // ============================================================================
+
+  /// After each assistant reply, ask the model to (re-)decide when the next
+  /// proactive care message should fire, then reschedule the alarm.
+  Future<void> _maybeUpdateProactiveCareFor(String conversationId) async {
+    if (!Platform.isAndroid || !ProactiveCareAlarmService.isSupported) return;
+
+    final convo = _chatService.getConversation(conversationId);
+    if (convo == null) return;
+
+    final assistantProvider = _contextProvider.read<AssistantProvider>();
+    final assistant = convo.assistantId != null
+        ? assistantProvider.getById(convo.assistantId!)
+        : assistantProvider.currentAssistant;
+    if (assistant == null || !assistant.enableProactiveCare) return;
+
+    final settings = _contextProvider.read<SettingsProvider>();
+    final provKey =
+        assistant.chatModelProvider ?? settings.currentModelProvider;
+    final mdlId = assistant.chatModelId ?? settings.currentModelId;
+    if (provKey == null || mdlId == null) return;
+    final cfg = settings.getProviderConfig(provKey);
+
+    final history = ProactiveCareMessageFlow.buildHistory(
+      conversation: convo,
+      messages: _chatService.getMessages(convo.id),
+    );
+
+    final l10n = AppLocalizations.of(_contextProvider);
+    final decisionPrompt = assistant.proactiveCareDecisionPrompt.trim().isEmpty
+        ? (l10n?.assistantEditProactiveCareDecisionPromptDefault ?? '')
+        : assistant.proactiveCareDecisionPrompt;
+
+    try {
+      final newTime = await ProactiveCareMessageFlow.decideNextCareTime(
+        config: cfg,
+        modelId: mdlId,
+        assistant: assistant,
+        userNickname: _contextProvider.read<UserProvider>().name,
+        history: history,
+        decisionPrompt: decisionPrompt,
+        fallbackThinkingBudget: settings.thinkingBudget,
+      );
+      if (newTime == null) return;
+
+      final latest = assistantProvider.getById(assistant.id);
+      if (latest == null || !latest.enableProactiveCare) return;
+      await assistantProvider.updateAssistant(
+        latest.copyWith(proactiveCareNextMessageAt: newTime),
+      );
+      // Reschedule the alarm with the new time.
+      await ProactiveCareAlarmService.scheduleAlarm(assistant.id, newTime);
+    } catch (e) {
+      FlutterLogger.log(
+        '[ProactiveCare] Decision request failed: $e',
+        tag: 'HomeViewModel',
+      );
+    }
+  }
+
+  /// Handles a proactive care alarm while the app process is alive.
+  /// Builds the care prompt, streams a reply, persists it, notifies the user,
+  /// and re-decides the next care time.
+  Future<void> handleProactiveCareTrigger(String assistantId) async {
+    final assistantProvider = _contextProvider.read<AssistantProvider>();
+    final assistant = assistantProvider.getById(assistantId);
+    if (assistant == null || !assistant.enableProactiveCare) return;
+
+    final settings = _contextProvider.read<SettingsProvider>();
+    final provKey =
+        assistant.chatModelProvider ?? settings.currentModelProvider;
+    final mdlId = assistant.chatModelId ?? settings.currentModelId;
+    final l10n = AppLocalizations.of(_contextProvider);
+    if (provKey == null || mdlId == null) {
+      FlutterLogger.log(
+        '[ProactiveCare] No chat model configured for $assistantId',
+        tag: 'HomeViewModel',
+      );
+      await _showProactiveCareNotification(
+        assistant,
+        l10n?.proactiveCareFailedNotificationBody,
+      );
+      return;
+    }
+    final cfg = settings.getProviderConfig(provKey);
+    final userNickname = _contextProvider.read<UserProvider>().name;
+
+    try {
+      Conversation? convo;
+      for (final c in _chatService.getAllConversations()) {
+        if (c.assistantId == assistantId) {
+          convo = c;
+          break;
+        }
+      }
+      convo ??= await _chatService.createConversation(assistantId: assistantId);
+
+      final history = ProactiveCareMessageFlow.buildHistory(
+        conversation: convo,
+        messages: _chatService.getMessages(convo.id),
+      );
+      final carePrompt = assistant.proactiveCarePrompt.trim().isNotEmpty
+          ? assistant.proactiveCarePrompt
+          : (l10n?.assistantEditProactiveCarePromptDefault ?? '');
+      final apiMessages = await ProactiveCareMessageFlow.buildCareApiMessages(
+        assistant: assistant,
+        userNickname: userNickname,
+        modelId: mdlId,
+        history: history,
+        carePrompt: carePrompt,
+        now: DateTime.now(),
+      );
+
+      final reply = await ProactiveCareMessageFlow.requestCareReply(
+        config: cfg,
+        modelId: mdlId,
+        assistant: assistant,
+        apiMessages: apiMessages,
+        fallbackThinkingBudget: settings.thinkingBudget,
+      );
+      if (reply.isEmpty) {
+        throw StateError('model returned an empty proactive care reply');
+      }
+
+      final message = await _chatService.addMessage(
+        conversationId: convo.id,
+        role: 'assistant',
+        content: reply,
+        modelId: mdlId,
+        providerId: provKey,
+      );
+      if (currentConversation?.id == convo.id) {
+        if (_chatController.appendPersistedTailMessage(message)) {
+          restoreMessageUiState();
+        }
+        notifyListeners();
+      }
+
+      await _showProactiveCareNotification(assistant, reply);
+      await _maybeUpdateProactiveCareFor(convo.id);
+    } catch (e) {
+      FlutterLogger.log(
+        '[ProactiveCare] Foreground care flow failed: $e',
+        tag: 'HomeViewModel',
+      );
+      await _showProactiveCareNotification(
+        assistant,
+        l10n?.proactiveCareFailedNotificationBody,
+      );
+    }
+  }
+
+  Future<void> _showProactiveCareNotification(
+    Assistant assistant,
+    String? body,
+  ) async {
+    if (body == null || body.isEmpty) return;
+    try {
+      final id = ProactiveCareAlarmService.alarmIdFor(assistant.id);
+      await NotificationService.showProactiveCare(
+        id: id,
+        title: assistant.name,
+        body: body,
+      );
+    } catch (e) {
+      FlutterLogger.log(
+        '[ProactiveCare] Failed to show notification: $e',
+        tag: 'HomeViewModel',
+      );
+    }
   }
 
   // ============================================================================

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1521,7 +1521,6 @@ class HomeViewModel extends ChangeNotifier {
     return _generationController.isReasoningEnabled(budget);
   }
 
-
   // ============================================================================
   // Proactive Care
   // ============================================================================
@@ -1542,8 +1541,13 @@ class HomeViewModel extends ChangeNotifier {
 
     final settings = _contextProvider.read<SettingsProvider>();
     final provKey =
-        assistant.chatModelProvider ?? settings.currentModelProvider;
-    final mdlId = assistant.chatModelId ?? settings.currentModelId;
+        settings.proactiveCareDecisionModelProvider ??
+        assistant.chatModelProvider ??
+        settings.currentModelProvider;
+    final mdlId =
+        settings.proactiveCareDecisionModelId ??
+        assistant.chatModelId ??
+        settings.currentModelId;
     if (provKey == null || mdlId == null) return;
     final cfg = settings.getProviderConfig(provKey);
 

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -15,7 +15,7 @@ import '../../../core/services/notification_service.dart';
 import '../../../core/services/proactive_care_alarm_service.dart';
 import '../../../core/services/proactive_care_message_flow.dart';
 import '../../../core/providers/user_provider.dart';
-import '../../../utils/avatar_cache.dart';
+
 import '../../../l10n/app_localizations.dart';
 import '../../chat/widgets/chat_message_widget.dart' show ToolUIPart;
 import '../../chat/utils/thinking_tag_parser.dart';
@@ -1575,7 +1575,9 @@ class HomeViewModel extends ChangeNotifier {
         latest.copyWith(proactiveCareNextMessageAt: newTime),
       );
       // Reschedule the alarm with the new time.
-      await ProactiveCareAlarmService.scheduleAlarm(assistant.id, newTime);
+      await ProactiveCareAlarmService.sync(
+        latest.copyWith(proactiveCareNextMessageAt: newTime),
+      );
     } catch (e) {
       FlutterLogger.log(
         '[ProactiveCare] Decision request failed: $e',

--- a/lib/features/model/pages/default_model_page.dart
+++ b/lib/features/model/pages/default_model_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/providers/settings_provider.dart';
@@ -227,6 +229,33 @@ class DefaultModelPage extends StatelessWidget {
             },
             configAction: () => showOcrPromptSheet(context),
           ),
+          if (Platform.isAndroid) ...[
+            const SizedBox(height: 16),
+            _ModelCard(
+              icon: Lucide.HeartPulse,
+              title: l10n.defaultModelPageProactiveCareModelTitle,
+              subtitle: l10n.defaultModelPageProactiveCareModelSubtitle,
+              modelProvider: settings.proactiveCareDecisionModelProvider,
+              modelId: settings.proactiveCareDecisionModelId,
+              fallbackProvider: settings.currentModelProvider,
+              fallbackModelId: settings.currentModelId,
+              onReset: () async {
+                await settings.resetProactiveCareDecisionModel();
+              },
+              onPick: () async {
+                final sel = await pickConfiguredModel(
+                  settings.proactiveCareDecisionModelProvider,
+                  settings.proactiveCareDecisionModelId,
+                );
+                if (sel != null) {
+                  await settings.setProactiveCareDecisionModel(
+                    sel.providerKey,
+                    sel.modelId,
+                  );
+                }
+              },
+            ),
+          ],
         ],
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2667,5 +2667,65 @@
   "multiAIRetryBlockedUnresolvedComparison": "Please adopt or drop the comparison results before retrying.",
   "@multiAIRetryBlockedUnresolvedComparison": {
     "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
+  },
+  "assistantEditPageProactiveLetterTab": "Their Letter",
+  "@assistantEditPageProactiveLetterTab": {
+    "description": "Tab label for proactive care / their letter settings"
+  },
+  "assistantEditProactiveCareEnableTitle": "Proactive Care",
+  "@assistantEditProactiveCareEnableTitle": {
+    "description": "Title for the proactive care enable switch"
+  },
+  "assistantEditProactiveCareNextMessageTimeTitle": "Next proactive message time",
+  "@assistantEditProactiveCareNextMessageTimeTitle": {
+    "description": "Label for the next proactive message time row"
+  },
+  "assistantEditProactiveCareNextMessageTimeUnset": "Not set",
+  "@assistantEditProactiveCareNextMessageTimeUnset": {
+    "description": "Shown when no proactive message time is set"
+  },
+  "assistantEditProactiveCarePromptTitle": "Proactive care prompt",
+  "@assistantEditProactiveCarePromptTitle": {
+    "description": "Title for the proactive care prompt editor"
+  },
+  "assistantEditProactiveCarePromptHint": "Prompt used when the assistant proactively sends a message",
+  "@assistantEditProactiveCarePromptHint": {
+    "description": "Hint text for the proactive care prompt field"
+  },
+  "assistantEditProactiveCarePromptDefault": "It is time to proactively message the user. Stay in character, consider the conversation context and the current time, and write one natural, caring message to the user. Output only the message itself.",
+  "@assistantEditProactiveCarePromptDefault": {
+    "description": "Default proactive care prompt"
+  },
+  "assistantEditProactiveCareDecisionPromptTitle": "Decision time instruction prompt",
+  "@assistantEditProactiveCareDecisionPromptTitle": {
+    "description": "Title for the decision prompt editor"
+  },
+  "assistantEditProactiveCareDecisionPromptDefault": "You are in the \"proactive message time decision\" phase. Take on the assistant's role and decide when to message the user next.\n\n[Feature description]\n- Proactive messaging: the assistant sends a message at the scheduled time without waiting for the user to ask.\n- First check the next scheduled message time. Keep it if it still fits; otherwise change it.\n- As the assistant, using context and the time of your last reply, consider:\n1. If the user has not messaged you, when would you reach out?\n2. Match timing to personality: clingy or warm personalities message sooner; aloof personalities later.\n3. If context mentions reminders, supervision, or care, message sooner at a fitting time.\n4. If you were sleeping or busy, message when you would wake up or finish.\n5. You may invent a situational event and schedule the message for when it would happen.",
+  "@assistantEditProactiveCareDecisionPromptDefault": {
+    "description": "Default decision prompt for proactive care timing"
+  },
+  "assistantEditProactiveCareDateTimePickerTitle": "Choose date and time",
+  "@assistantEditProactiveCareDateTimePickerTitle": {
+    "description": "Title for the date/time picker bottom sheet"
+  },
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "Exact alarm permission not granted. Proactive care cannot wake the app on time. Please allow \"Alarms & reminders\" in system settings.",
+  "@assistantEditProactiveCareExactAlarmPermissionDenied": {
+    "description": "Warning when exact alarm permission is denied"
+  },
+  "assistantEditProactiveCareNotificationPermissionDenied": "Notification permission not granted. Proactive care messages cannot notify you. Please enable notifications in system settings.",
+  "@assistantEditProactiveCareNotificationPermissionDenied": {
+    "description": "Warning when notification permission is denied"
+  },
+  "defaultModelPageProactiveCareModelTitle": "Ta's Letter Decision Model",
+  "@defaultModelPageProactiveCareModelTitle": {
+    "description": "Title for the proactive care decision model card"
+  },
+  "defaultModelPageProactiveCareModelSubtitle": "Model used to decide when the assistant should proactively message",
+  "@defaultModelPageProactiveCareModelSubtitle": {
+    "description": "Subtitle for the proactive care decision model card"
+  },
+  "proactiveCareFailedNotificationBody": "Couldn't generate the proactive care message. Open the app to check the model settings and network.",
+  "@proactiveCareFailedNotificationBody": {
+    "description": "Notification body when proactive care message generation fails"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10705,6 +10705,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Please adopt or drop the comparison results before retrying.'**
   String get multiAIRetryBlockedUnresolvedComparison;
+
+  /// Tab label for proactive care / their letter settings
+  ///
+  /// In en, this message translates to:
+  /// **'Their Letter'**
+  String get assistantEditPageProactiveLetterTab;
+
+  /// Title for the proactive care enable switch
+  ///
+  /// In en, this message translates to:
+  /// **'Proactive Care'**
+  String get assistantEditProactiveCareEnableTitle;
+
+  /// Label for the next proactive message time row
+  ///
+  /// In en, this message translates to:
+  /// **'Next proactive message time'**
+  String get assistantEditProactiveCareNextMessageTimeTitle;
+
+  /// Shown when no proactive message time is set
+  ///
+  /// In en, this message translates to:
+  /// **'Not set'**
+  String get assistantEditProactiveCareNextMessageTimeUnset;
+
+  /// Title for the proactive care prompt editor
+  ///
+  /// In en, this message translates to:
+  /// **'Proactive care prompt'**
+  String get assistantEditProactiveCarePromptTitle;
+
+  /// Hint text for the proactive care prompt field
+  ///
+  /// In en, this message translates to:
+  /// **'Prompt used when the assistant proactively sends a message'**
+  String get assistantEditProactiveCarePromptHint;
+
+  /// Default proactive care prompt
+  ///
+  /// In en, this message translates to:
+  /// **'It is time to proactively message the user. Stay in character, consider the conversation context and the current time, and write one natural, caring message to the user. Output only the message itself.'**
+  String get assistantEditProactiveCarePromptDefault;
+
+  /// Title for the decision prompt editor
+  ///
+  /// In en, this message translates to:
+  /// **'Decision time instruction prompt'**
+  String get assistantEditProactiveCareDecisionPromptTitle;
+
+  /// Default decision prompt for proactive care timing
+  ///
+  /// In en, this message translates to:
+  /// **'You are in the \"proactive message time decision\" phase. Take on the assistant\'s role and decide when to message the user next.\n\n[Feature description]\n- Proactive messaging: the assistant sends a message at the scheduled time without waiting for the user to ask.\n- First check the next scheduled message time. Keep it if it still fits; otherwise change it.\n- As the assistant, using context and the time of your last reply, consider:\n1. If the user has not messaged you, when would you reach out?\n2. Match timing to personality: clingy or warm personalities message sooner; aloof personalities later.\n3. If context mentions reminders, supervision, or care, message sooner at a fitting time.\n4. If you were sleeping or busy, message when you would wake up or finish.\n5. You may invent a situational event and schedule the message for when it would happen.'**
+  String get assistantEditProactiveCareDecisionPromptDefault;
+
+  /// Title for the date/time picker bottom sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Choose date and time'**
+  String get assistantEditProactiveCareDateTimePickerTitle;
+
+  /// Warning when exact alarm permission is denied
+  ///
+  /// In en, this message translates to:
+  /// **'Exact alarm permission not granted. Proactive care cannot wake the app on time. Please allow \"Alarms & reminders\" in system settings.'**
+  String get assistantEditProactiveCareExactAlarmPermissionDenied;
+
+  /// Warning when notification permission is denied
+  ///
+  /// In en, this message translates to:
+  /// **'Notification permission not granted. Proactive care messages cannot notify you. Please enable notifications in system settings.'**
+  String get assistantEditProactiveCareNotificationPermissionDenied;
+
+  /// Title for the proactive care decision model card
+  ///
+  /// In en, this message translates to:
+  /// **'Ta\'s Letter Decision Model'**
+  String get defaultModelPageProactiveCareModelTitle;
+
+  /// Subtitle for the proactive care decision model card
+  ///
+  /// In en, this message translates to:
+  /// **'Model used to decide when the assistant should proactively message'**
+  String get defaultModelPageProactiveCareModelSubtitle;
+
+  /// Notification body when proactive care message generation fails
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t generate the proactive care message. Open the app to check the model settings and network.'**
+  String get proactiveCareFailedNotificationBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5834,4 +5834,60 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get multiAIRetryBlockedUnresolvedComparison =>
       'Please adopt or drop the comparison results before retrying.';
+
+  @override
+  String get assistantEditPageProactiveLetterTab => 'Their Letter';
+
+  @override
+  String get assistantEditProactiveCareEnableTitle => 'Proactive Care';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeTitle =>
+      'Next proactive message time';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeUnset => 'Not set';
+
+  @override
+  String get assistantEditProactiveCarePromptTitle => 'Proactive care prompt';
+
+  @override
+  String get assistantEditProactiveCarePromptHint =>
+      'Prompt used when the assistant proactively sends a message';
+
+  @override
+  String get assistantEditProactiveCarePromptDefault =>
+      'It is time to proactively message the user. Stay in character, consider the conversation context and the current time, and write one natural, caring message to the user. Output only the message itself.';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptTitle =>
+      'Decision time instruction prompt';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptDefault =>
+      'You are in the \"proactive message time decision\" phase. Take on the assistant\'s role and decide when to message the user next.\n\n[Feature description]\n- Proactive messaging: the assistant sends a message at the scheduled time without waiting for the user to ask.\n- First check the next scheduled message time. Keep it if it still fits; otherwise change it.\n- As the assistant, using context and the time of your last reply, consider:\n1. If the user has not messaged you, when would you reach out?\n2. Match timing to personality: clingy or warm personalities message sooner; aloof personalities later.\n3. If context mentions reminders, supervision, or care, message sooner at a fitting time.\n4. If you were sleeping or busy, message when you would wake up or finish.\n5. You may invent a situational event and schedule the message for when it would happen.';
+
+  @override
+  String get assistantEditProactiveCareDateTimePickerTitle =>
+      'Choose date and time';
+
+  @override
+  String get assistantEditProactiveCareExactAlarmPermissionDenied =>
+      'Exact alarm permission not granted. Proactive care cannot wake the app on time. Please allow \"Alarms & reminders\" in system settings.';
+
+  @override
+  String get assistantEditProactiveCareNotificationPermissionDenied =>
+      'Notification permission not granted. Proactive care messages cannot notify you. Please enable notifications in system settings.';
+
+  @override
+  String get defaultModelPageProactiveCareModelTitle =>
+      'Ta\'s Letter Decision Model';
+
+  @override
+  String get defaultModelPageProactiveCareModelSubtitle =>
+      'Model used to decide when the assistant should proactively message';
+
+  @override
+  String get proactiveCareFailedNotificationBody =>
+      'Couldn\'t generate the proactive care message. Open the app to check the model settings and network.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5599,6 +5599,56 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get multiAIRetryBlockedUnresolvedComparison => '请先采纳或丢弃对比结果，再进行重试。';
+
+  @override
+  String get assistantEditPageProactiveLetterTab => 'Ta的来信';
+
+  @override
+  String get assistantEditProactiveCareEnableTitle => '主动关怀';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeTitle => '下次助手主动发消息时间';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeUnset => '未设置';
+
+  @override
+  String get assistantEditProactiveCarePromptTitle => '主动关怀提示词';
+
+  @override
+  String get assistantEditProactiveCarePromptHint => '助手主动发消息时使用的提示词';
+
+  @override
+  String get assistantEditProactiveCarePromptDefault =>
+      '现在到了你主动给用户发消息的时间。请保持你的角色设定，结合上下文与当前时间，主动给用户发一条自然、贴心的消息。只输出消息内容本身。';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptTitle => '决策时间功能说明提示词';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptDefault =>
+      '你现在在\"主动发消息时间决策\"。你需要代入助手的角色，判断下次什么时候给用户发消息。\n【功能说明】\n- 主动发消息功能：助手会在设定的时间主动给用户发送一条消息，无需用户提问。\n- 请你先看一下下次发消息的时间，如果你认为当前设定的时间无需改变，则保持原时间。反之，则修改\n- 请你代入助手的角色，根据上下文，以及助手最后一次回复用户消息的时间，从以下几方面考虑:\n1.用户没有给你发消息，你希望什么时候主动找用户\n2.请根据助手设定的性格决定时间；如果助手是依赖用户的性格或热情的性格，就早些给用户发消息；反之，高冷性格就晚些发\n3.如果上下文提到了助手要提醒/监督/关心用户，就早些按符合助手设定的时间主动给用户发消息\n4.如果上文提到助手睡觉/在忙等等，就按助手起床/忙完的时间给用户发消息\n5.你也可以根据上下文制造一些突发事件，按你制造的突发事件的时间给用户发消息）';
+
+  @override
+  String get assistantEditProactiveCareDateTimePickerTitle => '选择日期和时间';
+
+  @override
+  String get assistantEditProactiveCareExactAlarmPermissionDenied =>
+      '未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许「闹钟和提醒」。';
+
+  @override
+  String get assistantEditProactiveCareNotificationPermissionDenied =>
+      '未授予通知权限，主动关怀消息将无法通知你，请在系统设置中开启通知。';
+
+  @override
+  String get defaultModelPageProactiveCareModelTitle => 'Ta的来信决策模型';
+
+  @override
+  String get defaultModelPageProactiveCareModelSubtitle => '用于决定助手何时主动发消息的模型';
+
+  @override
+  String get proactiveCareFailedNotificationBody =>
+      '主动关怀消息生成失败，请打开应用检查模型配置与网络。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -11196,6 +11246,56 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get multiAIRetryBlockedUnresolvedComparison => '请先采纳或丢弃对比结果，再进行重试。';
+
+  @override
+  String get assistantEditPageProactiveLetterTab => 'Ta的来信';
+
+  @override
+  String get assistantEditProactiveCareEnableTitle => '主动关怀';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeTitle => '下次助手主动发消息时间';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeUnset => '未设置';
+
+  @override
+  String get assistantEditProactiveCarePromptTitle => '主动关怀提示词';
+
+  @override
+  String get assistantEditProactiveCarePromptHint => '助手主动发消息时使用的提示词';
+
+  @override
+  String get assistantEditProactiveCarePromptDefault =>
+      '现在到了你主动给用户发消息的时间。请保持你的角色设定，结合上下文与当前时间，主动给用户发一条自然、贴心的消息。只输出消息内容本身。';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptTitle => '决策时间功能说明提示词';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptDefault =>
+      '你现在在\"主动发消息时间决策\"。你需要代入助手的角色，判断下次什么时候给用户发消息。\n【功能说明】\n- 主动发消息功能：助手会在设定的时间主动给用户发送一条消息，无需用户提问。\n- 请你先看一下下次发消息的时间，如果你认为当前设定的时间无需改变，则保持原时间。反之，则修改\n- 请你代入助手的角色，根据上下文，以及助手最后一次回复用户消息的时间，从以下几方面考虑:\n1.用户没有给你发消息，你希望什么时候主动找用户\n2.请根据助手设定的性格决定时间；如果助手是依赖用户的性格或热情的性格，就早些给用户发消息；反之，高冷性格就晚些发\n3.如果上下文提到了助手要提醒/监督/关心用户，就早些按符合助手设定的时间主动给用户发消息\n4.如果上文提到助手睡觉/在忙等等，就按助手起床/忙完的时间给用户发消息\n5.你也可以根据上下文制造一些突发事件，按你制造的突发事件的时间给用户发消息）';
+
+  @override
+  String get assistantEditProactiveCareDateTimePickerTitle => '选择日期和时间';
+
+  @override
+  String get assistantEditProactiveCareExactAlarmPermissionDenied =>
+      '未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许「闹钟和提醒」。';
+
+  @override
+  String get assistantEditProactiveCareNotificationPermissionDenied =>
+      '未授予通知权限，主动关怀消息将无法通知你，请在系统设置中开启通知。';
+
+  @override
+  String get defaultModelPageProactiveCareModelTitle => 'Ta的来信决策模型';
+
+  @override
+  String get defaultModelPageProactiveCareModelSubtitle => '用于决定助手何时主动发消息的模型';
+
+  @override
+  String get proactiveCareFailedNotificationBody =>
+      '主动关怀消息生成失败，请打开应用检查模型配置与网络。';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -16793,4 +16893,54 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get multiAIRetryBlockedUnresolvedComparison => '請先採納或丟棄對比結果，再進行重試。';
+
+  @override
+  String get assistantEditPageProactiveLetterTab => 'Ta的來信';
+
+  @override
+  String get assistantEditProactiveCareEnableTitle => '主動關懷';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeTitle => '下次助手主動發訊息時間';
+
+  @override
+  String get assistantEditProactiveCareNextMessageTimeUnset => '未設定';
+
+  @override
+  String get assistantEditProactiveCarePromptTitle => '主動關懷提示詞';
+
+  @override
+  String get assistantEditProactiveCarePromptHint => '助手主動發訊息時使用的提示詞';
+
+  @override
+  String get assistantEditProactiveCarePromptDefault =>
+      '現在到了你主動給使用者發訊息的時間。請保持你的角色設定，結合上下文與目前時間，主動給使用者發一條自然、貼心的訊息。只輸出訊息內容本身。';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptTitle => '決策時間功能說明提示詞';
+
+  @override
+  String get assistantEditProactiveCareDecisionPromptDefault =>
+      '你現在在\"主動發訊息時間決策\"。你需要代入助手的角色，判斷下次什麼時候給使用者發訊息。\n【功能說明】\n- 主動發訊息功能：助手會在設定的時間主動給使用者發送一條訊息，無需使用者提問。\n- 請你先看一下下次發訊息的時間，如果你認為目前設定的時間無需改變，則保持原時間。反之，則修改\n- 請你代入助手的角色，根據上下文，以及助手最後一次回覆使用者訊息的時間，從以下幾方面考慮:\n1.使用者沒有給你發訊息，你希望什麼時候主動找使用者\n2.請根據助手設定的性格決定時間；如果助手是依賴使用者的性格或熱情的性格，就早些給使用者發訊息；反之，高冷性格就晚些發\n3.如果上下文提到了助手要提醒/監督/關心使用者，就早些按符合助手設定的時間主動給使用者發訊息\n4.如果上文提到助手睡覺/在忙等等，就按助手起床/忙完的時間給使用者發訊息\n5.你也可以根據上下文製造一些突發事件，按你製造的突發事件的時間給使用者發訊息）';
+
+  @override
+  String get assistantEditProactiveCareDateTimePickerTitle => '選擇日期和時間';
+
+  @override
+  String get assistantEditProactiveCareExactAlarmPermissionDenied =>
+      '未授予精確鬧鐘權限，主動關懷無法按時喚醒應用程式，請在系統設定中允許「鬧鐘和提醒」。';
+
+  @override
+  String get assistantEditProactiveCareNotificationPermissionDenied =>
+      '未授予通知權限，主動關懷訊息將無法通知你，請在系統設定中開啟通知。';
+
+  @override
+  String get defaultModelPageProactiveCareModelTitle => 'Ta的來信決策模型';
+
+  @override
+  String get defaultModelPageProactiveCareModelSubtitle => '用於決定助手何時主動發訊息的模型';
+
+  @override
+  String get proactiveCareFailedNotificationBody =>
+      '主動關懷訊息生成失敗，請開啟應用程式檢查模型配置與網路。';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2255,7 +2255,7 @@
   "@assistantEditProactiveCareDateTimePickerTitle": {
     "description": "日期时间选择器标题"
   },
-  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许"闹钟和提醒"。",
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许「闹钟和提醒」。",
   "@assistantEditProactiveCareExactAlarmPermissionDenied": {
     "description": "精确闹钟权限被拒绝时的警告"
   },

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2214,5 +2214,65 @@
   "multiAIRetryBlockedUnresolvedComparison": "请先采纳或丢弃对比结果，再进行重试。",
   "@multiAIRetryBlockedUnresolvedComparison": {
     "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
+  },
+  "assistantEditPageProactiveLetterTab": "Ta的来信",
+  "@assistantEditPageProactiveLetterTab": {
+    "description": "主动关怀/Ta的来信设置页签标签"
+  },
+  "assistantEditProactiveCareEnableTitle": "主动关怀",
+  "@assistantEditProactiveCareEnableTitle": {
+    "description": "主动关怀开关标题"
+  },
+  "assistantEditProactiveCareNextMessageTimeTitle": "下次助手主动发消息时间",
+  "@assistantEditProactiveCareNextMessageTimeTitle": {
+    "description": "下次主动发消息时间标签"
+  },
+  "assistantEditProactiveCareNextMessageTimeUnset": "未设置",
+  "@assistantEditProactiveCareNextMessageTimeUnset": {
+    "description": "未设置主动发消息时间时显示"
+  },
+  "assistantEditProactiveCarePromptTitle": "主动关怀提示词",
+  "@assistantEditProactiveCarePromptTitle": {
+    "description": "主动关怀提示词编辑器标题"
+  },
+  "assistantEditProactiveCarePromptHint": "助手主动发消息时使用的提示词",
+  "@assistantEditProactiveCarePromptHint": {
+    "description": "主动关怀提示词输入框提示"
+  },
+  "assistantEditProactiveCarePromptDefault": "现在到了你主动给用户发消息的时间。请保持你的角色设定，结合上下文与当前时间，主动给用户发一条自然、贴心的消息。只输出消息内容本身。",
+  "@assistantEditProactiveCarePromptDefault": {
+    "description": "默认主动关怀提示词"
+  },
+  "assistantEditProactiveCareDecisionPromptTitle": "决策时间功能说明提示词",
+  "@assistantEditProactiveCareDecisionPromptTitle": {
+    "description": "决策提示词编辑器标题"
+  },
+  "assistantEditProactiveCareDecisionPromptDefault": "你现在在\"主动发消息时间决策\"。你需要代入助手的角色，判断下次什么时候给用户发消息。\n【功能说明】\n- 主动发消息功能：助手会在设定的时间主动给用户发送一条消息，无需用户提问。\n- 请你先看一下下次发消息的时间，如果你认为当前设定的时间无需改变，则保持原时间。反之，则修改\n- 请你代入助手的角色，根据上下文，以及助手最后一次回复用户消息的时间，从以下几方面考虑:\n1.用户没有给你发消息，你希望什么时候主动找用户\n2.请根据助手设定的性格决定时间；如果助手是依赖用户的性格或热情的性格，就早些给用户发消息；反之，高冷性格就晚些发\n3.如果上下文提到了助手要提醒/监督/关心用户，就早些按符合助手设定的时间主动给用户发消息\n4.如果上文提到助手睡觉/在忙等等，就按助手起床/忙完的时间给用户发消息\n5.你也可以根据上下文制造一些突发事件，按你制造的突发事件的时间给用户发消息）",
+  "@assistantEditProactiveCareDecisionPromptDefault": {
+    "description": "默认决策时间提示词"
+  },
+  "assistantEditProactiveCareDateTimePickerTitle": "选择日期和时间",
+  "@assistantEditProactiveCareDateTimePickerTitle": {
+    "description": "日期时间选择器标题"
+  },
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许"闹钟和提醒"。",
+  "@assistantEditProactiveCareExactAlarmPermissionDenied": {
+    "description": "精确闹钟权限被拒绝时的警告"
+  },
+  "assistantEditProactiveCareNotificationPermissionDenied": "未授予通知权限，主动关怀消息将无法通知你，请在系统设置中开启通知。",
+  "@assistantEditProactiveCareNotificationPermissionDenied": {
+    "description": "通知权限被拒绝时的警告"
+  },
+  "defaultModelPageProactiveCareModelTitle": "Ta的来信决策模型",
+  "@defaultModelPageProactiveCareModelTitle": {
+    "description": "主动关怀决策模型卡片标题"
+  },
+  "defaultModelPageProactiveCareModelSubtitle": "用于决定助手何时主动发消息的模型",
+  "@defaultModelPageProactiveCareModelSubtitle": {
+    "description": "主动关怀决策模型卡片副标题"
+  },
+  "proactiveCareFailedNotificationBody": "主动关怀消息生成失败，请打开应用检查模型配置与网络。",
+  "@proactiveCareFailedNotificationBody": {
+    "description": "主动关怀消息生成失败时的通知内容"
   }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2255,7 +2255,7 @@
   "@assistantEditProactiveCareDateTimePickerTitle": {
     "description": "日期时间选择器标题"
   },
-  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许"闹钟和提醒"。",
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许「闹钟和提醒」。",
   "@assistantEditProactiveCareExactAlarmPermissionDenied": {
     "description": "精确闹钟权限被拒绝时的警告"
   },

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2214,5 +2214,65 @@
   "multiAIRetryBlockedUnresolvedComparison": "请先采纳或丢弃对比结果，再进行重试。",
   "@multiAIRetryBlockedUnresolvedComparison": {
     "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
+  },
+  "assistantEditPageProactiveLetterTab": "Ta的来信",
+  "@assistantEditPageProactiveLetterTab": {
+    "description": "主动关怀/Ta的来信设置页签标签"
+  },
+  "assistantEditProactiveCareEnableTitle": "主动关怀",
+  "@assistantEditProactiveCareEnableTitle": {
+    "description": "主动关怀开关标题"
+  },
+  "assistantEditProactiveCareNextMessageTimeTitle": "下次助手主动发消息时间",
+  "@assistantEditProactiveCareNextMessageTimeTitle": {
+    "description": "下次主动发消息时间标签"
+  },
+  "assistantEditProactiveCareNextMessageTimeUnset": "未设置",
+  "@assistantEditProactiveCareNextMessageTimeUnset": {
+    "description": "未设置主动发消息时间时显示"
+  },
+  "assistantEditProactiveCarePromptTitle": "主动关怀提示词",
+  "@assistantEditProactiveCarePromptTitle": {
+    "description": "主动关怀提示词编辑器标题"
+  },
+  "assistantEditProactiveCarePromptHint": "助手主动发消息时使用的提示词",
+  "@assistantEditProactiveCarePromptHint": {
+    "description": "主动关怀提示词输入框提示"
+  },
+  "assistantEditProactiveCarePromptDefault": "现在到了你主动给用户发消息的时间。请保持你的角色设定，结合上下文与当前时间，主动给用户发一条自然、贴心的消息。只输出消息内容本身。",
+  "@assistantEditProactiveCarePromptDefault": {
+    "description": "默认主动关怀提示词"
+  },
+  "assistantEditProactiveCareDecisionPromptTitle": "决策时间功能说明提示词",
+  "@assistantEditProactiveCareDecisionPromptTitle": {
+    "description": "决策提示词编辑器标题"
+  },
+  "assistantEditProactiveCareDecisionPromptDefault": "你现在在\"主动发消息时间决策\"。你需要代入助手的角色，判断下次什么时候给用户发消息。\n【功能说明】\n- 主动发消息功能：助手会在设定的时间主动给用户发送一条消息，无需用户提问。\n- 请你先看一下下次发消息的时间，如果你认为当前设定的时间无需改变，则保持原时间。反之，则修改\n- 请你代入助手的角色，根据上下文，以及助手最后一次回复用户消息的时间，从以下几方面考虑:\n1.用户没有给你发消息，你希望什么时候主动找用户\n2.请根据助手设定的性格决定时间；如果助手是依赖用户的性格或热情的性格，就早些给用户发消息；反之，高冷性格就晚些发\n3.如果上下文提到了助手要提醒/监督/关心用户，就早些按符合助手设定的时间主动给用户发消息\n4.如果上文提到助手睡觉/在忙等等，就按助手起床/忙完的时间给用户发消息\n5.你也可以根据上下文制造一些突发事件，按你制造的突发事件的时间给用户发消息）",
+  "@assistantEditProactiveCareDecisionPromptDefault": {
+    "description": "默认决策时间提示词"
+  },
+  "assistantEditProactiveCareDateTimePickerTitle": "选择日期和时间",
+  "@assistantEditProactiveCareDateTimePickerTitle": {
+    "description": "日期时间选择器标题"
+  },
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精确闹钟权限，主动关怀无法按时唤醒应用，请在系统设置中允许"闹钟和提醒"。",
+  "@assistantEditProactiveCareExactAlarmPermissionDenied": {
+    "description": "精确闹钟权限被拒绝时的警告"
+  },
+  "assistantEditProactiveCareNotificationPermissionDenied": "未授予通知权限，主动关怀消息将无法通知你，请在系统设置中开启通知。",
+  "@assistantEditProactiveCareNotificationPermissionDenied": {
+    "description": "通知权限被拒绝时的警告"
+  },
+  "defaultModelPageProactiveCareModelTitle": "Ta的来信决策模型",
+  "@defaultModelPageProactiveCareModelTitle": {
+    "description": "主动关怀决策模型卡片标题"
+  },
+  "defaultModelPageProactiveCareModelSubtitle": "用于决定助手何时主动发消息的模型",
+  "@defaultModelPageProactiveCareModelSubtitle": {
+    "description": "主动关怀决策模型卡片副标题"
+  },
+  "proactiveCareFailedNotificationBody": "主动关怀消息生成失败，请打开应用检查模型配置与网络。",
+  "@proactiveCareFailedNotificationBody": {
+    "description": "主动关怀消息生成失败时的通知内容"
   }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2214,5 +2214,65 @@
   "multiAIRetryBlockedUnresolvedComparison": "請先採納或丟棄對比結果，再進行重試。",
   "@multiAIRetryBlockedUnresolvedComparison": {
     "description": "Toast shown when retry is blocked due to active or unresolved multi-AI comparison state"
+  },
+  "assistantEditPageProactiveLetterTab": "Ta的來信",
+  "@assistantEditPageProactiveLetterTab": {
+    "description": "主動關懷/Ta的來信設定頁籤標籤"
+  },
+  "assistantEditProactiveCareEnableTitle": "主動關懷",
+  "@assistantEditProactiveCareEnableTitle": {
+    "description": "主動關懷開關標題"
+  },
+  "assistantEditProactiveCareNextMessageTimeTitle": "下次助手主動發訊息時間",
+  "@assistantEditProactiveCareNextMessageTimeTitle": {
+    "description": "下次主動發訊息時間標籤"
+  },
+  "assistantEditProactiveCareNextMessageTimeUnset": "未設定",
+  "@assistantEditProactiveCareNextMessageTimeUnset": {
+    "description": "未設定主動發訊息時間時顯示"
+  },
+  "assistantEditProactiveCarePromptTitle": "主動關懷提示詞",
+  "@assistantEditProactiveCarePromptTitle": {
+    "description": "主動關懷提示詞編輯器標題"
+  },
+  "assistantEditProactiveCarePromptHint": "助手主動發訊息時使用的提示詞",
+  "@assistantEditProactiveCarePromptHint": {
+    "description": "主動關懷提示詞輸入框提示"
+  },
+  "assistantEditProactiveCarePromptDefault": "現在到了你主動給使用者發訊息的時間。請保持你的角色設定，結合上下文與目前時間，主動給使用者發一條自然、貼心的訊息。只輸出訊息內容本身。",
+  "@assistantEditProactiveCarePromptDefault": {
+    "description": "預設主動關懷提示詞"
+  },
+  "assistantEditProactiveCareDecisionPromptTitle": "決策時間功能說明提示詞",
+  "@assistantEditProactiveCareDecisionPromptTitle": {
+    "description": "決策提示詞編輯器標題"
+  },
+  "assistantEditProactiveCareDecisionPromptDefault": "你現在在\"主動發訊息時間決策\"。你需要代入助手的角色，判斷下次什麼時候給使用者發訊息。\n【功能說明】\n- 主動發訊息功能：助手會在設定的時間主動給使用者發送一條訊息，無需使用者提問。\n- 請你先看一下下次發訊息的時間，如果你認為目前設定的時間無需改變，則保持原時間。反之，則修改\n- 請你代入助手的角色，根據上下文，以及助手最後一次回覆使用者訊息的時間，從以下幾方面考慮:\n1.使用者沒有給你發訊息，你希望什麼時候主動找使用者\n2.請根據助手設定的性格決定時間；如果助手是依賴使用者的性格或熱情的性格，就早些給使用者發訊息；反之，高冷性格就晚些發\n3.如果上下文提到了助手要提醒/監督/關心使用者，就早些按符合助手設定的時間主動給使用者發訊息\n4.如果上文提到助手睡覺/在忙等等，就按助手起床/忙完的時間給使用者發訊息\n5.你也可以根據上下文製造一些突發事件，按你製造的突發事件的時間給使用者發訊息）",
+  "@assistantEditProactiveCareDecisionPromptDefault": {
+    "description": "預設決策時間提示詞"
+  },
+  "assistantEditProactiveCareDateTimePickerTitle": "選擇日期和時間",
+  "@assistantEditProactiveCareDateTimePickerTitle": {
+    "description": "日期時間選擇器標題"
+  },
+  "assistantEditProactiveCareExactAlarmPermissionDenied": "未授予精確鬧鐘權限，主動關懷無法按時喚醒應用程式，請在系統設定中允許「鬧鐘和提醒」。",
+  "@assistantEditProactiveCareExactAlarmPermissionDenied": {
+    "description": "精確鬧鐘權限被拒絕時的警告"
+  },
+  "assistantEditProactiveCareNotificationPermissionDenied": "未授予通知權限，主動關懷訊息將無法通知你，請在系統設定中開啟通知。",
+  "@assistantEditProactiveCareNotificationPermissionDenied": {
+    "description": "通知權限被拒絕時的警告"
+  },
+  "defaultModelPageProactiveCareModelTitle": "Ta的來信決策模型",
+  "@defaultModelPageProactiveCareModelTitle": {
+    "description": "主動關懷決策模型卡片標題"
+  },
+  "defaultModelPageProactiveCareModelSubtitle": "用於決定助手何時主動發訊息的模型",
+  "@defaultModelPageProactiveCareModelSubtitle": {
+    "description": "主動關懷決策模型卡片副標題"
+  },
+  "proactiveCareFailedNotificationBody": "主動關懷訊息生成失敗，請開啟應用程式檢查模型配置與網路。",
+  "@proactiveCareFailedNotificationBody": {
+    "description": "主動關懷訊息生成失敗時的通知內容"
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,7 @@ import 'dart:io'
     show Platform; // kept for global override usage inside provider
 import 'core/services/android_background.dart';
 import 'core/services/notification_service.dart';
+import 'core/services/proactive_care_alarm_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final RouteObserver<ModalRoute<dynamic>> routeObserver =
@@ -272,6 +273,13 @@ class MyApp extends StatelessWidget {
                         await NotificationService.ensureInitialized();
                         await NotificationService.ensureAndroidNotificationsPermission();
                       }
+                      // Initialize proactive care alarms (reschedule any pending)
+                      try {
+                        if (Platform.isAndroid &&
+                            ProactiveCareAlarmService.isSupported) {
+                          await ProactiveCareAlarmService.initialize();
+                        }
+                      } catch (_) {}
                     }
                   }
                 } catch (_) {}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'dart:io'
 import 'core/services/android_background.dart';
 import 'core/services/notification_service.dart';
 import 'core/services/proactive_care_alarm_service.dart';
+import 'core/services/proactive_care_message_flow.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final RouteObserver<ModalRoute<dynamic>> routeObserver =
@@ -255,6 +256,11 @@ class MyApp extends StatelessWidget {
                     if (mode != AndroidBackgroundChatMode.off) {
                       final l10n = AppLocalizations.of(context);
                       if (l10n == null) return;
+                      // Capture before any async gap to satisfy
+                      // use_build_context_synchronously.
+                      final allAssistants = context
+                          .read<AssistantProvider>()
+                          .assistants;
                       // Enable only if currently disabled to avoid duplicate ROM prompts
                       try {
                         final already =
@@ -278,6 +284,23 @@ class MyApp extends StatelessWidget {
                         if (Platform.isAndroid &&
                             ProactiveCareAlarmService.isSupported) {
                           await ProactiveCareAlarmService.initialize();
+                          // Persist l10n strings so the background isolate can
+                          // use localized text instead of English fallbacks.
+                          await ProactiveCareL10nSnapshot.save(
+                            defaultConversationTitle:
+                                l10n.chatServiceDefaultConversationTitle,
+                            carePromptDefault:
+                                l10n.assistantEditProactiveCarePromptDefault,
+                            decisionPromptDefault: l10n
+                                .assistantEditProactiveCareDecisionPromptDefault,
+                            failureNotificationBody:
+                                l10n.proactiveCareFailedNotificationBody,
+                          );
+                          // Recover alarms lost after force-stop or process
+                          // death by re-scheduling all enabled assistants.
+                          await ProactiveCareAlarmService.rescheduleAll(
+                            allAssistants,
+                          );
                         }
                       } catch (_) {}
                     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
     path: ./dependencies/flutter_tts
   flutter_background: ^1.3.0+1
   flutter_local_notifications: ^17.2.3
+  android_alarm_manager_plus: ^4.0.5
   image: ^4.8.0
   math_expressions: ^2.6.2
 


### PR DESCRIPTION
## 功能概述

为 cuplivo 移植 Kelivo 的主动关怀「Ta的来信」功能，让 AI 助手能够主动关心用户，定时发送关怀消息。

## 主要变更

### 数据层
- `Assistant` 模型新增主动关怀字段（`proactiveCareEnabled`、`proactiveCareInterval`、`proactiveCareLastSentAt` 等）
- `SettingsProvider` 新增主动关怀决策模型配置

### 核心服务
- 新增 `ProactiveCareService`：管理主动关怀的调度、触发和消息生成
- 新增 `ProactiveCareAlarmReceiver`：Android 后台闹钟接收器
- 新增 `ProactiveCareMessageFlow`：后台消息流处理

### UI 层
- 助手设置页新增「Ta的来信」Tab（仅 Android 可见）
- 默认模型页新增主动关怀模型卡片入口
- 新增 `ProactiveCareDateTimePicker` 时间选择组件

### 逻辑集成
- `HomeViewModel` 集成主动关怀触发逻辑
- `AssistantProvider` 在助手更新/删除时调度/取消闹钟
- `ChatActions` 在消息流结束时触发主动关怀检查
- `HomePageController` 添加报警 isolate 端口监听

### 平台配置
- Android: 添加 `RECEIVE_BOOT_COMPLETED`、`SCHEDULE_EXACT_ALARM` 权限
- 添加 `android_alarm_manager_plus` 依赖
- `main.dart` 初始化主动关怀闹钟服务

## 测试
- [x] GitHub Actions CI 编译通过
- [x] 仅 Android 平台可见/启用