### PR TITLE
feat: render update release notes as markdown in side drawer

### DIFF
--- a/lib/features/home/widgets/side_drawer.dart
+++ b/lib/features/home/widgets/side_drawer.dart
@@ -28,6 +28,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:intl/intl.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:animations/animations.dart';
 import '../../../utils/sandbox_path_resolver.dart';
@@ -3322,7 +3323,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                         ),
                         if ((info.notes ?? '').trim().isNotEmpty) ...[
                           const SizedBox(height: 6),
-                          Text(
+                          GptMarkdown(
                             info.notes!,
                             style: TextStyle(
                               fontSize: 13,


### PR DESCRIPTION
## Summary

The update banner in the side drawer displayed GitHub release notes as plain text via a `Text` widget. Since GitHub release bodies are markdown-formatted, headings, lists, bold text, links, etc. appeared as raw markdown syntax to users.

## Changes

- Replace `Text(info.notes!)` with `GptMarkdown(info.notes!)` in the update banner (`side_drawer.dart`)
- Add `gpt_markdown` import (already a project dependency, no new packages needed)

## Before / After

**Before:** Release notes shown as raw markdown text (e.g. `## What's Changed`, `- **feat**: ...`)
**After:** Release notes rendered with proper markdown formatting (headings, bold, lists, links)

## Test Plan

- [ ] Open the app with a newer release available on GitHub
- [ ] Verify the update banner in the side drawer renders release notes with markdown formatting
- [ ] Verify links in release notes are tappable
- [ ] Verify the banner still collapses/hides correctly when no update is available