### PR TITLE
fix: rename userImagePaths to userMediaPaths, fix office doc handling in Responses API

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -563,7 +563,7 @@ class ChatApiService {
     required ProviderConfig config,
     required String modelId,
     required List<Map<String, dynamic>> messages,
-    List<String>? userImagePaths,
+    List<String>? userMediaPaths,
     int? thinkingBudget,
     double? temperature,
     double? topP,
@@ -602,9 +602,9 @@ class ChatApiService {
     final safeMessages = stripUnsupportedImageInputs
         ? await _stripImageInputsFromMessages(unicodeSafeMessages)
         : unicodeSafeMessages;
-    final safeUserImagePaths = stripUnsupportedImageInputs
+    final safeUserMediaPaths = stripUnsupportedImageInputs
         ? const <String>[]
-        : userImagePaths;
+        : userMediaPaths;
     final client = _clientFor(config, cancelToken);
 
     try {
@@ -615,7 +615,7 @@ class ChatApiService {
             config,
             modelId,
             safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
           );
@@ -625,7 +625,7 @@ class ChatApiService {
             config,
             modelId,
             safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             thinkingBudget: thinkingBudget,
             temperature: temperature,
             topP: topP,
@@ -642,7 +642,7 @@ class ChatApiService {
             config,
             modelId,
             safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             thinkingBudget: thinkingBudget,
             temperature: temperature,
             topP: topP,
@@ -660,7 +660,7 @@ class ChatApiService {
           config,
           modelId,
           safeMessages,
-          userImagePaths: safeUserImagePaths,
+          userMediaPaths: safeUserMediaPaths,
           thinkingBudget: thinkingBudget,
           temperature: temperature,
           topP: topP,
@@ -681,7 +681,7 @@ class ChatApiService {
             config: config,
             modelId: modelId,
             messages: safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             thinkingBudget: thinkingBudget,
             temperature: temperature,
             topP: topP,
@@ -698,7 +698,7 @@ class ChatApiService {
             config,
             modelId,
             safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             thinkingBudget: thinkingBudget,
             temperature: temperature,
             topP: topP,
@@ -715,7 +715,7 @@ class ChatApiService {
             config,
             modelId,
             safeMessages,
-            userImagePaths: safeUserImagePaths,
+            userMediaPaths: safeUserMediaPaths,
             thinkingBudget: thinkingBudget,
             temperature: temperature,
             topP: topP,

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -25,7 +25,7 @@ Stream<ChatStreamChunk> _sendClaudeStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -214,12 +214,12 @@ Stream<ChatStreamChunk> _sendClaudeStream(
       continue;
     }
     if (isLast &&
-        (userImagePaths?.isNotEmpty == true) &&
+        (userMediaPaths?.isNotEmpty == true) &&
         (m['role'] == 'user')) {
       final parts = <Map<String, dynamic>>[];
       final text = (m['content'] ?? '').toString();
       if (text.isNotEmpty) parts.add({'type': 'text', 'text': text});
-      for (final p in userImagePaths!) {
+      for (final p in userMediaPaths!) {
         if (p.startsWith('http') || p.startsWith('data:')) {
           parts.add({'type': 'text', 'text': p});
         } else {

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -251,7 +251,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -271,7 +271,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       config: config,
       modelId: modelId,
       messages: messages,
-      userImagePaths: userImagePaths,
+      userMediaPaths: userMediaPaths,
       thinkingBudget: thinkingBudget,
       temperature: temperature,
       topP: topP,
@@ -361,7 +361,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       final hasMarkdownImages = raw.contains('![') && raw.contains('](');
       final hasCustomImages = raw.contains('[image:');
       final hasAttachedImages =
-          isLast && role == 'user' && (userImagePaths?.isNotEmpty == true);
+          isLast && role == 'user' && (userMediaPaths?.isNotEmpty == true);
       if (hasMarkdownImages || hasCustomImages || hasAttachedImages) {
         final parsed = await _parseTextAndImages(
           raw,
@@ -396,7 +396,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           }
         }
         if (hasAttachedImages) {
-          for (final p in userImagePaths!) {
+          for (final p in userMediaPaths!) {
             final normalized = normalizeSrc(p);
             if (!seenSources.add(normalized)) continue;
             if (p.startsWith('data:')) {
@@ -795,7 +795,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     final hasMarkdownImages = raw.contains('![') && raw.contains('](');
     final hasCustomImages = raw.contains('[image:');
     final hasAttachedImages =
-        isLast && role == 'user' && (userImagePaths?.isNotEmpty == true);
+        isLast && role == 'user' && (userMediaPaths?.isNotEmpty == true);
 
     if (hasMarkdownImages || hasCustomImages || hasAttachedImages) {
       final parsed = await _parseTextAndImages(
@@ -834,7 +834,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         }
       }
       if (hasAttachedImages) {
-        for (final p in userImagePaths!) {
+        for (final p in userMediaPaths!) {
           final normalized = normalizeSrc(p);
           if (!seenSources.add(normalized)) continue;
           if (p.startsWith('data:')) {

--- a/lib/core/services/api/providers/google_gemini.dart
+++ b/lib/core/services/api/providers/google_gemini.dart
@@ -186,7 +186,7 @@ Stream<ChatStreamChunk> _sendGoogleGeminiStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -203,7 +203,7 @@ Stream<ChatStreamChunk> _sendGoogleGeminiStream(
     cfg,
     modelId,
     messages,
-    userImagePaths: userImagePaths,
+    userMediaPaths: userMediaPaths,
     thinkingBudget: thinkingBudget,
     temperature: temperature,
     topP: topP,

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -5,7 +5,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -22,7 +22,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexStream(
     cfg,
     modelId,
     messages,
-    userImagePaths: userImagePaths,
+    userMediaPaths: userMediaPaths,
     thinkingBudget: thinkingBudget,
     temperature: temperature,
     topP: topP,
@@ -118,7 +118,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
   required ProviderConfig config,
   required String modelId,
   required List<Map<String, dynamic>> messages,
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -197,12 +197,12 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
     final m = nonSystemMessages[i];
     final isLast = i == nonSystemMessages.length - 1;
     if (isLast &&
-        (userImagePaths?.isNotEmpty == true) &&
+        (userMediaPaths?.isNotEmpty == true) &&
         (m['role'] == 'user')) {
       final parts = <Map<String, dynamic>>[];
       final text = (m['content'] ?? '').toString();
       if (text.isNotEmpty) parts.add({'type': 'text', 'text': text});
-      for (final p in userImagePaths!) {
+      for (final p in userMediaPaths!) {
         // Vertex AI Claude does not support remote URLs in 'image' blocks generally.
         // We must download and encode.
         String mime;

--- a/lib/core/services/api/providers/openai_chat_completions.dart
+++ b/lib/core/services/api/providers/openai_chat_completions.dart
@@ -78,7 +78,7 @@ Stream<ChatStreamChunk> _sendOpenAIChatCompletionsStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -95,7 +95,7 @@ Stream<ChatStreamChunk> _sendOpenAIChatCompletionsStream(
     cfg,
     modelId,
     messages,
-    userImagePaths: userImagePaths,
+    userMediaPaths: userMediaPaths,
     thinkingBudget: thinkingBudget,
     temperature: temperature,
     topP: topP,

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -930,7 +930,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -1128,7 +1128,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       final hasAttachedImages =
           canImageInput &&
           isLast &&
-          (userImagePaths?.isNotEmpty == true) &&
+          (userMediaPaths?.isNotEmpty == true) &&
           (m['role'] == 'user');
       // For the last user message, also attach the last assistant image if available
       final shouldAttachAssistantImage =
@@ -1210,12 +1210,29 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             addImage(url);
           }
         }
-        // Additional images explicitly attached to the last user message
+        // Additional media explicitly attached to the last user message
         if (hasAttachedImages) {
-          for (final p in userImagePaths!) {
+          for (final p in userMediaPaths!) {
             final normalized = normalizeSrc(p);
             if (!seenImageSources.add(normalized)) continue;
-            final dataUrl = (p.startsWith('http') || p.startsWith('data:'))
+            final bool isInlineUrl =
+                p.startsWith('http') || p.startsWith('data:');
+            final String mime = isInlineUrl
+                ? _mimeFromDataUrl(p)
+                : _mimeFromPath(p);
+            if (isOfficeDocumentMime(mime) || mime == 'application/pdf') {
+              final fileName = p.replaceAll('\\', '/').split('/').last;
+              final dataUrl = isInlineUrl
+                  ? p
+                  : await _encodeBase64File(p, withPrefix: true);
+              parts.add({
+                'type': 'input_file',
+                'filename': fileName,
+                'file_data': dataUrl,
+              });
+              continue;
+            }
+            final dataUrl = isInlineUrl
                 ? p
                 : await _encodeBase64File(p, withPrefix: true);
             addImage(dataUrl);
@@ -1322,7 +1339,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         'model': upstreamModelId,
         'messages': await _buildLongCatOmniMessages(
           messages,
-          userMediaPaths: userImagePaths,
+          userMediaPaths: userMediaPaths,
         ),
         'stream': stream,
         'output_modalities': const ['text'],
@@ -1337,7 +1354,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     } else {
       final mm = await _buildOpenAIChatCompletionMessages(
         messages,
-        userMediaPaths: userImagePaths,
+        userMediaPaths: userMediaPaths,
         canImageInput: canImageInput,
       );
       body = {
@@ -1667,11 +1684,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           reqBody['messages'] = useLongCatOmniPayload
               ? await _buildLongCatOmniMessages(
                   next,
-                  userMediaPaths: userImagePaths,
+                  userMediaPaths: userMediaPaths,
                 )
               : await _buildOpenAIChatCompletionMessages(
                   next,
-                  userMediaPaths: userImagePaths,
+                  userMediaPaths: userMediaPaths,
                   canImageInput: canImageInput,
                 );
           reqBody.remove('stream');
@@ -1874,7 +1891,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     'model': upstreamModelId,
                     'messages': await _buildLongCatOmniMessages(
                       currentMessages,
-                      userMediaPaths: userImagePaths,
+                      userMediaPaths: userMediaPaths,
                     ),
                     'stream': true,
                     'output_modalities': const ['text'],
@@ -1891,7 +1908,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     'model': upstreamModelId,
                     'messages': await _buildOpenAIChatCompletionMessages(
                       currentMessages,
-                      userMediaPaths: userImagePaths,
+                      userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
                     ),
                     'stream': true,
@@ -3344,7 +3361,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     'model': upstreamModelId,
                     'messages': await _buildLongCatOmniMessages(
                       currentMessages,
-                      userMediaPaths: userImagePaths,
+                      userMediaPaths: userMediaPaths,
                     ),
                     'stream': true,
                     'output_modalities': const ['text'],
@@ -3361,7 +3378,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     'model': upstreamModelId,
                     'messages': await _buildOpenAIChatCompletionMessages(
                       currentMessages,
-                      userMediaPaths: userImagePaths,
+                      userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
                     ),
                     'stream': true,
@@ -3858,7 +3875,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         'model': upstreamModelId,
                         'messages': await _buildLongCatOmniMessages(
                           currentMessages,
-                          userMediaPaths: userImagePaths,
+                          userMediaPaths: userMediaPaths,
                         ),
                         'stream': true,
                         'output_modalities': const ['text'],
@@ -3875,7 +3892,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         'model': upstreamModelId,
                         'messages': await _buildOpenAIChatCompletionMessages(
                           currentMessages,
-                          userMediaPaths: userImagePaths,
+                          userMediaPaths: userMediaPaths,
                           canImageInput: canImageInput,
                         ),
                         'stream': true,

--- a/lib/core/services/api/providers/openai_images.dart
+++ b/lib/core/services/api/providers/openai_images.dart
@@ -34,11 +34,11 @@ Stream<ChatStreamChunk> _sendOpenAIImagesStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
 }) async* {
-  final input = await _openAIImagesInput(messages, userImagePaths);
+  final input = await _openAIImagesInput(messages, userMediaPaths);
   final outputMime = _openAIImagesOutputMime(config, modelId, extraBody);
   final upstreamModelId = _apiModelId(config, modelId);
   if (input.imageRefs.isNotEmpty &&
@@ -200,10 +200,10 @@ Future<String> _lastOpenAIImagePrompt(
 
 Future<_OpenAIImagesInput> _openAIImagesInput(
   List<Map<String, dynamic>> messages,
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
 ) async {
   final prompt = await _lastOpenAIImagePrompt(messages);
-  final explicitPaths = (userImagePaths ?? const <String>[])
+  final explicitPaths = (userMediaPaths ?? const <String>[])
       .map((path) => path.trim())
       .where((path) => path.isNotEmpty)
       .toList(growable: false);

--- a/lib/core/services/api/providers/openai_responses.dart
+++ b/lib/core/services/api/providers/openai_responses.dart
@@ -70,7 +70,7 @@ Stream<ChatStreamChunk> _sendOpenAIResponsesStream(
   ProviderConfig config,
   String modelId,
   List<Map<String, dynamic>> messages, {
-  List<String>? userImagePaths,
+  List<String>? userMediaPaths,
   int? thinkingBudget,
   double? temperature,
   double? topP,
@@ -87,7 +87,7 @@ Stream<ChatStreamChunk> _sendOpenAIResponsesStream(
     cfg,
     modelId,
     messages,
-    userImagePaths: userImagePaths,
+    userMediaPaths: userMediaPaths,
     thinkingBudget: thinkingBudget,
     temperature: temperature,
     topP: topP,

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -570,20 +570,21 @@ class ChatActions {
             askUserService: askUserService,
           );
 
-      // Build user image paths
-      final userImagePaths = messageGenerationService.buildUserImagePaths(
+      // Build user media paths
+      final userMediaPaths = messageGenerationService.buildUserMediaPaths(
         input: input,
-        lastUserImagePaths: prepared.lastUserImagePaths,
+        lastUserMediaPaths: prepared.lastUserImagePaths,
         settings: settings,
         providerKey: providerKey,
         modelId: modelId,
+        assistant: assistant,
       );
 
       // Execute generation
       final ctx = messageGenerationService.buildGenerationContext(
         assistantMessage: assistantMessage,
         prepared: prepared,
-        userImagePaths: userImagePaths,
+        userMediaPaths: userMediaPaths,
         allowImagesApiRouting: input.allowImagesApiRouting,
         providerKey: providerKey,
         modelId: modelId,
@@ -770,20 +771,21 @@ class ChatActions {
           askUserService: regenAskUserService,
         );
 
-    // Build user image paths
-    final userImagePaths = messageGenerationService.buildUserImagePaths(
+    // Build user media paths
+    final userMediaPaths = messageGenerationService.buildUserMediaPaths(
       input: null,
-      lastUserImagePaths: prepared.lastUserImagePaths,
+      lastUserMediaPaths: prepared.lastUserImagePaths,
       settings: settings,
       providerKey: providerKey,
       modelId: modelId,
+      assistant: assistant,
     );
 
     // Execute generation
     final ctx = messageGenerationService.buildGenerationContext(
       assistantMessage: assistantMessage,
       prepared: prepared,
-      userImagePaths: userImagePaths,
+      userMediaPaths: userMediaPaths,
       allowImagesApiRouting: allowImagesApiRouting,
       providerKey: providerKey,
       modelId: modelId,
@@ -877,18 +879,19 @@ class ChatActions {
             askUserService: askUserService,
           );
 
-      final userImagePaths = messageGenerationService.buildUserImagePaths(
+      final userMediaPaths = messageGenerationService.buildUserMediaPaths(
         input: null,
-        lastUserImagePaths: prepared.lastUserImagePaths,
+        lastUserMediaPaths: prepared.lastUserImagePaths,
         settings: settings,
         providerKey: providerKey,
         modelId: modelId,
+        assistant: assistant,
       );
 
       final ctx = messageGenerationService.buildGenerationContext(
         assistantMessage: streamingMessage,
         prepared: prepared,
-        userImagePaths: userImagePaths,
+        userMediaPaths: userMediaPaths,
         allowImagesApiRouting: allowImagesApiRouting,
         providerKey: providerKey,
         modelId: modelId,
@@ -1064,7 +1067,7 @@ class ChatActions {
         config: ctx.config,
         modelId: ctx.modelId,
         messages: ctx.apiMessages,
-        userImagePaths: ctx.userImagePaths,
+        userMediaPaths: ctx.userMediaPaths,
         thinkingBudget:
             assistant?.thinkingBudget ?? ctx.settings.thinkingBudget,
         temperature: assistant?.temperature,

--- a/lib/features/home/controllers/generation_controller.dart
+++ b/lib/features/home/controllers/generation_controller.dart
@@ -205,7 +205,7 @@ class GenerationController {
   stream_ctrl.GenerationContext buildGenerationContext({
     required ChatMessage assistantMessage,
     required List<Map<String, dynamic>> apiMessages,
-    required List<String> userImagePaths,
+    required List<String> userMediaPaths,
     required bool allowImagesApiRouting,
     required String providerKey,
     required String modelId,
@@ -229,7 +229,7 @@ class GenerationController {
     return stream_ctrl.GenerationContext(
       assistantMessage: assistantMessage,
       apiMessages: apiMessages,
-      userImagePaths: userImagePaths,
+      userMediaPaths: userMediaPaths,
       allowImagesApiRouting: allowImagesApiRouting,
       providerKey: providerKey,
       modelId: modelId,

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -1316,7 +1316,7 @@ class GenerationContext {
   GenerationContext({
     required this.assistantMessage,
     required this.apiMessages,
-    required this.userImagePaths,
+    required this.userMediaPaths,
     required this.allowImagesApiRouting,
     required this.providerKey,
     required this.modelId,
@@ -1336,7 +1336,7 @@ class GenerationContext {
 
   final ChatMessage assistantMessage;
   final List<Map<String, dynamic>> apiMessages;
-  final List<String> userImagePaths;
+  final List<String> userMediaPaths;
   final bool allowImagesApiRouting;
   final String providerKey;
   final String modelId;

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -302,7 +302,7 @@ class MessageGenerationService {
   stream_ctrl.GenerationContext buildGenerationContext({
     required ChatMessage assistantMessage,
     required PreparedGeneration prepared,
-    required List<String> userImagePaths,
+    required List<String> userMediaPaths,
     required bool allowImagesApiRouting,
     required String providerKey,
     required String modelId,
@@ -320,7 +320,7 @@ class MessageGenerationService {
     return stream_ctrl.GenerationContext(
       assistantMessage: assistantMessage,
       apiMessages: prepared.apiMessages,
-      userImagePaths: userImagePaths,
+      userMediaPaths: userMediaPaths,
       allowImagesApiRouting: allowImagesApiRouting,
       providerKey: providerKey,
       modelId: modelId,
@@ -559,13 +559,14 @@ class MessageGenerationService {
         .toList(growable: false);
   }
 
-  /// Build user image paths considering OCR mode.
-  List<String> buildUserImagePaths({
+  /// Build user media paths (images, videos, audio, office docs) considering OCR mode.
+  List<String> buildUserMediaPaths({
     required ChatInputData? input,
-    required List<String> lastUserImagePaths,
+    required List<String> lastUserMediaPaths,
     required SettingsProvider settings,
     required String providerKey,
     required String modelId,
+    Assistant? assistant,
   }) {
     final bool ocrActive =
         settings.ocrEnabled &&
@@ -578,12 +579,38 @@ class MessageGenerationService {
       modelId: modelId,
     );
 
+    /// Skip office docs in 'extract' mode: their text is already injected
+    /// into the API message via processUserMessagesForApi.
+    bool skipOfficeDoc(String mime) {
+      final lower = mime.toLowerCase();
+      if (assistant != null) {
+        if (lower == 'application/pdf') return assistant.pdfMode != 'direct';
+        if (lower ==
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+          return assistant.docxMode != 'direct';
+        }
+        if (isOfficeDocumentMime(lower)) {
+          return assistant.otherOfficeMode != 'direct';
+        }
+        return true;
+      }
+      // No assistant — use defaults:
+      if (lower == 'application/pdf' ||
+          lower ==
+              'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+        return true; // default extract
+      }
+      if (isOfficeDocumentMime(lower)) return false; // default direct
+      return true;
+    }
+
     if (input != null) {
       final currentMediaPaths = <String>[];
       for (final d in input.documents) {
         final effectiveMime = _effectiveAttachmentMime(d);
         if (isVideoMime(effectiveMime) ||
-            isOfficeDocumentMime(effectiveMime) ||
+            (isOfficeDocumentMime(effectiveMime) &&
+                !skipOfficeDoc(effectiveMime)) ||
             (includeAudio && isAudioMime(effectiveMime))) {
           currentMediaPaths.add(d.path);
         }
@@ -595,7 +622,7 @@ class MessageGenerationService {
     }
 
     return _filterMediaPathsForProvider(
-      lastUserImagePaths
+      lastUserMediaPaths
           .where((path) {
             if (!ocrActive) return true;
             return !isImageMime(

--- a/lib/features/home/services/message_pipeline.dart
+++ b/lib/features/home/services/message_pipeline.dart
@@ -137,20 +137,21 @@ class MessagePipeline {
             askUserService: context.askUserService,
           );
 
-      final userImagePaths = inputData != null
-          ? _messageGenerationService.buildUserImagePaths(
+      final userMediaPaths = inputData != null
+          ? _messageGenerationService.buildUserMediaPaths(
               input: inputData,
-              lastUserImagePaths: prepared.lastUserImagePaths,
+              lastUserMediaPaths: prepared.lastUserImagePaths,
               settings: settings,
               providerKey: providerKey,
               modelId: modelId,
+              assistant: assistant,
             )
           : const <String>[];
 
       final ctx = _messageGenerationService.buildGenerationContext(
         assistantMessage: assistantMessage,
         prepared: prepared,
-        userImagePaths: userImagePaths,
+        userMediaPaths: userMediaPaths,
         allowImagesApiRouting: allowImagesApiRouting,
         providerKey: providerKey,
         modelId: modelId,

--- a/lib/features/home/services/ocr_service.dart
+++ b/lib/features/home/services/ocr_service.dart
@@ -101,7 +101,7 @@ class OcrService {
       config: cfg,
       modelId: model,
       messages: messages,
-      userImagePaths: imagePaths,
+      userMediaPaths: imagePaths,
       thinkingBudget: null,
       temperature: 0.0,
       topP: null,

--- a/test/chat_api_custom_image_marker_test.dart
+++ b/test/chat_api_custom_image_marker_test.dart
@@ -200,7 +200,7 @@ void main() {
           messages: const [
             {'role': 'user', 'content': 'continue'},
           ],
-          userImagePaths: [file.path],
+          userMediaPaths: [file.path],
           stream: false,
         ).toList();
       });

--- a/test/chat_api_office_doc_routing_test.dart
+++ b/test/chat_api_office_doc_routing_test.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _openAiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'OpenAITest',
+    enabled: true,
+    name: 'OpenAITest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    useResponseApi: false,
+  );
+}
+
+ProviderConfig _openAiResponsesConfig(String baseUrl) {
+  return _openAiConfig(baseUrl).copyWith(useResponseApi: true);
+}
+
+/// Build a minimal valid DOCX (ZIP containing word/document.xml).
+Uint8List _buildMinimalDocx(String text) {
+  final archive = Archive();
+  final documentXml =
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+      '<w:body><w:p><w:r><w:t>$text</w:t></w:r></w:p></w:body>'
+      '</w:document>';
+  archive.addFile(
+    ArchiveFile(
+      'word/document.xml',
+      documentXml.length,
+      utf8.encode(documentXml),
+    ),
+  );
+  final encoded = ZipEncoder().encode(archive);
+  return Uint8List.fromList(encoded);
+}
+
+void main() {
+  late Directory tempDir;
+  late String docxPath;
+  late String pngPath;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('kelivo_office_doc_');
+    docxPath = '${tempDir.path}/test.docx';
+    await File(docxPath).writeAsBytes(_buildMinimalDocx('Hello World'));
+    pngPath = '${tempDir.path}/img.png';
+    await File(
+      pngPath,
+    ).writeAsBytes(const [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('Chat completions path', () {
+    test('routes DOCX via userMediaPaths as file type', () async {
+      final body = await _sendAndCaptureChatBody((baseUrl) {
+        return ChatApiService.sendMessageStream(
+          config: _openAiConfig(baseUrl),
+          modelId: 'gpt-4.1',
+          messages: const [
+            {'role': 'user', 'content': 'summarize this'},
+          ],
+          userMediaPaths: [docxPath],
+          stream: false,
+        ).toList();
+      });
+
+      final parts = _extractChatMessageParts(body);
+      expect(parts, hasLength(2));
+      expect(parts[0]['type'], 'text');
+      expect(parts[0]['text'], 'summarize this');
+      expect(parts[1]['type'], 'file');
+      expect(parts[1]['file']['filename'], 'test.docx');
+      final fileData = parts[1]['file']['file_data'] as String;
+      expect(
+        fileData.startsWith(
+          'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not send image_url for DOCX', () async {
+      final body = await _sendAndCaptureChatBody((baseUrl) {
+        return ChatApiService.sendMessageStream(
+          config: _openAiConfig(baseUrl),
+          modelId: 'gpt-4.1',
+          messages: const [
+            {'role': 'user', 'content': 'summarize this'},
+          ],
+          userMediaPaths: [docxPath],
+          stream: false,
+        ).toList();
+      });
+
+      expect(jsonEncode(body), isNot(contains('image_url')));
+    });
+
+    test('still routes images as image_url alongside DOCX file', () async {
+      final body = await _sendAndCaptureChatBody((baseUrl) {
+        return ChatApiService.sendMessageStream(
+          config: _openAiConfig(baseUrl),
+          modelId: 'gpt-4.1',
+          messages: const [
+            {'role': 'user', 'content': 'describe this'},
+          ],
+          userMediaPaths: [pngPath, docxPath],
+          stream: false,
+        ).toList();
+      });
+
+      final encoded = jsonEncode(body);
+      expect(encoded, contains('image_url'));
+      expect(encoded, contains('file'));
+      final parts = _extractChatMessageParts(body);
+      final imageParts = parts.where((p) => p['type'] == 'image_url').toList();
+      final fileParts = parts.where((p) => p['type'] == 'file').toList();
+      expect(imageParts, hasLength(1));
+      expect(fileParts, hasLength(1));
+      expect(fileParts[0]['file']['filename'], 'test.docx');
+    });
+  });
+
+  group('Responses API path', () {
+    test('routes DOCX via userMediaPaths as input_file type', () async {
+      final requestBodies = await _sendAndCaptureResponsesBodies((baseUrl) {
+        return ChatApiService.sendMessageStream(
+          config: _openAiResponsesConfig(baseUrl),
+          modelId: 'gpt-4.1',
+          messages: const [
+            {'role': 'user', 'content': 'summarize this'},
+          ],
+          userMediaPaths: [docxPath],
+          stream: false,
+        ).toList();
+      });
+
+      expect(requestBodies, hasLength(1));
+      final input = (requestBodies[0]['input'] as List)
+          .map((e) => (e as Map).cast<String, dynamic>())
+          .toList(growable: false);
+      final userMsg = input.firstWhere((item) => item['role'] == 'user');
+      final content = (userMsg['content'] as List)
+          .map((e) => (e as Map).cast<String, dynamic>())
+          .toList(growable: false);
+
+      expect(content, hasLength(2));
+      expect(content[0]['type'], 'input_text');
+      expect(content[0]['text'], 'summarize this');
+      expect(content[1]['type'], 'input_file');
+      expect(content[1]['filename'], 'test.docx');
+      final fileData = content[1]['file_data'] as String;
+      expect(
+        fileData.startsWith(
+          'data:application/vnd.openxmlformats-officedocument.wordprocessingml.document;base64,',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not send input_image for DOCX in Responses API', () async {
+      final requestBodies = await _sendAndCaptureResponsesBodies((baseUrl) {
+        return ChatApiService.sendMessageStream(
+          config: _openAiResponsesConfig(baseUrl),
+          modelId: 'gpt-4.1',
+          messages: const [
+            {'role': 'user', 'content': 'summarize this'},
+          ],
+          userMediaPaths: [docxPath],
+          stream: false,
+        ).toList();
+      });
+
+      final encoded = jsonEncode(requestBodies[0]);
+      expect(encoded, isNot(contains('input_image')));
+    });
+
+    test(
+      'still routes images as input_image alongside DOCX input_file',
+      () async {
+        final requestBodies = await _sendAndCaptureResponsesBodies((baseUrl) {
+          return ChatApiService.sendMessageStream(
+            config: _openAiResponsesConfig(baseUrl),
+            modelId: 'gpt-4.1',
+            messages: const [
+              {'role': 'user', 'content': 'describe this'},
+            ],
+            userMediaPaths: [pngPath, docxPath],
+            stream: false,
+          ).toList();
+        });
+
+        expect(requestBodies, hasLength(1));
+        final encoded = jsonEncode(requestBodies[0]);
+        expect(encoded, contains('input_image'));
+        expect(encoded, contains('input_file'));
+      },
+    );
+  });
+}
+
+/// Send a request through the Chat Completions (JSON) path and capture the body.
+Future<Map<String, dynamic>> _sendAndCaptureChatBody(
+  Future<List<dynamic>> Function(String baseUrl) sendRequest,
+) async {
+  Map<String, dynamic>? requestBody;
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+
+  try {
+    server.listen((request) async {
+      final rawBody = await utf8.decoder.bind(request).join();
+      requestBody = (jsonDecode(rawBody) as Map).cast<String, dynamic>();
+      request.response.statusCode = HttpStatus.ok;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode({
+          'id': 'chatcmpl-1',
+          'object': 'chat.completion',
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'finish_reason': 'stop',
+            },
+          ],
+          'usage': {
+            'prompt_tokens': 1,
+            'completion_tokens': 1,
+            'total_tokens': 2,
+          },
+        }),
+      );
+      await request.response.close();
+    });
+
+    final chunks = await sendRequest(baseUrl);
+    expect(chunks, isNotEmpty);
+    expect(requestBody, isNotNull);
+    return requestBody!;
+  } finally {
+    await server.close(force: true);
+  }
+}
+
+/// Extract structured content parts from a Chat Completions message body.
+List<Map<String, dynamic>> _extractChatMessageParts(Map<String, dynamic> body) {
+  final messages = (body['messages'] as List).cast<dynamic>();
+  expect(messages, hasLength(1));
+  final content =
+      (messages.single as Map<String, dynamic>)['content'] as List<dynamic>;
+  return content
+      .map((e) => (e as Map).cast<String, dynamic>())
+      .toList(growable: false);
+}
+
+/// Send a request through the Responses API (non-streaming) path and capture all request bodies.
+Future<List<Map<String, dynamic>>> _sendAndCaptureResponsesBodies(
+  Future<List<dynamic>> Function(String baseUrl) sendRequest,
+) async {
+  final requestBodies = <Map<String, dynamic>>[];
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+
+  try {
+    server.listen((request) async {
+      final rawBody = await utf8.decoder.bind(request).join();
+      requestBodies.add((jsonDecode(rawBody) as Map).cast<String, dynamic>());
+      request.response.statusCode = HttpStatus.ok;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode({
+          'output_text': 'done',
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        }),
+      );
+      await request.response.close();
+    });
+
+    final chunks = await sendRequest(baseUrl);
+    expect(chunks, isNotEmpty);
+    expect(requestBodies, isNotEmpty);
+    return requestBodies;
+  } finally {
+    await server.close(force: true);
+  }
+}

--- a/test/chat_api_text_only_image_filter_test.dart
+++ b/test/chat_api_text_only_image_filter_test.dart
@@ -138,7 +138,7 @@ void main() {
               {'role': 'user', 'content': 'before [image:${file.path}] after'},
               {'role': 'user', 'content': 'continue'},
             ],
-            userImagePaths: [file.path],
+            userMediaPaths: [file.path],
             stream: false,
           ).toList();
         },
@@ -171,7 +171,7 @@ void main() {
               {'role': 'user', 'content': 'before [image:${file.path}] after'},
               {'role': 'user', 'content': 'continue'},
             ],
-            userImagePaths: [file.path],
+            userMediaPaths: [file.path],
             stream: false,
           ).toList();
         },

--- a/test/claude_thinking_compat_test.dart
+++ b/test/claude_thinking_compat_test.dart
@@ -1301,7 +1301,7 @@ data: {"type":"message_stop"}
         messages: [
           {'role': 'user', 'content': 'inspect'},
         ],
-        userImagePaths: [file.path],
+        userMediaPaths: [file.path],
         onToolCall: (name, args, {toolCallId}) async => '{"result":"ok"}',
         stream: false,
       ).toList();

--- a/test/features/chat/widgets/chat_message_widget_background_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_background_test.dart
@@ -232,7 +232,7 @@ void main() {
           home_stream.GenerationContext(
             assistantMessage: message,
             apiMessages: const [],
-            userImagePaths: const [],
+            userMediaPaths: const [],
             allowImagesApiRouting: false,
             providerKey: 'test',
             modelId: 'test-model',

--- a/test/features/home/controllers/stream_controller_content_split_test.dart
+++ b/test/features/home/controllers/stream_controller_content_split_test.dart
@@ -43,7 +43,7 @@ void main() {
       GenerationContext(
         assistantMessage: message,
         apiMessages: const [],
-        userImagePaths: const [],
+        userMediaPaths: const [],
         allowImagesApiRouting: false,
         providerKey: 'test',
         modelId: 'test-model',
@@ -79,7 +79,7 @@ void main() {
       GenerationContext(
         assistantMessage: message,
         apiMessages: const [],
-        userImagePaths: const [],
+        userMediaPaths: const [],
         allowImagesApiRouting: false,
         providerKey: 'test',
         modelId: 'test-model',

--- a/test/openai_images_api_test.dart
+++ b/test/openai_images_api_test.dart
@@ -271,7 +271,7 @@ void main() {
           messages: const [
             {'role': 'user', 'content': 'describe this image'},
           ],
-          userImagePaths: [inputImage.path],
+          userMediaPaths: [inputImage.path],
           allowImagesApiRouting: false,
           stream: false,
         ).toList();
@@ -325,7 +325,7 @@ void main() {
         messages: const [
           {'role': 'user', 'content': 'make the background blue'},
         ],
-        userImagePaths: [inputImage.path],
+        userMediaPaths: [inputImage.path],
       ).toList();
 
       expect(requestUri.path, '/v1/images/edits');
@@ -378,7 +378,7 @@ void main() {
         messages: const [
           {'role': 'user', 'content': 'make it cinematic'},
         ],
-        userImagePaths: [inputImage.path],
+        userMediaPaths: [inputImage.path],
       ).toList();
 
       expect(requestBody, contains('filename="source.jpg"'));
@@ -447,7 +447,7 @@ void main() {
           messages: const [
             {'role': 'user', 'content': 'edit this image'},
           ],
-          userImagePaths: const ['/tmp/source.png'],
+          userMediaPaths: const ['/tmp/source.png'],
         ).toList(),
         throwsA(
           isA<UnsupportedError>().having(


### PR DESCRIPTION
Fixes #65.

- Rename buildUserImagePaths → buildUserMediaPaths and userImagePaths → userMediaPaths across 21 files for accurate semantics
- Fix Responses API path to detect office doc MIME types and use input_file instead of input_image (was the root cause of HTTP 400)
- Skip extract-mode office docs in buildUserMediaPaths to avoid redundant text-injection + file attachment