### PR TITLE
fix: workaround Flutter engine bug for Win+V clipboard history paste

### DIFF
--- a/lib/desktop/windows_paste_fix.dart
+++ b/lib/desktop/windows_paste_fix.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+import 'dart:ui';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+class WindowsPasteFix {
+  WindowsPasteFix._();
+
+  static final WindowsPasteFix instance = WindowsPasteFix._();
+
+  // Constants verified against real Win+V output on Flutter 3.44.2 / Win11
+  static const int _junkPhysical = 0x1600000000;
+  static const int _cleanPhysicalCtrl = 0x700e0;
+  static const int _cleanPhysicalV = 0x70019;
+  static const int _logicalCtrl = 0x200000100;
+  static const int _logicalV = 0x76;
+  static const int _maxInstallRetries = 5;
+
+  int _step = 0;
+  int _installAttempts = 0;
+
+  void inject() {
+    if (!Platform.isWindows) return;
+    // Handler is installed by ServicesBinding.initInstances() during
+    // ensureInitialized(), so synchronous install is safe. The fallback
+    // to post-frame callback is purely defensive.
+    _install();
+  }
+
+  void _install() {
+    final original = PlatformDispatcher.instance.onKeyData;
+    if (original == null) {
+      _installAttempts++;
+      if (_installAttempts >= _maxInstallRetries) {
+        debugPrint(
+          '[WindowsPasteFix] onKeyData still null after '
+          '$_maxInstallRetries attempts, giving up.',
+        );
+        return;
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) => _install());
+      return;
+    }
+    PlatformDispatcher.instance.onKeyData = (KeyData data) {
+      final rewritten = rewrite(data);
+      if (rewritten == null) return true;
+      return original(rewritten);
+    };
+  }
+
+  KeyData _copyWith(
+    KeyData data, {
+    required KeyEventType type,
+    required int physical,
+    required int logical,
+  }) {
+    return KeyData(
+      timeStamp: data.timeStamp,
+      type: type,
+      physical: physical,
+      logical: logical,
+      character: null,
+      synthesized: false,
+      deviceType: data.deviceType,
+    );
+  }
+
+  @visibleForTesting
+  void resetState() => _step = 0;
+
+  @visibleForTesting
+  KeyData? rewrite(KeyData data) {
+    // Swallow all-zero garbage events that occur during focus transitions.
+    if (data.physical == 0 && data.logical == 0) return null;
+
+    // Normal hardware keys: pass through, reset state machine.
+    if (data.physical != _junkPhysical) {
+      _step = 0;
+      return data;
+    }
+
+    final down = data.type == KeyEventType.down;
+    final up = data.type == KeyEventType.up;
+    final isCtrl = data.logical == _logicalCtrl;
+    final isV = data.logical == _logicalV;
+
+    switch (_step) {
+      case 0:
+        // Expect Ctrl↓ (synth=false) → emit clean Ctrl↓
+        if (isCtrl && down && !data.synthesized) {
+          _step = 1;
+          return _copyWith(
+            data,
+            type: KeyEventType.down,
+            physical: _cleanPhysicalCtrl,
+            logical: _logicalCtrl,
+          );
+        }
+      case 1:
+        // Expect Ctrl↑ (synth=true) → swallow (keep Ctrl logically pressed)
+        if (isCtrl && up && data.synthesized) {
+          _step = 2;
+          return null;
+        }
+      case 2:
+        // Expect V↓ → emit clean V↓
+        if (isV && down) {
+          _step = 3;
+          return _copyWith(
+            data,
+            type: KeyEventType.down,
+            physical: _cleanPhysicalV,
+            logical: _logicalV,
+          );
+        }
+      case 3:
+        // Expect V↑ → emit clean V↑
+        if (isV && up) {
+          _step = 4;
+          return _copyWith(
+            data,
+            type: KeyEventType.up,
+            physical: _cleanPhysicalV,
+            logical: _logicalV,
+          );
+        }
+      case 4:
+        // Expect Ctrl↓ (synth=true) → swallow (duplicate from Windows)
+        if (isCtrl && down && data.synthesized) {
+          _step = 5;
+          return null;
+        }
+      case 5:
+        // Expect Ctrl↑ (synth=true) → emit clean Ctrl↑
+        if (isCtrl && up && data.synthesized) {
+          _step = 0;
+          return _copyWith(
+            data,
+            type: KeyEventType.up,
+            physical: _cleanPhysicalCtrl,
+            logical: _logicalCtrl,
+          );
+        }
+    }
+
+    // Sequence broken: reset and pass through.
+    _step = 0;
+    return data;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:window_manager/window_manager.dart';
 import 'desktop/desktop_window_controller.dart';
 import 'desktop/desktop_tray_controller.dart';
+import 'desktop/windows_paste_fix.dart';
 // import 'package:logging/logging.dart' as logging;
 // Theme is now managed in SettingsProvider
 import 'theme/theme_factory.dart';
@@ -58,6 +59,11 @@ Future<void> main() async {
   await runZoned(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
+
+      // Windows clipboard history (Win+V) sends malformed Ctrl+V key sequences.
+      // Workaround Flutter engine bug flutter#143997 until upstream is fixed.
+      WindowsPasteFix.instance.inject();
+
       FlutterLogger.installGlobalHandlers();
       try {
         final prefs = await SharedPreferences.getInstance();

--- a/test/windows_paste_fix_test.dart
+++ b/test/windows_paste_fix_test.dart
@@ -1,0 +1,215 @@
+import 'dart:ui';
+
+import 'package:Cuplivo/desktop/windows_paste_fix.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const junkPhysical = 0x1600000000;
+  const cleanPhysicalCtrl = 0x700e0;
+  const cleanPhysicalV = 0x70019;
+  const logicalCtrl = 0x200000100;
+  const logicalV = 0x76;
+
+  late WindowsPasteFix fix;
+
+  KeyData makeKey({
+    required KeyEventType type,
+    required int physical,
+    required int logical,
+    bool synthesized = false,
+  }) {
+    return KeyData(
+      timeStamp: Duration.zero,
+      type: type,
+      physical: physical,
+      logical: logical,
+      character: null,
+      synthesized: synthesized,
+    );
+  }
+
+  KeyData ctrlDown({bool synthesized = false, int physical = junkPhysical}) =>
+      makeKey(
+        type: KeyEventType.down,
+        physical: physical,
+        logical: logicalCtrl,
+        synthesized: synthesized,
+      );
+
+  KeyData ctrlUp({bool synthesized = false, int physical = junkPhysical}) =>
+      makeKey(
+        type: KeyEventType.up,
+        physical: physical,
+        logical: logicalCtrl,
+        synthesized: synthesized,
+      );
+
+  KeyData vDown({int physical = junkPhysical}) =>
+      makeKey(type: KeyEventType.down, physical: physical, logical: logicalV);
+
+  KeyData vUp({int physical = junkPhysical}) =>
+      makeKey(type: KeyEventType.up, physical: physical, logical: logicalV);
+
+  setUp(() {
+    fix = WindowsPasteFix.instance;
+    fix.resetState();
+  });
+
+  group('normal hardware keys passthrough', () {
+    test('regular key passes through and resets state', () {
+      final key = makeKey(
+        type: KeyEventType.down,
+        physical: 0x70004,
+        logical: 0x61,
+      );
+      final result = fix.rewrite(key);
+      expect(result, same(key));
+    });
+
+    test('regular key resets mid-sequence state', () {
+      fix.rewrite(ctrlDown());
+      expect(fix.rewrite(ctrlDown()), isNotNull);
+    });
+  });
+
+  group('all-zero garbage events', () {
+    test('swallows all-zero event', () {
+      final key = makeKey(type: KeyEventType.down, physical: 0, logical: 0);
+      expect(fix.rewrite(key), isNull);
+    });
+  });
+
+  group('full Win+V 6-step sequence', () {
+    test('rewrites complete sequence correctly', () {
+      final step1 = fix.rewrite(ctrlDown(synthesized: false));
+      expect(step1, isNotNull);
+      expect(step1!.type, KeyEventType.down);
+      expect(step1.physical, cleanPhysicalCtrl);
+      expect(step1.logical, logicalCtrl);
+      expect(step1.synthesized, isFalse);
+
+      final step2 = fix.rewrite(ctrlUp(synthesized: true));
+      expect(step2, isNull);
+
+      final step3 = fix.rewrite(vDown());
+      expect(step3, isNotNull);
+      expect(step3!.type, KeyEventType.down);
+      expect(step3.physical, cleanPhysicalV);
+      expect(step3.logical, logicalV);
+      expect(step3.synthesized, isFalse);
+
+      final step4 = fix.rewrite(vUp());
+      expect(step4, isNotNull);
+      expect(step4!.type, KeyEventType.up);
+      expect(step4.physical, cleanPhysicalV);
+      expect(step4.logical, logicalV);
+      expect(step4.synthesized, isFalse);
+
+      final step5 = fix.rewrite(ctrlDown(synthesized: true));
+      expect(step5, isNull);
+
+      final step6 = fix.rewrite(ctrlUp(synthesized: true));
+      expect(step6, isNotNull);
+      expect(step6!.type, KeyEventType.up);
+      expect(step6.physical, cleanPhysicalCtrl);
+      expect(step6.logical, logicalCtrl);
+      expect(step6.synthesized, isFalse);
+    });
+
+    test('state resets after complete sequence', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      fix.rewrite(ctrlUp(synthesized: true));
+      fix.rewrite(vDown());
+      fix.rewrite(vUp());
+      fix.rewrite(ctrlDown(synthesized: true));
+      fix.rewrite(ctrlUp(synthesized: true));
+
+      final next = fix.rewrite(ctrlDown(synthesized: false));
+      expect(next, isNotNull);
+      expect(next!.physical, cleanPhysicalCtrl);
+    });
+  });
+
+  group('broken sequence reset', () {
+    test('step 0: V down instead of Ctrl down resets', () {
+      final result = fix.rewrite(vDown());
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+
+    test('step 1: Ctrl down instead of Ctrl up resets and passes through', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      final result = fix.rewrite(ctrlDown(synthesized: false));
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+
+    test('step 2: Ctrl down instead of V down resets and passes through', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      fix.rewrite(ctrlUp(synthesized: true));
+      final result = fix.rewrite(ctrlDown(synthesized: false));
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+
+    test('step 3: Ctrl down instead of V up resets and passes through', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      fix.rewrite(ctrlUp(synthesized: true));
+      fix.rewrite(vDown());
+      final result = fix.rewrite(ctrlDown(synthesized: false));
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+
+    test('step 4: V down instead of Ctrl down resets', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      fix.rewrite(ctrlUp(synthesized: true));
+      fix.rewrite(vDown());
+      fix.rewrite(vUp());
+      final result = fix.rewrite(vDown());
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+
+    test('step 5: V up instead of Ctrl up resets', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      fix.rewrite(ctrlUp(synthesized: true));
+      fix.rewrite(vDown());
+      fix.rewrite(vUp());
+      fix.rewrite(ctrlDown(synthesized: true));
+      final result = fix.rewrite(vUp());
+      expect(result, isNotNull);
+      expect(result!.physical, junkPhysical);
+    });
+  });
+
+  group('repeated sequences', () {
+    test('two consecutive Win+V sequences both rewrite correctly', () {
+      for (var i = 0; i < 2; i++) {
+        final s1 = fix.rewrite(ctrlDown(synthesized: false));
+        expect(s1!.physical, cleanPhysicalCtrl, reason: 'iter $i step1');
+
+        expect(
+          fix.rewrite(ctrlUp(synthesized: true)),
+          isNull,
+          reason: 'iter $i step2',
+        );
+
+        final s3 = fix.rewrite(vDown());
+        expect(s3!.physical, cleanPhysicalV, reason: 'iter $i step3');
+
+        final s4 = fix.rewrite(vUp());
+        expect(s4!.physical, cleanPhysicalV, reason: 'iter $i step4');
+
+        expect(
+          fix.rewrite(ctrlDown(synthesized: true)),
+          isNull,
+          reason: 'iter $i step5',
+        );
+
+        final s6 = fix.rewrite(ctrlUp(synthesized: true));
+        expect(s6!.physical, cleanPhysicalCtrl, reason: 'iter $i step6');
+      }
+    });
+  });
+}


### PR DESCRIPTION
Windows 11 Win+V sends malformed <kbd>Ctrl+V</kbd> key sequences with `physical=0x1600000000` and Ctrl↑ **arriving before** V↓, breaking the standard paste path in all Flutter input fields.

WindowsPasteFix intercepts PlatformDispatcher.onKeyData, rewrites the 6-step malformed sequence into clean key events, restoring full Win+V text and image paste support.

References flutter/flutter#143997, fixes Chevey339/kelivo#438
