### PR TITLE
feat(skills): v2 — yaml parser, async IO, GitHub import, auxiliary file tools

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,8 +106,8 @@
 
 ### Core Concept
 
-- **Skill**: A directory at `<appData>/skills/<name>/SKILL.md` containing a specialized instruction set + optional auxiliary files (scripts/, references/, assets/). The directory name IS the skill's identity — it must match the `name` field in YAML frontmatter and follow AgentSkills naming rules (lowercase letters, digits, hyphens; ≤64 chars; no leading/trailing/consecutive hyphens).
-- **`SkillManager`**: The facade that owns all skill CRUD. Reads SKILL.md from disk lazily — no memory cache. Atomic write pattern: staging dir → rename target→backup → rename staging→target → cleanup. Path safety: rejects names containing `/`, `..`, leading/trailing dots, and whitespace.
+- **Skill**: A directory at `<appData>/skills/<name>/SKILL.md` containing a specialized instruction set + optional auxiliary files (scripts/, references/, assets/). The directory name IS the skill's identity — it must match the `name` field in YAML frontmatter and follow AgentSkills naming rules (lowercase letters, digits, hyphens; ≤64 chars; no leading/trailing/consecutive hyphens). Auxiliary files are readable by the model via `read_skill_file`.
+- **`SkillManager`**: The facade that owns all skill CRUD. Reads SKILL.md from disk lazily — no memory cache. Atomic write pattern: staging dir → rename target→backup → rename staging→target → cleanup. Path safety: rejects names containing `/`, `..`, leading/trailing dots, and whitespace. Frontmatter parsing uses the `yaml` package (not a hand-rolled line parser).
 - **`AppDirectories.getSkillsDirectory()`**: Returns `<appData>/skills/`. Each skill lives in its own subdirectory matching the skill name.
 
 ### Lifecycle
@@ -115,7 +115,7 @@
 - **Import** (three channels, all funnel to `SkillManager.saveSkill()`):
   - Manual paste: User pastes complete SKILL.md (YAML frontmatter + body) into a text box. Real-time frontmatter parsing + name validation.
   - File picker: System file picker selects a single `.md` file or `.zip` archive. ZIPs are scanned for all `SKILL.md` files (any nesting depth), each validated and imported independently.
-  - GitHub URL: v1 not implemented; user can download ZIP and use file picker. If added later, uses GitHub Contents API + `saveSkillFilesAtomically()`.
+  - GitHub URL: User pastes a `github.com/{owner}/{repo}[/tree/{branch}[/sub/path]]` URL. App downloads the repo archive ZIP from `github.com/{owner}/{repo}/archive/refs/heads/{branch}.zip` (no API rate limit, no auth for public repos), then reuses the same ZIP import pipeline (scan for all `SKILL.md` at any depth, multi-select dialog if >1 found). If a subpath is specified, the scan is scoped to that subdirectory. Private/missing repos return 404 → localized "not found or private" error. GitHub only — no GitLab/generic git hosts.
 - **Update**: Re-import with the same name overwrites the directory. Atomic write handles crash safety.
 - **Delete**: `SkillManager.deleteSkill(name)` removes the directory. Removes from all assistants' `skillIds` (orphan cleanup).
 - **Export**: Included in backup via `_packZipSync` — `skills/` directory packed independently of `includeFiles`, always included. Incremental backup uses mtime ≥ since filtering (same mechanism as upload/avatars/images/fonts).
@@ -134,11 +134,24 @@
 
 ### Tool Layer
 
-- **`load_skill`**: A built-in tool exposed to the model (gated by `assistant.skillIds`). Named to mirror `read_memory` (memory 'tool' mode). Parameter `{ name: string }` (required). Returns the SKILL.md Markdown body as plain text. Optional parameters can be added later by extending `properties` without changing `required`.
+- **`load_skill`**: A built-in tool exposed to the model (gated by `assistant.skillIds`). Named to mirror `read_memory` (memory 'tool' mode). Parameter `{ name: string }` (required). Returns XML:
+  ```xml
+  <skill name="pdf-processing">
+    <instructions>
+      [SKILL.md Markdown body]
+    </instructions>
+    <files>
+      <file path="scripts/extract.py" size="2150"/>
+      <file path="references/api-docs.md" size="8602"/>
+    </files>
+  </skill>
+  ```
+  Skills with no auxiliary files omit the `<files>` element. Progressive disclosure level 2: the model sees the file tree only after choosing to load the skill.
+- **`read_skill_file`**: A built-in tool exposed to the model (gated by same `assistant.skillIds` as `load_skill`). Parameters `{ name: string, path: string }` (both required). Returns the content of an auxiliary file within a skill directory. Security boundaries: rejects paths containing `..`, absolute paths, and backslashes (forward-slash relative paths only). Binary files → error message. Content capped at 64 KB with `[truncated]` suffix. Progressive disclosure level 3: the model reads specific files on demand after seeing the listing in `load_skill`.
 
 ### Assistant Binding
 
-- **`assistant.skillIds`**: `List<String>` on the `Assistant` model, stored in SQLite as JSON (`skillIdsJson` TEXT column, same pattern as `localToolIdsJson`). Only skills in this list are injected into the assistant's `<available_skills>` and have their `load_skill` tool definition exposed.
+- **`assistant.skillIds`**: `List<String>` on the `Assistant` model, stored in SQLite as JSON (`skillIdsJson` TEXT column, same pattern as `localToolIdsJson`). Only skills in this list are injected into the assistant's `<available_skills>` and have their `load_skill`/`read_skill_file` tool definitions exposed.
 
 ### Backup Integration
 

--- a/docs/adr/0003-skills-filesystem-storage.md
+++ b/docs/adr/0003-skills-filesystem-storage.md
@@ -12,7 +12,7 @@
 
 1. **AgentSkills 规范是文件系统原生的**：spec 定义的 `scripts/`、`references/`、`assets/` 目录结构无法无损压平为 JSON。选择文件系统就是选择与规范对齐，非 JSON blob 能模拟。
 2. **RikkaHub 的先例验证**：同领域项目 RikkaHub 采用纯文件系统方案，路径安全（`SkillPaths` 防 `../` 遍历）、原子写入（staging→rename→backup→rollback）等模式可直接移植。
-3. **v1 小投入为 v2 预留能力**：辅助文件（scripts/references/assets）v1 不使用但全量落盘，v2 仅需在 `load_skill` 工具中增加文件清单返回逻辑，无需迁移数据和重新导入。
+3. **辅助文件全量落盘，按需读取**：辅助文件（scripts/references/assets）全量落盘。`load_skill` 返回文件清单，`read_skill_file` 按需读取单个文件。无需迁移数据和重新导入。此为最终形态，无后续版本。
 4. **补丁式备份接入**：现有 `_packZipSync` 加一行 `_addDirectoryToZip` 即可覆盖，增量 mtime 过滤自动生效。无需在 `_exportSettingsJson` 中开新序列化通道。
 5. **Assistant 绑定侵入最小**：只在 `Assistant` 模型加一个 `skillIds` 字段（与 `localToolIds` 同构），无新 table 或 DataStore。
 
@@ -22,6 +22,6 @@
 
 ## Consequences
 
-- **正向**：规范对齐、导入体验自然、v1→v2 前向兼容、备份增量无缝
+- **正向**：规范对齐、导入体验自然、辅助文件按需读取、备份增量无缝
 - **反向**：新增 `lib/features/skills/` 模块 + `SkillManager` + `SkillPaths`
 - **风险**：路径安全校验必须到位，否则目录遍历攻击可经 ZIP 条目进入 filesDir。已有 `_extractZipSync` 的 `..` 剥离作为第二防线

--- a/lib/features/home/services/local_tools_service.dart
+++ b/lib/features/home/services/local_tools_service.dart
@@ -17,6 +17,7 @@ class LocalToolNames {
   static const String askUser = 'ask_user_input_v0';
   static const String calculate = 'calculate';
   static const String loadSkill = 'load_skill';
+  static const String readSkillFile = 'read_skill_file';
 }
 
 class LocalToolsService {
@@ -176,6 +177,29 @@ class LocalToolsService {
           },
         },
       });
+      tools.add(const {
+        'type': 'function',
+        'function': {
+          'name': LocalToolNames.readSkillFile,
+          'description':
+              'Read an auxiliary file from a skill directory. Use this after load_skill shows available files and you need to read a specific one.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'name': {
+                'type': 'string',
+                'description': 'The name of the skill',
+              },
+              'path': {
+                'type': 'string',
+                'description':
+                    'Relative path to the file within the skill directory (forward slashes only)',
+              },
+            },
+            'required': ['name', 'path'],
+          },
+        },
+      });
     }
     return tools;
   }
@@ -191,6 +215,9 @@ class LocalToolsService {
     // load_skill is gated by skillIds, not localToolIds
     if (name == LocalToolNames.loadSkill) {
       return _handleLoadSkill(args, assistant);
+    }
+    if (name == LocalToolNames.readSkillFile) {
+      return _handleReadSkillFile(args, assistant);
     }
 
     if (!assistant.localToolIds.contains(name)) {
@@ -348,6 +375,59 @@ class LocalToolsService {
             'Skill "$name" was not found on disk. It may have been deleted.',
       });
     }
-    return body;
+
+    final sb = StringBuffer();
+    sb.writeln('<skill name="$name">');
+    sb.writeln('  <instructions>');
+    sb.writeln(body);
+    sb.writeln('  </instructions>');
+
+    final files = await SkillManager.listSkillFiles(name);
+    if (files.isNotEmpty) {
+      sb.writeln('  <files>');
+      for (final f in files) {
+        sb.writeln('    <file path="${f.path}" size="${f.size}"/>');
+      }
+      sb.writeln('  </files>');
+    }
+
+    sb.write('</skill>');
+    return sb.toString();
+  }
+
+  static Future<String?> _handleReadSkillFile(
+    Map<String, dynamic> args,
+    Assistant assistant,
+  ) async {
+    final name = (args['name'] ?? '').toString().trim();
+    final path = (args['path'] ?? '').toString().trim();
+    if (name.isEmpty || path.isEmpty) {
+      return jsonEncode({
+        'error': 'missing_params',
+        'message': 'Both "name" and "path" parameters are required.',
+      });
+    }
+    if (!assistant.skillIds.contains(name)) {
+      return jsonEncode({
+        'error': 'skill_not_found',
+        'message': 'Skill "$name" is not enabled for this assistant.',
+      });
+    }
+
+    final result = await SkillManager.readSkillFile(name, path);
+    if (result == null) {
+      return jsonEncode({
+        'error': 'file_not_found',
+        'message':
+            'File "$path" not found in skill "$name", or path is invalid.',
+      });
+    }
+    if (result.isBinary) {
+      return jsonEncode({
+        'error': 'binary_file',
+        'message': 'File "$path" is binary and cannot be displayed.',
+      });
+    }
+    return result.content;
   }
 }

--- a/lib/features/skills/github_importer.dart
+++ b/lib/features/skills/github_importer.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+class GitHubRepoInfo {
+  final String owner;
+  final String repo;
+  final String branch;
+  final String? subPath;
+
+  const GitHubRepoInfo({
+    required this.owner,
+    required this.repo,
+    required this.branch,
+    this.subPath,
+  });
+
+  String get archiveUrl =>
+      'https://github.com/$owner/$repo/archive/refs/heads/$branch.zip';
+
+  String get stripPrefix => '$repo-$branch/';
+}
+
+GitHubRepoInfo? parseGitHubUrl(String url) {
+  final trimmed = url.trim();
+  final uri = Uri.tryParse(trimmed);
+  if (uri == null) return null;
+
+  final host = uri.host.toLowerCase();
+  if (host != 'github.com' && host != 'www.github.com') return null;
+
+  final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+  if (segments.length < 2) return null;
+
+  final owner = segments[0];
+  final repo = segments[1];
+
+  if (owner.isEmpty || repo.isEmpty) return null;
+
+  String branch = 'main';
+  String? subPath;
+
+  if (segments.length >= 4 && segments[2] == 'tree') {
+    branch = segments[3];
+    if (segments.length > 4) {
+      subPath = segments.sublist(4).join('/');
+    }
+  }
+
+  return GitHubRepoInfo(
+    owner: owner,
+    repo: repo,
+    branch: branch,
+    subPath: subPath,
+  );
+}
+
+Future<File?> downloadGitHubArchive(
+  GitHubRepoInfo info, {
+  http.Client? client,
+}) async {
+  final c = client ?? http.Client();
+  try {
+    final response = await c
+        .get(Uri.parse(info.archiveUrl))
+        .timeout(const Duration(seconds: 60));
+    if (response.statusCode != 200) return null;
+
+    final tmpDir = Directory.systemTemp;
+    final tmpFile = File(
+      p.join(
+        tmpDir.path,
+        'cuplivo_skill_${DateTime.now().millisecondsSinceEpoch}.zip',
+      ),
+    );
+    await tmpFile.writeAsBytes(response.bodyBytes, flush: true);
+    return tmpFile;
+  } catch (_) {
+    return null;
+  } finally {
+    if (client == null) c.close();
+  }
+}

--- a/lib/features/skills/pages/skills_page.dart
+++ b/lib/features/skills/pages/skills_page.dart
@@ -10,8 +10,10 @@ import 'package:provider/provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../github_importer.dart';
 import '../skill_manager.dart';
 
 class SkillsPage extends StatefulWidget {
@@ -50,6 +52,8 @@ class _SkillsPageState extends State<SkillsPage> {
     switch (error.code) {
       case 'invalid_frontmatter':
         return l10n.skillsInvalidFrontmatter;
+      case 'name_invalid':
+        return l10n.skillsNameInvalid;
       case 'name_missing':
         return l10n.skillsFrontmatterNameMissing;
       case 'name_mismatch':
@@ -129,6 +133,355 @@ class _SkillsPageState extends State<SkillsPage> {
     await _refresh();
   }
 
+  Future<void> _showImportChoice() async {
+    final l10n = AppLocalizations.of(context)!;
+    final choice = await showDialog<String>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: Text(l10n.skillsImportChoiceTitle),
+        children: [
+          SimpleDialogOption(
+            onPressed: () => Navigator.of(ctx).pop('file'),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Row(
+                children: [
+                  const Icon(Lucide.FileText),
+                  const SizedBox(width: 16),
+                  Text(l10n.skillsImportFromFile),
+                ],
+              ),
+            ),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.of(ctx).pop('github'),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Row(
+                children: [
+                  const Icon(Lucide.Globe),
+                  const SizedBox(width: 16),
+                  Text(l10n.skillsImportFromGitHub),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (choice == null || !mounted) return;
+    if (choice == 'file') {
+      await _importFromFile();
+    } else if (choice == 'github') {
+      await _importFromGitHub();
+    }
+  }
+
+  Future<void> _importFromGitHub() async {
+    final l10n = AppLocalizations.of(context)!;
+    final controller = TextEditingController();
+
+    final url = await showDialog<String>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            final text = controller.text.trim();
+            final isValid = text.isEmpty || parseGitHubUrl(text) != null;
+
+            return AlertDialog(
+              title: Text(l10n.skillsGitHubImportTitle),
+              content: SizedBox(
+                width: 400,
+                child: TextField(
+                  controller: controller,
+                  decoration: InputDecoration(
+                    hintText: l10n.skillsGitHubUrlHint,
+                    border: const OutlineInputBorder(),
+                    errorText: isValid ? null : l10n.skillsGitHubUrlInvalid,
+                  ),
+                  style: const TextStyle(fontSize: 13),
+                  onChanged: (_) => setDialogState(() {}),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+                ),
+                FilledButton(
+                  onPressed: text.isNotEmpty && isValid
+                      ? () => Navigator.of(ctx).pop(text)
+                      : null,
+                  child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (url == null || url.isEmpty || !mounted) return;
+
+    final info = parseGitHubUrl(url);
+    if (info == null) return;
+
+    final zipFile = await downloadGitHubArchive(info);
+    if (zipFile == null || !mounted) {
+      if (mounted) {
+        showAppSnackBar(
+          context,
+          message: l10n.skillsGitHubDownloadFailed,
+          type: NotificationType.error,
+        );
+      }
+      return;
+    }
+
+    try {
+      final discovered = _scanZipForSkills(
+        zipFile,
+        subPath: info.subPath,
+        stripPrefix: info.stripPrefix,
+      );
+
+      if (discovered == null) {
+        if (!mounted) return;
+        showAppSnackBar(
+          context,
+          message: l10n.skillsGitHubDownloadFailed,
+          type: NotificationType.error,
+        );
+        return;
+      }
+
+      if (discovered.isEmpty) {
+        if (!mounted) return;
+        showAppSnackBar(
+          context,
+          message: l10n.skillsImportFailed(0),
+          type: NotificationType.error,
+        );
+        return;
+      }
+
+      List<_DiscoveredSkill> selected;
+      if (discovered.length == 1) {
+        selected = discovered;
+      } else {
+        if (!mounted) return;
+        final result = await _showSkillSelectionDialog(discovered);
+        if (result == null || result.isEmpty) return;
+        selected = result;
+      }
+
+      if (!mounted) return;
+      await _importDiscoveredSkills(selected);
+    } finally {
+      try {
+        await zipFile.delete();
+      } catch (_) {}
+    }
+  }
+
+  List<_DiscoveredSkill>? _scanZipForSkills(
+    File file, {
+    String? subPath,
+    String? stripPrefix,
+  }) {
+    final discovered = <_DiscoveredSkill>[];
+    try {
+      final bytes = file.readAsBytesSync();
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      final skillDirs = <String>{};
+      final allFiles = <String, List<int>>{};
+
+      for (final entry in archive) {
+        if (!entry.isFile) continue;
+
+        var relativePath = entry.name;
+        if (stripPrefix != null && relativePath.startsWith(stripPrefix)) {
+          relativePath = relativePath.substring(stripPrefix.length);
+        }
+        if (subPath != null && subPath.isNotEmpty) {
+          final normalized = subPath.endsWith('/') ? subPath : '$subPath/';
+          if (!relativePath.startsWith(normalized) && relativePath != subPath) {
+            continue;
+          }
+        }
+
+        if (_isExcludedPath(relativePath) ||
+            relativePath.contains('..') ||
+            !p.isRelative(relativePath)) {
+          continue;
+        }
+        if (entry.size > _maxImportFileSize) continue;
+
+        allFiles[relativePath] = entry.content as List<int>;
+
+        if (p.basename(relativePath) == 'SKILL.md') {
+          final dir = p.dirname(relativePath);
+          skillDirs.add(dir == '.' ? '' : dir);
+        }
+      }
+
+      for (final skillDir in skillDirs) {
+        final skillMdKey = skillDir.isEmpty ? 'SKILL.md' : '$skillDir/SKILL.md';
+        final skillMdBytes = allFiles[skillMdKey];
+        if (skillMdBytes == null) continue;
+
+        final content = utf8.decode(skillMdBytes);
+        final parsed = SkillManager.parseFrontmatter(content);
+        if (parsed == null) continue;
+        final name = parsed.fields['name'];
+        if (name == null || name.isEmpty) continue;
+
+        final files = <String, List<int>>{};
+        final prefix = skillDir.isEmpty ? '' : '$skillDir/';
+        for (final entry in allFiles.entries) {
+          if (!entry.key.startsWith(prefix)) continue;
+          final relativeToSkill = entry.key.substring(prefix.length);
+          if (relativeToSkill.isEmpty) continue;
+          files[relativeToSkill] = entry.value;
+        }
+
+        discovered.add(
+          _DiscoveredSkill(
+            name: name,
+            description: parsed.fields['description'] ?? '',
+            files: files,
+          ),
+        );
+      }
+      archive.clear();
+    } catch (e) {
+      debugPrint('_scanZipForSkills: failed to scan ZIP: $e');
+      return null;
+    }
+    return discovered;
+  }
+
+  static bool _isExcludedPath(String path) {
+    final segments = path.split('/');
+    for (final seg in segments) {
+      if (seg.startsWith('.')) return true;
+      if (seg == '__pycache__' || seg == 'node_modules') return true;
+    }
+    return false;
+  }
+
+  static const int _maxImportFileSize = 1024 * 1024;
+
+  Future<List<_DiscoveredSkill>?> _showSkillSelectionDialog(
+    List<_DiscoveredSkill> skills,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    final selected = skills.length >= 5
+        ? <int>{}
+        : Set<int>.from(List.generate(skills.length, (i) => i));
+
+    return showDialog<List<_DiscoveredSkill>>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            return AlertDialog(
+              title: Text(l10n.skillsGitHubSelectTitle),
+              content: SizedBox(
+                width: 400,
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: skills.length,
+                  itemBuilder: (_, i) {
+                    final skill = skills[i];
+                    return ListTile(
+                      leading: IosCheckbox(
+                        value: selected.contains(i),
+                        onChanged: (v) {
+                          setDialogState(() {
+                            if (v) {
+                              selected.add(i);
+                            } else {
+                              selected.remove(i);
+                            }
+                          });
+                        },
+                      ),
+                      title: Text(skill.name),
+                      subtitle: skill.description.isNotEmpty
+                          ? Text(
+                              skill.description,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            )
+                          : null,
+                      onTap: () {
+                        setDialogState(() {
+                          if (selected.contains(i)) {
+                            selected.remove(i);
+                          } else {
+                            selected.add(i);
+                          }
+                        });
+                      },
+                    );
+                  },
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+                ),
+                FilledButton(
+                  onPressed: selected.isNotEmpty
+                      ? () => Navigator.of(
+                          ctx,
+                        ).pop(selected.map((i) => skills[i]).toList())
+                      : null,
+                  child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _importDiscoveredSkills(List<_DiscoveredSkill> skills) async {
+    int imported = 0;
+    int failed = 0;
+
+    for (final skill in skills) {
+      final error = await SkillManager.saveSkillWithFiles(
+        name: skill.name,
+        files: skill.files,
+      );
+      if (error != null) {
+        failed++;
+      } else {
+        imported++;
+      }
+    }
+
+    if (!mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    if (imported > 0) {
+      showAppSnackBar(context, message: l10n.skillsImportSuccess(imported));
+    }
+    if (failed > 0) {
+      showAppSnackBar(
+        context,
+        message: l10n.skillsImportFailed(failed),
+        type: NotificationType.error,
+      );
+    }
+    await _refresh();
+  }
+
   Future<void> _importFromFile() async {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.any,
@@ -142,37 +495,22 @@ class _SkillsPageState extends State<SkillsPage> {
     final path = file.path!;
     final ext = p.extension(path).toLowerCase();
 
-    int imported = 0;
-    int failed = 0;
-
     if (ext == '.zip') {
-      try {
-        final bytes = await File(path).readAsBytes();
-        final archive = ZipDecoder().decodeBytes(bytes);
-        for (final entry in archive) {
-          if (entry.isFile && p.basename(entry.name) == 'SKILL.md') {
-            final content = utf8.decode(entry.content as List<int>);
-            final name = _extractNameFromFrontmatter(content);
-            if (name == null) {
-              failed++;
-              continue;
-            }
-            final error = await SkillManager.saveSkill(
-              name: name,
-              content: content,
-            );
-            if (error != null) {
-              failed++;
-            } else {
-              imported++;
-            }
-          }
-        }
-        archive.clear();
-      } catch (_) {
-        failed++;
+      final discovered = _scanZipForSkills(File(path));
+      if (discovered == null || discovered.isEmpty) {
+        if (!mounted) return;
+        final l10n = AppLocalizations.of(context)!;
+        showAppSnackBar(
+          context,
+          message: l10n.skillsImportFailed(0),
+          type: NotificationType.error,
+        );
+        return;
       }
+      await _importDiscoveredSkills(discovered);
     } else {
+      int imported = 0;
+      int failed = 0;
       try {
         final content = await File(path).readAsString();
         final name = _extractNameFromFrontmatter(content);
@@ -192,21 +530,21 @@ class _SkillsPageState extends State<SkillsPage> {
       } catch (_) {
         failed++;
       }
-    }
 
-    if (!mounted) return;
-    final l10n = AppLocalizations.of(context)!;
-    if (imported > 0) {
-      showAppSnackBar(context, message: l10n.skillsImportSuccess(imported));
+      if (!mounted) return;
+      final l10n = AppLocalizations.of(context)!;
+      if (imported > 0) {
+        showAppSnackBar(context, message: l10n.skillsImportSuccess(imported));
+      }
+      if (failed > 0) {
+        showAppSnackBar(
+          context,
+          message: l10n.skillsImportFailed(failed),
+          type: NotificationType.error,
+        );
+      }
+      await _refresh();
     }
-    if (failed > 0) {
-      showAppSnackBar(
-        context,
-        message: l10n.skillsImportFailed(failed),
-        type: NotificationType.error,
-      );
-    }
-    await _refresh();
   }
 
   Future<void> _deleteSkill(String name) async {
@@ -251,8 +589,8 @@ class _SkillsPageState extends State<SkillsPage> {
         actions: [
           IconButton(
             icon: const Icon(Lucide.Upload),
-            tooltip: l10n.skillsImportFileLabel,
-            onPressed: _importFromFile,
+            tooltip: l10n.skillsImportChoiceTitle,
+            onPressed: _showImportChoice,
           ),
         ],
       ),
@@ -310,4 +648,16 @@ class _SkillsPageState extends State<SkillsPage> {
             ),
     );
   }
+}
+
+class _DiscoveredSkill {
+  final String name;
+  final String description;
+  final Map<String, List<int>> files;
+
+  const _DiscoveredSkill({
+    required this.name,
+    required this.description,
+    required this.files,
+  });
 }

--- a/lib/features/skills/skill_manager.dart
+++ b/lib/features/skills/skill_manager.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
 import '../../utils/app_directories.dart';
 import 'skill_paths.dart';
 
@@ -27,6 +29,25 @@ class SkillSaveError {
   const SkillSaveError(this.code, [this.params = const {}]);
 }
 
+class SkillFileInfo {
+  final String path;
+  final int size;
+  const SkillFileInfo({required this.path, required this.size});
+}
+
+class SkillFileContent {
+  final String? content;
+  final bool isBinary;
+  final bool truncated;
+  final int size;
+  const SkillFileContent({
+    required this.content,
+    required this.isBinary,
+    required this.truncated,
+    required this.size,
+  });
+}
+
 class SkillManager {
   SkillManager._();
 
@@ -41,14 +62,19 @@ class SkillManager {
     final body = trimmed.substring(endIndex + 3).trim();
 
     final fields = <String, String>{};
-    for (final line in raw.split('\n')) {
-      final colon = line.indexOf(':');
-      if (colon <= 0) continue;
-      final key = line.substring(0, colon).trim().toLowerCase();
-      final value = line.substring(colon + 1).trim();
-      if (key.isNotEmpty) {
-        fields[key] = value;
+    try {
+      final doc = loadYaml(raw);
+      if (doc is YamlMap) {
+        for (final entry in doc.entries) {
+          final key = entry.key.toString().toLowerCase();
+          final value = entry.value?.toString() ?? '';
+          if (key.isNotEmpty) {
+            fields[key] = value;
+          }
+        }
       }
+    } catch (_) {
+      return null;
     }
 
     return FrontmatterResult(fields: fields, body: body);
@@ -64,13 +90,16 @@ class SkillManager {
     }
   }
 
-  static String? _skillsRoot;
+  static Future<String>? _rootFuture;
 
-  static Future<String> _getSkillsRoot() async {
-    if (_skillsRoot != null) return _skillsRoot!;
+  static Future<String> _getSkillsRoot() {
+    _rootFuture ??= _resolveRoot();
+    return _rootFuture!;
+  }
+
+  static Future<String> _resolveRoot() async {
     final dir = await AppDirectories.getSkillsDirectory();
-    _skillsRoot = dir.path;
-    return _skillsRoot!;
+    return dir.path;
   }
 
   static Future<void> _ensureSkillsDir() async {
@@ -86,14 +115,13 @@ class SkillManager {
   }
 
   static Future<List<SkillMetadata>> listSkills() async {
-    final root = _skillsRoot;
-    if (root == null) return [];
+    final root = await _getSkillsRoot();
 
     final dir = Directory(root);
     if (!await dir.exists()) return [];
 
     final skills = <SkillMetadata>[];
-    final entries = dir.listSync(followLinks: false);
+    final entries = await dir.list(followLinks: false).toList();
     for (final entry in entries) {
       if (entry is! Directory) continue;
       final name = p.basename(entry.path);
@@ -124,8 +152,7 @@ class SkillManager {
     final dirName = _dirNameFor(name);
     if (dirName == null) return null;
 
-    final root = _skillsRoot;
-    if (root == null) return null;
+    final root = await _getSkillsRoot();
 
     final filePath = SkillPaths.skillFilePath(root, dirName);
     final content = await _readFileContent(filePath);
@@ -155,24 +182,40 @@ class SkillManager {
   static Future<bool> skillExists(String name) async {
     final dirName = _dirNameFor(name);
     if (dirName == null) return false;
-    final root = _skillsRoot;
-    if (root == null) return false;
+    final root = await _getSkillsRoot();
     return File(SkillPaths.skillFilePath(root, dirName)).exists();
   }
 
   static Future<SkillSaveError?> saveSkill({
     required String name,
     required String content,
+  }) {
+    return saveSkillWithFiles(
+      name: name,
+      files: {'SKILL.md': utf8.encode(content)},
+    );
+  }
+
+  static Future<SkillSaveError?> saveSkillWithFiles({
+    required String name,
+    required Map<String, List<int>> files,
   }) async {
     final nameError = SkillPaths.validateName(name);
     if (nameError != null) {
       return SkillSaveError('name_invalid', {'detail': nameError});
     }
 
+    final skillMdBytes = files['SKILL.md'];
+    if (skillMdBytes == null) {
+      return const SkillSaveError('invalid_frontmatter');
+    }
+
     await _ensureSkillsDir();
     final root = await _getSkillsRoot();
 
-    final parsed = parseFrontmatter(content);
+    final parsed = parseFrontmatter(
+      utf8.decode(skillMdBytes, allowMalformed: true),
+    );
     if (parsed == null) {
       return const SkillSaveError('invalid_frontmatter');
     }
@@ -195,19 +238,29 @@ class SkillManager {
 
     final dirPath = SkillPaths.skillDirPath(root, name);
 
-    // Atomic write: staging → backup → target → cleanup
     final tmpId = DateTime.now().microsecondsSinceEpoch;
     final stagingDir = Directory('$dirPath.staging.$tmpId.tmp');
     final targetDir = Directory(dirPath);
 
     try {
-      // Create staging
       await stagingDir.create(recursive: true);
-      await File(
-        p.join(stagingDir.path, 'SKILL.md'),
-      ).writeAsString(content, flush: true);
 
-      // Verify staging has SKILL.md
+      for (final entry in files.entries) {
+        final relPath = entry.key;
+        if (relPath.contains('..') ||
+            relPath.contains('\\') ||
+            !p.isRelative(relPath)) {
+          await _deleteDirQuietly(stagingDir);
+          return SkillSaveError('io_error', {
+            'detail': 'Unsafe file path: $relPath',
+          });
+        }
+        final filePath = p.join(stagingDir.path, relPath);
+        final file = File(filePath);
+        await file.parent.create(recursive: true);
+        await file.writeAsBytes(entry.value, flush: true);
+      }
+
       if (!await File(p.join(stagingDir.path, 'SKILL.md')).exists()) {
         await _deleteDirQuietly(stagingDir);
         return const SkillSaveError('io_error', {
@@ -215,7 +268,6 @@ class SkillManager {
         });
       }
 
-      // If target exists, rename to backup
       Directory? backupDir;
       if (await targetDir.exists()) {
         final backupPath = '$dirPath.backup.$tmpId.tmp';
@@ -223,11 +275,9 @@ class SkillManager {
         backupDir = Directory(backupPath);
       }
 
-      // Rename staging → target
       try {
         await stagingDir.rename(dirPath);
       } catch (e) {
-        // Rename failed, restore backup
         if (backupDir != null && await backupDir.exists()) {
           await backupDir.rename(dirPath);
         }
@@ -237,7 +287,6 @@ class SkillManager {
         });
       }
 
-      // Cleanup backup
       if (backupDir != null) {
         await _deleteDirQuietly(backupDir);
       }
@@ -246,15 +295,14 @@ class SkillManager {
       return SkillSaveError('io_error', {'detail': 'Failed to save skill: $e'});
     }
 
-    return null; // success
+    return null;
   }
 
   static Future<void> deleteSkill(String name) async {
     final dirName = _dirNameFor(name);
     if (dirName == null) return;
 
-    final root = _skillsRoot;
-    if (root == null) return;
+    final root = await _getSkillsRoot();
 
     final dir = Directory(SkillPaths.skillDirPath(root, dirName));
     if (await dir.exists()) {
@@ -271,10 +319,104 @@ class SkillManager {
   }
 
   static Future<void> initRoot() async {
-    if (_skillsRoot != null) return;
-    try {
-      final dir = await AppDirectories.getSkillsDirectory();
-      _skillsRoot = dir.path;
-    } catch (_) {}
+    await _getSkillsRoot();
+  }
+
+  static Future<List<SkillFileInfo>> listSkillFiles(String name) async {
+    final dirName = _dirNameFor(name);
+    if (dirName == null) return [];
+
+    final root = await _getSkillsRoot();
+    final skillDir = Directory(SkillPaths.skillDirPath(root, dirName));
+    if (!await skillDir.exists()) return [];
+
+    final files = <SkillFileInfo>[];
+    await for (final entity in skillDir.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! File) continue;
+      final relativePath = p
+          .relative(entity.path, from: skillDir.path)
+          .replaceAll('\\', '/');
+      if (relativePath == 'SKILL.md') continue;
+      final stat = await entity.stat();
+      files.add(SkillFileInfo(path: relativePath, size: stat.size));
+    }
+    files.sort((a, b) => a.path.compareTo(b.path));
+    return files;
+  }
+
+  static Future<SkillFileContent?> readSkillFile(
+    String name,
+    String relativePath,
+  ) async {
+    if (relativePath.contains('..') ||
+        relativePath.contains('\\') ||
+        !p.isRelative(relativePath)) {
+      return null;
+    }
+
+    final dirName = _dirNameFor(name);
+    if (dirName == null) return null;
+
+    final root = await _getSkillsRoot();
+    final skillDir = Directory(SkillPaths.skillDirPath(root, dirName));
+    final file = File(p.join(skillDir.path, relativePath));
+
+    if (!await file.exists()) return null;
+
+    final stat = await file.stat();
+    const maxSize = 64 * 1024;
+
+    if (stat.size > maxSize) {
+      final raf = await file.open();
+      try {
+        final bytes = await raf.read(maxSize);
+        if (_isBinary(bytes)) {
+          return SkillFileContent(
+            content: null,
+            isBinary: true,
+            truncated: false,
+            size: stat.size,
+          );
+        }
+        final content = utf8.decode(bytes, allowMalformed: true);
+        return SkillFileContent(
+          content: '$content\n[truncated]',
+          isBinary: false,
+          truncated: true,
+          size: stat.size,
+        );
+      } finally {
+        await raf.close();
+      }
+    }
+
+    final bytes = await file.readAsBytes();
+    if (_isBinary(bytes)) {
+      return SkillFileContent(
+        content: null,
+        isBinary: true,
+        truncated: false,
+        size: stat.size,
+      );
+    }
+
+    final content = utf8.decode(bytes, allowMalformed: true);
+    return SkillFileContent(
+      content: content,
+      isBinary: false,
+      truncated: false,
+      size: stat.size,
+    );
+  }
+
+  static bool _isBinary(List<int> bytes) {
+    final checkLen = bytes.length < 8000 ? bytes.length : 8000;
+    for (var i = 0; i < checkLen; i++) {
+      if (bytes[i] == 0) return true;
+    }
+    return false;
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2762,10 +2762,17 @@
     "description": "Tooltip for the add model button in multi-AI card footer"
   },
   "skillsTitle": "Skills",
-  "skillsAddTooltip": "Add Skill",
   "skillsImportManualTitle": "Add Manually",
   "skillsImportManualHint": "Paste the complete SKILL.md content (including YAML frontmatter)",
   "skillsImportFileLabel": "Import from File",
+  "skillsImportChoiceTitle": "Import Skill",
+  "skillsImportFromFile": "From File",
+  "skillsImportFromGitHub": "From GitHub URL",
+  "skillsGitHubImportTitle": "Import from GitHub",
+  "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
+  "skillsGitHubUrlInvalid": "Invalid GitHub URL.",
+  "skillsGitHubDownloadFailed": "Failed to download repository. It may not exist or is private.",
+  "skillsGitHubSelectTitle": "Select skills to import",
   "skillsEmptyMessage": "No skills yet. Import from a file or create one manually.",
   "skillsDeleteConfirmTitle": "Delete Skill",
   "skillsDeleteConfirmMessage": "Delete \"{name}\"? This cannot be undone.",
@@ -2784,7 +2791,6 @@
       }
     }
   },
-  "skillsTab": "Skills",
   "skillsFrontmatterNameMismatch": "Frontmatter name \"{frontmatterName}\" must match directory name \"{dirName}\".",
   "@skillsFrontmatterNameMismatch": {
     "placeholders": {
@@ -2797,14 +2803,7 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md must contain valid YAML frontmatter with a name field.",
-  "skillsNotFound": "Skill not found: {name}",
-  "@skillsNotFound": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
+  "skillsNameInvalid": "Skill name is invalid. Use lowercase letters, digits, and hyphens only (no spaces, slashes, or dots).",
   "skillsFrontmatterNameMissing": "SKILL.md frontmatter must contain a name field.",
   "skillsSaveFailed": "Failed to save skill: {detail}",
   "@skillsSaveFailed": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10814,12 +10814,6 @@ abstract class AppLocalizations {
   /// **'Skills'**
   String get skillsTitle;
 
-  /// No description provided for @skillsAddTooltip.
-  ///
-  /// In en, this message translates to:
-  /// **'Add Skill'**
-  String get skillsAddTooltip;
-
   /// No description provided for @skillsImportManualTitle.
   ///
   /// In en, this message translates to:
@@ -10837,6 +10831,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Import from File'**
   String get skillsImportFileLabel;
+
+  /// No description provided for @skillsImportChoiceTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import Skill'**
+  String get skillsImportChoiceTitle;
+
+  /// No description provided for @skillsImportFromFile.
+  ///
+  /// In en, this message translates to:
+  /// **'From File'**
+  String get skillsImportFromFile;
+
+  /// No description provided for @skillsImportFromGitHub.
+  ///
+  /// In en, this message translates to:
+  /// **'From GitHub URL'**
+  String get skillsImportFromGitHub;
+
+  /// No description provided for @skillsGitHubImportTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Import from GitHub'**
+  String get skillsGitHubImportTitle;
+
+  /// No description provided for @skillsGitHubUrlHint.
+  ///
+  /// In en, this message translates to:
+  /// **'https://github.com/owner/repo[/tree/branch[/path]]'**
+  String get skillsGitHubUrlHint;
+
+  /// No description provided for @skillsGitHubUrlInvalid.
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid GitHub URL.'**
+  String get skillsGitHubUrlInvalid;
+
+  /// No description provided for @skillsGitHubDownloadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to download repository. It may not exist or is private.'**
+  String get skillsGitHubDownloadFailed;
+
+  /// No description provided for @skillsGitHubSelectTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select skills to import'**
+  String get skillsGitHubSelectTitle;
 
   /// No description provided for @skillsEmptyMessage.
   ///
@@ -10862,12 +10904,6 @@ abstract class AppLocalizations {
   /// **'Imported {count} skill(s)'**
   String skillsImportSuccess(int count);
 
-  /// No description provided for @skillsTab.
-  ///
-  /// In en, this message translates to:
-  /// **'Skills'**
-  String get skillsTab;
-
   /// No description provided for @skillsFrontmatterNameMismatch.
   ///
   /// In en, this message translates to:
@@ -10880,11 +10916,11 @@ abstract class AppLocalizations {
   /// **'SKILL.md must contain valid YAML frontmatter with a name field.'**
   String get skillsInvalidFrontmatter;
 
-  /// No description provided for @skillsNotFound.
+  /// No description provided for @skillsNameInvalid.
   ///
   /// In en, this message translates to:
-  /// **'Skill not found: {name}'**
-  String skillsNotFound(String name);
+  /// **'Skill name is invalid. Use lowercase letters, digits, and hyphens only (no spaces, slashes, or dots).'**
+  String get skillsNameInvalid;
 
   /// No description provided for @skillsFrontmatterNameMissing.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5901,9 +5901,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get skillsTitle => 'Skills';
 
   @override
-  String get skillsAddTooltip => 'Add Skill';
-
-  @override
   String get skillsImportManualTitle => 'Add Manually';
 
   @override
@@ -5912,6 +5909,32 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get skillsImportFileLabel => 'Import from File';
+
+  @override
+  String get skillsImportChoiceTitle => 'Import Skill';
+
+  @override
+  String get skillsImportFromFile => 'From File';
+
+  @override
+  String get skillsImportFromGitHub => 'From GitHub URL';
+
+  @override
+  String get skillsGitHubImportTitle => 'Import from GitHub';
+
+  @override
+  String get skillsGitHubUrlHint =>
+      'https://github.com/owner/repo[/tree/branch[/path]]';
+
+  @override
+  String get skillsGitHubUrlInvalid => 'Invalid GitHub URL.';
+
+  @override
+  String get skillsGitHubDownloadFailed =>
+      'Failed to download repository. It may not exist or is private.';
+
+  @override
+  String get skillsGitHubSelectTitle => 'Select skills to import';
 
   @override
   String get skillsEmptyMessage =>
@@ -5931,9 +5954,6 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get skillsTab => 'Skills';
-
-  @override
   String skillsFrontmatterNameMismatch(String frontmatterName, String dirName) {
     return 'Frontmatter name \"$frontmatterName\" must match directory name \"$dirName\".';
   }
@@ -5943,9 +5963,8 @@ class AppLocalizationsEn extends AppLocalizations {
       'SKILL.md must contain valid YAML frontmatter with a name field.';
 
   @override
-  String skillsNotFound(String name) {
-    return 'Skill not found: $name';
-  }
+  String get skillsNameInvalid =>
+      'Skill name is invalid. Use lowercase letters, digits, and hyphens only (no spaces, slashes, or dots).';
 
   @override
   String get skillsFrontmatterNameMissing =>

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5660,9 +5660,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsTitle => '技能';
 
   @override
-  String get skillsAddTooltip => '添加技能';
-
-  @override
   String get skillsImportManualTitle => '手动添加';
 
   @override
@@ -5670,6 +5667,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get skillsImportFileLabel => '从文件导入';
+
+  @override
+  String get skillsImportChoiceTitle => '导入技能';
+
+  @override
+  String get skillsImportFromFile => '从文件导入';
+
+  @override
+  String get skillsImportFromGitHub => '从 GitHub URL 导入';
+
+  @override
+  String get skillsGitHubImportTitle => '从 GitHub 导入';
+
+  @override
+  String get skillsGitHubUrlHint =>
+      'https://github.com/owner/repo[/tree/branch[/path]]';
+
+  @override
+  String get skillsGitHubUrlInvalid => '无效的 GitHub URL。';
+
+  @override
+  String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
+
+  @override
+  String get skillsGitHubSelectTitle => '选择要导入的技能';
 
   @override
   String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
@@ -5688,9 +5710,6 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get skillsTab => '技能';
-
-  @override
   String skillsFrontmatterNameMismatch(String frontmatterName, String dirName) {
     return '前置元数据中的名称 \"$frontmatterName\" 必须与目录名 \"$dirName\" 一致。';
   }
@@ -5700,9 +5719,7 @@ class AppLocalizationsZh extends AppLocalizations {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String skillsNotFound(String name) {
-    return '未找到技能：$name';
-  }
+  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
@@ -11394,9 +11411,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsTitle => '技能';
 
   @override
-  String get skillsAddTooltip => '添加技能';
-
-  @override
   String get skillsImportManualTitle => '手动添加';
 
   @override
@@ -11404,6 +11418,31 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get skillsImportFileLabel => '从文件导入';
+
+  @override
+  String get skillsImportChoiceTitle => '导入技能';
+
+  @override
+  String get skillsImportFromFile => '从文件导入';
+
+  @override
+  String get skillsImportFromGitHub => '从 GitHub URL 导入';
+
+  @override
+  String get skillsGitHubImportTitle => '从 GitHub 导入';
+
+  @override
+  String get skillsGitHubUrlHint =>
+      'https://github.com/owner/repo[/tree/branch[/path]]';
+
+  @override
+  String get skillsGitHubUrlInvalid => '无效的 GitHub URL。';
+
+  @override
+  String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
+
+  @override
+  String get skillsGitHubSelectTitle => '选择要导入的技能';
 
   @override
   String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
@@ -11422,9 +11461,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   }
 
   @override
-  String get skillsTab => '技能';
-
-  @override
   String skillsFrontmatterNameMismatch(String frontmatterName, String dirName) {
     return '前置元数据中的名称 \"$frontmatterName\" 必须与目录名 \"$dirName\" 一致。';
   }
@@ -11434,9 +11470,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String skillsNotFound(String name) {
-    return '未找到技能：$name';
-  }
+  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
@@ -17128,9 +17162,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsTitle => '技能';
 
   @override
-  String get skillsAddTooltip => '新增技能';
-
-  @override
   String get skillsImportManualTitle => '手動新增';
 
   @override
@@ -17138,6 +17169,31 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get skillsImportFileLabel => '從檔案匯入';
+
+  @override
+  String get skillsImportChoiceTitle => '匯入技能';
+
+  @override
+  String get skillsImportFromFile => '從檔案匯入';
+
+  @override
+  String get skillsImportFromGitHub => '從 GitHub URL 匯入';
+
+  @override
+  String get skillsGitHubImportTitle => '從 GitHub 匯入';
+
+  @override
+  String get skillsGitHubUrlHint =>
+      'https://github.com/owner/repo[/tree/branch[/path]]';
+
+  @override
+  String get skillsGitHubUrlInvalid => '無效的 GitHub URL。';
+
+  @override
+  String get skillsGitHubDownloadFailed => '下載儲存庫失敗。儲存庫可能不存在或為私有。';
+
+  @override
+  String get skillsGitHubSelectTitle => '選擇要匯入的技能';
 
   @override
   String get skillsEmptyMessage => '暫無技能。從檔案匯入或手動建立一個。';
@@ -17156,9 +17212,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   }
 
   @override
-  String get skillsTab => '技能';
-
-  @override
   String skillsFrontmatterNameMismatch(String frontmatterName, String dirName) {
     return '前置元資料中的名稱 \"$frontmatterName\" 必須與目錄名稱 \"$dirName\" 一致。';
   }
@@ -17168,9 +17221,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       'SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。';
 
   @override
-  String skillsNotFound(String name) {
-    return '找不到技能：$name';
-  }
+  String get skillsNameInvalid => '技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元資料必須包含 name 欄位。';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2309,10 +2309,17 @@
     "description": "多AI卡片底部添加模型按钮的提示"
   },
   "skillsTitle": "技能",
-  "skillsAddTooltip": "添加技能",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
+  "skillsImportChoiceTitle": "导入技能",
+  "skillsImportFromFile": "从文件导入",
+  "skillsImportFromGitHub": "从 GitHub URL 导入",
+  "skillsGitHubImportTitle": "从 GitHub 导入",
+  "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
+  "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
+  "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
+  "skillsGitHubSelectTitle": "选择要导入的技能",
   "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
   "skillsDeleteConfirmTitle": "删除技能",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
@@ -2331,7 +2338,6 @@
       }
     }
   },
-  "skillsTab": "技能",
   "skillsFrontmatterNameMismatch": "前置元数据中的名称 \"{frontmatterName}\" 必须与目录名 \"{dirName}\" 一致。",
   "@skillsFrontmatterNameMismatch": {
     "placeholders": {
@@ -2344,14 +2350,7 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNotFound": "未找到技能：{name}",
-  "@skillsNotFound": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
+  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
   "skillsSaveFailed": "保存技能失败：{detail}",
   "@skillsSaveFailed": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2281,10 +2281,17 @@
     "description": "多AI卡片底部添加模型按钮的提示"
   },
   "skillsTitle": "技能",
-  "skillsAddTooltip": "添加技能",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
+  "skillsImportChoiceTitle": "导入技能",
+  "skillsImportFromFile": "从文件导入",
+  "skillsImportFromGitHub": "从 GitHub URL 导入",
+  "skillsGitHubImportTitle": "从 GitHub 导入",
+  "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
+  "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
+  "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
+  "skillsGitHubSelectTitle": "选择要导入的技能",
   "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
   "skillsDeleteConfirmTitle": "删除技能",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
@@ -2303,7 +2310,6 @@
       }
     }
   },
-  "skillsTab": "技能",
   "skillsFrontmatterNameMismatch": "前置元数据中的名称 \"{frontmatterName}\" 必须与目录名 \"{dirName}\" 一致。",
   "@skillsFrontmatterNameMismatch": {
     "placeholders": {
@@ -2316,14 +2322,7 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNotFound": "未找到技能：{name}",
-  "@skillsNotFound": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
+  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
   "skillsSaveFailed": "保存技能失败：{detail}",
   "@skillsSaveFailed": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2309,10 +2309,17 @@
     "description": "多AI卡片底部添加模型按鈕的提示"
   },
   "skillsTitle": "技能",
-  "skillsAddTooltip": "新增技能",
   "skillsImportManualTitle": "手動新增",
   "skillsImportManualHint": "貼上完整的 SKILL.md 內容（包含 YAML 前置元資料）",
   "skillsImportFileLabel": "從檔案匯入",
+  "skillsImportChoiceTitle": "匯入技能",
+  "skillsImportFromFile": "從檔案匯入",
+  "skillsImportFromGitHub": "從 GitHub URL 匯入",
+  "skillsGitHubImportTitle": "從 GitHub 匯入",
+  "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
+  "skillsGitHubUrlInvalid": "無效的 GitHub URL。",
+  "skillsGitHubDownloadFailed": "下載儲存庫失敗。儲存庫可能不存在或為私有。",
+  "skillsGitHubSelectTitle": "選擇要匯入的技能",
   "skillsEmptyMessage": "暫無技能。從檔案匯入或手動建立一個。",
   "skillsDeleteConfirmTitle": "刪除技能",
   "skillsDeleteConfirmMessage": "確定刪除 \"{name}\"？此操作不可復原。",
@@ -2331,7 +2338,6 @@
       }
     }
   },
-  "skillsTab": "技能",
   "skillsFrontmatterNameMismatch": "前置元資料中的名稱 \"{frontmatterName}\" 必須與目錄名稱 \"{dirName}\" 一致。",
   "@skillsFrontmatterNameMismatch": {
     "placeholders": {
@@ -2344,14 +2350,7 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。",
-  "skillsNotFound": "找不到技能：{name}",
-  "@skillsNotFound": {
-    "placeholders": {
-      "name": {
-        "type": "String"
-      }
-    }
-  },
+  "skillsNameInvalid": "技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元資料必須包含 name 欄位。",
   "skillsSaveFailed": "儲存技能失敗：{detail}",
   "@skillsSaveFailed": {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   android_alarm_manager_plus: ^4.0.5
   image: ^4.8.0
   math_expressions: ^2.6.2
+  yaml: ^3.1.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Closes #29.

- Replace hand-rolled frontmatter parser with yaml package (multi-line support)
- Make listSkills() async with cached _rootFuture (fixes sync IO + race condition)
- Add name_invalid case to _localizeSaveError with descriptive l10n message
- Remove unused l10n keys: skillsAddTooltip, skillsTab, skillsNotFound
- Add GitHub URL import: parseGitHubUrl + archive ZIP download + reuse ZIP pipeline
- Multi-select dialog for monorepos (>=5 skills defaults to unchecked)
- Import-time filter: exclude dotfiles, __pycache__, node_modules, files >1MB
- saveSkillWithFiles: atomic write of multiple files (auxiliary files land on disk)
- load_skill returns XML with <instructions> + <files> listing
- New read_skill_file tool: path traversal rejection, binary error, 64KB cap
- Update CONTEXT.md and ADR-0003 to reflect final design (no v3)