### PR TITLE
fix: translate stop button actually closes HTTP connection (CancelToken force-close)

### DIFF
--- a/lib/desktop/desktop_translate_page.dart
+++ b/lib/desktop/desktop_translate_page.dart
@@ -34,6 +34,7 @@ class _DesktopTranslatePageState extends State<DesktopTranslatePage> {
 
   StreamSubscription? _subscription;
   bool _translating = false;
+  String? _requestId;
 
   @override
   void initState() {
@@ -44,6 +45,7 @@ class _DesktopTranslatePageState extends State<DesktopTranslatePage> {
 
   @override
   void dispose() {
+    ChatApiService.cancelRequest(_requestId ?? '');
     _subscription?.cancel();
     _source.dispose();
     _output.dispose();
@@ -168,12 +170,14 @@ class _DesktopTranslatePageState extends State<DesktopTranslatePage> {
     });
 
     try {
+      _requestId = 'translate_${DateTime.now().millisecondsSinceEpoch}';
       final stream = ChatApiService.sendMessageStream(
         config: cfg,
         modelId: modelId,
         messages: [
           {'role': 'user', 'content': prompt},
         ],
+        requestId: _requestId,
       );
 
       _subscription = stream.listen(
@@ -212,6 +216,7 @@ class _DesktopTranslatePageState extends State<DesktopTranslatePage> {
   }
 
   Future<void> _stopTranslate() async {
+    ChatApiService.cancelRequest(_requestId ?? '');
     try {
       await _subscription?.cancel();
     } catch (_) {}

--- a/lib/features/translate/pages/translate_page.dart
+++ b/lib/features/translate/pages/translate_page.dart
@@ -33,6 +33,7 @@ class _TranslatePageState extends State<TranslatePage> {
   String? _modelId;
   StreamSubscription? _sub;
   bool _loading = false;
+  String? _requestId;
 
   @override
   void initState() {
@@ -42,6 +43,7 @@ class _TranslatePageState extends State<TranslatePage> {
 
   @override
   void dispose() {
+    ChatApiService.cancelRequest(_requestId ?? '');
     _sub?.cancel();
     _src.dispose();
     _dst.dispose();
@@ -131,12 +133,14 @@ class _TranslatePageState extends State<TranslatePage> {
     });
 
     try {
+      _requestId = 'translate_${DateTime.now().millisecondsSinceEpoch}';
       final stream = ChatApiService.sendMessageStream(
         config: cfg,
         modelId: mid,
         messages: [
           {'role': 'user', 'content': p},
         ],
+        requestId: _requestId,
       );
       _sub = stream.listen(
         (chunk) {
@@ -175,6 +179,7 @@ class _TranslatePageState extends State<TranslatePage> {
   }
 
   Future<void> _stop() async {
+    ChatApiService.cancelRequest(_requestId ?? '');
     try {
       await _sub?.cancel();
     } catch (_) {}


### PR DESCRIPTION
The stop buttons on both mobile and desktop translate pages only cancelled the Dart StreamSubscription, leaving the underlying HTTP connection alive. This meant the server-side request continued to completion (observed by the user as a complete cpa record), and the stop button often needed multiple clicks.

Align with the pattern established in PR #79 for chat stop button:
- Generate a unique requestId for each translation request
- Pass it to sendMessageStream so the CancelToken is registered
- Call ChatApiService.cancelRequest() on stop/dispose to force-close the TCP connection via _dio.close(force: true)

Closes https://github.com/cuplivo/cuplivo/issues/94