### PR TITLE
port: feat(search) configure Grok reasoning effort

### DIFF
--- a/lib/core/services/search/search_service.dart
+++ b/lib/core/services/search/search_service.dart
@@ -529,13 +529,14 @@ class SerperOptions extends SearchServiceOptions {
 
 class GrokOptions extends SearchServiceOptions {
   static const String defaultUrl = 'https://api.x.ai/v1/responses';
-  static const String defaultModel = 'grok-4.3';
-  static const String defaultReasoningEffort = 'none';
+  static const String defaultModel = 'grok-4.5';
+  static const String defaultReasoningEffort = 'low';
   static const String defaultSystemPrompt =
       "You are a helpful search assistant. Search the web to find accurate and up-to-date information for the user's query. Provide a comprehensive answer with citations.";
 
   final String apiKey;
   final String model;
+  final String reasoningEffort;
   final String customUrl;
   final String systemPrompt;
 
@@ -543,9 +544,14 @@ class GrokOptions extends SearchServiceOptions {
     required super.id,
     required this.apiKey,
     this.model = defaultModel,
+    String? reasoningEffort,
     this.customUrl = defaultUrl,
     this.systemPrompt = defaultSystemPrompt,
-  });
+  }) : reasoningEffort =
+           reasoningEffort ??
+           ((model.trim().isEmpty || model.trim() == defaultModel)
+               ? defaultReasoningEffort
+               : '');
 
   String get resolvedUrl {
     final trimmed = customUrl.trim();
@@ -557,13 +563,7 @@ class GrokOptions extends SearchServiceOptions {
     return trimmed.isEmpty ? defaultModel : trimmed;
   }
 
-  String get resolvedReasoningEffort {
-    final trimmed = model.trim();
-    if (trimmed.isEmpty || trimmed == defaultModel) {
-      return defaultReasoningEffort;
-    }
-    return '';
-  }
+  String get resolvedReasoningEffort => reasoningEffort.trim();
 
   String get resolvedSystemPrompt {
     final trimmed = systemPrompt.trim();
@@ -576,6 +576,7 @@ class GrokOptions extends SearchServiceOptions {
     'id': id,
     'apiKey': apiKey,
     'model': model.trim(),
+    'reasoningEffort': reasoningEffort.trim(),
     'customUrl': customUrl.trim(),
     'systemPrompt': systemPrompt,
   };
@@ -584,6 +585,7 @@ class GrokOptions extends SearchServiceOptions {
     id: json['id'],
     apiKey: json['apiKey'] ?? '',
     model: json['model'] ?? defaultModel,
+    reasoningEffort: json['reasoningEffort'],
     customUrl: json['customUrl'] ?? defaultUrl,
     systemPrompt: json['systemPrompt'] ?? defaultSystemPrompt,
   );

--- a/lib/desktop/setting/search_services_pane.dart
+++ b/lib/desktop/setting/search_services_pane.dart
@@ -787,6 +787,9 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
     'countries': TextEditingController(),
     'languages': TextEditingController(),
     'model': TextEditingController(text: GrokOptions.defaultModel),
+    'reasoningEffort': TextEditingController(
+      text: GrokOptions.defaultReasoningEffort,
+    ),
     'customUrl': TextEditingController(text: GrokOptions.defaultUrl),
     'systemPrompt': TextEditingController(
       text: GrokOptions.defaultSystemPrompt,
@@ -999,6 +1002,14 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
           ),
           const SizedBox(height: 12),
           TextField(
+            controller: _controllers['reasoningEffort'],
+            decoration: _deskInputDecoration(context).copyWith(
+              labelText: l10n.reasoningBudgetSheetTitle,
+              hintText: 'none / low / medium / high / xhigh',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
             controller: _controllers['customUrl'],
             decoration: _deskInputDecoration(context).copyWith(
               labelText: l10n.searchServicesFieldCustomUrlOptional,
@@ -1118,6 +1129,7 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
           id: id,
           apiKey: _controllers['apiKey']!.text,
           model: _controllers['model']!.text.trim(),
+          reasoningEffort: _controllers['reasoningEffort']!.text,
           customUrl: _controllers['customUrl']!.text.trim(),
           systemPrompt: _controllers['systemPrompt']!.text,
         );
@@ -1197,6 +1209,9 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     } else if (s is GrokOptions) {
       _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['model'] = TextEditingController(text: s.model);
+      _controllers['reasoningEffort'] = TextEditingController(
+        text: s.reasoningEffort,
+      );
       _controllers['customUrl'] = TextEditingController(text: s.customUrl);
       _controllers['systemPrompt'] = TextEditingController(
         text: s.systemPrompt,
@@ -1333,6 +1348,14 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
           decoration: _deskInputDecoration(context).copyWith(
             labelText: l10n.searchServicesDialogModel,
             hintText: GrokOptions.defaultModel,
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _controllers['reasoningEffort'],
+          decoration: _deskInputDecoration(context).copyWith(
+            labelText: l10n.reasoningBudgetSheetTitle,
+            hintText: 'none / low / medium / high / xhigh',
           ),
         ),
         const SizedBox(height: 12),
@@ -1534,6 +1557,7 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
         id: s.id,
         apiKey: _controllers['apiKey']!.text,
         model: _controllers['model']!.text.trim(),
+        reasoningEffort: _controllers['reasoningEffort']!.text,
         customUrl: _controllers['customUrl']!.text.trim(),
         systemPrompt: _controllers['systemPrompt']!.text,
       );

--- a/lib/features/search/pages/search_services_page.dart
+++ b/lib/features/search/pages/search_services_page.dart
@@ -1131,6 +1131,13 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
           ),
           const SizedBox(height: 12),
           buildTextField(
+            key: 'reasoningEffort',
+            label: l10n.reasoningBudgetSheetTitle,
+            hint: 'none / low / medium / high / xhigh',
+            initialValue: GrokOptions.defaultReasoningEffort,
+          ),
+          const SizedBox(height: 12),
+          buildTextField(
             key: 'customUrl',
             label: l10n.searchServicesFieldCustomUrlOptional,
             hint: GrokOptions.defaultUrl,
@@ -1261,6 +1268,7 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
           id: id,
           apiKey: _controllers['apiKey']!.text,
           model: _controllers['model']!.text.trim(),
+          reasoningEffort: _controllers['reasoningEffort']!.text,
           customUrl: _controllers['customUrl']!.text.trim(),
           systemPrompt: _controllers['systemPrompt']!.text,
         );
@@ -1349,6 +1357,9 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     } else if (service is GrokOptions) {
       _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['model'] = TextEditingController(text: service.model);
+      _controllers['reasoningEffort'] = TextEditingController(
+        text: service.reasoningEffort,
+      );
       _controllers['customUrl'] = TextEditingController(
         text: service.customUrl,
       );
@@ -1673,6 +1684,12 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
         ),
         const SizedBox(height: 12),
         buildTextField(
+          key: 'reasoningEffort',
+          label: l10n.reasoningBudgetSheetTitle,
+          hint: 'none / low / medium / high / xhigh',
+        ),
+        const SizedBox(height: 12),
+        buildTextField(
           key: 'customUrl',
           label: l10n.searchServicesFieldCustomUrlOptional,
           hint: GrokOptions.defaultUrl,
@@ -1819,6 +1836,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
         id: service.id,
         apiKey: _controllers['apiKey']!.text,
         model: _controllers['model']!.text.trim(),
+        reasoningEffort: _controllers['reasoningEffort']!.text,
         customUrl: _controllers['customUrl']!.text.trim(),
         systemPrompt: _controllers['systemPrompt']!.text,
       );

--- a/test/core/services/search/grok_search_service_test.dart
+++ b/test/core/services/search/grok_search_service_test.dart
@@ -14,6 +14,7 @@ void main() {
         id: 'grok-1',
         apiKey: 'xai-test',
         model: 'grok-test',
+        reasoningEffort: 'medium',
         customUrl: 'https://example.com/responses',
         systemPrompt: 'Search carefully.',
       );
@@ -25,6 +26,7 @@ void main() {
       expect(grok.id, 'grok-1');
       expect(grok.apiKey, 'xai-test');
       expect(grok.model, 'grok-test');
+      expect(grok.reasoningEffort, 'medium');
       expect(grok.customUrl, 'https://example.com/responses');
       expect(grok.systemPrompt, 'Search carefully.');
       expect(SearchService.getService(grok), isA<GrokSearchService>());
@@ -109,7 +111,7 @@ void main() {
       expect(result.items.single.text, isEmpty);
     });
 
-    test('keeps explicitly configured model unchanged', () async {
+    test('keeps explicitly configured model and reasoning unchanged', () async {
       http.Request? captured;
       final service = GrokSearchService(
         client: MockClient((request) async {
@@ -138,15 +140,16 @@ void main() {
           id: 'grok-1',
           apiKey: 'xai-test',
           model: 'grok-4-1-fast-non-reasoning',
+          reasoningEffort: 'none',
         ),
       );
 
       final body = jsonDecode(captured!.body) as Map<String, dynamic>;
       expect(body['model'], 'grok-4-1-fast-non-reasoning');
-      expect(body.containsKey('reasoning'), isFalse);
+      expect(body['reasoning'], {'effort': 'none'});
     });
 
-    test('uses current default model with non-reasoning effort', () async {
+    test('uses Grok 4.5 default with minimum reasoning effort', () async {
       http.Request? captured;
       final service = GrokSearchService(
         client: MockClient((request) async {
@@ -175,8 +178,8 @@ void main() {
       );
 
       final body = jsonDecode(captured!.body) as Map<String, dynamic>;
-      expect(body['model'], 'grok-4.3');
-      expect(body['reasoning'], {'effort': 'none'});
+      expect(body['model'], 'grok-4.5');
+      expect(body['reasoning'], {'effort': 'low'});
     });
 
     test(


### PR DESCRIPTION
Cherry-picked 41be1647 from origin/master.

- Add reasoningEffort field to GrokOptions with user-configurable default
- Default model grok-4.3 → grok-4.5, default effort none → low
- Add reasoningEffort input field to desktop add/edit dialogs
- Add reasoningEffort input field to mobile add/edit bottom sheets
- Update serialization round-trip and search request tests
