### PR TITLE
feat: toast notification on truncated response (max_tokens / context window exceeded)

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -1494,6 +1494,9 @@ class ChatStreamChunk {
   final TokenUsage? usage;
   final List<ToolCallInfo>? toolCalls;
   final List<ToolResultInfo>? toolResults;
+  // Non-null when the response was truncated (e.g. max_tokens, context exceeded).
+  // Value maps to ARB key suffixes: 'max_tokens' or 'context_exceeded'.
+  final String? truncationReason;
 
   ChatStreamChunk({
     required this.content,
@@ -1503,6 +1506,7 @@ class ChatStreamChunk {
     this.usage,
     this.toolCalls,
     this.toolResults,
+    this.truncationReason,
   });
 }
 

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -509,11 +509,18 @@ Stream<ChatStreamChunk> _sendClaudeStream(
         continue; // next round
       }
       // No tool use -> return final text
+      final sr = (obj['stop_reason'] ?? obj['stopReason'] ?? '').toString();
       yield ChatStreamChunk(
         content: buf.toString(),
         isDone: true,
         totalTokens: (totalUsage?.totalTokens ?? 0),
         usage: totalUsage,
+        truncationReason:
+            sr == 'max_tokens' || sr == 'model_context_window_exceeded'
+            ? (sr == 'model_context_window_exceeded'
+                  ? 'context_exceeded'
+                  : 'max_tokens')
+            : null,
       );
       return;
     }
@@ -957,6 +964,12 @@ Stream<ChatStreamChunk> _sendClaudeStream(
           isDone: true,
           totalTokens: (totalUsage?.totalTokens ?? roundTokens),
           usage: totalUsage ?? usage,
+          truncationReason:
+              sr == 'max_tokens' || sr == 'model_context_window_exceeded'
+              ? (sr == 'model_context_window_exceeded'
+                    ? 'context_exceeded'
+                    : 'max_tokens')
+              : null,
         );
         return;
       }

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -708,11 +708,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         final metaComment = _collectThoughtSigCommentFromParts(parts);
         if (metaComment.isNotEmpty) contentStr += metaComment;
       }
+      final fr = (cand['finishReason'] ?? cand['finish_reason'] ?? '')
+          .toString();
       yield ChatStreamChunk(
         content: contentStr,
         isDone: true,
         totalTokens: totalUsage?.totalTokens ?? 0,
         usage: totalUsage,
+        truncationReason: fr == 'MAX_TOKENS' ? 'max_tokens' : null,
       );
       return;
     }
@@ -1127,6 +1130,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       return sb.toString();
     }
 
+    String? finishReason; // detect stream completion from server
     await for (final chunk in _ensureTrailingNewline(sse)) {
       buffer += chunk;
       final lines = buffer.split('\n');
@@ -1152,7 +1156,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           if (candidates is List && candidates.isNotEmpty) {
             String textDelta = '';
             String reasoningDelta = '';
-            String? finishReason; // detect stream completion from server
             for (final cand in candidates) {
               if (cand is! Map) continue;
               final content = cand['content'];
@@ -1515,6 +1518,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 isDone: true,
                 totalTokens: totalTokens,
                 usage: usage,
+                truncationReason: finishReason == 'MAX_TOKENS'
+                    ? 'max_tokens'
+                    : null,
               );
               return;
             }
@@ -1559,6 +1565,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         isDone: true,
         totalTokens: totalTokens,
         usage: usage,
+        truncationReason: finishReason == 'MAX_TOKENS' ? 'max_tokens' : null,
       );
       return;
     }

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -1740,6 +1740,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           isDone: true,
           totalTokens: aggUsage?.totalTokens ?? 0,
           usage: aggUsage,
+          truncationReason: (c0['finish_reason'] as String?) == 'length'
+              ? 'max_tokens'
+              : null,
         );
         return;
       }
@@ -1779,6 +1782,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
   List<Map<String, dynamic>> lastResponseOutputItems =
       const <Map<String, dynamic>>[];
   String? finishReason;
+  String?
+  incompleteReason; // Responses API: json['response']['incomplete_details']['reason']
 
   await for (final chunk in _ensureTrailingNewline(sse)) {
     buffer += chunk;
@@ -2404,6 +2409,22 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 entry['args'] = (entry['args'] ?? '') + argsDelta;
               }
             }
+          } else if (type == 'response.incomplete') {
+            final u = json['response']?['usage'];
+            if (u != null) {
+              final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
+              final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
+              usage = (usage ?? const TokenUsage()).merge(
+                TokenUsage(promptTokens: inTok, completionTokens: outTok),
+              );
+              totalTokens = usage.totalTokens;
+            }
+            try {
+              final details = json['response']?['incomplete_details'];
+              if (details is Map) {
+                incompleteReason = (details['reason'] ?? '').toString();
+              }
+            } catch (_) {}
           } else if (type == 'response.completed') {
             final u = json['response']?['usage'];
             if (u != null) {
@@ -2822,6 +2843,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     isDone: true,
                     totalTokens: usage?.totalTokens ?? approxTotal2,
                     usage: usage,
+                    truncationReason: incompleteReason == 'max_tokens'
+                        ? 'max_tokens'
+                        : null,
                   );
                   return;
                 }
@@ -2928,6 +2952,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 isDone: true,
                 totalTokens: usage?.totalTokens ?? approxTotal,
                 usage: usage,
+                truncationReason: incompleteReason == 'max_tokens'
+                    ? 'max_tokens'
+                    : null,
               );
               return;
             }
@@ -2941,6 +2968,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               isDone: true,
               totalTokens: usage?.totalTokens ?? approxTotal,
               usage: usage,
+              truncationReason: incompleteReason == 'max_tokens'
+                  ? 'max_tokens'
+                  : null,
             );
             return;
           } else {
@@ -3760,6 +3790,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 isDone: true,
                 totalTokens: usage?.totalTokens ?? approxTotal,
                 usage: usage,
+                truncationReason: finishReason == 'length'
+                    ? 'max_tokens'
+                    : null,
               );
               return;
             }
@@ -4285,5 +4318,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     isDone: true,
     totalTokens: approxTotal,
     usage: usage,
+    truncationReason:
+        finishReason == 'length' || incompleteReason == 'max_tokens'
+        ? 'max_tokens'
+        : null,
   );
 }

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -11,6 +11,7 @@ import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/ios_background_generation.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/assistant_regex.dart';
 import '../../../core/models/assistant_regex.dart';
 import '../../../utils/markdown_media_sanitizer.dart';
@@ -1484,6 +1485,23 @@ class ChatActions {
         messageId,
         reasoningText: r.text,
         reasoningFinishedAt: r.finishedAt,
+      );
+    }
+
+    // Show truncation warning if the response was cut off
+    final tr = chunk.truncationReason;
+    if (tr != null) {
+      if (!contextProvider.mounted) return;
+      final l10n = _l10n;
+      if (l10n == null) return;
+      final reasonText = tr == 'max_tokens'
+          ? l10n.truncationReasonMaxTokens
+          : l10n.truncationReasonContextExceeded;
+      showAppSnackBar(
+        contextProvider,
+        message: l10n.responseTruncated(reasonText),
+        type: NotificationType.warning,
+        duration: const Duration(seconds: 30),
       );
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2824,5 +2824,15 @@
   },
   "skillsDeleteConfirmDeleteButton": "Delete",
   "assistantEditPageSkillsTab": "Skills",
-  "settingsPageSkills": "Skills"
+  "settingsPageSkills": "Skills",
+  "responseTruncated": "Response was truncated ({reason}). The content may be incomplete.",
+  "@responseTruncated": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "truncationReasonMaxTokens": "output length limit",
+  "truncationReasonContextExceeded": "context window exceeded"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10921,6 +10921,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skills'**
   String get settingsPageSkills;
+
+  /// No description provided for @responseTruncated.
+  ///
+  /// In en, this message translates to:
+  /// **'Response was truncated ({reason}). The content may be incomplete.'**
+  String responseTruncated(String reason);
+
+  /// No description provided for @truncationReasonMaxTokens.
+  ///
+  /// In en, this message translates to:
+  /// **'output length limit'**
+  String get truncationReasonMaxTokens;
+
+  /// No description provided for @truncationReasonContextExceeded.
+  ///
+  /// In en, this message translates to:
+  /// **'context window exceeded'**
+  String get truncationReasonContextExceeded;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5969,4 +5969,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsPageSkills => 'Skills';
+
+  @override
+  String responseTruncated(String reason) {
+    return 'Response was truncated ($reason). The content may be incomplete.';
+  }
+
+  @override
+  String get truncationReasonMaxTokens => 'output length limit';
+
+  @override
+  String get truncationReasonContextExceeded => 'context window exceeded';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5725,6 +5725,17 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsPageSkills => '技能';
+
+  @override
+  String responseTruncated(String reason) {
+    return '回答已被截断（$reason），内容可能不完整';
+  }
+
+  @override
+  String get truncationReasonMaxTokens => '输出长度限制';
+
+  @override
+  String get truncationReasonContextExceeded => '上下文窗口超限';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -11448,6 +11459,17 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get settingsPageSkills => '技能';
+
+  @override
+  String responseTruncated(String reason) {
+    return '回答已被截断（$reason），内容可能不完整';
+  }
+
+  @override
+  String get truncationReasonMaxTokens => '输出长度限制';
+
+  @override
+  String get truncationReasonContextExceeded => '上下文窗口超限';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -17171,4 +17193,15 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get settingsPageSkills => '技能';
+
+  @override
+  String responseTruncated(String reason) {
+    return '回答已被截斷（$reason），內容可能不完整';
+  }
+
+  @override
+  String get truncationReasonMaxTokens => '輸出長度限制';
+
+  @override
+  String get truncationReasonContextExceeded => '上下文窗口超限';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2371,5 +2371,15 @@
   },
   "skillsDeleteConfirmDeleteButton": "删除",
   "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能"
+  "settingsPageSkills": "技能",
+  "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
+  "@responseTruncated": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "truncationReasonMaxTokens": "输出长度限制",
+  "truncationReasonContextExceeded": "上下文窗口超限"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2343,5 +2343,15 @@
   },
   "skillsDeleteConfirmDeleteButton": "删除",
   "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能"
+  "settingsPageSkills": "技能",
+  "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
+  "@responseTruncated": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "truncationReasonMaxTokens": "输出长度限制",
+  "truncationReasonContextExceeded": "上下文窗口超限"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2371,5 +2371,15 @@
   },
   "skillsDeleteConfirmDeleteButton": "刪除",
   "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能"
+  "settingsPageSkills": "技能",
+  "responseTruncated": "回答已被截斷（{reason}），內容可能不完整",
+  "@responseTruncated": {
+    "placeholders": {
+      "reason": {
+        "type": "String"
+      }
+    }
+  },
+  "truncationReasonMaxTokens": "輸出長度限制",
+  "truncationReasonContextExceeded": "上下文窗口超限"
 }


### PR DESCRIPTION
Closes #84.

All providers (OpenAI Chat Completions, OpenAI Responses API, Claude, Gemini) now detect truncation and surface it via a 30s dismissible toast with localized reason text.

- ChatStreamChunk: new truncationReason field
- OpenAI Chat Completions: finish_reason == 'length' -> 'max_tokens'
- OpenAI Responses API: response.incomplete -> incomplete_details.reason
- Claude: stop_reason == 'max_tokens' / model_context_window_exceeded
- Gemini: finishReason == 'MAX_TOKENS' -> 'max_tokens'
- Toast consumer in _handleStreamFinish (chat_actions.dart)
- ARB keys: responseTruncated, truncationReasonMaxTokens, truncationReasonContextExceeded