### PR TITLE
fix: input focus lost on app resume

### DIFF
--- a/lib/core/providers/hotkey_provider.dart
+++ b/lib/core/providers/hotkey_provider.dart
@@ -91,6 +91,14 @@ class HotkeyProvider extends ChangeNotifier {
       defaultMac: 'cmd+bracketright',
       enabledByDefault: true,
     ),
+    // Focus chat input (no default)
+    'focus_input': AppHotkey(
+      id: 'focus_input',
+      l10nLabelKey: 'hotkeyFocusInput',
+      defaultWinLinux: '',
+      defaultMac: '',
+      enabledByDefault: true,
+    ),
   };
 
   final Map<String, HotKey> _registered = <String, HotKey>{};
@@ -252,6 +260,9 @@ class HotkeyProvider extends ChangeNotifier {
         break;
       case 'toggle_topics':
         HotkeyEventBus.instance.fire(HotkeyAction.toggleLeftPanelTopics);
+        break;
+      case 'focus_input':
+        HotkeyEventBus.instance.fire(HotkeyAction.focusInput);
         break;
     }
   }

--- a/lib/desktop/desktop_home_page.dart
+++ b/lib/desktop/desktop_home_page.dart
@@ -117,6 +117,11 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
             ChatActionBus.instance.fire(ChatAction.toggleLeftPanelTopics);
           }
           break;
+        case HotkeyAction.focusInput:
+          if (_tabIndex == 0) {
+            ChatActionBus.instance.fire(ChatAction.focusInput);
+          }
+          break;
       }
     });
 

--- a/lib/desktop/hotkeys/hotkey_event_bus.dart
+++ b/lib/desktop/hotkeys/hotkey_event_bus.dart
@@ -9,6 +9,7 @@ enum HotkeyAction {
   switchModel,
   toggleLeftPanelAssistants,
   toggleLeftPanelTopics,
+  focusInput,
 }
 
 class HotkeyEventBus {

--- a/lib/desktop/setting/hotkeys_pane.dart
+++ b/lib/desktop/setting/hotkeys_pane.dart
@@ -149,6 +149,8 @@ class _HotkeyRowState extends State<_HotkeyRow> {
           return loc.hotkeyToggleAssistantPanel;
         case 'hotkeyToggleTopicPanel':
           return loc.hotkeyToggleTopicPanel;
+        case 'hotkeyFocusInput':
+          return loc.hotkeyFocusInput;
         default:
           return item.l10nLabelKey;
       }

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -555,8 +555,10 @@ class _ChatInputBarState extends State<ChatInputBar>
     // When app resumes from background, suppress context menu briefly to avoid flickering
     if (state == AppLifecycleState.resumed) {
       _suppressContextMenu = true;
-      // Also unfocus to reset any stuck toolbar state
-      widget.focusNode?.unfocus();
+      // Also unfocus to reset any stuck toolbar state (iOS only)
+      if (Platform.isIOS) {
+        widget.focusNode?.unfocus();
+      }
       // Re-enable context menu after a short delay
       Future.delayed(const Duration(milliseconds: 300), () {
         if (mounted) {
@@ -567,7 +569,9 @@ class _ChatInputBarState extends State<ChatInputBar>
         state == AppLifecycleState.paused) {
       // When going to background, hide any open toolbar
       _suppressContextMenu = true;
-      widget.focusNode?.unfocus();
+      if (Platform.isIOS) {
+        widget.focusNode?.unfocus();
+      }
     }
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -611,6 +611,7 @@
   "hotkeySwitchModel": "Switch Model",
   "hotkeyToggleAssistantPanel": "Toggle Assistants",
   "hotkeyToggleTopicPanel": "Toggle Topics",
+  "hotkeyFocusInput": "Focus Input",
   "hotkeysPressShortcut": "Press a shortcut",
   "hotkeysResetDefault": "Reset to default",
   "hotkeysClearShortcut": "Clear shortcut",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2837,6 +2837,12 @@ abstract class AppLocalizations {
   /// **'Toggle Topics'**
   String get hotkeyToggleTopicPanel;
 
+  /// No description provided for @hotkeyFocusInput.
+  ///
+  /// In en, this message translates to:
+  /// **'Focus Input'**
+  String get hotkeyFocusInput;
+
   /// No description provided for @hotkeysPressShortcut.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1474,6 +1474,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hotkeyToggleTopicPanel => 'Toggle Topics';
 
   @override
+  String get hotkeyFocusInput => 'Focus Input';
+
+  @override
   String get hotkeysPressShortcut => 'Press a shortcut';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1426,6 +1426,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get hotkeyToggleTopicPanel => '切换话题显示';
 
   @override
+  String get hotkeyFocusInput => '聚焦输入框';
+
+  @override
   String get hotkeysPressShortcut => '按下快捷键';
 
   @override
@@ -7023,6 +7026,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get hotkeyToggleTopicPanel => '切换话题显示';
 
   @override
+  String get hotkeyFocusInput => '聚焦输入框';
+
+  @override
   String get hotkeysPressShortcut => '按下快捷键';
 
   @override
@@ -12618,6 +12624,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get hotkeyToggleTopicPanel => '切換話題顯示';
+
+  @override
+  String get hotkeyFocusInput => '聚焦輸入框';
 
   @override
   String get hotkeysPressShortcut => '按下快捷鍵';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -424,6 +424,7 @@
   "hotkeySwitchModel": "切换模型",
   "hotkeyToggleAssistantPanel": "切换助手显示",
   "hotkeyToggleTopicPanel": "切换话题显示",
+  "hotkeyFocusInput": "聚焦输入框",
   "hotkeysPressShortcut": "按下快捷键",
   "hotkeysResetDefault": "重置为默认",
   "hotkeysClearShortcut": "清除快捷键",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -433,6 +433,7 @@
   "hotkeySwitchModel": "切换模型",
   "hotkeyToggleAssistantPanel": "切换助手显示",
   "hotkeyToggleTopicPanel": "切换话题显示",
+  "hotkeyFocusInput": "聚焦输入框",
   "hotkeysPressShortcut": "按下快捷键",
   "hotkeysResetDefault": "重置为默认",
   "hotkeysClearShortcut": "清除快捷键",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -236,6 +236,7 @@
   "hotkeySwitchModel": "切換模型",
   "hotkeyToggleAssistantPanel": "切換助理顯示",
   "hotkeyToggleTopicPanel": "切換話題顯示",
+  "hotkeyFocusInput": "聚焦輸入框",
   "hotkeysPressShortcut": "按下快捷鍵",
   "hotkeysResetDefault": "重置為預設",
   "hotkeysClearShortcut": "清除快捷鍵",


### PR DESCRIPTION
## Description

- Closes #60.

Two changes around chat input focus on desktop:

### 1. Fix: Alt+Tab no longer loses input focus (Windows)

When switching back to the app via Alt+Tab, `AppLifecycleState.resumed` fired and explicitly `unfocus()`-ed the input field. This was introduced as a belt-and-suspenders measure for an iOS context menu flicker fix, but ran on all platforms.

**Fix:** Gate `unfocus()` behind `Platform.isIOS` — keep `_suppressContextMenu` flag which already handles the original flicker issue on all platforms.

### 2. Feat: Configurable "Focus Input" hotkey

Add a new `focus_input` hotkey entry in Settings → Hotkeys so users can bind a keyboard shortcut to jump focus to the chat input.

**No default binding** — users opt in via the hotkeys pane.

### Happy path (manual, verified)

1. Open Settings → Hotkeys → "Focus Input" entry visible, shows "Press a shortcut"
2. Click entry → press `Ctrl+L` → binding shown
3. Click message list → press `Ctrl+L` → input receives focus
4. Switch to Settings tab → press `Ctrl+L` → no effect (chat-tab only)
5. Toggle switch off → press `Ctrl+L` → no effect
6. Clear/reset → returns to "Press a shortcut"
7. Restart app → binding persists
