### PR TITLE
feat(models): adapt latest model capabilities

### DIFF
--- a/lib/core/providers/model_provider.dart
+++ b/lib/core/providers/model_provider.dart
@@ -17,7 +17,7 @@ class ModelRegistry {
   // Vision-capable models (text + image input)
   static final RegExp vision = RegExp(
     // GPT family incl. 4o, 4.1, 5 (exclude gpt-5-chat), and OpenAI o* series
-    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|kimi-k2([-.])(?:5|6|7)|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
+    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|kimi-k2([-.])(?:5|6|7)|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|muse-spark-1\.1(?:$|[/_:@.-])|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite)',
     caseSensitive: false,
   );
   // Tool-using models
@@ -25,6 +25,7 @@ class ModelRegistry {
     (r'(gpt-4o|gpt-4\.1|gpt-oss|gpt-5(?!-chat)|o\d|'
             r'gemini|claude|'
             r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
+            r'muse-spark-1\.1(?:$|[/_:@.-])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3|chat|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -41,6 +42,7 @@ class ModelRegistry {
             r'gemma[-_]?4|'
             r'claude|'
             r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
+            r'muse-spark-1\.1(?:$|[/_:@.-])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -296,11 +298,15 @@ class GoogleProvider extends BaseProvider {
       // we manually inject known supported Claude models for convenience.
       if (cfg.vertexAI == true) {
         final knownClaude = [
+          'claude-fable-5',
+          'claude-opus-5',
+          'claude-opus-4-8',
           'claude-opus-4-7',
           'claude-opus-4-6',
           'claude-opus-4-5@20251101',
           'claude-opus-4-1@20250805',
           'claude-opus-4@20250514',
+          'claude-sonnet-5',
           'claude-sonnet-4-6',
           'claude-sonnet-4-5@20250929',
           'claude-sonnet-4@20250514',

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -465,6 +465,12 @@ class SettingsProvider extends ChangeNotifier {
     final lower = modelId.trim().toLowerCase();
     if (!lower.contains('claude-')) return false;
     if (lower.contains('fable') || lower.contains('mythos')) return true;
+    if (RegExp(
+      r'claude-(?:opus|sonnet)-5(?:$|[._:@/-])',
+      caseSensitive: false,
+    ).hasMatch(lower)) {
+      return true;
+    }
     final m = RegExp(
       r'claude-(opus|sonnet)-(\d+)[-.](\d+)',
       caseSensitive: false,
@@ -489,6 +495,12 @@ class SettingsProvider extends ChangeNotifier {
     final lower = modelId.trim().toLowerCase();
     if (!lower.contains('claude-')) return false;
     if (lower.contains('fable') || lower.contains('mythos')) return true;
+    if (RegExp(
+      r'claude-(?:opus|sonnet)-5(?:$|[._:@/-])',
+      caseSensitive: false,
+    ).hasMatch(lower)) {
+      return true;
+    }
     final m = RegExp(
       r'claude-(opus|sonnet)-(\d+)[-.](\d+)',
       caseSensitive: false,

--- a/lib/core/services/api/builtin_tools.dart
+++ b/lib/core/services/api/builtin_tools.dart
@@ -169,9 +169,11 @@ abstract class BuiltInToolsHelper {
     if (normalized.contains('mythos')) return true;
     const supported = <String>{
       'claude-fable-5',
+      'claude-opus-5',
       'claude-opus-4-8',
       'claude-opus-4-7',
       'claude-opus-4-6',
+      'claude-sonnet-5',
       'claude-sonnet-4-5-20250929',
       'claude-sonnet-4-20250514',
       'claude-3-7-sonnet-20250219',
@@ -188,9 +190,11 @@ abstract class BuiltInToolsHelper {
     final normalized = _normalizedModelId(modelId);
     return normalized.contains('mythos') ||
         normalized == 'claude-fable-5' ||
+        normalized == 'claude-opus-5' ||
         normalized == 'claude-opus-4-8' ||
         normalized == 'claude-opus-4-7' ||
         normalized == 'claude-opus-4-6' ||
+        normalized == 'claude-sonnet-5' ||
         normalized == 'claude-sonnet-4-6';
   }
 

--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -1216,10 +1216,18 @@ class ChatApiService {
         providerName.contains('deepseek');
   }
 
+  static bool _isClaude5AdaptiveThinkingModel(String modelId) {
+    return RegExp(
+      r'claude-(?:opus|sonnet)-5(?:$|[._:@/-])',
+      caseSensitive: false,
+    ).hasMatch(modelId.trim());
+  }
+
   static bool _supportsClaudeAdaptiveThinking(String modelId) {
     final lower = modelId.trim().toLowerCase();
     if (!lower.contains('claude-')) return false;
     if (lower.contains('fable') || lower.contains('mythos')) return true;
+    if (_isClaude5AdaptiveThinkingModel(lower)) return true;
     final m = RegExp(
       r'claude-(opus|sonnet)-(\d+)[-.](\d+)',
       caseSensitive: false,
@@ -1238,6 +1246,7 @@ class ChatApiService {
     final lower = modelId.trim().toLowerCase();
     if (!lower.contains('claude-')) return false;
     if (lower.contains('fable') || lower.contains('mythos')) return true;
+    if (_isClaude5AdaptiveThinkingModel(lower)) return true;
     final m = RegExp(
       r'claude-(opus|sonnet)-(\d+)[-.](\d+)',
       caseSensitive: false,
@@ -1282,6 +1291,7 @@ class ChatApiService {
 
     final lower = modelId.trim().toLowerCase();
     final supportsXhigh =
+        _isClaude5AdaptiveThinkingModel(lower) ||
         lower.contains('claude-opus-4-7') ||
         lower.contains('claude-opus-4.7') ||
         lower.contains('claude-opus-4-8') ||
@@ -1372,6 +1382,12 @@ class ChatApiService {
 
   static bool _claudeShouldOmitSamplingParams(String modelId, int? budget) {
     if (_isClaudeThinkingAlwaysOnModel(modelId)) return true;
+    final lower = modelId.trim().toLowerCase();
+    if (_isClaude5AdaptiveThinkingModel(lower) ||
+        lower.contains('claude-opus-4-8') ||
+        lower.contains('claude-opus-4.8')) {
+      return true;
+    }
     return _isClaudeAdaptiveOnlyThinkingModel(modelId) &&
         _isClaudeReasoningEnabled(budget);
   }

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -1,5 +1,16 @@
 part of '../chat_api_service.dart';
 
+int _defaultClaudeMaxOutputTokens(String modelId) {
+  final lower = modelId.trim().toLowerCase();
+  if (RegExp(
+    r'claude-(?:fable-5|mythos-5|opus-(?:5|4-8)|sonnet-5)(?:$|[._:@/-])',
+    caseSensitive: false,
+  ).hasMatch(lower)) {
+    return 128000;
+  }
+  return 64000;
+}
+
 int _readClaudeUsageInt(dynamic value) {
   if (value is num) return value.toInt();
   if (value is String) return int.tryParse(value) ?? 0;
@@ -356,7 +367,7 @@ Stream<ChatStreamChunk> _sendClaudeStream(
     // Prepare request body per round
     final body = <String, dynamic>{
       'model': upstreamModelId,
-      'max_tokens': maxTokens ?? 64000,
+      'max_tokens': maxTokens ?? _defaultClaudeMaxOutputTokens(upstreamModelId),
       'messages': convo,
       'stream': stream,
       if (systemPrompt.isNotEmpty) 'system': systemPrompt,

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -54,6 +54,18 @@ bool _isGemini35FlashModel(String modelId) {
   );
 }
 
+bool _isGemini35FlashLiteModel(String modelId) {
+  return modelId.contains(
+    RegExp(r'gemini-3\.5-flash-lite([._:@/-]|$)', caseSensitive: false),
+  );
+}
+
+bool _isGemini36FlashModel(String modelId) {
+  return modelId.contains(
+    RegExp(r'gemini-3\.6-flash([._:@/-]|$)', caseSensitive: false),
+  );
+}
+
 bool _isGemini3TextModel(String modelId) {
   return modelId.contains(
     RegExp(r'gemini-3(?:\.\d+)?-(?!pro-image)', caseSensitive: false),
@@ -91,6 +103,8 @@ Map<String, dynamic> _googleThinkingConfig(
     RegExp(r'gemini-3-flash(-preview)?', caseSensitive: false),
   );
   final isGemini35Flash = _isGemini35FlashModel(upstreamModelId);
+  final isGemini35FlashLite = _isGemini35FlashLiteModel(upstreamModelId);
+  final isGemini36Flash = _isGemini36FlashModel(upstreamModelId);
   if (isGemini3ProImage) {
     return {
       'includeThoughts': true,
@@ -120,9 +134,12 @@ Map<String, dynamic> _googleThinkingConfig(
     }
     return {'includeThoughts': true, 'thinkingLevel': level};
   }
-  // Gemini 3 Flash and 3.5 Flash: supports 'minimal', 'low', 'medium', 'high'
-  if (isGemini3Flash || isGemini35Flash) {
-    String level = isGemini35Flash ? 'medium' : 'high';
+  // Gemini 3 Flash, 3.5 Flash/Lite, and 3.6 Flash support
+  // 'minimal', 'low', 'medium', and 'high'.
+  if (isGemini3Flash || isGemini35Flash || isGemini36Flash) {
+    String level = isGemini35FlashLite
+        ? 'minimal'
+        : (isGemini35Flash || isGemini36Flash ? 'medium' : 'high');
     if (off) {
       level = 'minimal';
     } else if (budget != null && budget > 0) {
@@ -248,7 +265,10 @@ Map<String, dynamic> _googleApiPart(Map part) {
 }
 
 int? _defaultGeminiMaxOutputTokens(String upstreamModelId) {
-  if (_isGemini35FlashModel(upstreamModelId)) return 65536;
+  if (_isGemini35FlashModel(upstreamModelId) ||
+      _isGemini36FlashModel(upstreamModelId)) {
+    return 65536;
+  }
   return null;
 }
 

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -89,9 +89,11 @@ int _getMaxOutputTokensForClaudeModel(String modelId) {
   // Limits based on Google Vertex AI documentation
   switch (modelId) {
     case 'claude-fable-5':
+    case 'claude-opus-5':
     case 'claude-opus-4-8':
     case 'claude-opus-4-7':
     case 'claude-opus-4-6':
+    case 'claude-sonnet-5':
     case 'claude-sonnet-4-6':
       return 128000;
     case 'claude-opus-4-5@20251101':

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -120,9 +120,38 @@ bool _isKimiK25Model(String upstreamModelId) {
   return upstreamModelId.toLowerCase().contains('kimi-k2.5');
 }
 
+bool _isKimiK3Model(String upstreamModelId) {
+  final trimmed = upstreamModelId.trim();
+  return RegExp(
+        r'(^|[/_:@])kimi-k3(?:$|[-.])',
+        caseSensitive: false,
+      ).hasMatch(trimmed) ||
+      RegExp(
+        r'(?:^|[-_/])k3(?:$|[-.])',
+        caseSensitive: false,
+      ).hasMatch(trimmed);
+}
+
+bool _isRemoteHttpUrl(String source) {
+  final normalized = source.trim().toLowerCase();
+  return normalized.startsWith('http://') || normalized.startsWith('https://');
+}
+
+bool _isRemoteImageContentPart(dynamic part) {
+  if (part is! Map) return false;
+  final type = (part['type'] ?? '').toString().trim().toLowerCase();
+  if (type != 'image_url' && type != 'input_image') return false;
+
+  final imageUrl = part['image_url'];
+  final rawUrl = imageUrl is Map ? imageUrl['url'] : imageUrl;
+  return rawUrl is String && _isRemoteHttpUrl(rawUrl);
+}
+
 bool _isKimiOmitsSamplingParamsModel(String upstreamModelId) {
   final lower = upstreamModelId.toLowerCase();
-  return lower.contains('kimi-k2.5') || lower.contains('kimi-k2.7');
+  return lower.contains('kimi-k2.5') ||
+      lower.contains('kimi-k2.7') ||
+      _isKimiK3Model(lower);
 }
 
 bool _isKimiThinkingModel(String upstreamModelId) {
@@ -130,7 +159,8 @@ bool _isKimiThinkingModel(String upstreamModelId) {
   return lower.contains('kimi-k2-thinking') ||
       lower.contains('kimi-k2.5') ||
       lower.contains('kimi-k2.6') ||
-      lower.contains('kimi-k2.7');
+      lower.contains('kimi-k2.7') ||
+      _isKimiK3Model(lower);
 }
 
 void _removeMoonshotKimiUnsupportedSamplingParams(Map<String, dynamic> body) {
@@ -139,19 +169,6 @@ void _removeMoonshotKimiUnsupportedSamplingParams(Map<String, dynamic> body) {
   body.remove('n');
   body.remove('presence_penalty');
   body.remove('frequency_penalty');
-}
-
-void _sanitizeAlwaysStripSamplingParams(
-  Map<String, dynamic> body,
-  String upstreamModelId,
-) {
-  if (!openAIAlwaysStripsSamplingParams(upstreamModelId)) return;
-  body.remove('temperature');
-  body.remove('top_p');
-  body.remove('n');
-  body.remove('presence_penalty');
-  body.remove('frequency_penalty');
-  body.remove('logprobs');
 }
 
 bool _isZhipuLikeProvider({
@@ -175,6 +192,27 @@ void _normalizeMoonshotKimiChatBody(
   int? thinkingBudget,
 }) {
   if (!_isKimiThinkingModel(upstreamModelId)) return;
+
+  if (_isKimiK3Model(upstreamModelId)) {
+    body.remove('thinking');
+    _removeMoonshotKimiUnsupportedSamplingParams(body);
+    if (!isReasoning) {
+      body.remove('reasoning_effort');
+      return;
+    }
+    final rawEffort = body['reasoning_effort'];
+    if (rawEffort is! String || rawEffort.trim().isEmpty) {
+      body.remove('reasoning_effort');
+      return;
+    }
+    final effort = openAINormalizeReasoningEffort(rawEffort, upstreamModelId);
+    if (effort == 'auto') {
+      body.remove('reasoning_effort');
+    } else {
+      body['reasoning_effort'] = effort;
+    }
+    return;
+  }
 
   body.remove('reasoning_effort');
   if (!isReasoning) {
@@ -277,13 +315,14 @@ Map<String, dynamic> _buildAssistantToolCallMessage({
 
 String _openAIEffortForBudget(int? budget, String upstreamModelId) {
   final baseEffort = _effortForBudget(budget);
-  final requestedEffort = baseEffort == 'high' && budget != null
-      ? budget >= 128000
-            ? 'max'
-            : budget >= 64000
-            ? 'xhigh'
-            : baseEffort
-      : baseEffort;
+  var requestedEffort = baseEffort;
+  if (baseEffort == 'high' && budget != null) {
+    if (budget >= 128000 && openAISupportsMaxReasoning(upstreamModelId)) {
+      requestedEffort = 'max';
+    } else if (budget >= 64000) {
+      requestedEffort = 'xhigh';
+    }
+  }
   return openAINormalizeReasoningEffort(requestedEffort, upstreamModelId);
 }
 
@@ -312,9 +351,8 @@ bool _allowsSamplingParamsForOpenAIModel(
   String upstreamModelId, {
   required String effort,
 }) {
-  // Source: https://developers.openai.com/api/docs/guides/latest-model#gpt-54-parameter-compatibility
-  // Only the documented GPT-5.2 / GPT-5.4 base-model compatibility rules are
-  // enforced here; other GPT-5 variants keep their request body unchanged.
+  // Source: https://developers.openai.com/api/docs/guides/latest-model
+  // Only documented per-model compatibility rules are enforced here.
   return openAIAllowsSamplingParams(upstreamModelId, effort: effort);
 }
 
@@ -325,6 +363,14 @@ void _sanitizeOpenAIGpt5SamplingParams(
 }) {
   // Must run on the final request body (after override merges), otherwise
   // we may keep/drop sampling params based on stale effort assumptions.
+  final hasChatFunctionTools =
+      body['messages'] is List &&
+      body['tools'] is List &&
+      (body['tools'] as List).isNotEmpty;
+  if (hasChatFunctionTools &&
+      openAIChatCompletionsToolsRequireNone(upstreamModelId)) {
+    body['reasoning_effort'] = 'none';
+  }
   if (!body.containsKey('temperature') &&
       !body.containsKey('top_p') &&
       !body.containsKey('logprobs')) {
@@ -639,6 +685,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
   List<Map<String, dynamic>> messages, {
   List<String>? userMediaPaths,
   required bool canImageInput,
+  required bool allowRemoteImages,
   bool stripUnsignedReasoningContent = false,
 }) async {
   int lastUserIndex = -1;
@@ -677,7 +724,13 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
         const <String>[];
 
     if (originalContent is List) {
-      outMsg['content'] = canImageInput ? originalContent : raw;
+      outMsg['content'] = canImageInput
+          ? (allowRemoteImages
+                ? originalContent
+                : originalContent
+                      .where((part) => !_isRemoteImageContentPart(part))
+                      .toList(growable: false))
+          : raw;
       out.add(outMsg);
       continue;
     }
@@ -713,7 +766,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
 
     final parsed = await _parseTextAndImages(
       raw,
-      allowRemoteImages: canImageInput,
+      allowRemoteImages: canImageInput && allowRemoteImages,
       allowLocalImages: canImageInput,
       allowDataImages: canImageInput,
       keepRemoteMarkdownText: true,
@@ -741,6 +794,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
 
     void addImageUrl(String url) {
       if (url.isEmpty) return;
+      if (!allowRemoteImages && _isRemoteHttpUrl(url)) return;
       if (seenImageUrls.add(url)) {
         parts.add({
           'type': 'image_url',
@@ -781,9 +835,10 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
         if (isLastUser && userMediaPaths != null) ...userMediaPaths,
       ];
       for (final p in allMediaPaths) {
+        if (!allowRemoteImages && _isRemoteHttpUrl(p)) continue;
         final normalized = normalizeSrc(p);
         if (!seenSources.add(normalized)) continue;
-        final bool isInlineUrl = p.startsWith('http') || p.startsWith('data:');
+        final bool isInlineUrl = _isRemoteHttpUrl(p) || p.startsWith('data:');
         final String mime = isInlineUrl
             ? _mimeFromDataUrl(p)
             : _mimeFromPath(p);
@@ -874,7 +929,8 @@ class _OpenAIProviderInfo {
   bool get isSiliconFlow =>
       providerId.contains('siliconflow') || host.contains('siliconflow');
   bool get isAzureOpenAI => host.contains('openai.azure.com');
-  bool get isOpenRouter => host.contains('openrouter.ai');
+  bool get isOpenRouter =>
+      providerId.contains('openrouter') || host.contains('openrouter.ai');
   bool get isDeepSeek =>
       host.contains('deepseek') ||
       upstreamModelId.toLowerCase().contains('deepseek');
@@ -887,11 +943,7 @@ class _OpenAIProviderInfo {
       host.contains('intern-ai') ||
       host.contains('intern') ||
       host.contains('chat.intern-ai.org.cn');
-  bool get isKimiThinkingModel =>
-      upstreamModelId.toLowerCase().contains('kimi-k2-thinking') ||
-      upstreamModelId.toLowerCase().contains('kimi-k2.5') ||
-      upstreamModelId.toLowerCase().contains('kimi-k2.6') ||
-      upstreamModelId.toLowerCase().contains('kimi-k2.7');
+  bool get isKimiThinkingModel => _isKimiThinkingModel(upstreamModelId);
 
   bool get needsReasoningEcho =>
       isDeepSeek || isMimo || isZhipu || isKimiThinkingModel;
@@ -908,7 +960,11 @@ void _applyVendorReasoningKnobs(
   final off = _isOff(thinkingBudget);
   if (info.isOpenRouter) {
     if (isReasoning) {
-      if (off) {
+      final support = openAIReasoningSupport(info.upstreamModelId);
+      final requestedEffort = body['reasoning_effort'];
+      if (support?.offFallback != null && requestedEffort is String) {
+        body['reasoning'] = {'effort': requestedEffort};
+      } else if (off) {
         body['reasoning'] = {'enabled': false};
       } else {
         final obj = <String, dynamic>{'enabled': true};
@@ -1008,6 +1064,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
   final isReasoning = effectiveInfo.abilities.contains(ModelAbility.reasoning);
   final wantsImageOutput = effectiveInfo.output.contains(Modality.image);
   final bool canImageInput = effectiveInfo.input.contains(Modality.image);
+  final bool allowRemoteImages =
+      canImageInput && !_isKimiK3Model(upstreamModelId);
 
   final effort = _openAIEffortForBudget(thinkingBudget, upstreamModelId);
   final info = _OpenAIProviderInfo(
@@ -1203,7 +1261,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           shouldAttachAssistantImage) {
         final parsed = await _parseTextAndImages(
           raw,
-          allowRemoteImages: canImageInput,
+          allowRemoteImages: allowRemoteImages,
           allowLocalImages: canImageInput,
           allowDataImages: canImageInput,
           keepRemoteMarkdownText: true,
@@ -1239,6 +1297,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
 
         void addImage(String url) {
           if (url.isEmpty) return;
+          if (!allowRemoteImages && _isRemoteHttpUrl(url)) return;
           if (seenImageUrls.add(url)) {
             parts.add({'type': 'input_image', 'image_url': url});
           }
@@ -1273,10 +1332,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         // Additional media explicitly attached to the last user message
         if (hasAttachedImages) {
           for (final p in userMediaPaths!) {
+            if (!allowRemoteImages && _isRemoteHttpUrl(p)) continue;
             final normalized = normalizeSrc(p);
             if (!seenImageSources.add(normalized)) continue;
             final bool isInlineUrl =
-                p.startsWith('http') || p.startsWith('data:');
+                _isRemoteHttpUrl(p) || p.startsWith('data:');
             final String mime = isInlineUrl
                 ? _mimeFromDataUrl(p)
                 : _mimeFromPath(p);
@@ -1416,6 +1476,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         messages,
         userMediaPaths: userMediaPaths,
         canImageInput: canImageInput,
+        allowRemoteImages: allowRemoteImages,
         stripUnsignedReasoningContent: isClaudeUpstream,
       );
       body = {
@@ -1498,7 +1559,6 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     upstreamModelId,
     fallbackEffort: effort,
   );
-  _sanitizeAlwaysStripSamplingParams(body, upstreamModelId);
   _normalizeMoonshotKimiChatBody(
     body,
     upstreamModelId: upstreamModelId,
@@ -1749,6 +1809,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   next,
                   userMediaPaths: userMediaPaths,
                   canImageInput: canImageInput,
+                  allowRemoteImages: allowRemoteImages,
                   stripUnsignedReasoningContent: isClaudeUpstream,
                 );
           reqBody.remove('stream');
@@ -1976,6 +2037,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       currentMessages,
                       userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
+                      allowRemoteImages: allowRemoteImages,
                       stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
@@ -2027,7 +2089,6 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               upstreamModelId,
               fallbackEffort: effort,
             );
-            _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
             _normalizeMoonshotKimiChatBody(
               body2,
               upstreamModelId: upstreamModelId,
@@ -2377,7 +2438,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               content = delta;
               approxCompletionChars += content.length;
             }
-          } else if (type == 'response.reasoning_summary_text.delta') {
+          } else if (type == 'response.reasoning_summary_text.delta' ||
+              type == 'response.reasoning_text.delta') {
             final delta = json['delta'];
             if (delta is String) reasoning = delta;
           } else if (type == 'response.output_item.added') {
@@ -2775,7 +2837,6 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   upstreamModelId,
                   fallbackEffort: effort,
                 );
-                _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
 
                 final req2 = http.Request('POST', url);
                 final headers2 = <String, String>{
@@ -3470,6 +3531,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       currentMessages,
                       userMediaPaths: userMediaPaths,
                       canImageInput: canImageInput,
+                      allowRemoteImages: allowRemoteImages,
                       stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
@@ -3515,7 +3577,6 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               upstreamModelId,
               fallbackEffort: effort,
             );
-            _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
             _normalizeMoonshotKimiChatBody(
               body2,
               upstreamModelId: upstreamModelId,
@@ -3985,6 +4046,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                           currentMessages,
                           userMediaPaths: userMediaPaths,
                           canImageInput: canImageInput,
+                          allowRemoteImages: allowRemoteImages,
+                          stripUnsignedReasoningContent: isClaudeUpstream,
                         ),
                         'stream': true,
                         if (temperature != null) 'temperature': temperature,
@@ -4029,7 +4092,6 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   upstreamModelId,
                   fallbackEffort: effort,
                 );
-                _sanitizeAlwaysStripSamplingParams(body2, upstreamModelId);
                 _normalizeMoonshotKimiChatBody(
                   body2,
                   upstreamModelId: upstreamModelId,

--- a/lib/core/utils/openai_model_compat.dart
+++ b/lib/core/utils/openai_model_compat.dart
@@ -2,12 +2,16 @@ class OpenAIReasoningSupport {
   const OpenAIReasoningSupport({
     required this.supportedEfforts,
     this.samplingRequiresNone = false,
-    this.alwaysStripSampling = false,
+    this.samplingAllowsAuto = true,
+    this.effortParameterSupported = true,
+    this.offFallback,
   });
 
   final List<String> supportedEfforts;
   final bool samplingRequiresNone;
-  final bool alwaysStripSampling;
+  final bool samplingAllowsAuto;
+  final bool effortParameterSupported;
+  final String? offFallback;
 
   bool get supportsNone => supportedEfforts.contains('none');
   bool get supportsXhigh => supportedEfforts.contains('xhigh');
@@ -59,21 +63,25 @@ const OpenAIReasoningSupport _gpt55Support = OpenAIReasoningSupport(
 const OpenAIReasoningSupport _gpt55ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['medium', 'high', 'xhigh'],
 );
-// gpt-5.6-sol (alias gpt-5.6), gpt-5.6-luna, gpt-5.6-terra
-// all variants + -pro suffix support all 5 levels: low|medium|high|xhigh|max
 const OpenAIReasoningSupport _gpt56Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh', 'max'],
   samplingRequiresNone: true,
+  samplingAllowsAuto: false,
 );
-const OpenAIReasoningSupport _gpt56ProSupport = OpenAIReasoningSupport(
-  supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+const OpenAIReasoningSupport _kimiK3Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'high', 'max'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _grok45Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _museSpark11Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>[],
+  effortParameterSupported: false,
 );
 const OpenAIReasoningSupport _deepSeekSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
-);
-const OpenAIReasoningSupport _kimiK3Support = OpenAIReasoningSupport(
-  supportedEfforts: <String>['none', 'low', 'medium', 'high', 'max'],
-  alwaysStripSampling: true,
 );
 
 String resolveApiModelIdOverride(
@@ -91,12 +99,6 @@ bool isOpenAIGpt5FamilyModel(String modelId) {
   return RegExp(r'gpt-5(?=$|[-.])', caseSensitive: false).hasMatch(modelId);
 }
 
-bool isOpenAIKimiK3Model(String modelId) {
-  final lower = modelId.trim().toLowerCase();
-  return lower.contains('kimi-k3') ||
-      RegExp(r'(?:^|[-_/])k3(?:$|[-.])', caseSensitive: false).hasMatch(lower);
-}
-
 bool openAISupportsXhighReasoning(String modelId) {
   return openAIReasoningSupport(modelId)?.supportsXhigh ?? false;
 }
@@ -109,19 +111,26 @@ bool openAISupportsNoneReasoning(String modelId) {
   return openAIReasoningSupport(modelId)?.supportsNone ?? false;
 }
 
+bool openAIChatCompletionsToolsRequireNone(String modelId) {
+  return _matchesModel(
+    modelId.trim().toLowerCase(),
+    r'(^|[/_:@])gpt-5\.6(?:-(?:sol|terra|luna))?(?:$|[.@])',
+  );
+}
+
 String openAINormalizeReasoningEffort(String effort, String modelId) {
   final normalizedEffort = effort.trim().toLowerCase();
   if (normalizedEffort.isEmpty) return effort;
   if (normalizedEffort == 'auto') return 'auto';
 
   final support = openAIReasoningSupport(modelId);
+  if (support?.effortParameterSupported == false) return 'auto';
   if (normalizedEffort == 'off') {
-    return support?.supportsNone == true ? 'none' : 'off';
+    if (support?.supportsNone == true) return 'none';
+    return support?.offFallback ?? 'off';
   }
-  if (normalizedEffort == 'xhigh' && support == null) {
-    return 'high';
-  }
-  if (normalizedEffort == 'max' && support == null) {
+  if ((normalizedEffort == 'xhigh' || normalizedEffort == 'max') &&
+      support == null) {
     return 'high';
   }
   if (support == null) return normalizedEffort;
@@ -167,8 +176,8 @@ String openAINormalizeReasoningEffort(String effort, String modelId) {
     case 'xhigh':
       return _pickSupportedEffort(support, const <String>[
         'xhigh',
-        'max',
         'high',
+        'max',
         'medium',
         'low',
         'none',
@@ -193,27 +202,31 @@ bool openAIAllowsSamplingParams(String modelId, {required String effort}) {
   final normalizedEffort = openAINormalizeReasoningEffort(effort, modelId);
   return normalizedEffort == 'none' ||
       normalizedEffort == 'off' ||
-      normalizedEffort == 'auto';
-}
-
-bool openAIAlwaysStripsSamplingParams(String modelId) {
-  final support = openAIReasoningSupport(modelId);
-  return support?.alwaysStripSampling ?? false;
+      (normalizedEffort == 'auto' && support.samplingAllowsAuto);
 }
 
 OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   final normalized = modelId.trim().toLowerCase();
   if (normalized.contains('deepseek')) return _deepSeekSupport;
-  if (isOpenAIKimiK3Model(normalized)) return _kimiK3Support;
+  if (_matchesModel(normalized, r'(^|[/_:@])kimi-k3(?:$|[-.])') ||
+      RegExp(
+        r'(?:^|[-_/])k3(?:$|[-.])',
+        caseSensitive: false,
+      ).hasMatch(normalized)) {
+    return _kimiK3Support;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])grok-4\.5(?:$|[-.])')) {
+    return _grok45Support;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])muse-spark-1\.1(?:$|[-.])')) {
+    return _museSpark11Support;
+  }
   if (!isOpenAIGpt5FamilyModel(normalized)) return null;
 
   if (_matchesModel(
     normalized,
-    r'^gpt-5\.6(?:-sol|-luna|-terra)?-pro(?:$|[-.])',
+    r'(^|[/_:@])gpt-5\.6(?:-(?:sol|terra|luna))?(?:$|[.@])',
   )) {
-    return _gpt56ProSupport;
-  }
-  if (_matchesModel(normalized, r'^gpt-5\.6(?:-sol|-luna|-terra)?(?:$|[-.])')) {
     return _gpt56Support;
   }
   if (_matchesModel(normalized, r'^gpt-5\.5-pro(?:$|[-.])')) {

--- a/test/chat_api_generate_text_encoding_test.dart
+++ b/test/chat_api_generate_text_encoding_test.dart
@@ -195,6 +195,30 @@ void main() {
       },
     );
 
+    test('maps Kimi K3 effort and omits fixed request parameters', () async {
+      final maxBody = await _captureGenerateTextBody(
+        providerId: 'MoonshotCompatTest',
+        modelId: 'kimi-k3',
+        thinkingBudget: 128000,
+      );
+      final minimumBody = await _captureGenerateTextBody(
+        providerId: 'MoonshotCompatTest',
+        modelId: 'kimi-k3',
+        thinkingBudget: 0,
+      );
+
+      expect(maxBody['reasoning_effort'], 'max');
+      expect(minimumBody['reasoning_effort'], 'low');
+      for (final body in [maxBody, minimumBody]) {
+        expect(body.containsKey('thinking'), isFalse);
+        expect(body.containsKey('temperature'), isFalse);
+        expect(body.containsKey('top_p'), isFalse);
+        expect(body.containsKey('n'), isFalse);
+        expect(body.containsKey('presence_penalty'), isFalse);
+        expect(body.containsKey('frequency_penalty'), isFalse);
+      }
+    });
+
     test(
       'maps DeepSeek reasoning knobs for non-streaming text generation',
       () async {

--- a/test/claude_thinking_compat_test.dart
+++ b/test/claude_thinking_compat_test.dart
@@ -393,6 +393,36 @@ void main() {
       expect(body['output_config'], {'effort': 'max'});
     });
 
+    test('Opus 5 uses summarized adaptive thinking and max effort', () async {
+      final body = await _captureClaudeRequestBody(
+        modelId: 'claude-opus-5',
+        thinkingBudget: 128000,
+        temperature: 0.7,
+        topP: 0.8,
+      );
+
+      expect(body['thinking'], {'type': 'adaptive', 'display': 'summarized'});
+      expect(body['output_config'], {'effort': 'max'});
+      expect(body['max_tokens'], 128000);
+      expect(body.containsKey('temperature'), isFalse);
+      expect(body.containsKey('top_p'), isFalse);
+    });
+
+    test('Sonnet 5 can disable thinking but still rejects sampling', () async {
+      final body = await _captureClaudeRequestBody(
+        modelId: 'claude-sonnet-5',
+        thinkingBudget: 0,
+        temperature: 0.7,
+        topP: 0.8,
+      );
+
+      expect(body['thinking'], {'type': 'disabled'});
+      expect(body.containsKey('output_config'), isFalse);
+      expect(body['max_tokens'], 128000);
+      expect(body.containsKey('temperature'), isFalse);
+      expect(body.containsKey('top_p'), isFalse);
+    });
+
     test('Fable 5 never sends unsupported disabled thinking', () async {
       final offBody = await _captureClaudeRequestBody(
         modelId: 'claude-fable-5',
@@ -425,6 +455,29 @@ void main() {
       expect(body['thinking'], {'type': 'adaptive', 'display': 'summarized'});
       expect(body['output_config'], {'effort': 'max'});
     });
+
+    test(
+      'Mythos 5 never sends disabled thinking and returns summaries',
+      () async {
+        final offBody = await _captureClaudeRequestBody(
+          modelId: 'claude-mythos-5',
+          thinkingBudget: 0,
+        );
+        final maxBody = await _captureClaudeRequestBody(
+          modelId: 'claude-mythos-5',
+          thinkingBudget: 128000,
+        );
+
+        expect(offBody.containsKey('thinking'), isFalse);
+        expect(offBody.containsKey('output_config'), isFalse);
+        expect(maxBody['thinking'], {
+          'type': 'adaptive',
+          'display': 'summarized',
+        });
+        expect(maxBody['output_config'], {'effort': 'max'});
+        expect(maxBody['max_tokens'], 128000);
+      },
+    );
 
     test('OpenRouter Anthropic format uses Claude messages path', () async {
       late Uri requestUri;
@@ -567,20 +620,20 @@ void main() {
     });
 
     test(
-      'Claude built-in search support list includes Opus 4.8 and Fable 5',
+      'Claude built-in search support list includes latest Claude 5 models',
       () {
-        expect(
-          BuiltInToolsHelper.isClaudeBuiltInSearchSupportedModel(
-            'claude-opus-4-8',
-          ),
-          isTrue,
-        );
-        expect(
-          BuiltInToolsHelper.isClaudeBuiltInSearchSupportedModel(
-            'claude-fable-5',
-          ),
-          isTrue,
-        );
+        for (final modelId in const [
+          'claude-opus-4-8',
+          'claude-fable-5',
+          'claude-mythos-5',
+          'claude-opus-5',
+          'claude-sonnet-5',
+        ]) {
+          expect(
+            BuiltInToolsHelper.isClaudeBuiltInSearchSupportedModel(modelId),
+            isTrue,
+          );
+        }
       },
     );
 
@@ -595,6 +648,20 @@ void main() {
         BuiltInToolsHelper.supportsClaudeDynamicWebSearchForModel(
           cfg: official,
           modelId: 'claude-opus-4-8',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.supportsClaudeDynamicWebSearchForModel(
+          cfg: official,
+          modelId: 'claude-opus-5',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.supportsClaudeDynamicWebSearchForModel(
+          cfg: official,
+          modelId: 'claude-sonnet-5',
         ),
         isTrue,
       );

--- a/test/google_gemma4_thinking_config_test.dart
+++ b/test/google_gemma4_thinking_config_test.dart
@@ -170,4 +170,68 @@ void main() {
       expect(_thinkingConfig(capturedBody), isNull);
     });
   });
+
+  group('latest Gemini Flash thinking config', () {
+    test('Gemini 3.6 Flash defaults to medium with 64K output', () async {
+      late Map<String, dynamic> capturedBody;
+      final server = await _startGeminiServer((body) {
+        capturedBody = body;
+      });
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.6-flash',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        stream: false,
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(_thinkingConfig(capturedBody), {
+        'includeThoughts': true,
+        'thinkingLevel': 'medium',
+      });
+      expect(
+        (capturedBody['generationConfig'] as Map)['maxOutputTokens'],
+        65536,
+      );
+    });
+
+    test('Gemini 3.5 Flash-Lite defaults to minimal thinking', () async {
+      late Map<String, dynamic> capturedBody;
+      final server = await _startGeminiServer((body) {
+        capturedBody = body;
+      });
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.5-flash-lite',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        stream: false,
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(_thinkingConfig(capturedBody), {
+        'includeThoughts': true,
+        'thinkingLevel': 'minimal',
+      });
+      expect(
+        (capturedBody['generationConfig'] as Map)['maxOutputTokens'],
+        65536,
+      );
+    });
+  });
 }

--- a/test/openai_kimi_compat_test.dart
+++ b/test/openai_kimi_compat_test.dart
@@ -18,8 +18,127 @@ ProviderConfig _moonshotConfig(String baseUrl) {
   );
 }
 
+Future<Map<String, dynamic>> _captureMoonshotBody({
+  required String modelId,
+  required List<Map<String, dynamic>> messages,
+  List<String>? userMediaPaths,
+}) async {
+  late Map<String, dynamic> requestBody;
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  server.listen((request) async {
+    requestBody = (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+        .cast<String, dynamic>();
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType = ContentType.json;
+    request.response.write(
+      jsonEncode({
+        'choices': [
+          {
+            'message': {'content': 'ok'},
+            'finish_reason': 'stop',
+          },
+        ],
+      }),
+    );
+    await request.response.close();
+  });
+
+  await ChatApiService.sendMessageStream(
+    config: _moonshotConfig(
+      'http://${server.address.address}:${server.port}/v1',
+    ),
+    modelId: modelId,
+    messages: messages,
+    userMediaPaths: userMediaPaths,
+    stream: false,
+  ).toList();
+  return requestBody;
+}
+
 void main() {
   group('Moonshot Kimi compatibility', () {
+    test('kimi-k3 filters remote images from every input path', () async {
+      final dir = await Directory.systemTemp.createTemp(
+        'kelivo_kimi_k3_images_',
+      );
+      addTearDown(() async {
+        if (await dir.exists()) {
+          await dir.delete(recursive: true);
+        }
+      });
+      final localImage = File('${dir.path}/local.png');
+      await localImage.writeAsBytes(const [1, 2, 3, 4]);
+
+      final body = await _captureMoonshotBody(
+        modelId: 'moonshotai/kimi-k3',
+        messages: const [
+          {
+            'role': 'user',
+            'content': [
+              {'type': 'text', 'text': 'structured'},
+              {
+                'type': 'image_url',
+                'image_url': {'url': 'https://example.com/structured.png'},
+              },
+              {
+                'type': 'image_url',
+                'image_url': {'url': 'data:image/png;base64,QUJD'},
+              },
+            ],
+          },
+          {
+            'role': 'user',
+            'content':
+                'markdown ![remote](https://example.com/markdown.png) '
+                '![inline](data:image/png;base64,REVG)',
+          },
+        ],
+        userMediaPaths: [
+          'https://example.com/attached.png',
+          'data:image/png;base64,R0hJ',
+          localImage.path,
+        ],
+      );
+
+      final encoded = jsonEncode(body);
+      expect(encoded, isNot(contains('example.com/structured.png')));
+      expect(encoded, isNot(contains('example.com/attached.png')));
+      expect(encoded, contains('example.com/markdown.png'));
+
+      final imageUrls = <String>[];
+      for (final message in (body['messages'] as List).cast<Map>()) {
+        final content = message['content'];
+        if (content is! List) continue;
+        for (final part in content.whereType<Map>()) {
+          if (part['type'] != 'image_url') continue;
+          final imageUrl = part['image_url'];
+          if (imageUrl is Map && imageUrl['url'] is String) {
+            imageUrls.add(imageUrl['url'] as String);
+          }
+        }
+      }
+
+      expect(
+        imageUrls,
+        containsAll([
+          'data:image/png;base64,QUJD',
+          'data:image/png;base64,REVG',
+          'data:image/png;base64,R0hJ',
+          'data:image/png;base64,AQIDBA==',
+        ]),
+      );
+      expect(
+        imageUrls,
+        everyElement(
+          isNot(anyOf(startsWith('http://'), startsWith('https://'))),
+        ),
+      );
+    });
+
     test(
       'kimi-k2.5 disables thinking and strips unsupported sampling params',
       () async {
@@ -147,7 +266,7 @@ void main() {
     );
 
     test(
-      'kimi thinking tool continuation preserves reasoning_content and assistant content',
+      'kimi-k3 tool continuation preserves reasoning_content and assistant content',
       () async {
         final secondRequestCompleter = Completer<Map<String, dynamic>>();
         final toolInvocations = <Map<String, dynamic>>[];
@@ -177,7 +296,7 @@ void main() {
                 'id': 'cmpl-1',
                 'object': 'chat.completion.chunk',
                 'created': 0,
-                'model': 'kimi-k2-thinking',
+                'model': 'kimi-k3',
                 'choices': [
                   {
                     'index': 0,
@@ -208,7 +327,7 @@ void main() {
                 'id': 'cmpl-2',
                 'object': 'chat.completion.chunk',
                 'created': 0,
-                'model': 'kimi-k2-thinking',
+                'model': 'kimi-k3',
                 'choices': [
                   {
                     'index': 0,
@@ -227,7 +346,7 @@ void main() {
         final baseUrl = 'http://${server.address.address}:${server.port}/v1';
         final chunks = await ChatApiService.sendMessageStream(
           config: _moonshotConfig(baseUrl),
-          modelId: 'kimi-k2-thinking',
+          modelId: 'kimi-k3',
           messages: const [
             {'role': 'user', 'content': '今天几号？'},
           ],

--- a/test/openai_latest_models_compat_test.dart
+++ b/test/openai_latest_models_compat_test.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+import 'package:Cuplivo/core/utils/openai_model_compat.dart';
+
+ProviderConfig _openAIConfig(
+  String baseUrl, {
+  bool useResponseApi = false,
+  String providerId = 'LatestModelCompatTest',
+}) {
+  return ProviderConfig(
+    id: providerId,
+    enabled: true,
+    name: providerId,
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    useResponseApi: useResponseApi,
+  );
+}
+
+Future<Map<String, dynamic>> _captureChatBody({
+  required String modelId,
+  required int thinkingBudget,
+  double? temperature,
+  double? topP,
+  List<Map<String, dynamic>>? tools,
+  String providerId = 'LatestModelCompatTest',
+}) async {
+  late Map<String, dynamic> requestBody;
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  server.listen((request) async {
+    requestBody = (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+        .cast<String, dynamic>();
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType = ContentType(
+      'text',
+      'event-stream',
+      charset: 'utf-8',
+    );
+    request.response.write(
+      'data: ${jsonEncode({
+        'choices': [
+          {
+            'index': 0,
+            'delta': {'role': 'assistant', 'content': 'ok'},
+            'finish_reason': 'stop',
+          },
+        ],
+      })}\n\n',
+    );
+    request.response.write('data: [DONE]\n\n');
+    await request.response.close();
+  });
+
+  final chunks = await ChatApiService.sendMessageStream(
+    config: _openAIConfig(
+      'http://${server.address.address}:${server.port}/v1',
+      providerId: providerId,
+    ),
+    modelId: modelId,
+    messages: const [
+      {'role': 'user', 'content': 'hello'},
+    ],
+    thinkingBudget: thinkingBudget,
+    temperature: temperature,
+    topP: topP,
+    tools: tools,
+  ).toList();
+
+  expect(chunks.last.isDone, isTrue);
+  return requestBody;
+}
+
+void main() {
+  group('latest OpenAI-compatible model compatibility', () {
+    test('normalizes only officially supported reasoning efforts', () {
+      for (final modelId in const [
+        'gpt-5.6-sol',
+        'gpt-5.6-terra',
+        'gpt-5.6-luna',
+        'openai/gpt-5.6-sol',
+      ]) {
+        expect(openAINormalizeReasoningEffort('off', modelId), 'none');
+        expect(openAINormalizeReasoningEffort('xhigh', modelId), 'xhigh');
+        expect(openAINormalizeReasoningEffort('max', modelId), 'max');
+      }
+
+      expect(openAINormalizeReasoningEffort('off', 'kimi-k3'), 'low');
+      expect(openAINormalizeReasoningEffort('medium', 'kimi-k3'), 'high');
+      expect(openAINormalizeReasoningEffort('max', 'kimi-k3'), 'max');
+      expect(
+        openAINormalizeReasoningEffort('off', 'moonshotai/kimi-k3'),
+        'low',
+      );
+      expect(openAISupportsMaxReasoning('moonshotai/kimi-k3'), isTrue);
+      expect(openAINormalizeReasoningEffort('off', 'grok-4.5'), 'low');
+      expect(openAINormalizeReasoningEffort('max', 'grok-4.5'), 'high');
+      expect(openAINormalizeReasoningEffort('off', 'x-ai/grok-4.5'), 'low');
+      expect(
+        openAINormalizeReasoningEffort('high', 'meta/muse-spark-1.1'),
+        'auto',
+      );
+    });
+
+    test(
+      'OpenRouter keeps mandatory reasoning enabled for namespaced models',
+      () async {
+        final kimiOff = await _captureChatBody(
+          modelId: 'moonshotai/kimi-k3',
+          thinkingBudget: 0,
+          providerId: 'OpenRouter',
+        );
+        final kimiMax = await _captureChatBody(
+          modelId: 'moonshotai/kimi-k3',
+          thinkingBudget: 128000,
+          providerId: 'OpenRouter',
+        );
+        final grokOff = await _captureChatBody(
+          modelId: 'x-ai/grok-4.5',
+          thinkingBudget: 0,
+          providerId: 'OpenRouter',
+        );
+
+        expect(kimiOff['reasoning'], {'effort': 'low'});
+        expect(kimiMax['reasoning'], {'effort': 'max'});
+        expect(grokOff['reasoning'], {'effort': 'low'});
+        for (final body in [kimiOff, kimiMax, grokOff]) {
+          expect(body.containsKey('reasoning_effort'), isFalse);
+          expect(body['reasoning'], isNot({'enabled': false}));
+        }
+      },
+    );
+
+    test('GPT-5.6 Chat tools force the documented none effort', () async {
+      final body = await _captureChatBody(
+        modelId: 'openai/gpt-5.6-sol',
+        thinkingBudget: 128000,
+        temperature: 0.7,
+        topP: 0.8,
+        tools: const [
+          {
+            'type': 'function',
+            'function': {
+              'name': 'lookup',
+              'description': 'Look something up',
+              'parameters': {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            },
+          },
+        ],
+      );
+
+      expect(body['reasoning_effort'], 'none');
+      expect(body['temperature'], 0.7);
+      expect(body['top_p'], 0.8);
+    });
+
+    test('GPT-5.6 auto effort omits incompatible sampling params', () async {
+      final body = await _captureChatBody(
+        modelId: 'openai/gpt-5.6-terra',
+        thinkingBudget: -1,
+        temperature: 0.7,
+        topP: 0.8,
+      );
+
+      expect(body.containsKey('reasoning_effort'), isFalse);
+      expect(body.containsKey('temperature'), isFalse);
+      expect(body.containsKey('top_p'), isFalse);
+    });
+
+    test('Muse Spark does not invent an undocumented effort field', () async {
+      final body = await _captureChatBody(
+        modelId: 'meta/muse-spark-1.1',
+        thinkingBudget: 128000,
+      );
+
+      expect(body.containsKey('reasoning_effort'), isFalse);
+    });
+
+    test('Grok Responses streams reasoning text and clamps off to low', () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody =
+            (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+                .cast<String, dynamic>();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({'type': 'response.reasoning_text.delta', 'delta': 'reasoning summary'})}\n\n',
+        );
+        request.response.write(
+          'data: ${jsonEncode({'type': 'response.output_text.delta', 'delta': 'answer'})}\n\n',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'type': 'response.completed',
+            'response': {
+              'output': const [],
+              'usage': {'input_tokens': 1, 'output_tokens': 2},
+            },
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _openAIConfig(
+          'http://${server.address.address}:${server.port}/v1',
+          useResponseApi: true,
+        ),
+        modelId: 'grok-4.5',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 0,
+      ).toList();
+
+      expect((requestBody['reasoning'] as Map)['effort'], 'low');
+      expect(
+        chunks.map((chunk) => chunk.reasoning ?? '').join(),
+        contains('reasoning summary'),
+      );
+      expect(chunks.map((chunk) => chunk.content).join(), contains('answer'));
+    });
+  });
+}

--- a/test/settings_provider_reasoning_support_test.dart
+++ b/test/settings_provider_reasoning_support_test.dart
@@ -52,12 +52,18 @@ void main() {
       expect(settings.providersOrder.take(3), ['OpenAI', 'Zhipu AI', 'Grok']);
     });
 
-    test('latest GLM and Kimi model ids infer expected capabilities', () {
+    test('latest model ids infer only their documented capabilities', () {
       final glm = ModelRegistry.infer(
         ModelInfo(id: 'glm-5.2', displayName: 'glm-5.2'),
       );
-      final kimi = ModelRegistry.infer(
+      final kimiK2 = ModelRegistry.infer(
         ModelInfo(id: 'kimi-k2.7-code', displayName: 'kimi-k2.7-code'),
+      );
+      final kimiK3 = ModelRegistry.infer(
+        ModelInfo(id: 'kimi-k3', displayName: 'kimi-k3'),
+      );
+      final muse = ModelRegistry.infer(
+        ModelInfo(id: 'muse-spark-1.1', displayName: 'muse-spark-1.1'),
       );
 
       expect(glm.input, const [Modality.text]);
@@ -66,26 +72,52 @@ void main() {
         glm.abilities,
         containsAll([ModelAbility.tool, ModelAbility.reasoning]),
       );
-      expect(kimi.input, contains(Modality.image));
-      expect(kimi.output, const [Modality.text]);
-      expect(
-        kimi.abilities,
-        containsAll([ModelAbility.tool, ModelAbility.reasoning]),
-      );
-    });
-
-    test('Kimi K3 model ids infer expected capabilities', () {
-      for (final id in const ['kimi-k3', 'k3']) {
-        final m = ModelRegistry.infer(ModelInfo(id: id, displayName: id));
-        expect(m.input, contains(Modality.image), reason: '$id vision');
-        expect(m.output, const [Modality.text], reason: '$id output');
+      for (final model in [kimiK2, kimiK3, muse]) {
+        expect(model.input, contains(Modality.image));
+        expect(model.output, const [Modality.text]);
         expect(
-          m.abilities,
+          model.abilities,
           containsAll([ModelAbility.tool, ModelAbility.reasoning]),
-          reason: '$id abilities',
         );
       }
+      expect(kimiK2.id, 'kimi-k2.7-code');
+      expect(kimiK3.id, 'kimi-k3');
+      expect(muse.id, 'muse-spark-1.1');
     });
+
+    test(
+      'OpenAI-compatible latest models expose documented effort caps',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final settings = SettingsProvider();
+
+        await _waitForSettingsLoad();
+
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'gpt-5.6-sol'),
+          isTrue,
+        );
+        expect(settings.supportsMaxReasoning('OpenAI', 'gpt-5.6-sol'), isTrue);
+        expect(
+          settings.supportsXhighReasoning('OpenRouter', 'openai/gpt-5.6-sol'),
+          isTrue,
+        );
+        expect(
+          settings.supportsMaxReasoning('OpenRouter', 'openai/gpt-5.6-sol'),
+          isTrue,
+        );
+        expect(settings.supportsMaxReasoning('OpenAI', 'kimi-k3'), isTrue);
+        expect(
+          settings.supportsMaxReasoning('OpenRouter', 'moonshotai/kimi-k3'),
+          isTrue,
+        );
+        expect(settings.supportsMaxReasoning('OpenAI', 'grok-4.5'), isFalse);
+        expect(
+          settings.supportsMaxReasoning('OpenAI', 'muse-spark-1.1'),
+          isFalse,
+        );
+      },
+    );
 
     test('OpenRouter can be routed through Anthropic format explicitly', () {
       final cfg = ProviderConfig(
@@ -168,6 +200,51 @@ void main() {
       ]);
     });
 
+    test(
+      'Claude latest models expose xhigh and max reasoning without presets',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final settings = SettingsProvider();
+
+        await _waitForSettingsLoad();
+        await settings.setProviderConfig(
+          'Claude',
+          ProviderConfig(
+            id: 'Claude',
+            enabled: true,
+            name: 'Claude',
+            apiKey: 'test-key',
+            baseUrl: 'https://api.anthropic.com/v1',
+            providerType: ProviderKind.claude,
+            models: const [
+              'claude-fable-5',
+              'claude-mythos-5',
+              'claude-opus-4-8',
+              'claude-opus-5',
+              'claude-sonnet-5',
+            ],
+          ),
+        );
+
+        for (final model in const [
+          'claude-fable-5',
+          'claude-mythos-5',
+          'claude-opus-4-8',
+          'claude-opus-5',
+          'claude-sonnet-5',
+        ]) {
+          expect(settings.supportsXhighReasoning('Claude', model), isTrue);
+          expect(settings.supportsMaxReasoning('Claude', model), isTrue);
+        }
+        expect(settings.getProviderConfig('Claude').models, [
+          'claude-fable-5',
+          'claude-mythos-5',
+          'claude-opus-4-8',
+          'claude-opus-5',
+          'claude-sonnet-5',
+        ]);
+      },
+    );
     test('OpenRouter Anthropic format exposes Claude max reasoning', () async {
       SharedPreferences.setMockInitialValues({});
       final settings = SettingsProvider();


### PR DESCRIPTION
Cherry-pick 6dffd1cc + conflict resolution for cuplivo-next:

- Claude 5 (Opus 5, Sonnet 5) adaptive thinking, max_tokens, built-in search
- Gemini 3.6 Flash, 3.5 Flash-Lite thinking config and max output
- Kimi K3, Grok 4.5, Muse Spark 1.1, GPT 5.6 reasoning support
- upstream-style OpenAIReasoningSupport with offFallback/effortParameterSupported/samplingAllowsAuto
- Removed cuplivo-specific alwaysStripSampling; unified under upstream field system
- k3 bare alias preserved as cuplivo addition
- allowRemoteImages parameter for Kimi K3 image filtering
- openAIChatCompletionsToolsRequireNone for GPT-5.6+function tools
- response.reasoning_text.delta event support for Grok Responses API
- OpenRouter providerId-based detection
- Tests: openai_latest_models_compat_test.dart (new), extended kimi/claude/google/settings tests