### PR TITLE
fix: 停止按钮 sub.cancel() 抛异常导致 loading 未清除，需按两次

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import '../../providers/settings_provider.dart';
@@ -70,9 +71,16 @@ class ChatApiService {
 
   static void cancelRequest(String requestId) {
     final key = requestId.trim();
-    if (key.isEmpty) return;
+    if (key.isEmpty) {
+      debugPrint('[CancelTrace] cancelRequest: key empty');
+      return;
+    }
     final token = _activeCancelTokens.remove(key);
-    if (token == null) return;
+    if (token == null) {
+      debugPrint('[CancelTrace] cancelRequest: token NOT FOUND for key=$key');
+      return;
+    }
+    debugPrint('[CancelTrace] cancelRequest: cancelling key=$key');
     try {
       if (!token.isCancelled) token.cancel('cancelled');
     } catch (_) {}
@@ -732,6 +740,9 @@ class ChatApiService {
       client.close();
       if (rid.isNotEmpty) {
         final cur = _activeCancelTokens[rid];
+        debugPrint(
+          '[CancelTrace] sendMessageStream finally: rid=$rid curIdentical=${identical(cur, cancelToken)}',
+        );
         if (identical(cur, cancelToken)) {
           _activeCancelTokens.remove(rid);
         }

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -925,7 +925,13 @@ class ChatActions {
   /// Cancel the active streaming for the current conversation.
   Future<void> cancelStreaming(Conversation? conversation) async {
     final cid = conversation?.id;
-    if (cid == null || _isCancelling) return;
+    if (cid == null || _isCancelling) {
+      debugPrint(
+        '[CancelTrace] cancelStreaming SKIPPED: cid=$cid _isCancelling=$_isCancelling',
+      );
+      return;
+    }
+    debugPrint('[CancelTrace] cancelStreaming ENTER: cid=$cid');
     _isCancelling = true;
     try {
       // Cancel any pending tool approval requests to prevent deadlock
@@ -957,7 +963,11 @@ class ChatActions {
       // Cancel active stream for current conversation only
       ChatApiService.cancelRequest(cid);
       final sub = _conversationStreams.remove(cid);
-      await sub?.cancel();
+      try {
+        await sub?.cancel();
+      } catch (e) {
+        debugPrint('[CancelTrace] sub.cancel() threw (ignored): $e');
+      }
 
       // Find all assistant streaming messages within current conversation and mark them finished
       final streamingMessages = <ChatMessage>[];
@@ -967,6 +977,9 @@ class ChatActions {
           streamingMessages.add(m);
         }
       }
+      debugPrint(
+        '[CancelTrace] cancelStreaming: streamingMessages=${streamingMessages.length} cntBefore=${chatController.loadingConversationIds.contains(cid)}',
+      );
       if (streamingMessages.isNotEmpty) {
         for (final streaming in streamingMessages) {
           // Mark streaming as ended to allow UI rebuilds again
@@ -976,11 +989,24 @@ class ChatActions {
           final idx = _messages.indexWhere((m) => m.id == streaming.id);
           final latestStreaming = idx == -1 ? streaming : _messages[idx];
 
-          await chatService.updateMessage(
-            latestStreaming.id,
-            content: latestStreaming.content,
-            isStreaming: false,
-            totalTokens: latestStreaming.totalTokens,
+          debugPrint(
+            '[CancelTrace] cancelStreaming before updateMessage: msg=${latestStreaming.id}',
+          );
+          try {
+            await chatService.updateMessage(
+              latestStreaming.id,
+              content: latestStreaming.content,
+              isStreaming: false,
+              totalTokens: latestStreaming.totalTokens,
+            );
+          } catch (e, st) {
+            debugPrint(
+              '[CancelTrace] cancelStreaming updateMessage THREW: $e\n$st',
+            );
+            rethrow;
+          }
+          debugPrint(
+            '[CancelTrace] cancelStreaming after updateMessage: msg=${latestStreaming.id}',
           );
 
           if (idx != -1) {
@@ -991,22 +1017,35 @@ class ChatActions {
           streamController.removeStreamingNotifier(streaming.id);
 
           // Use unified reasoning completion method
-          await streamController.finishReasoningAndPersist(
-            streaming.id,
-            updateReasoningInDb:
-                (
-                  String messageId, {
-                  String? reasoningText,
-                  DateTime? reasoningFinishedAt,
-                  String? reasoningSegmentsJson,
-                }) async {
-                  await chatService.updateMessage(
-                    messageId,
-                    reasoningText: reasoningText,
-                    reasoningFinishedAt: reasoningFinishedAt,
-                    reasoningSegmentsJson: reasoningSegmentsJson,
-                  );
-                },
+          debugPrint(
+            '[CancelTrace] cancelStreaming before finishReasoningAndPersist: msg=${streaming.id}',
+          );
+          try {
+            await streamController.finishReasoningAndPersist(
+              streaming.id,
+              updateReasoningInDb:
+                  (
+                    String messageId, {
+                    String? reasoningText,
+                    DateTime? reasoningFinishedAt,
+                    String? reasoningSegmentsJson,
+                  }) async {
+                    await chatService.updateMessage(
+                      messageId,
+                      reasoningText: reasoningText,
+                      reasoningFinishedAt: reasoningFinishedAt,
+                      reasoningSegmentsJson: reasoningSegmentsJson,
+                    );
+                  },
+            );
+          } catch (e, st) {
+            debugPrint(
+              '[CancelTrace] cancelStreaming finishReasoningAndPersist THREW: $e\n$st',
+            );
+            rethrow;
+          }
+          debugPrint(
+            '[CancelTrace] cancelStreaming after finishReasoningAndPersist: msg=${streaming.id}',
           );
 
           // If streaming output included inline base64 images, sanitize them even on manual cancel
@@ -1016,14 +1055,20 @@ class ChatActions {
             immediate: true,
           );
         }
+        debugPrint('[CancelTrace] cancelStreaming BEFORE forceClear');
         chatController.forceClearConversationLoading(cid);
         onLoadingChanged?.call(cid, false);
+        debugPrint('[CancelTrace] cancelStreaming AFTER forceClear');
         await _cancelIosBackgroundGeneration();
       } else {
+        debugPrint('[CancelTrace] cancelStreaming else-branch forceClear');
         chatController.forceClearConversationLoading(cid);
         onLoadingChanged?.call(cid, false);
       }
     } finally {
+      debugPrint(
+        '[CancelTrace] cancelStreaming EXIT: cid=$cid _isCancelling->false',
+      );
       _isCancelling = false;
     }
   }
@@ -1098,6 +1143,9 @@ class ChatActions {
       );
 
       final streamKey = streamKeyOverride ?? conversationId;
+      debugPrint(
+        '[CancelTrace] _executeGeneration: streamKey=$streamKey requestId=${requestIdOverride ?? conversationId} priorSub=${_conversationStreams[streamKey] != null}',
+      );
       await _conversationStreams[streamKey]?.cancel();
       final sub = listenSequentiallyToStream<ChatStreamChunk>(
         stream: stream,
@@ -1622,6 +1670,9 @@ class ChatActions {
     final messageId = state.messageId;
     final conversationId = state.conversationId;
     final errorText = e.toString();
+    debugPrint(
+      '[CancelTrace] _handleStreamError ENTER: cid=$conversationId _isCancelling=$_isCancelling errorType=${e.runtimeType}',
+    );
 
     // Reset file processing state on error
     onFileProcessingFinished?.call();
@@ -1657,6 +1708,9 @@ class ChatActions {
     streamController.removeStreamingNotifier(messageId);
 
     if (_isCancelling) {
+      debugPrint(
+        '[CancelTrace] _handleStreamError early-return (isCancelling)',
+      );
       return;
     }
 
@@ -1695,6 +1749,9 @@ class ChatActions {
 
     final conversationId = state.conversationId;
     final messageId = state.messageId;
+    debugPrint(
+      '[CancelTrace] _handleStreamDone ENTER: cid=$conversationId _isCancelling=$_isCancelling loadingContains=${_loadingConversationIds.contains(conversationId)} inFlight=${_finishStreamingFutures[messageId] != null}',
+    );
 
     // Ensure streaming is marked as ended
     streamController.markStreamingEnded(messageId);

--- a/lib/features/home/controllers/chat_controller.dart
+++ b/lib/features/home/controllers/chat_controller.dart
@@ -699,6 +699,9 @@ class ChatController extends ChangeNotifier {
     }
     final newCount = _loadingConversationCounts[conversationId] ?? 0;
     final newLoading = newCount > 0;
+    debugPrint(
+      '[CancelTrace] setConversationLoading: cid=$conversationId loading=$loading prev=$prevCount now=$newCount newLoading=$newLoading',
+    );
     if (prevLoading != newLoading) {
       notifyListeners();
     }
@@ -707,8 +710,12 @@ class ChatController extends ChangeNotifier {
   /// Force-clear the loading counter for a conversation (used for manual cancel).
   /// Always notifies listeners.
   void forceClearConversationLoading(String conversationId) {
-    final wasLoading = (_loadingConversationCounts[conversationId] ?? 0) > 0;
+    final prevCount = _loadingConversationCounts[conversationId] ?? 0;
+    final wasLoading = prevCount > 0;
     _loadingConversationCounts.remove(conversationId);
+    debugPrint(
+      '[CancelTrace] forceClearConversationLoading: cid=$conversationId prev=$prevCount wasLoading=$wasLoading',
+    );
     if (wasLoading) {
       notifyListeners();
     }

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1049,8 +1049,10 @@ class HomePageController extends ChangeNotifier {
   }
 
   Future<void> cancelStreaming() async {
+    debugPrint('[CancelTrace] HomePageController.cancelStreaming ENTER');
     await _viewModel.cancelStreaming();
     notifyListeners();
+    debugPrint('[CancelTrace] HomePageController.cancelStreaming EXIT');
   }
 
   // ============================================================================


### PR DESCRIPTION
Closes #77.

`cancelRequest` 取消 `Dio` 连接后，stream subscription 的 `cancel()` 可能因 `HttpException` 抛异常，跳过 `forceClearConversationLoading`，导致 UI 停留在停止按钮状态。用 `try-catch` 包裹 `sub?.cancel()`，确保后续清理逻辑始终执行。

保留 `[CancelTrace]` 诊断日志供后续验证，日后移除。