### PR TITLE
fix: use p.basename() for cross-platform log file categorization on Windows

### DIFF
--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -70,7 +71,7 @@ class _LogViewerPageState extends State<LogViewerPage>
         final request = <File>[];
         final app = <File>[];
         for (final f in all) {
-          final name = f.path.split('/').last.toLowerCase();
+          final name = p.basename(f.path).toLowerCase();
           if (name.startsWith('flutter_logs')) {
             app.add(f);
           } else if (name.startsWith('logs')) {
@@ -294,7 +295,7 @@ class _LogFilesList extends StatelessWidget {
       itemBuilder: (context, index) {
         final file = files[index];
         final stat = file.statSync();
-        final fileName = file.path.split('/').last;
+        final fileName = p.basename(file.path);
         final isCurrentLog =
             fileName.toLowerCase() == activeFileName.toLowerCase();
 
@@ -439,7 +440,7 @@ class _PlainLogContentPageState extends State<_PlainLogContentPage> {
       await SharePlus.instance.share(
         ShareParams(
           files: [XFile(widget.file.path)],
-          subject: widget.file.path.split('/').last,
+          subject: p.basename(widget.file.path),
         ),
       );
     } catch (e) {
@@ -546,7 +547,7 @@ class _RequestLogFilePageState extends State<_RequestLogFilePage> {
       await SharePlus.instance.share(
         ShareParams(
           files: [XFile(widget.file.path)],
-          subject: widget.file.path.split('/').last,
+          subject: p.basename(widget.file.path),
         ),
       );
     } catch (e) {


### PR DESCRIPTION
Replace hardcoded split('/') with p.basename() in log_viewer_page.dart. On Windows, path separators are backslashes, causing all log files to be miscategorized as app logs and leaving the request logs tab empty.

Closes #88.
