### PR TITLE
feat: add custom dynamic color (seed) support

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -105,6 +105,7 @@ class SettingsProvider extends ChangeNotifier {
   static const String _compressPromptKey = 'compress_prompt_v1';
   static const String _themePaletteKey = 'theme_palette_v1';
   static const String _useDynamicColorKey = 'use_dynamic_color_v1';
+  static const String _dynamicColorSeedKey = 'dynamic_color_seed_v1';
   static const String _thinkingBudgetKey = 'thinking_budget_v1';
   static const String _titleGenerationThinkingEnabledKey =
       'title_generation_thinking_enabled_v1';
@@ -357,6 +358,8 @@ class SettingsProvider extends ChangeNotifier {
   String get themePaletteId => _themePaletteId;
   bool _useDynamicColor = true; // when supported on Android
   bool get useDynamicColor => _useDynamicColor;
+  int? _dynamicColorSeed;
+  int? get dynamicColorSeed => _dynamicColorSeed;
   bool _dynamicColorSupported = false; // runtime capability, not persisted
   bool get dynamicColorSupported => _dynamicColorSupported;
 
@@ -666,6 +669,7 @@ class SettingsProvider extends ChangeNotifier {
     }
     _themePaletteId = prefs.getString(_themePaletteKey) ?? 'default';
     _useDynamicColor = prefs.getBool(_useDynamicColorKey) ?? true;
+    _dynamicColorSeed = prefs.getInt(_dynamicColorSeedKey);
     var providerConfigsLoaded = false;
     final cfgStr = prefs.getString(_providerConfigsKey);
     if (cfgStr != null && cfgStr.isNotEmpty) {
@@ -2302,6 +2306,18 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_useDynamicColorKey, v);
+  }
+
+  Future<void> setDynamicColorSeed(int? seed) async {
+    if (_dynamicColorSeed == seed) return;
+    _dynamicColorSeed = seed;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    if (seed != null) {
+      await prefs.setInt(_dynamicColorSeedKey, seed);
+    } else {
+      await prefs.remove(_dynamicColorSeedKey);
+    }
   }
 
   Future<void> setUsePureBackground(bool v) async {

--- a/lib/core/providers/update_provider.dart
+++ b/lib/core/providers/update_provider.dart
@@ -137,9 +137,10 @@ class UpdateProvider extends ChangeNotifier {
       final url = Uri.parse(
         'https://api.github.com/repos/cuplivo/cuplivo/releases/latest',
       );
-      final resp = await http.get(url, headers: {
-        'Accept': 'application/vnd.github+json',
-      });
+      final resp = await http.get(
+        url,
+        headers: {'Accept': 'application/vnd.github+json'},
+      );
       if (resp.statusCode != 200) {
         throw Exception('HTTP ${resp.statusCode}');
       }

--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -10,6 +10,7 @@ import '../icons/lucide_adapter.dart' as lucide;
 import '../l10n/app_localizations.dart';
 import '../theme/app_font_weights.dart';
 import '../theme/palettes.dart';
+import '../shared/widgets/hue_slider.dart';
 import '../core/providers/settings_provider.dart';
 import '../core/providers/model_provider.dart';
 import '../core/services/logging/flutter_logger.dart';

--- a/lib/desktop/setting/about_pane.dart
+++ b/lib/desktop/setting/about_pane.dart
@@ -172,8 +172,7 @@ class _DesktopAboutPaneState extends State<DesktopAboutPane> {
                   _DeskNavRowSvg(
                     svgAsset: 'assets/icons/github.svg',
                     label: l10n.aboutPageGithub,
-                    onTap: () =>
-                        _openUrl('https://github.com/cuplivo/cuplivo'),
+                    onTap: () => _openUrl('https://github.com/cuplivo/cuplivo'),
                   ),
                   const _DeskRowDivider(),
                   _DeskNavRow(

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -399,16 +399,33 @@ class _ThemeDots extends StatelessWidget {
   Widget build(BuildContext context) {
     final sp = context.watch<SettingsProvider>();
     final selected = sp.themePaletteId;
+    final regularPalettes = ThemePalettes.all
+        .where((p) => p.id != ThemePalettes.customDynamicId)
+        .toList();
     return Wrap(
       spacing: 10,
       runSpacing: 10,
       children: [
-        for (final p in ThemePalettes.all)
+        for (final p in regularPalettes)
           _ThemeDot(
             color: p.light.primary,
             selected: selected == p.id,
             onTap: () => context.read<SettingsProvider>().setThemePalette(p.id),
           ),
+        _CustomDynamicDot(
+          selected: selected == ThemePalettes.customDynamicId,
+          onTap: () {
+            final settings = context.read<SettingsProvider>();
+            final previousId = settings.themePaletteId;
+            settings.setThemePalette(ThemePalettes.customDynamicId);
+            _showDesktopHuePicker(
+              context,
+              settings,
+              settings.dynamicColorSeed,
+              previousId,
+            );
+          },
+        ),
       ],
     );
   }
@@ -459,13 +476,136 @@ class _ThemeDotState extends State<_ThemeDot> {
               color: widget.selected
                   ? cs.onSurface.withValues(alpha: 0.85)
                   : Colors.white,
-              width: widget.selected ? 2 : 2,
+              width: 2,
             ),
           ),
         ),
       ),
     );
   }
+}
+
+class _CustomDynamicDot extends StatefulWidget {
+  const _CustomDynamicDot({required this.selected, required this.onTap});
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  State<_CustomDynamicDot> createState() => _CustomDynamicDotState();
+}
+
+class _CustomDynamicDotState extends State<_CustomDynamicDot> {
+  bool _hover = false;
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final settings = context.watch<SettingsProvider>();
+    final seed = settings.dynamicColorSeed;
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hover = true),
+      onExit: (_) => setState(() => _hover = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 140),
+          curve: Curves.easeOutCubic,
+          width: 24,
+          height: 24,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: seed != null
+                ? null
+                : const SweepGradient(
+                    colors: [
+                      Color(0xFFFF0000),
+                      Color(0xFFFFFF00),
+                      Color(0xFF00FF00),
+                      Color(0xFF00FFFF),
+                      Color(0xFF0000FF),
+                      Color(0xFFFF00FF),
+                      Color(0xFFFF0000),
+                    ],
+                  ),
+            color: seed != null ? Color(seed) : null,
+            boxShadow: _hover
+                ? [
+                    BoxShadow(
+                      color: (seed != null ? Color(seed) : cs.onSurface)
+                          .withValues(alpha: 0.45),
+                      blurRadius: 14,
+                      spreadRadius: 1,
+                    ),
+                  ]
+                : [],
+            border: Border.all(
+              color: widget.selected
+                  ? cs.onSurface.withValues(alpha: 0.85)
+                  : Colors.white,
+              width: 2,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _showDesktopHuePicker(
+  BuildContext context,
+  SettingsProvider settings,
+  int? currentSeed,
+  String previousPaletteId,
+) async {
+  final l10n = AppLocalizations.of(context)!;
+  double hue = currentSeed != null
+      ? HSVColor.fromColor(Color(currentSeed)).hue
+      : 260.0;
+
+  await showDialog(
+    context: context,
+    builder: (dialogContext) {
+      return StatefulBuilder(
+        builder: (context, setDialogState) {
+          return AlertDialog(
+            title: Text(l10n.themeSettingsPageSeedColorLabel),
+            content: SizedBox(
+              width: 280,
+              child: HueSlider(
+                hue: hue,
+                onChanged: (v) {
+                  setDialogState(() => hue = v);
+                },
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  settings.setThemePalette(previousPaletteId);
+                  Navigator.of(dialogContext).pop();
+                },
+                child: Text(l10n.homePageCancel),
+              ),
+              TextButton(
+                onPressed: () {
+                  final seedColor = HSVColor.fromAHSV(
+                    1.0,
+                    hue,
+                    0.85,
+                    0.90,
+                  ).toColor();
+                  settings.setDynamicColorSeed(seedColor.toARGB32());
+                  settings.setThemePalette(ThemePalettes.customDynamicId);
+                  Navigator.of(dialogContext).pop();
+                },
+                child: Text(l10n.assistantEditEmojiDialogSave),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
 }
 
 class _ToggleRowPureBackground extends StatelessWidget {

--- a/lib/features/settings/pages/theme_settings_page.dart
+++ b/lib/features/settings/pages/theme_settings_page.dart
@@ -7,6 +7,7 @@ import '../../../theme/palettes.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../core/services/haptics.dart';
+import '../../../shared/widgets/hue_slider.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
 
 class ThemeSettingsPage extends StatelessWidget {
@@ -83,14 +84,18 @@ class ThemeSettingsPage extends StatelessWidget {
           _iosSectionCard(
             children: [
               for (int i = 0; i < ThemePalettes.all.length; i++) ...[
-                _paletteRow(
-                  context,
-                  palette: ThemePalettes.all[i],
-                  selected: settings.themePaletteId == ThemePalettes.all[i].id,
-                  onTap: () => context.read<SettingsProvider>().setThemePalette(
-                    ThemePalettes.all[i].id,
+                if (ThemePalettes.all[i].id == ThemePalettes.customDynamicId)
+                  _customDynamicRow(context)
+                else
+                  _paletteRow(
+                    context,
+                    palette: ThemePalettes.all[i],
+                    selected:
+                        settings.themePaletteId == ThemePalettes.all[i].id,
+                    onTap: () => context
+                        .read<SettingsProvider>()
+                        .setThemePalette(ThemePalettes.all[i].id),
                   ),
-                ),
                 if (i != ThemePalettes.all.length - 1) _iosDivider(context),
               ],
             ],
@@ -346,6 +351,163 @@ Widget _paletteRow(
             ],
           ),
         ),
+      );
+    },
+  );
+}
+
+Widget _customDynamicRow(BuildContext context) {
+  final cs = Theme.of(context).colorScheme;
+  final settings = context.watch<SettingsProvider>();
+  final l10n = AppLocalizations.of(context)!;
+  final selected = settings.themePaletteId == ThemePalettes.customDynamicId;
+  final seed = settings.dynamicColorSeed;
+  final dotColor = seed != null
+      ? Color(seed)
+      : cs.onSurface.withValues(alpha: 0.3);
+
+  return _TactileRow(
+    onTap: () {
+      final sp = context.read<SettingsProvider>();
+      _showHuePickerSheet(context, sp, seed);
+    },
+    builder: (pressed) {
+      final baseColor = cs.onSurface.withValues(alpha: 0.9);
+      return _AnimatedPressColor(
+        pressed: pressed,
+        base: baseColor,
+        builder: (c) => Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          child: Row(
+            children: [
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: seed != null
+                      ? null
+                      : const SweepGradient(
+                          colors: [
+                            Color(0xFFFF0000),
+                            Color(0xFFFFFF00),
+                            Color(0xFF00FF00),
+                            Color(0xFF00FFFF),
+                            Color(0xFF0000FF),
+                            Color(0xFFFF00FF),
+                            Color(0xFFFF0000),
+                          ],
+                        ),
+                  color: seed != null ? dotColor : null,
+                  boxShadow: Theme.of(context).brightness == Brightness.dark
+                      ? []
+                      : [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.08),
+                            blurRadius: 8,
+                            offset: const Offset(0, 2),
+                          ),
+                        ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(
+                  l10n.themeSettingsPageCustomDynamicTitle,
+                  style: TextStyle(fontSize: 15, color: c),
+                ),
+              ),
+              if (selected)
+                Icon(Lucide.Check, size: 18, color: cs.primary)
+              else
+                const SizedBox(width: 18, height: 18),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+Future<void> _showHuePickerSheet(
+  BuildContext context,
+  SettingsProvider settings,
+  int? currentSeed,
+) async {
+  final l10n = AppLocalizations.of(context)!;
+  double hue = currentSeed != null
+      ? HSVColor.fromColor(Color(currentSeed)).hue
+      : 260.0;
+
+  await showModalBottomSheet(
+    context: context,
+    builder: (sheetContext) {
+      return StatefulBuilder(
+        builder: (context, setSheetState) {
+          return Padding(
+            padding: EdgeInsets.only(
+              left: 24,
+              right: 24,
+              top: 20,
+              bottom: MediaQuery.of(context).padding.bottom + 20,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.themeSettingsPageSeedColorLabel,
+                  style: TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.w600,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Center(
+                  child: SizedBox(
+                    width: 260,
+                    child: HueSlider(
+                      hue: hue,
+                      onChanged: (v) {
+                        setSheetState(() => hue = v);
+                      },
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      final seedColor = HSVColor.fromAHSV(
+                        1.0,
+                        hue,
+                        0.85,
+                        0.90,
+                      ).toColor();
+                      settings.setDynamicColorSeed(seedColor.toARGB32());
+                      settings.setThemePalette(ThemePalettes.customDynamicId);
+                      Navigator.of(sheetContext).pop();
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                    child: Text(
+                      l10n.assistantEditEmojiDialogSave,
+                      style: const TextStyle(fontSize: 15),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
       );
     },
   );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1770,6 +1770,8 @@
   "themeSettingsPageUsePureBackgroundTitle": "Pure Background",
   "themeSettingsPageUsePureBackgroundSubtitle": "Bubbles and accents follow theme.",
   "themeSettingsPageColorPalettesSection": "Color Palettes",
+  "themeSettingsPageCustomDynamicTitle": "Custom Dynamic",
+  "themeSettingsPageSeedColorLabel": "Seed Color",
   "ttsServicesPageBackButton": "Back",
   "ttsServicesPageTitle": "Text-to-Speech",
   "ttsServicesPageSettingsTooltip": "TTS settings",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7856,6 +7856,18 @@ abstract class AppLocalizations {
   /// **'Color Palettes'**
   String get themeSettingsPageColorPalettesSection;
 
+  /// No description provided for @themeSettingsPageCustomDynamicTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom Dynamic'**
+  String get themeSettingsPageCustomDynamicTitle;
+
+  /// No description provided for @themeSettingsPageSeedColorLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Seed Color'**
+  String get themeSettingsPageSeedColorLabel;
+
   /// No description provided for @ttsServicesPageBackButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4233,6 +4233,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get themeSettingsPageColorPalettesSection => 'Color Palettes';
 
   @override
+  String get themeSettingsPageCustomDynamicTitle => 'Custom Dynamic';
+
+  @override
+  String get themeSettingsPageSeedColorLabel => 'Seed Color';
+
+  @override
   String get ttsServicesPageBackButton => 'Back';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4060,6 +4060,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get themeSettingsPageColorPalettesSection => '配色方案';
 
   @override
+  String get themeSettingsPageCustomDynamicTitle => '自定义动态色';
+
+  @override
+  String get themeSettingsPageSeedColorLabel => '种子颜色';
+
+  @override
   String get ttsServicesPageBackButton => '返回';
 
   @override
@@ -9794,6 +9800,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get themeSettingsPageColorPalettesSection => '配色方案';
 
   @override
+  String get themeSettingsPageCustomDynamicTitle => '自定义动态色';
+
+  @override
+  String get themeSettingsPageSeedColorLabel => '种子颜色';
+
+  @override
   String get ttsServicesPageBackButton => '返回';
 
   @override
@@ -15524,6 +15536,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get themeSettingsPageColorPalettesSection => '配色方案';
+
+  @override
+  String get themeSettingsPageCustomDynamicTitle => '自訂動態色';
+
+  @override
+  String get themeSettingsPageSeedColorLabel => '種子顏色';
 
   @override
   String get ttsServicesPageBackButton => '返回';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1415,6 +1415,8 @@
   "themeSettingsPageUsePureBackgroundTitle": "纯色背景",
   "themeSettingsPageUsePureBackgroundSubtitle": "仅气泡与强调色随主题变化",
   "themeSettingsPageColorPalettesSection": "配色方案",
+  "themeSettingsPageCustomDynamicTitle": "自定义动态色",
+  "themeSettingsPageSeedColorLabel": "种子颜色",
   "ttsServicesPageBackButton": "返回",
   "ttsServicesPageTitle": "语音服务",
   "ttsServicesPageSettingsTooltip": "TTS 设置",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1435,6 +1435,8 @@
   "themeSettingsPageUsePureBackgroundTitle": "纯色背景",
   "themeSettingsPageUsePureBackgroundSubtitle": "仅气泡与强调色随主题变化",
   "themeSettingsPageColorPalettesSection": "配色方案",
+  "themeSettingsPageCustomDynamicTitle": "自定义动态色",
+  "themeSettingsPageSeedColorLabel": "种子颜色",
   "ttsServicesPageBackButton": "返回",
   "ttsServicesPageTitle": "语音服务",
   "ttsServicesPageSettingsTooltip": "TTS 设置",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1405,6 +1405,8 @@
   "themeSettingsPageUsePureBackgroundSubtitle": "僅氣泡與強調色隨主題變化",
   "themeSettingsPageUseDynamicColorSubtitle": "基於系統配色（Android 12+）",
   "themeSettingsPageColorPalettesSection": "配色方案",
+  "themeSettingsPageCustomDynamicTitle": "自訂動態色",
+  "themeSettingsPageSeedColorLabel": "種子顏色",
   "ttsServicesPageBackButton": "返回",
   "ttsServicesPageTitle": "語音服務",
   "ttsServicesPageSettingsTooltip": "TTS 設定",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -317,15 +317,36 @@ class MyApp extends StatelessWidget {
 
               final useDyn = isAndroid && settings.useDynamicColor;
               final palette = ThemePalettes.byId(settings.themePaletteId);
+              final isCustomDyn =
+                  settings.themePaletteId == ThemePalettes.customDynamicId;
+
+              ColorScheme? lightDynOverride;
+              ColorScheme? darkDynOverride;
+              if (isCustomDyn) {
+                final seed = settings.dynamicColorSeed;
+                if (seed != null) {
+                  lightDynOverride = ColorScheme.fromSeed(
+                    seedColor: Color(seed),
+                    brightness: Brightness.light,
+                  );
+                  darkDynOverride = ColorScheme.fromSeed(
+                    seedColor: Color(seed),
+                    brightness: Brightness.dark,
+                  );
+                }
+              } else if (useDyn) {
+                lightDynOverride = lightDynamic;
+                darkDynOverride = darkDynamic;
+              }
 
               final light = buildLightThemeForScheme(
                 palette.light,
-                dynamicScheme: useDyn ? lightDynamic : null,
+                dynamicScheme: lightDynOverride,
                 pureBackground: settings.usePureBackground,
               );
               final dark = buildDarkThemeForScheme(
                 palette.dark,
-                dynamicScheme: useDyn ? darkDynamic : null,
+                dynamicScheme: darkDynOverride,
                 pureBackground: settings.usePureBackground,
               );
               // Resolve effective app font family (system/Google/local alias)

--- a/lib/shared/widgets/hue_slider.dart
+++ b/lib/shared/widgets/hue_slider.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+class HueSlider extends StatefulWidget {
+  final double hue;
+  final ValueChanged<double> onChanged;
+  final double saturation;
+  final double brightness;
+
+  const HueSlider({
+    super.key,
+    required this.hue,
+    required this.onChanged,
+    this.saturation = 0.85,
+    this.brightness = 0.90,
+  });
+
+  @override
+  State<HueSlider> createState() => _HueSliderState();
+}
+
+class _HueSliderState extends State<HueSlider> {
+  static const List<Color> _hueColors = [
+    Color(0xFFFF0000),
+    Color(0xFFFFFF00),
+    Color(0xFF00FF00),
+    Color(0xFF00FFFF),
+    Color(0xFF0000FF),
+    Color(0xFFFF00FF),
+    Color(0xFFFF0000),
+  ];
+
+  double _getHueFromDx(double dx, double width) {
+    return (dx / width).clamp(0.0, 1.0) * 360.0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final width = constraints.maxWidth;
+            const trackHeight = 32.0;
+            const thumbSize = 28.0;
+            return GestureDetector(
+              onPanDown: (d) {
+                final dx = d.localPosition.dx;
+                widget.onChanged(_getHueFromDx(dx, width));
+              },
+              onPanUpdate: (d) {
+                final dx = d.localPosition.dx;
+                widget.onChanged(_getHueFromDx(dx, width));
+              },
+              child: SizedBox(
+                height: trackHeight,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Container(
+                      height: trackHeight,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(trackHeight / 2),
+                        gradient: const LinearGradient(colors: _hueColors),
+                      ),
+                    ),
+                    Positioned(
+                      left: ((widget.hue / 360.0) * width - thumbSize / 2)
+                          .clamp(0, width - thumbSize),
+                      top: (trackHeight - thumbSize) / 2,
+                      child: Container(
+                        width: thumbSize,
+                        height: thumbSize,
+                        decoration: BoxDecoration(
+                          color: HSVColor.fromAHSV(
+                            1.0,
+                            widget.hue,
+                            widget.saturation,
+                            widget.brightness,
+                          ).toColor(),
+                          shape: BoxShape.circle,
+                          border: Border.all(color: Colors.white, width: 3),
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withValues(alpha: 0.25),
+                              blurRadius: 4,
+                              offset: const Offset(0, 1),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 16),
+        Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            color: HSVColor.fromAHSV(
+              1.0,
+              widget.hue,
+              widget.saturation,
+              widget.brightness,
+            ).toColor(),
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: cs.outlineVariant.withValues(alpha: 0.4),
+              width: 1,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.1),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/theme/palettes.dart
+++ b/lib/theme/palettes.dart
@@ -29,6 +29,7 @@ class ThemePalettes {
   static const String terracottaId = 'terracotta';
   static const String monochromeId = 'monochrome';
   static const String docThemeId = 'doc_theme';
+  static const String customDynamicId = 'custom_dynamic';
 
   static const ThemePalette defaultPalette = ThemePalette(
     id: defaultId,
@@ -630,7 +631,15 @@ class ThemePalettes {
       surfaceTint: Color(0xFF00B96B),
     ),
   );
-  static const List<ThemePalette> all = <ThemePalette>[
+  static final ThemePalette customDynamicPalette = ThemePalette(
+    id: customDynamicId,
+    zhName: '自定义动态色',
+    enName: 'Custom Dynamic',
+    light: ThemePalettes.defaultPalette.light,
+    dark: ThemePalettes.defaultPalette.dark,
+  );
+
+  static final List<ThemePalette> all = <ThemePalette>[
     defaultPalette,
     blue,
     green,
@@ -640,6 +649,7 @@ class ThemePalettes {
     terracotta,
     monochrome,
     docTheme,
+    customDynamicPalette,
   ];
 
   static ThemePalette byId(String id) {


### PR DESCRIPTION
Fixed Chevey339/kelivo#794.

Verified on Windows 11.

- SettingsProvider: new dynamicColorSeed field, load/save, setter
- ThemePalettes: add customDynamicPalette entry with custom_dynamic ID
- HueSlider: new reusable hue slider widget (0-360° gradient)
- main.dart: prioritize custom seed -> system dynamic -> static palette
- Mobile: palette list bottom entry + bottom sheet color picker
- Desktop: rainbow dot + dialog color picker
- l10n: add themeSettingsPageCustomDynamicTitle / SeedColor keys