### PR TITLE
fix: 「Ta的来信」主动关怀到点不触发、时间不更新

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -23,6 +23,7 @@ import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/tts/tts_text_selection.dart';
 import '../../../core/services/haptics.dart';
 import '../../../core/services/proactive_care_alarm_service.dart';
+import '../../../core/services/logging/flutter_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/platform_utils.dart';
@@ -327,16 +328,34 @@ class HomePageController extends ChangeNotifier {
   /// forward proactive care triggers to [HomeViewModel.handleProactiveCareTrigger].
   void _registerProactiveCarePort() {
     if (!Platform.isAndroid || !ProactiveCareAlarmService.isSupported) return;
-    _proactiveCarePort = ReceivePort();
-    IsolateNameServer.registerPortWithName(
-      _proactiveCarePort!.sendPort,
-      proactiveCareMainPortName,
-    );
-    _proactiveCarePort!.listen((dynamic data) {
-      final assistantId = data as String?;
-      if (assistantId == null || assistantId.isEmpty) return;
-      _viewModel.handleProactiveCareTrigger(assistantId);
-    });
+    try {
+      // A stale mapping can survive a hot restart; replace it.
+      IsolateNameServer.removePortNameMapping(proactiveCareMainPortName);
+      final port = ReceivePort();
+      final registered = IsolateNameServer.registerPortWithName(
+        port.sendPort,
+        proactiveCareMainPortName,
+      );
+      if (!registered) {
+        port.close();
+        FlutterLogger.log(
+          'Proactive care port registration failed',
+          tag: 'HomePageController',
+        );
+        return;
+      }
+      _proactiveCarePort = port;
+      port.listen((dynamic data) {
+        final assistantId = data?.toString() ?? '';
+        if (assistantId.isEmpty) return;
+        unawaited(_viewModel.handleProactiveCareTrigger(assistantId));
+      });
+    } catch (e) {
+      FlutterLogger.log(
+        'Proactive care port setup failed: $e',
+        tag: 'HomePageController',
+      );
+    }
   }
 
   void _initializeAnimations() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,6 +82,10 @@ Future<void> main() async {
       await SandboxPathResolver.init();
       // Enable edge-to-edge to allow content under system bars (Android)
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+      // Android: start AlarmManager service for proactive care exact alarms
+      if (!kIsWeb && Platform.isAndroid) {
+        await ProactiveCareAlarmService.initialize();
+      }
       // Start app (Flutter log capture is toggleable and off by default)
       runApp(const MyApp());
     },
@@ -253,14 +257,14 @@ class MyApp extends StatelessWidget {
                 try {
                   if (Platform.isAndroid) {
                     final mode = settings.androidBackgroundChatMode;
+                    final l10n = AppLocalizations.of(context);
+                    if (l10n == null) return;
+                    // Capture before any async gap to satisfy
+                    // use_build_context_synchronously.
+                    final allAssistants = context
+                        .read<AssistantProvider>()
+                        .assistants;
                     if (mode != AndroidBackgroundChatMode.off) {
-                      final l10n = AppLocalizations.of(context);
-                      if (l10n == null) return;
-                      // Capture before any async gap to satisfy
-                      // use_build_context_synchronously.
-                      final allAssistants = context
-                          .read<AssistantProvider>()
-                          .assistants;
                       // Enable only if currently disabled to avoid duplicate ROM prompts
                       try {
                         final already =
@@ -279,31 +283,32 @@ class MyApp extends StatelessWidget {
                         await NotificationService.ensureInitialized();
                         await NotificationService.ensureAndroidNotificationsPermission();
                       }
-                      // Initialize proactive care alarms (reschedule any pending)
-                      try {
-                        if (Platform.isAndroid &&
-                            ProactiveCareAlarmService.isSupported) {
-                          await ProactiveCareAlarmService.initialize();
-                          // Persist l10n strings so the background isolate can
-                          // use localized text instead of English fallbacks.
-                          await ProactiveCareL10nSnapshot.save(
-                            defaultConversationTitle:
-                                l10n.chatServiceDefaultConversationTitle,
-                            carePromptDefault:
-                                l10n.assistantEditProactiveCarePromptDefault,
-                            decisionPromptDefault: l10n
-                                .assistantEditProactiveCareDecisionPromptDefault,
-                            failureNotificationBody:
-                                l10n.proactiveCareFailedNotificationBody,
-                          );
-                          // Recover alarms lost after force-stop or process
-                          // death by re-scheduling all enabled assistants.
-                          await ProactiveCareAlarmService.rescheduleAll(
-                            allAssistants,
-                          );
-                        }
-                      } catch (_) {}
                     }
+                    // Initialize proactive care alarms (reschedule any pending).
+                    // This runs regardless of background chat mode, because
+                    // proactive care uses its own exact-alarm mechanism
+                    // independent of the background chat service.
+                    try {
+                      if (ProactiveCareAlarmService.isSupported) {
+                        // Persist l10n strings so the background isolate can
+                        // use localized text instead of English fallbacks.
+                        await ProactiveCareL10nSnapshot.save(
+                          defaultConversationTitle:
+                              l10n.chatServiceDefaultConversationTitle,
+                          carePromptDefault:
+                              l10n.assistantEditProactiveCarePromptDefault,
+                          decisionPromptDefault: l10n
+                              .assistantEditProactiveCareDecisionPromptDefault,
+                          failureNotificationBody:
+                              l10n.proactiveCareFailedNotificationBody,
+                        );
+                        // Recover alarms lost after force-stop or process
+                        // death by re-scheduling all enabled assistants.
+                        await ProactiveCareAlarmService.rescheduleAll(
+                          allAssistants,
+                        );
+                      }
+                    } catch (_) {}
                   }
                 } catch (_) {}
               });


### PR DESCRIPTION
## 问题

「Ta的来信」功能中，到达主动关怀时间后：
- 助手不会自动发送消息
- 主动关怀时间字段不会更新

## 根因

**Bug 1（主因）**：`main.dart` 中 `ProactiveCareAlarmService.initialize()`、`L10nSnapshot.save()` 和 `rescheduleAll()` 被嵌套在 `if (mode != AndroidBackgroundChatMode.off)` 条件内。当用户未开启后台聊天模式（默认 off）时，闹钟服务永远不会初始化，所有 `AndroidAlarmManager.oneShotAt()` 调用都是空操作。

**Bug 2（次要）**：`home_page_controller.dart` 端口注册缺少 stale mapping 清理（未先 `removePortNameMapping`），热重启后注册可能失败，导致前台闹钟转发路径断裂。

## 修复

| 文件 | 修改 |
|------|------|
| `lib/main.dart` | ① 在 `runApp()` 前无条件调用 `ProactiveCareAlarmService.initialize()`（与 reference kelivo 一致）；② 将 `L10nSnapshot.save()` + `rescheduleAll()` 从 background mode 条件中移出 |
| `lib/features/home/controllers/home_page_controller.dart` | 端口注册前先 `removePortNameMapping`，增加注册失败日志和 `unawaited()` 包裹 |

## 测试

- [x] 主动关怀时间到达后助手自动发送消息 ✅
- [x] 主动关怀时间正确更新 ✅
- [x] GitHub Actions Android 构建通过 ✅