### PR TITLE
fix(chat): preserve provider reasoning signatures

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -1500,6 +1500,10 @@ class ChatStreamChunk {
   final String content;
   // Optional reasoning delta (when model supports reasoning)
   final String? reasoning;
+  // Optional vendor reasoning details (OpenRouter-style `reasoning_details`
+  // array, may carry thinking signatures). Emitted as a cumulative snapshot so
+  // it can be persisted and echoed back on later requests.
+  final dynamic reasoningDetails;
   final bool isDone;
   final int totalTokens;
   final TokenUsage? usage;
@@ -1512,6 +1516,7 @@ class ChatStreamChunk {
   ChatStreamChunk({
     required this.content,
     this.reasoning,
+    this.reasoningDetails,
     required this.isDone,
     required this.totalTokens,
     this.usage,

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -160,7 +160,8 @@ Map<String, dynamic>? _googleFunctionCallPartFromToolCall(Map toolCall) {
     if (google is Map) {
       final part = google['part'];
       if (part is Map && part['functionCall'] is Map) {
-        return part.cast<String, dynamic>();
+        // Mutable copy: callers may need to backfill a thought signature.
+        return Map<String, dynamic>.from(part);
       }
     }
   }
@@ -180,6 +181,25 @@ Map<String, dynamic>? _googleFunctionCallPartFromToolCall(Map toolCall) {
   final id = (toolCall['id'] ?? '').toString();
   if (id.isNotEmpty) part['id'] = id;
   return part;
+}
+
+/// Gemini 3 validates that the first functionCall part of a replayed model
+/// turn carries a thought signature; a missing one fails the whole request
+/// with "Function call is missing a thought_signature in functionCall parts".
+/// When the original signature was not persisted (legacy history, non-streaming
+/// responses), fall back to the documented placeholder so old conversations
+/// keep working.
+void _ensureGeminiFunctionCallThoughtSig(List<Map<String, dynamic>> parts) {
+  for (final part in parts) {
+    if (part['functionCall'] is! Map) continue;
+    final hasSig =
+        part.containsKey('thoughtSignature') ||
+        part.containsKey('thought_signature');
+    if (!hasSig) {
+      part['thoughtSignature'] = _geminiDummyThoughtSignature;
+    }
+    return; // Only the first functionCall part is validated.
+  }
 }
 
 Map<String, dynamic> _googleFunctionResponsePartFromToolMessage(
@@ -332,7 +352,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       if (roleRaw == 'assistant' && msg['tool_calls'] is List) {
         final parts = <Map<String, dynamic>>[];
-        final raw = (msg['content'] ?? '').toString();
+        final raw = _extractGeminiThoughtMeta(
+          (msg['content'] ?? '').toString(),
+        ).cleanedText;
         if (raw.trim().isNotEmpty && raw.trim() != '\n\n') {
           parts.add({'text': raw});
         }
@@ -340,6 +362,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           if (tc is! Map) continue;
           final part = _googleFunctionCallPartFromToolCall(tc);
           if (part != null) parts.add(part);
+        }
+        if (persistGeminiThoughtSigs) {
+          _ensureGeminiFunctionCallThoughtSig(parts);
         }
         if (parts.isNotEmpty) contents.add({'role': 'model', 'parts': parts});
         continue;
@@ -777,6 +802,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         final part = _googleFunctionCallPartFromToolCall(tc);
         if (part != null) parts.add(part);
       }
+      if (persistGeminiThoughtSigs) _ensureGeminiFunctionCallThoughtSig(parts);
       if (parts.isNotEmpty) contents.add({'role': 'model', 'parts': parts});
       continue;
     }

--- a/lib/core/services/api/providers/google_gemini.dart
+++ b/lib/core/services/api/providers/google_gemini.dart
@@ -1,6 +1,12 @@
 part of '../chat_api_service.dart';
 
 const String _geminiThoughtSigTag = 'gemini_thought_signatures';
+
+/// Placeholder thought signature accepted by the Gemini API when the original
+/// signature is unavailable (e.g. legacy history persisted before signatures
+/// were captured). Same value used by Google's own Gemini CLI.
+const String _geminiDummyThoughtSignature =
+    'context_engineering_is_the_way_to_go';
 final RegExp _geminiThoughtSigComment = RegExp(
   r'<!--\s*gemini_thought_signatures:(.*?)-->',
   dotAll: true,
@@ -116,7 +122,7 @@ void _applyGeminiThoughtSignatures(
       }
     }
   } else if (attachDummyWhenMissing) {
-    const dummy = 'context_engineering_is_the_way_to_go';
+    const dummy = _geminiDummyThoughtSignature;
     bool inlineFound = false;
     bool textTagged = false;
     for (final part in parts) {

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -196,6 +196,57 @@ void _normalizeMoonshotKimiChatBody(
   }
 }
 
+/// Accumulates streamed `reasoning_details` entries.
+///
+/// OpenRouter streams the array as ordered deltas (each chunk may carry one
+/// or more new entries) that must be concatenated and replayed unmodified
+/// and in the original order, so chunks are appended by default and identical
+/// consecutive deltas are preserved. Some other providers instead resend the
+/// full array-so-far with each chunk; for those (when [allowSnapshots] is
+/// set) a chunk that positively looks like such a cumulative snapshot (same
+/// entries plus new ones appended) switches the accumulator to snapshot
+/// mode, and later chunks replace the buffer instead of appending
+/// duplicates. For OpenRouter itself [allowSnapshots] is cleared because its
+/// documented semantics are always delta-style concatenation.
+class _ReasoningDetailsAccumulator {
+  _ReasoningDetailsAccumulator({this.allowSnapshots = true});
+
+  /// Whether cumulative-snapshot detection is enabled (false for OpenRouter,
+  /// whose documented semantics are delta-style concatenation).
+  final bool allowSnapshots;
+  List<dynamic> _details = const <dynamic>[];
+  bool _snapshotMode = false;
+
+  /// The accumulated entries, or null when nothing was captured.
+  List<dynamic>? get detailsOrNull => _details.isEmpty ? null : _details;
+
+  void add(List<dynamic> incoming) {
+    if (incoming.isEmpty) return;
+    if (_details.isEmpty) {
+      _details = List<dynamic>.of(incoming);
+      return;
+    }
+    final prefixMatches = allowSnapshots && _hasCurrentAsPrefix(incoming);
+    if (prefixMatches && incoming.length > _details.length) {
+      _snapshotMode = true;
+      _details = List<dynamic>.of(incoming);
+      return;
+    }
+    if (_snapshotMode && prefixMatches) {
+      return;
+    }
+    _details = <dynamic>[..._details, ...incoming];
+  }
+
+  bool _hasCurrentAsPrefix(List<dynamic> incoming) {
+    if (incoming.length < _details.length) return false;
+    for (var i = 0; i < _details.length; i++) {
+      if (jsonEncode(_details[i]) != jsonEncode(incoming[i])) return false;
+    }
+    return true;
+  }
+}
+
 Map<String, dynamic> _buildAssistantToolCallMessage({
   required List<Map<String, dynamic>> calls,
   dynamic content,
@@ -588,6 +639,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
   List<Map<String, dynamic>> messages, {
   List<String>? userMediaPaths,
   required bool canImageInput,
+  bool stripUnsignedReasoningContent = false,
 }) async {
   int lastUserIndex = -1;
   for (int i = messages.length - 1; i >= 0; i--) {
@@ -609,6 +661,14 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
     final outMsg = Map<String, dynamic>.from(m);
     outMsg.remove(multimodalInternalMediaPathsKey);
     outMsg['role'] = role;
+    if (stripUnsignedReasoningContent && role == 'assistant') {
+      final details = outMsg['reasoning_details'];
+      final hasSignedDetails = details is List && details.isNotEmpty;
+      if (!hasSignedDetails) {
+        outMsg.remove('reasoning_content');
+        outMsg.remove('reasoning');
+      }
+    }
     final internalMediaPaths =
         (m[multimodalInternalMediaPathsKey] as List?)
             ?.map((e) => e.toString().trim())
@@ -835,7 +895,6 @@ class _OpenAIProviderInfo {
 
   bool get needsReasoningEcho =>
       isDeepSeek || isMimo || isZhipu || isKimiThinkingModel;
-  bool get preserveReasoningDetails => isOpenRouter;
   String get completionTokensKey =>
       (isAzureOpenAI || isMimo) ? 'max_completion_tokens' : 'max_tokens';
 }
@@ -943,6 +1002,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
 }) async* {
   final upstreamModelId = _apiModelId(config, modelId);
   final url = _openAICompatibleUrl(config);
+  final isClaudeUpstream = upstreamModelId.toLowerCase().contains('claude');
 
   final effectiveInfo = _effectiveModelInfo(config, modelId);
   final isReasoning = effectiveInfo.abilities.contains(ModelAbility.reasoning);
@@ -960,8 +1020,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     upstreamModelId,
   );
   final bool needsReasoningEcho = info.needsReasoningEcho && isReasoning;
-  final bool preserveReasoningDetails =
-      info.preserveReasoningDetails && isReasoning;
+  final reasoningDetailsAllowSnapshots =
+      !BuiltInToolsHelper.isOpenRouterProvider(config);
   void setMaxTokens(Map<String, dynamic> map) {
     if (maxTokens != null) map[info.completionTokensKey] = maxTokens;
   }
@@ -1356,6 +1416,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         messages,
         userMediaPaths: userMediaPaths,
         canImageInput: canImageInput,
+        stripUnsignedReasoningContent: isClaudeUpstream,
       );
       body = {
         'model': upstreamModelId,
@@ -1660,9 +1721,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             content: msg['content'],
             reasoningContent: needsReasoningEcho ? reasoningForTools : null,
             includeEmptyReasoningContent: needsReasoningEcho,
-            reasoningDetails: preserveReasoningDetails
-                ? reasoningDetailsForTools
-                : null,
+            reasoningDetails: reasoningDetailsForTools,
           );
           next.add(assistantToolCallMsg);
           for (final r in results) {
@@ -1690,6 +1749,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   next,
                   userMediaPaths: userMediaPaths,
                   canImageInput: canImageInput,
+                  stripUnsignedReasoningContent: isClaudeUpstream,
                 );
           reqBody.remove('stream');
           req.body = jsonEncode(reqBody);
@@ -1737,6 +1797,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         }
         yield ChatStreamChunk(
           content: content,
+          reasoningDetails: cmsg?['reasoning_details'],
           isDone: true,
           totalTokens: aggUsage?.totalTokens ?? 0,
           usage: aggUsage,
@@ -1765,7 +1826,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
   final int approxPromptTokens = approxTokensFromChars(approxPromptChars);
   int approxCompletionChars = 0;
   String reasoningBuffer = '';
-  dynamic reasoningDetailsBuffer;
+  final reasoningDetailsBuffer = _ReasoningDetailsAccumulator(
+    allowSnapshots: reasoningDetailsAllowSnapshots,
+  );
   String assistantContentBuffer = '';
 
   // Track potential tool calls (OpenAI Chat Completions)
@@ -1867,9 +1930,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             content: assistantContentBuffer,
             reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
             includeEmptyReasoningContent: needsReasoningEcho,
-            reasoningDetails: preserveReasoningDetails
-                ? reasoningDetailsBuffer
-                : null,
+            reasoningDetails: reasoningDetailsBuffer.detailsOrNull,
           );
           mm2.add(assistantToolCallMsg);
           for (final r in results) {
@@ -1915,6 +1976,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       currentMessages,
                       userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
+                      stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
                     if (temperature != null) 'temperature': temperature,
@@ -1999,7 +2061,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             String? finishReason2;
             String contentAccum = ''; // Accumulate content for this round
             String reasoningAccum = '';
-            dynamic reasoningDetailsAccum;
+            final reasoningDetailsAccum = _ReasoningDetailsAccumulator(
+              allowSnapshots: reasoningDetailsAllowSnapshots,
+            );
             await for (final ch in _ensureTrailingNewline(s2)) {
               buf2 += ch;
               final lines2 = buf2.split('\n');
@@ -2095,15 +2159,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         reasoningAccum += rcMsg;
                       }
                     }
-                    if (preserveReasoningDetails) {
-                      final rd = delta?['reasoning_details'];
-                      if (rd is List && rd.isNotEmpty) {
-                        reasoningDetailsAccum = rd;
-                      }
-                      final rdMsg = message?['reasoning_details'];
-                      if (rdMsg is List && rdMsg.isNotEmpty) {
-                        reasoningDetailsAccum = rdMsg;
-                      }
+                    final rd = delta?['reasoning_details'];
+                    if (rd is List && rd.isNotEmpty) {
+                      reasoningDetailsAccum.add(rd);
+                    }
+                    final rdMsg = message?['reasoning_details'];
+                    if (rdMsg is List && rdMsg.isNotEmpty) {
+                      reasoningDetailsAccum.add(rdMsg);
                     }
                     // Handle image outputs from OpenRouter-style deltas
                     // Possible shapes:
@@ -2252,9 +2314,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 content: contentAccum,
                 reasoningContent: needsReasoningEcho ? reasoningAccum : null,
                 includeEmptyReasoningContent: needsReasoningEcho,
-                reasoningDetails: preserveReasoningDetails
-                    ? reasoningDetailsAccum
-                    : null,
+                reasoningDetails: reasoningDetailsAccum.detailsOrNull,
               );
               currentMessages = [
                 ...currentMessages,
@@ -2281,6 +2341,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   approxTokensFromChars(approxCompletionChars);
               yield ChatStreamChunk(
                 content: '',
+                reasoningDetails: reasoningDetailsAccum.detailsOrNull,
                 isDone: true,
                 totalTokens: usage?.totalTokens ?? approxTotal,
                 usage: usage,
@@ -2294,6 +2355,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             approxPromptTokens + approxTokensFromChars(approxCompletionChars);
         yield ChatStreamChunk(
           content: '',
+          reasoningDetails: reasoningDetailsBuffer.detailsOrNull,
           isDone: true,
           totalTokens: usage?.totalTokens ?? approxTotal,
           usage: usage,
@@ -3022,9 +3084,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 reasoning = rc;
                 if (needsReasoningEcho) reasoningBuffer += rc;
               }
-              if (preserveReasoningDetails) {
-                final rd = delta['reasoning_details'];
-                if (rd is List && rd.isNotEmpty) reasoningDetailsBuffer = rd;
+              final rdDelta = delta['reasoning_details'];
+              if (rdDelta is List && rdDelta.isNotEmpty) {
+                reasoningDetailsBuffer.add(rdDelta);
               }
 
               // images handling from delta (unchanged)
@@ -3089,10 +3151,10 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               }
             }
 
-            if (preserveReasoningDetails && message != null) {
+            if (message != null) {
               final rdMsg = message['reasoning_details'];
               if (rdMsg is List && rdMsg.isNotEmpty) {
-                reasoningDetailsBuffer = rdMsg;
+                reasoningDetailsBuffer.add(rdMsg);
               }
             }
 
@@ -3363,9 +3425,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             content: assistantContentBuffer,
             reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
             includeEmptyReasoningContent: needsReasoningEcho,
-            reasoningDetails: preserveReasoningDetails
-                ? reasoningDetailsBuffer
-                : null,
+            reasoningDetails: reasoningDetailsBuffer.detailsOrNull,
           );
           mm2.add(assistantToolCallMsg);
           for (final r in results) {
@@ -3410,6 +3470,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       currentMessages,
                       userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
+                      stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
                     if (temperature != null) 'temperature': temperature,
@@ -3485,7 +3546,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             String? finishReason2;
             String contentAccum = '';
             String reasoningAccum = '';
-            dynamic reasoningDetailsAccum;
+            final reasoningDetailsAccum = _ReasoningDetailsAccumulator(
+              allowSnapshots: reasoningDetailsAllowSnapshots,
+            );
             await for (final ch in _ensureTrailingNewline(s2)) {
               buf2 += ch;
               final lines2 = buf2.split('\n');
@@ -3652,15 +3715,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         reasoningAccum += rcMsg;
                       }
                     }
-                    if (preserveReasoningDetails) {
-                      final rd = delta?['reasoning_details'];
-                      if (rd is List && rd.isNotEmpty) {
-                        reasoningDetailsAccum = rd;
-                      }
-                      final rdMsg = message?['reasoning_details'];
-                      if (rdMsg is List && rdMsg.isNotEmpty) {
-                        reasoningDetailsAccum = rdMsg;
-                      }
+                    final rd = delta?['reasoning_details'];
+                    if (rd is List && rd.isNotEmpty) {
+                      reasoningDetailsAccum.add(rd);
+                    }
+                    final rdMsg = message?['reasoning_details'];
+                    if (rdMsg is List && rdMsg.isNotEmpty) {
+                      reasoningDetailsAccum.add(rdMsg);
                     }
                   }
                   // XinLiu compatibility for follow-up requests too
@@ -3760,9 +3821,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 content: contentAccum,
                 reasoningContent: needsReasoningEcho ? reasoningAccum : null,
                 includeEmptyReasoningContent: needsReasoningEcho,
-                reasoningDetails: preserveReasoningDetails
-                    ? reasoningDetailsAccum
-                    : null,
+                reasoningDetails: reasoningDetailsAccum.detailsOrNull,
               );
               currentMessages = [
                 ...currentMessages,
@@ -3787,6 +3846,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   approxTokensFromChars(approxCompletionChars);
               yield ChatStreamChunk(
                 content: '',
+                reasoningDetails: reasoningDetailsAccum.detailsOrNull,
                 isDone: true,
                 totalTokens: usage?.totalTokens ?? approxTotal,
                 usage: usage,
@@ -3880,9 +3940,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 content: assistantContentBuffer,
                 reasoningContent: needsReasoningEcho ? reasoningBuffer : null,
                 includeEmptyReasoningContent: needsReasoningEcho,
-                reasoningDetails: preserveReasoningDetails
-                    ? reasoningDetailsBuffer
-                    : null,
+                reasoningDetails: reasoningDetailsBuffer.detailsOrNull,
               );
               mm2.add(assistantToolCallMsg);
               for (final r in results) {
@@ -4003,7 +4061,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                 String? finishReason2;
                 String contentAccum = '';
                 String reasoningAccum = '';
-                dynamic reasoningDetailsAccum;
+                final reasoningDetailsAccum = _ReasoningDetailsAccumulator(
+                  allowSnapshots: reasoningDetailsAllowSnapshots,
+                );
                 await for (final ch in _ensureTrailingNewline(s2)) {
                   buf2 += ch;
                   final lines2 = buf2.split('\n');
@@ -4145,15 +4205,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                             reasoningAccum += rcMsg;
                           }
                         }
-                        if (preserveReasoningDetails) {
-                          final rd = delta?['reasoning_details'];
-                          if (rd is List && rd.isNotEmpty) {
-                            reasoningDetailsAccum = rd;
-                          }
-                          final rdMsg = message?['reasoning_details'];
-                          if (rdMsg is List && rdMsg.isNotEmpty) {
-                            reasoningDetailsAccum = rdMsg;
-                          }
+                        final rd = delta?['reasoning_details'];
+                        if (rd is List && rd.isNotEmpty) {
+                          reasoningDetailsAccum.add(rd);
+                        }
+                        final rdMsg = message?['reasoning_details'];
+                        if (rdMsg is List && rdMsg.isNotEmpty) {
+                          reasoningDetailsAccum.add(rdMsg);
                         }
                       }
                       // XinLiu compatibility for follow-up requests too
@@ -4256,9 +4314,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         ? reasoningAccum
                         : null,
                     includeEmptyReasoningContent: needsReasoningEcho,
-                    reasoningDetails: preserveReasoningDetails
-                        ? reasoningDetailsAccum
-                        : null,
+                    reasoningDetails: reasoningDetailsAccum.detailsOrNull,
                   );
                   currentMessages = [
                     ...currentMessages,
@@ -4283,6 +4339,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       approxTokensFromChars(approxCompletionChars);
                   yield ChatStreamChunk(
                     content: '',
+                    reasoningDetails: reasoningDetailsAccum.detailsOrNull,
                     isDone: true,
                     totalTokens: usage?.totalTokens ?? approxTotal,
                     usage: usage,
@@ -4315,6 +4372,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       (approxPromptTokens + approxTokensFromChars(approxCompletionChars));
   yield ChatStreamChunk(
     content: '',
+    reasoningDetails: reasoningDetailsBuffer.detailsOrNull,
     isDone: true,
     totalTokens: approxTotal,
     usage: usage,

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -1183,6 +1183,15 @@ class ChatActions {
           )
         : '';
 
+    // Persist vendor reasoning details (may carry thinking signatures) so
+    // they can be echoed back on subsequent turns.
+    if (chunk.reasoningDetails != null) {
+      streamController.setReasoningDetails(
+        state.messageId,
+        chunk.reasoningDetails,
+      );
+    }
+
     // Handle reasoning
     if ((chunk.reasoning ?? '').isNotEmpty && state.ctx.supportsReasoning) {
       await _handleReasoningChunk(chunk, state);
@@ -1320,6 +1329,7 @@ class ChatActions {
               contentSplitOffsets: state.contentSplitOffsets,
               reasoningCountAtSplit: state.reasoningCountAtSplit,
               toolCountAtSplit: state.toolCountAtSplit,
+              reasoningDetails: streamController.reasoningDetails[messageId],
             ),
       );
     }
@@ -1852,6 +1862,8 @@ class ChatActions {
                 toolCountAtSplit: streamController
                     .getContentSplitData(streaming.id)
                     ?.toolCounts,
+                reasoningDetails:
+                    streamController.reasoningDetails[streaming.id],
               ),
         );
       } else if (streamController.getContentSplitData(streaming.id) != null) {
@@ -1864,6 +1876,8 @@ class ChatActions {
                 contentSplitOffsets: splits.offsets,
                 reasoningCountAtSplit: splits.reasoningCounts,
                 toolCountAtSplit: splits.toolCounts,
+                reasoningDetails:
+                    streamController.reasoningDetails[streaming.id],
               ),
         );
       }

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -109,6 +109,18 @@ class StreamController {
   final Map<String, String> _geminiThoughtSigs = <String, String>{};
   Map<String, String> get geminiThoughtSigs => _geminiThoughtSigs;
 
+  /// Vendor reasoning details (OpenRouter-style `reasoning_details`, may carry
+  /// thinking signatures) per assistant message. Persisted inside the
+  /// reasoningSegmentsJson payload so they can be echoed back on later turns.
+  final Map<String, dynamic> _reasoningDetails = <String, dynamic>{};
+  Map<String, dynamic> get reasoningDetails => _reasoningDetails;
+
+  /// Store the latest reasoning details snapshot for a message.
+  void setReasoningDetails(String messageId, dynamic details) {
+    if (details == null) return;
+    _reasoningDetails[messageId] = details;
+  }
+
   // ============================================================================
   // Throttle State
   // ============================================================================
@@ -216,6 +228,7 @@ class StreamController {
     _contentSplits.remove(messageId);
     _toolParts.remove(messageId);
     _geminiThoughtSigs.remove(messageId);
+    _reasoningDetails.remove(messageId);
     _cleanupStreamTimers(messageId);
   }
 
@@ -226,6 +239,7 @@ class StreamController {
     _contentSplits.clear();
     _toolParts.clear();
     _geminiThoughtSigs.clear();
+    _reasoningDetails.clear();
     _cancelAllTimers();
     streamingContentNotifier.clear();
   }
@@ -297,6 +311,7 @@ class StreamController {
     List<int>? contentSplitOffsets,
     List<int>? reasoningCountAtSplit,
     List<int>? toolCountAtSplit,
+    dynamic reasoningDetails,
   }) {
     final list = segments
         .map(
@@ -312,7 +327,8 @@ class StreamController {
 
     if (contentSplitOffsets == null &&
         reasoningCountAtSplit == null &&
-        toolCountAtSplit == null) {
+        toolCountAtSplit == null &&
+        reasoningDetails == null) {
       return _encodeJson(list);
     }
 
@@ -332,7 +348,23 @@ class StreamController {
         'reasoningCounts': normalized.reasoningCounts,
         'toolCounts': normalized.toolCounts,
       },
+      if (reasoningDetails != null) 'reasoningDetails': reasoningDetails,
     });
+  }
+
+  /// Extract persisted vendor reasoning details (if any) from a serialized
+  /// reasoningSegmentsJson payload.
+  dynamic deserializeReasoningDetails(String? json) {
+    if (json == null || json.isEmpty) return null;
+    try {
+      final decoded = _decodeJson(json);
+      if (decoded is! Map<String, dynamic>) return null;
+      final details = decoded['reasoningDetails'];
+      if (details is List && details.isNotEmpty) return details;
+      return null;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// Deserialize reasoning segments from JSON string.
@@ -1293,6 +1325,12 @@ class StreamController {
     );
     if (contentSplits != null) {
       _contentSplits[messageId] = contentSplits;
+    }
+
+    // Restore vendor reasoning details (thinking signatures) for API replays
+    final details = deserializeReasoningDetails(message.reasoningSegmentsJson);
+    if (details != null) {
+      _reasoningDetails[messageId] = details;
     }
   }
 

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -128,6 +128,10 @@ class MessageBuilderService {
 
     for (final m in source) {
       String? toolContinuationReasoningContent;
+      dynamic reasoningDetails;
+      if (m.role == 'assistant') {
+        reasoningDetails = _reasoningDetailsForApi(m);
+      }
       if (includeToolMessages && m.role == 'assistant') {
         final events = chatService.getToolEvents(m.id);
         if (events.isNotEmpty) {
@@ -206,6 +210,9 @@ class MessageBuilderService {
       if (toolContinuationReasoningContent?.isNotEmpty == true) {
         message['reasoning_content'] = toolContinuationReasoningContent;
       }
+      if (reasoningDetails != null) {
+        message['reasoning_details'] = reasoningDetails;
+      }
       out.add(message);
     }
 
@@ -218,6 +225,30 @@ class MessageBuilderService {
       if (candidate.id == message.id) return candidate;
     }
     return null;
+  }
+
+  /// Extract persisted vendor reasoning details (OpenRouter-style
+  /// `reasoning_details`, may carry thinking signatures) so they can be
+  /// echoed back to the provider on later turns.
+  dynamic _reasoningDetailsForApi(ChatMessage message) {
+    dynamic pick(ChatMessage candidate) {
+      final raw = (candidate.reasoningSegmentsJson ?? '').trim();
+      if (raw.isEmpty) return null;
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is! Map) return null;
+        final details = decoded['reasoningDetails'];
+        if (details is List && details.isNotEmpty) return details;
+      } catch (_) {}
+      return null;
+    }
+
+    final fromMessage = pick(message);
+    if (fromMessage != null) return fromMessage;
+
+    final persisted = _latestPersistedMessage(message);
+    if (persisted == null) return null;
+    return pick(persisted);
   }
 
   String _reasoningContentForToolContinuation(ChatMessage message) {

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -254,6 +254,61 @@ void main() {
       expect(finalAssistantMessage.containsKey('reasoning_content'), isFalse);
     });
 
+    test('reasoning_details 只挂在最终 assistant 消息，不重复到 tool call 消息', () {
+      final service = MessageBuilderService(
+        chatService: _FakeChatService({
+          'a1': [
+            {
+              'id': 'call_1',
+              'name': 'get_weather',
+              'arguments': {'location': 'Hangzhou'},
+              'content': 'Cloudy 7~13°C',
+            },
+          ],
+        }),
+        contextProvider: _FakeBuildContext(),
+      );
+
+      const reasoningDetails = [
+        {
+          'type': 'reasoning.text',
+          'text': 'final round thinking',
+          'signature': 'sig-final',
+        },
+      ];
+      final apiMessages = service.buildApiMessages(
+        messages: [
+          _message(id: 'u1', role: 'user', content: '杭州明天天气怎么样？'),
+          ChatMessage(
+            id: 'a1',
+            role: 'assistant',
+            content: '明天多云，7 到 13 度。',
+            conversationId: 'conversation-1',
+            reasoningSegmentsJson:
+                '{"v":2,"segments":[],"reasoningDetails":[{"type":"reasoning.text","text":"final round thinking","signature":"sig-final"}]}',
+          ),
+        ],
+        versionSelections: const {},
+        currentConversation: Conversation(title: 'test'),
+        includeToolMessages: true,
+      );
+
+      final assistantToolMessage = apiMessages.firstWhere(
+        (message) =>
+            message['role'] == 'assistant' && message['tool_calls'] is List,
+      );
+      final finalAssistantMessage = apiMessages.lastWhere(
+        (message) =>
+            message['role'] == 'assistant' && message['tool_calls'] == null,
+      );
+
+      // Replaying the same reasoning on both assistant messages makes
+      // OpenRouter/Anthropic reject the history; only the final message may
+      // carry it.
+      expect(assistantToolMessage.containsKey('reasoning_details'), isFalse);
+      expect(finalAssistantMessage['reasoning_details'], reasoningDetails);
+    });
+
     test('恢复工具回答续写时只发送 tool call 和 tool result', () {
       final service = MessageBuilderService(
         chatService: _FakeChatService({


### PR DESCRIPTION
Manual port of upstream cbac3dc3 for cuplivo-next. Adds reasoning details accumulation, persistence, and echo-back across all provider paths.