### PR TITLE
fix: 更新关于页面 GitHub 链接及自动检测更新为 cuplivo/cuplivo

### DIFF
--- a/lib/core/providers/update_provider.dart
+++ b/lib/core/providers/update_provider.dart
@@ -72,6 +72,52 @@ class UpdateInfo {
       downloads: downloads,
     );
   }
+
+  /// Parses a GitHub Releases API response into [UpdateInfo].
+  factory UpdateInfo.fromGithubRelease(Map<String, dynamic> json) {
+    final tag = (json['tag_name'] ?? '').toString();
+    // Strip leading 'v' prefix if present (e.g. "v1.2.3" -> "1.2.3")
+    final version = tag.startsWith('v') ? tag.substring(1) : tag;
+
+    DateTime? released;
+    final publishedAt = json['published_at']?.toString();
+    if (publishedAt != null && publishedAt.isNotEmpty) {
+      try {
+        released = DateTime.parse(publishedAt);
+      } catch (_) {}
+    }
+
+    // Map release assets to platform download keys
+    final downloads = <String, String>{};
+    final assets = (json['assets'] as List?) ?? const [];
+    for (final asset in assets) {
+      if (asset is! Map) continue;
+      final name = (asset['name'] ?? '').toString().toLowerCase();
+      final url = (asset['browser_download_url'] ?? '').toString();
+      if (url.isEmpty) continue;
+      if (name.endsWith('.apk')) {
+        downloads['android'] = url;
+      } else if (name.endsWith('.ipa')) {
+        downloads['ios'] = url;
+      } else if (name.endsWith('.dmg') || name.endsWith('.pkg')) {
+        downloads['macos'] = url;
+      } else if (name.endsWith('.exe') || name.endsWith('.msix')) {
+        downloads['windows'] = url;
+      } else if (name.endsWith('.appimage') ||
+          name.endsWith('.deb') ||
+          name.endsWith('.rpm')) {
+        downloads['linux'] = url;
+      }
+    }
+
+    return UpdateInfo(
+      app: 'cuplivo',
+      version: version,
+      releasedAt: released,
+      notes: (json['body'] ?? '').toString(),
+      downloads: downloads,
+    );
+  }
 }
 
 class UpdateProvider extends ChangeNotifier {
@@ -88,17 +134,18 @@ class UpdateProvider extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
-      final ts = DateTime.now().millisecondsSinceEpoch;
       final url = Uri.parse(
-        'https://kelivo.psycheas.top/update.json?kelivo=$ts',
+        'https://api.github.com/repos/cuplivo/cuplivo/releases/latest',
       );
-      final resp = await http.get(url);
+      final resp = await http.get(url, headers: {
+        'Accept': 'application/vnd.github+json',
+      });
       if (resp.statusCode != 200) {
         throw Exception('HTTP ${resp.statusCode}');
       }
       final data =
           jsonDecode(utf8.decode(resp.bodyBytes)) as Map<String, dynamic>;
-      final info = UpdateInfo.fromJson(data);
+      final info = UpdateInfo.fromGithubRelease(data);
 
       final pkg = await PackageInfo.fromPlatform();
       final currentVer = pkg.version; // e.g., 1.0.0

--- a/lib/desktop/setting/about_pane.dart
+++ b/lib/desktop/setting/about_pane.dart
@@ -173,14 +173,14 @@ class _DesktopAboutPaneState extends State<DesktopAboutPane> {
                     svgAsset: 'assets/icons/github.svg',
                     label: l10n.aboutPageGithub,
                     onTap: () =>
-                        _openUrl('https://github.com/Chevey339/kelivo'),
+                        _openUrl('https://github.com/cuplivo/cuplivo'),
                   ),
                   const _DeskRowDivider(),
                   _DeskNavRow(
                     icon: lucide.Lucide.FileText,
                     label: l10n.aboutPageLicense,
                     onTap: () => _openUrl(
-                      'https://github.com/Chevey339/kelivo/blob/master/LICENSE',
+                      'https://github.com/cuplivo/cuplivo/blob/master/LICENSE',
                     ),
                   ),
                   const _DeskRowDivider(),

--- a/lib/features/settings/pages/about_page.dart
+++ b/lib/features/settings/pages/about_page.dart
@@ -411,7 +411,7 @@ class _AboutPageState extends State<AboutPage> {
                 context,
                 svgAsset: 'assets/icons/github.svg',
                 label: l10n.aboutPageGithub,
-                onTap: () => _openUrl('https://github.com/Chevey339/kelivo'),
+                onTap: () => _openUrl('https://github.com/cuplivo/cuplivo'),
               ),
               _iosDivider(context),
               _iosNavRow(
@@ -419,7 +419,7 @@ class _AboutPageState extends State<AboutPage> {
                 icon: Lucide.FileText,
                 label: l10n.aboutPageLicense,
                 onTap: () => _openUrl(
-                  'https://github.com/Chevey339/kelivo/blob/master/LICENSE',
+                  'https://github.com/cuplivo/cuplivo/blob/master/LICENSE',
                 ),
               ),
               _iosDivider(context),


### PR DESCRIPTION
## 变更内容

1. **关于页面 GitHub 链接**（移动端 + 桌面端）
   - GitHub 链接：`Chevey339/kelivo` → `cuplivo/cuplivo`
   - LICENSE 链接：`Chevey339/kelivo/blob/master/LICENSE` → `cuplivo/cuplivo/blob/master/LICENSE`

2. **自动检测更新**
   - 更新源：`kelivo.psycheas.top/update.json` → GitHub Releases API (`api.github.com/repos/cuplivo/cuplivo/releases/latest`)
   - 新增 `UpdateInfo.fromGithubRelease` 工厂方法，解析 GitHub Release 响应（tag 版本号、release notes、各平台 asset 下载链接）

## 涉及文件

- `lib/features/settings/pages/about_page.dart` — 移动端关于页面
- `lib/desktop/setting/about_pane.dart` — 桌面端关于面板
- `lib/core/providers/update_provider.dart` — 更新检测逻辑