### PR TITLE
fix: multi-AI anchor system uses groupId instead of messageId

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -844,7 +844,9 @@ class HomePageController extends ChangeNotifier {
     if (lastAssistantIdx != null && lastAssistantIdx > 0) {
       for (int i = lastAssistantIdx - 1; i >= 0; i--) {
         if (msgs[i].role == 'user') {
-          if (message.id == msgs[i].id) return true;
+          final msgGid = message.groupId ?? message.id;
+          final anchorGid = msgs[i].groupId ?? msgs[i].id;
+          if (msgGid == anchorGid) return true;
           break; // 找到第一个 user 就停，不穿透到更早轮次
         }
       }
@@ -925,7 +927,7 @@ class HomePageController extends ChangeNotifier {
     if (message.role == 'user' &&
         multiAIEngine.isActive &&
         _chatController.subgroupActiveGroupIds.isNotEmpty) {
-      final anchorUserMsgId = message.id;
+      final anchorUserMsgId = message.groupId ?? message.id;
       final settings = _context.read<SettingsProvider>();
       final assistant = _context.read<AssistantProvider>().currentAssistant;
       await multiAIEngine.retryRound(

--- a/lib/features/home/services/multi_ai_engine.dart
+++ b/lib/features/home/services/multi_ai_engine.dart
@@ -92,14 +92,20 @@ class MultiAIEngine extends ChangeNotifier {
   Set<String> get subgroupActiveGroupIds =>
       _chatController.subgroupActiveGroupIds;
 
-  /// Compute anchor user-message IDs → set of distinct subgroupIds across
-  /// all rounds, filtered to only anchors with ≥ 2 distinct threads.
+  /// Compute anchor user-message groupIds → set of distinct subgroupIds
+  /// across all rounds, filtered to only anchors with ≥ 2 distinct threads.
+  ///
+  /// Uses groupId (not message id) so that edited user-message versions
+  /// (which share the same groupId) resolve to the same anchor. Otherwise
+  /// after an edit-resend the anchor key would point at the stale original
+  /// version id and the comparison cards would disappear from the new
+  /// version in the collapsed list.
   static Map<String, Set<String>> _computeAnchors(List<ChatMessage> messages) {
     final anchors = <String, Set<String>>{};
     String? lastUser;
     for (final m in messages) {
       if (m.role == 'user') {
-        lastUser = m.id;
+        lastUser = m.groupId ?? m.id;
       } else if (m.subgroupId != null && lastUser != null) {
         anchors.putIfAbsent(lastUser, () => <String>{}).add(m.subgroupId!);
       }
@@ -123,15 +129,21 @@ class MultiAIEngine extends ChangeNotifier {
   int get roundCount => _computeAnchors(_chatController.messages).length;
 
   /// Collect all subgroup messages that belong to the round anchored by
-  /// [anchorUserMsgId]. Reads forwards from the anchor until the next user
-  /// message (or end of list), groups by subgroupId, and sorts by version
-  /// within each group.
+  /// [anchorUserMsgId] (a user-message groupId). Reads forwards from the
+  /// anchor until the next user message with a different groupId (or end of
+  /// list), groups by subgroupId, and sorts by version within each group.
+  ///
+  /// Matching by groupId (instead of message id) ensures that edited
+  /// user-message versions — which share the original groupId — keep
+  /// collecting the same round's subgroup messages instead of terminating
+  /// the scan at the new version.
   Map<String, List<ChatMessage>> getMessagesForAnchor(String anchorUserMsgId) {
     bool collecting = false;
     final result = <String, List<ChatMessage>>{};
     for (final m in _chatController.messages) {
       if (m.role == 'user') {
-        if (m.id == anchorUserMsgId) {
+        final gid = m.groupId ?? m.id;
+        if (gid == anchorUserMsgId) {
           collecting = true;
           continue;
         } else if (collecting) {
@@ -956,7 +968,9 @@ class MultiAIEngine extends ChangeNotifier {
       conversation,
     );
     if (anchorId != null) {
-      final anchorIdx = completeMessages.indexWhere((m) => m.id == anchorId);
+      final anchorIdx = completeMessages.indexWhere(
+        (m) => m.role == 'user' && (m.groupId ?? m.id) == anchorId,
+      );
       if (anchorIdx >= 0) {
         completeMessages = completeMessages.sublist(0, anchorIdx + 1);
       }

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -626,8 +626,11 @@ class _MessageListViewState extends State<MessageListView> {
             padding: widget.dividerPadding,
             child: _buildContextDivider(context),
           ),
-        if (widget.afterMessageWidgets?.containsKey(message.id) == true)
-          widget.afterMessageWidgets![message.id]!,
+        if (widget.afterMessageWidgets?.containsKey(
+              message.groupId ?? message.id,
+            ) ==
+            true)
+          widget.afterMessageWidgets![message.groupId ?? message.id]!,
       ],
     );
 


### PR DESCRIPTION
Two defects caused edit-resend to break multi-AI comparison cards:

Defect A (_isRetryableInMultiAI): compared by message.id, so the new version created by edit (new id) never matched the original user message in the scan → Guard 2 intercepted with a misleading toast.

Defect B (_computeAnchors / afterMessageWidgets lookup): anchor keys were message ids, but after edit the collapsed list shows the new version whose id differs from the stale anchor key → cards disappeared.

Fix: use groupId (shared across edit versions) for:
- _computeAnchors anchor keys
- getMessagesForAnchor scan/break logic
- _isRetryableInMultiAI user-message comparison
- BRANCH C anchorUserMsgId
- afterMessageWidgets MessageListView lookup
- addModelsAndExecute context-truncation indexWhere (was missed in the original analysis — would have silently used full history instead of truncating at the anchor)

Closes #70.