### PR TITLE
fix: await AssistantProvider loading before message generation to prevent system prompt race

### DIFF
--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -44,6 +44,12 @@ class AssistantProvider extends ChangeNotifier {
 
   AssistantProvider({this.chatService});
 
+  /// Ensures loading completes, then returns [currentAssistant].
+  Future<Assistant?> getLoadedCurrentAssistant() async {
+    await ensureLoaded();
+    return currentAssistant;
+  }
+
   Future<void> ensureLoaded() async {
     if (_loaded) return;
     final repo = _repo;

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -455,10 +455,6 @@ class ChatActions {
     }
 
     final settings = contextProvider.read<SettingsProvider>();
-    final assistant = contextProvider
-        .read<AssistantProvider>()
-        .currentAssistant;
-    final assistantId = assistant?.id;
     // Capture approval service reference before async gap
     ToolApprovalService? approvalService;
     AskUserInteractionService? askUserService;
@@ -468,6 +464,10 @@ class ChatActions {
     try {
       askUserService = contextProvider.read<AskUserInteractionService>();
     } catch (_) {}
+    final assistant = await contextProvider
+        .read<AssistantProvider>()
+        .getLoadedCurrentAssistant();
+    final assistantId = assistant?.id;
     final modelConfig = messageGenerationService.getModelConfig(
       settings,
       assistant,
@@ -622,9 +622,6 @@ class ChatActions {
   }) async {
     // Avoid using BuildContext across async gaps (this class holds a BuildContext).
     final settings = contextProvider.read<SettingsProvider>();
-    final assistant = contextProvider
-        .read<AssistantProvider>()
-        .currentAssistant;
     // Capture approval service reference before async gap
     ToolApprovalService? regenApprovalService;
     AskUserInteractionService? regenAskUserService;
@@ -634,9 +631,11 @@ class ChatActions {
     try {
       regenAskUserService = contextProvider.read<AskUserInteractionService>();
     } catch (_) {}
-
     final shouldGenerateTitleOnRetry =
         conversation.title == getTitleForLocale(contextProvider);
+    final assistant = await contextProvider
+        .read<AssistantProvider>()
+        .getLoadedCurrentAssistant();
 
     await cancelStreaming(conversation);
 
@@ -802,9 +801,6 @@ class ChatActions {
     bool allowImagesApiRouting = true,
   }) async {
     final settings = contextProvider.read<SettingsProvider>();
-    final assistant = contextProvider
-        .read<AssistantProvider>()
-        .currentAssistant;
     ToolApprovalService? approvalService;
     AskUserInteractionService? askUserService;
     try {
@@ -813,6 +809,9 @@ class ChatActions {
     try {
       askUserService = contextProvider.read<AskUserInteractionService>();
     } catch (_) {}
+    final assistant = await contextProvider
+        .read<AssistantProvider>()
+        .getLoadedCurrentAssistant();
 
     final visibleIndex = _messages.indexWhere(
       (candidate) => candidate.id == message.id,

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -686,7 +686,9 @@ class HomePageController extends ChangeNotifier {
     } else if (multiAIEngine.isActive) {
       if (!_context.mounted) return ChatInputSubmissionResult.rejected;
       final settings = _context.read<SettingsProvider>();
-      final assistant = _context.read<AssistantProvider>().currentAssistant;
+      final assistant = await _context
+          .read<AssistantProvider>()
+          .getLoadedCurrentAssistant();
       final gid = await multiAIEngine.startRound(
         input: input,
         conversation: currentConversation!,


### PR DESCRIPTION
Fixes #56.

`AssistantProvider` loads assistant config asynchronously (`ensureLoaded`). Message generation entry points (`sendMessage`, `regenerateAtMessage`, `continueAssistantMessageAfterToolAnswer`, `Multi-AI`) previously read currentAssistant synchronously, which could return null if loading had not completed — causing system prompt, message template, and other per-assistant config to be silently dropped on the first message after app launch.

- Add `getLoadedCurrentAssistant()` to AssistantProvider
- Guard all 4 message generation paths with `await getLoadedCurrentAssistant()`
- Move `context` reads before the async gap to avoid `use_build_context_synchronously`