### PR TITLE
feat: per-server heartbeat interval to avoid 429 rate limit

### DIFF
--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -118,6 +118,7 @@ class McpServerConfig {
   final List<String> args;
   final Map<String, String> env;
   final String? workingDirectory;
+  final int? heartbeatIntervalSeconds; // null = use default (12s)
 
   McpServerConfig({
     required this.id,
@@ -131,6 +132,7 @@ class McpServerConfig {
     this.args = const [],
     this.env = const {},
     this.workingDirectory,
+    this.heartbeatIntervalSeconds,
   });
 
   McpServerConfig copyWith({
@@ -146,6 +148,8 @@ class McpServerConfig {
     Map<String, String>? env,
     String? workingDirectory,
     bool clearWorkingDirectory = false,
+    int? heartbeatIntervalSeconds,
+    bool clearHeartbeatIntervalSeconds = false,
   }) => McpServerConfig(
     id: id ?? this.id,
     enabled: enabled ?? this.enabled,
@@ -160,6 +164,9 @@ class McpServerConfig {
     workingDirectory: clearWorkingDirectory
         ? null
         : (workingDirectory ?? this.workingDirectory),
+    heartbeatIntervalSeconds: clearHeartbeatIntervalSeconds
+        ? null
+        : (heartbeatIntervalSeconds ?? this.heartbeatIntervalSeconds),
   );
 
   Map<String, dynamic> toJson() => {
@@ -179,6 +186,8 @@ class McpServerConfig {
     if (transport == McpTransportType.stdio) 'env': env,
     if (transport == McpTransportType.stdio && workingDirectory != null)
       'workingDirectory': workingDirectory,
+    if (heartbeatIntervalSeconds != null)
+      'heartbeatIntervalSeconds': heartbeatIntervalSeconds,
   };
 
   factory McpServerConfig.fromJson(Map<String, dynamic> json) {
@@ -197,6 +206,7 @@ class McpServerConfig {
             )
             .toList() ??
         const <McpToolConfig>[];
+    final heartbeatIntervalSeconds = json['heartbeatIntervalSeconds'] as int?;
     if (t == McpTransportType.stdio) {
       final argsAny = json['args'];
       final envAny = json['env'];
@@ -214,6 +224,7 @@ class McpServerConfig {
             ? envAny.map((k, v) => MapEntry(k.toString(), v.toString()))
             : const <String, String>{},
         workingDirectory: (json['workingDirectory'] as String?)?.trim(),
+        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
       );
     } else if (t == McpTransportType.inmemory) {
       return McpServerConfig(
@@ -222,6 +233,7 @@ class McpServerConfig {
         name: json['name'] as String? ?? '',
         transport: McpTransportType.inmemory,
         tools: tools,
+        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
       );
     } else {
       return McpServerConfig(
@@ -236,6 +248,7 @@ class McpServerConfig {
               (k, v) => MapEntry(k.toString(), v.toString()),
             )) ??
             const {},
+        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
       );
     }
   }
@@ -628,6 +641,7 @@ class McpProvider extends ChangeNotifier {
     List<String> args = const <String>[],
     Map<String, String> env = const <String, String>{},
     String? workingDirectory,
+    int? heartbeatIntervalSeconds,
   }) async {
     final id = const Uuid().v4();
     final cfg = McpServerConfig(
@@ -643,6 +657,7 @@ class McpProvider extends ChangeNotifier {
       workingDirectory: (workingDirectory?.trim().isNotEmpty ?? false)
           ? workingDirectory!.trim()
           : null,
+      heartbeatIntervalSeconds: heartbeatIntervalSeconds,
     );
     _servers = [..._servers, cfg];
     _status[id] = McpStatus.idle;
@@ -786,7 +801,10 @@ class McpProvider extends ChangeNotifier {
         _errors.remove(id);
         notifyListeners();
         await refreshTools(id);
-        _startHeartbeat(id);
+        _startHeartbeat(
+          id,
+          interval: Duration(seconds: server.heartbeatIntervalSeconds ?? 12),
+        );
         return;
       }
 
@@ -852,7 +870,10 @@ class McpProvider extends ChangeNotifier {
       // debugPrint('[MCP/Tools] refresh done for id=$id');
 
       // Start/refresh heartbeat for this connection
-      _startHeartbeat(id);
+      _startHeartbeat(
+        id,
+        interval: Duration(seconds: server.heartbeatIntervalSeconds ?? 12),
+      );
     } catch (e) {
       // debugPrint('[MCP/Error] connect failed for id=$id (${server.name})');
       // _logMcpException('connect', serverId: id, error: e, stack: st);

--- a/lib/desktop/setting/mcp_edit_dialog.dart
+++ b/lib/desktop/setting/mcp_edit_dialog.dart
@@ -52,6 +52,7 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
   McpTransportType _transport = McpTransportType.http;
   final _urlCtrl = TextEditingController();
   final List<_HeaderEntry> _headers = [];
+  int _heartbeatIntervalSeconds = 12;
   // STDIO fields (desktop only)
   final _cmdCtrl = TextEditingController();
   final _argsCtrl = TextEditingController(); // space-separated args
@@ -67,6 +68,7 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
       _nameCtrl.text = server.name;
       _transport = server.transport;
       _urlCtrl.text = server.url;
+      _heartbeatIntervalSeconds = server.heartbeatIntervalSeconds ?? 12;
       server.headers.forEach((k, v) {
         _headers.add(
           _HeaderEntry(
@@ -168,6 +170,8 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
             env: env,
             workingDirectory: clearing ? null : cwd,
             clearWorkingDirectory: clearing,
+            heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
+            clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
           ),
         );
       } else {
@@ -179,6 +183,9 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           args: args,
           env: env,
           workingDirectory: cwd.isEmpty ? null : cwd,
+          heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
+              ? null
+              : _heartbeatIntervalSeconds,
         );
       }
     } else {
@@ -200,6 +207,8 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
             transport: _transport,
             url: url,
             headers: headers,
+            heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
+            clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
           ),
         );
       } else {
@@ -209,6 +218,9 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           transport: _transport,
           url: url,
           headers: headers,
+          heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
+              ? null
+              : _heartbeatIntervalSeconds,
         );
       }
     }
@@ -378,6 +390,25 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
                 : 'http://localhost:3000',
             bold: true,
           ),
+        if (!isBuiltin) ...[
+          const SizedBox(height: 16),
+          Text(
+            l10n.mcpServerEditSheetHeartbeatLabel,
+            style: TextStyle(fontSize: 13, fontWeight: AppFontWeights.semibold),
+          ),
+          const SizedBox(height: 6),
+          _heartbeatPicker(),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              l10n.mcpServerEditSheetHeartbeatHint,
+              style: TextStyle(
+                fontSize: 12,
+                color: cs.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ],
         if (!isBuiltin && _transport == McpTransportType.stdio) ...[
           _labeledField(
             label: l10n.mcpServerEditSheetStdioCommandLabel,
@@ -714,6 +745,20 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
     // Simple whitespace split; users can provide quoted args as a single token for now.
     // For advanced quoting, consider a shell-like parser later.
     return text.split(RegExp(r"\s+")).where((e) => e.isNotEmpty).toList();
+  }
+
+  static const _heartbeatOptions = [12, 30, 60, 120, 300];
+
+  Widget _heartbeatPicker() {
+    final labels = _heartbeatOptions.map((s) => '${s}s').toList();
+    final idx = _heartbeatOptions.indexOf(_heartbeatIntervalSeconds);
+    final selected = idx >= 0 ? idx : 0;
+    return _SegChoiceBar(
+      labels: labels,
+      selectedIndex: selected,
+      onSelected: (i) =>
+          setState(() => _heartbeatIntervalSeconds = _heartbeatOptions[i]),
+    );
   }
 
   @override

--- a/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
@@ -56,6 +56,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
   McpTransportType _transport = McpTransportType.http;
   final _urlCtrl = TextEditingController();
   final List<_HeaderEntry> _headers = [];
+  int _heartbeatIntervalSeconds = 12;
 
   @override
   void initState() {
@@ -68,6 +69,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
       _nameCtrl.text = server.name;
       _transport = server.transport;
       _urlCtrl.text = server.url;
+      _heartbeatIntervalSeconds = server.heartbeatIntervalSeconds ?? 12;
       server.headers.forEach((k, v) {
         _headers.add(
           _HeaderEntry(
@@ -212,6 +214,20 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
     );
   }
 
+  static const _heartbeatOptions = [12, 30, 60, 120, 300];
+
+  Widget _heartbeatPicker() {
+    final labels = _heartbeatOptions.map((s) => '${s}s').toList();
+    final idx = _heartbeatOptions.indexOf(_heartbeatIntervalSeconds);
+    final selected = idx >= 0 ? idx : 0;
+    return _SegChoiceBar(
+      labels: labels,
+      selectedIndex: selected,
+      onSelected: (i) =>
+          setState(() => _heartbeatIntervalSeconds = _heartbeatOptions[i]),
+    );
+  }
+
   Widget _basicForm() {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
@@ -287,6 +303,23 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
             hint: _transport == McpTransportType.sse
                 ? 'http://localhost:3000/sse'
                 : 'http://localhost:3000',
+          ),
+          const SizedBox(height: 16),
+          Text(
+            l10n.mcpServerEditSheetHeartbeatLabel,
+            style: TextStyle(fontSize: 13, fontWeight: AppFontWeights.semibold),
+          ),
+          const SizedBox(height: 6),
+          _heartbeatPicker(),
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              l10n.mcpServerEditSheetHeartbeatHint,
+              style: TextStyle(
+                fontSize: 12,
+                color: cs.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
           ),
           const SizedBox(height: 16),
           Text(
@@ -398,6 +431,8 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
           transport: _transport,
           url: url,
           headers: headers,
+          heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
+          clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
         ),
       );
     } else {
@@ -407,6 +442,9 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
         transport: _transport,
         url: url,
         headers: headers,
+        heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
+            ? null
+            : _heartbeatIntervalSeconds,
       );
     }
     if (mounted) Navigator.of(context).pop();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1207,6 +1207,8 @@
   "mcpServerEditSheetNameLabel": "Name",
   "mcpServerEditSheetTransportLabel": "Transport",
   "mcpServerEditSheetSseRetryHint": "If SSE fails, try a few times",
+  "mcpServerEditSheetHeartbeatLabel": "Heartbeat Interval",
+  "mcpServerEditSheetHeartbeatHint": "If you encounter frequent 429 (rate limit) errors, try increasing this interval.",
   "mcpServerEditSheetUrlLabel": "Server URL",
   "mcpServerEditSheetCustomHeadersTitle": "Custom Headers",
   "mcpServerEditSheetHeaderNameLabel": "Header Name",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5171,6 +5171,18 @@ abstract class AppLocalizations {
   /// **'If SSE fails, try a few times'**
   String get mcpServerEditSheetSseRetryHint;
 
+  /// No description provided for @mcpServerEditSheetHeartbeatLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Heartbeat Interval'**
+  String get mcpServerEditSheetHeartbeatLabel;
+
+  /// No description provided for @mcpServerEditSheetHeartbeatHint.
+  ///
+  /// In en, this message translates to:
+  /// **'If you encounter frequent 429 (rate limit) errors, try increasing this interval.'**
+  String get mcpServerEditSheetHeartbeatHint;
+
   /// No description provided for @mcpServerEditSheetUrlLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2752,6 +2752,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mcpServerEditSheetSseRetryHint => 'If SSE fails, try a few times';
 
   @override
+  String get mcpServerEditSheetHeartbeatLabel => 'Heartbeat Interval';
+
+  @override
+  String get mcpServerEditSheetHeartbeatHint =>
+      'If you encounter frequent 429 (rate limit) errors, try increasing this interval.';
+
+  @override
   String get mcpServerEditSheetUrlLabel => 'Server URL';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2657,6 +2657,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mcpServerEditSheetSseRetryHint => '如果SSE连接失败，请多试几次';
 
   @override
+  String get mcpServerEditSheetHeartbeatLabel => '心跳间隔';
+
+  @override
+  String get mcpServerEditSheetHeartbeatHint => '若频繁遇到 429 (限流) 错误，建议延长心跳间隔。';
+
+  @override
   String get mcpServerEditSheetUrlLabel => '服务器地址';
 
   @override
@@ -8391,6 +8397,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get mcpServerEditSheetSseRetryHint => '如果SSE连接失败，请多试几次';
 
   @override
+  String get mcpServerEditSheetHeartbeatLabel => '心跳间隔';
+
+  @override
+  String get mcpServerEditSheetHeartbeatHint => '若频繁遇到 429 (限流) 错误，建议延长心跳间隔。';
+
+  @override
   String get mcpServerEditSheetUrlLabel => '服务器地址';
 
   @override
@@ -14122,6 +14134,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get mcpServerEditSheetSseRetryHint => '如果SSE連線失敗，請多試幾次';
+
+  @override
+  String get mcpServerEditSheetHeartbeatLabel => '心跳間隔';
+
+  @override
+  String get mcpServerEditSheetHeartbeatHint => '若頻繁遇到 429 (限流) 錯誤，建議延長心跳間隔。';
 
   @override
   String get mcpServerEditSheetUrlLabel => '伺服器地址';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -929,6 +929,8 @@
   "mcpServerEditSheetNameLabel": "名称",
   "mcpServerEditSheetTransportLabel": "传输类型",
   "mcpServerEditSheetSseRetryHint": "如果SSE连接失败，请多试几次",
+  "mcpServerEditSheetHeartbeatLabel": "心跳间隔",
+  "mcpServerEditSheetHeartbeatHint": "若频繁遇到 429 (限流) 错误，建议延长心跳间隔。",
   "mcpServerEditSheetUrlLabel": "服务器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自定义请求头",
   "mcpServerEditSheetHeaderNameLabel": "请求头名称",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -952,6 +952,8 @@
   "mcpServerEditSheetNameLabel": "名称",
   "mcpServerEditSheetTransportLabel": "传输类型",
   "mcpServerEditSheetSseRetryHint": "如果SSE连接失败，请多试几次",
+  "mcpServerEditSheetHeartbeatLabel": "心跳间隔",
+  "mcpServerEditSheetHeartbeatHint": "若频繁遇到 429 (限流) 错误，建议延长心跳间隔。",
   "mcpServerEditSheetUrlLabel": "服务器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自定义请求头",
   "mcpServerEditSheetHeaderNameLabel": "请求头名称",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -922,6 +922,8 @@
   "mcpServerEditSheetNameLabel": "名稱",
   "mcpServerEditSheetTransportLabel": "傳輸類型",
   "mcpServerEditSheetSseRetryHint": "如果SSE連線失敗，請多試幾次",
+  "mcpServerEditSheetHeartbeatLabel": "心跳間隔",
+  "mcpServerEditSheetHeartbeatHint": "若頻繁遇到 429 (限流) 錯誤，建議延長心跳間隔。",
   "mcpServerEditSheetUrlLabel": "伺服器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自訂請求標頭",
   "mcpServerEditSheetHeaderNameLabel": "請求標頭名稱",


### PR DESCRIPTION
McpServerConfig now has optional heartbeatIntervalSeconds (null=12s). Mobile and Desktop edit forms include a segmented picker (12/30/60/120/300s) with a hint about 429 rate limiting.

Fixes Chevey339/kelivo#788. Fixes Chevey339/kelivo#779. Fixes Chevey339/kelivo#765.