### PR TITLE
port: unify built-in Fetch MCP into single token-conscious tool

### DIFF
--- a/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_inmemory.dart
+++ b/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_inmemory.dart
@@ -66,17 +66,21 @@ Future<List<(mcp.Tool tool, String id)>> listFetchTools(
       .toList(growable: false);
 }
 
-/// Call one of the in-memory fetch tools.
-/// name must be one of: fetch_html | fetch_markdown | fetch_txt | fetch_json
+/// Fetch a URL through the in-memory tool with bounded output.
 Future<mcp.CallToolResult> callFetchTool(
-  mcp.Client client,
-  String name, {
+  mcp.Client client, {
   required String url,
   Map<String, String>? headers,
+  int? maxLength,
+  int? startIndex,
+  bool raw = false,
 }) async {
-  final result = await client.callTool(name, {
+  final result = await client.callTool('kelivo_fetch', {
     'url': url,
     if (headers != null && headers.isNotEmpty) 'headers': headers,
+    if (maxLength != null) 'max_length': maxLength,
+    if (startIndex != null) 'start_index': startIndex,
+    if (raw) 'raw': true,
   });
   return result;
 }

--- a/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart
+++ b/lib/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as html_parser;
@@ -9,11 +10,9 @@ import 'package:mcp_client/mcp_client.dart' as mcp;
 
 /// @kelivo/fetch — In-memory MCP server engine and transport (Flutter/Dart)
 ///
-/// Provides four tools:
-/// - fetch_html     → returns raw HTML text
-/// - fetch_markdown → HTML converted to Markdown
-/// - fetch_txt      → plain text (script/style removed, whitespace collapsed)
-/// - fetch_json     → JSON stringified
+/// Provides one token-conscious `fetch` tool. HTML is simplified to Markdown
+/// by default, while raw content requires an explicit opt-in. Responses are
+/// bounded and can be continued with `start_index`.
 ///
 /// The server implements a minimal subset of MCP over JSON-RPC 2.0:
 /// initialize, tools/list, tools/call. It is intended to run in the same
@@ -21,16 +20,27 @@ import 'package:mcp_client/mcp_client.dart' as mcp;
 /// in-memory ClientTransport.
 
 class KelivoFetchRequestPayload {
+  static const defaultMaxLength = 5000;
+  static const maximumMaxLength = 20000;
+
   final Uri url;
   final Map<String, String> headers;
+  final int maxLength;
+  final int startIndex;
+  final bool raw;
 
-  KelivoFetchRequestPayload({required this.url, Map<String, String>? headers})
-    : headers = headers ?? const {};
+  KelivoFetchRequestPayload({
+    required this.url,
+    Map<String, String>? headers,
+    this.maxLength = defaultMaxLength,
+    this.startIndex = 0,
+    this.raw = false,
+  }) : headers = headers ?? const {};
 
   static KelivoFetchRequestPayload parse(Object? args) {
     if (args is! Map) {
       throw ArgumentError(
-        'Invalid arguments: expected object with url[, headers]',
+        'Invalid arguments: expected an object containing url',
       );
     }
     final map = args.cast<String, dynamic>();
@@ -47,7 +57,49 @@ class KelivoFetchRequestPayload {
         headers[k.toString()] = v.toString();
       });
     }
-    return KelivoFetchRequestPayload(url: uri, headers: headers);
+    final maxLength = _parseInteger(
+      map['max_length'],
+      name: 'max_length',
+      defaultValue: defaultMaxLength,
+    );
+    if (maxLength < 1 || maxLength > maximumMaxLength) {
+      throw ArgumentError(
+        'Invalid max_length: expected a value from 1 to $maximumMaxLength',
+      );
+    }
+    final startIndex = _parseInteger(
+      map['start_index'],
+      name: 'start_index',
+      defaultValue: 0,
+    );
+    if (startIndex < 0) {
+      throw ArgumentError('Invalid start_index: expected a non-negative value');
+    }
+    final rawAny = map['raw'];
+    if (rawAny != null && rawAny is! bool) {
+      throw ArgumentError('Invalid raw: expected a boolean');
+    }
+
+    return KelivoFetchRequestPayload(
+      url: uri,
+      headers: headers,
+      maxLength: maxLength,
+      startIndex: startIndex,
+      raw: rawAny as bool? ?? false,
+    );
+  }
+
+  static int _parseInteger(
+    Object? value, {
+    required String name,
+    required int defaultValue,
+  }) {
+    if (value == null) return defaultValue;
+    if (value is int) return value;
+    if (value is num && value.isFinite && value == value.roundToDouble()) {
+      return value.toInt();
+    }
+    throw ArgumentError('Invalid $name: expected an integer');
   }
 }
 
@@ -73,59 +125,95 @@ class KelivoFetcher {
     }
   }
 
-  static Future<Map<String, dynamic>> html(
+  static Future<Map<String, dynamic>> fetch(
     KelivoFetchRequestPayload payload,
   ) async {
     try {
       final resp = await _fetch(payload);
-      final text = resp.body;
-      return _ok(text);
+      final contentType = (resp.headers['content-type'] ?? '').toLowerCase();
+      final body = resp.body;
+      final text = payload.raw
+          ? body
+          : _contentForModel(body, contentType: contentType);
+      return _ok(_bounded(text, payload));
     } catch (e) {
       return _err(e.toString());
     }
   }
 
-  static Future<Map<String, dynamic>> json(
-    KelivoFetchRequestPayload payload,
-  ) async {
-    try {
-      final resp = await _fetch(payload);
-      final raw = resp.body;
-      final dynamic data = jsonDecode(raw);
-      return _ok(const JsonEncoder.withIndent('  ').convert(data));
-    } catch (e) {
-      return _err(e.toString());
+  static String _contentForModel(String body, {required String contentType}) {
+    if (_isHtml(body, contentType: contentType)) {
+      return _htmlToMarkdown(body);
     }
+    if (contentType.contains('application/json') ||
+        contentType.contains('+json')) {
+      try {
+        return jsonEncode(jsonDecode(body));
+      } catch (_) {}
+    }
+    return body.trim();
   }
 
-  static Future<Map<String, dynamic>> txt(
-    KelivoFetchRequestPayload payload,
-  ) async {
-    try {
-      final resp = await _fetch(payload);
-      final html = resp.body;
-      final dom.Document document = html_parser.parse(html);
-      document.querySelectorAll('script,style').forEach((el) => el.remove());
-      final text = document.body?.text ?? '';
-      final normalized = text.replaceAll(RegExp(r'\s+'), ' ').trim();
-      return _ok(normalized);
-    } catch (e) {
-      return _err(e.toString());
+  static bool _isHtml(String body, {required String contentType}) {
+    if (contentType.contains('text/html') ||
+        contentType.contains('application/xhtml+xml')) {
+      return true;
     }
+    if (contentType.isNotEmpty) return false;
+    final prefix = body.length > 256 ? body.substring(0, 256) : body;
+    return RegExp(
+      r'<\s*(?:!doctype\s+html|html)\b',
+      caseSensitive: false,
+    ).hasMatch(prefix);
   }
 
-  static Future<Map<String, dynamic>> markdown(
-    KelivoFetchRequestPayload payload,
-  ) async {
-    try {
-      final resp = await _fetch(payload);
-      final html = resp.body;
-      final md = html2md.convert(html, ignore: ['script', 'style']);
-      return _ok(md);
-    } catch (e) {
-      return _err(e.toString());
+  static String _htmlToMarkdown(String html) {
+    final dom.Document document = html_parser.parse(html);
+    document
+        .querySelectorAll(
+          'script,style,noscript,template,svg,iframe,nav,aside,footer,form',
+        )
+        .forEach((element) => element.remove());
+
+    final mainContent = document.querySelector('main,article,[role="main"]');
+    final source = mainContent?.outerHtml ?? document.body?.innerHtml ?? html;
+    final markdown = html2md.convert(source).trim();
+    if (markdown.isNotEmpty) {
+      return markdown.replaceAll(RegExp(r'\n{3,}'), '\n\n');
     }
+    return (mainContent?.text ?? document.body?.text ?? '')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .trim();
   }
+
+  static String _bounded(String text, KelivoFetchRequestPayload payload) {
+    if (payload.startIndex >= text.length) {
+      return 'No more content available.';
+    }
+
+    var start = payload.startIndex;
+    if (start > 0 && _isLowSurrogate(text.codeUnitAt(start))) {
+      start -= 1;
+    }
+    var end = math.min(start + payload.maxLength, text.length);
+    if (end < text.length &&
+        end > start &&
+        _isHighSurrogate(text.codeUnitAt(end - 1)) &&
+        _isLowSurrogate(text.codeUnitAt(end))) {
+      end = end - start == 1 ? end + 1 : end - 1;
+    }
+
+    final content = text.substring(start, end);
+    if (end >= text.length) return content;
+    return '$content\n\n[Content truncated: showing characters $start-${end - 1} '
+        'of ${text.length}. Call kelivo_fetch with start_index=$end to continue.]';
+  }
+
+  static bool _isHighSurrogate(int codeUnit) =>
+      codeUnit >= 0xD800 && codeUnit <= 0xDBFF;
+
+  static bool _isLowSurrogate(int codeUnit) =>
+      codeUnit >= 0xDC00 && codeUnit <= 0xDFFF;
 
   static Map<String, dynamic> _ok(String text) => {
     'content': [
@@ -204,17 +292,8 @@ class KelivoFetchMcpServerEngine {
             return _ok(id, result: KelivoFetcher._err(e.toString()));
           }
 
-          if (name == 'fetch_html') {
-            return _ok(id, result: await KelivoFetcher.html(payload));
-          }
-          if (name == 'fetch_markdown') {
-            return _ok(id, result: await KelivoFetcher.markdown(payload));
-          }
-          if (name == 'fetch_txt') {
-            return _ok(id, result: await KelivoFetcher.txt(payload));
-          }
-          if (name == 'fetch_json') {
-            return _ok(id, result: await KelivoFetcher.json(payload));
+          if (name == 'kelivo_fetch') {
+            return _ok(id, result: await KelivoFetcher.fetch(payload));
           }
           return _error(id, code: -32101, message: 'Tool not found: $name');
 
@@ -256,10 +335,35 @@ class KelivoFetchMcpServerEngine {
     Map<String, dynamic> schema() => {
       'type': 'object',
       'properties': {
-        'url': {'type': 'string', 'description': 'URL of the website to fetch'},
+        'url': {
+          'type': 'string',
+          'description':
+              'Use the URL exactly as given; do not add www. It must include '
+              'http:// or https://: https://example.com is valid, while '
+              'example.com is invalid.',
+        },
         'headers': {
           'type': 'object',
           'description': 'Optional headers to include in the request',
+        },
+        'max_length': {
+          'type': 'integer',
+          'description': 'Maximum content characters to return',
+          'default': KelivoFetchRequestPayload.defaultMaxLength,
+          'minimum': 1,
+          'maximum': KelivoFetchRequestPayload.maximumMaxLength,
+        },
+        'start_index': {
+          'type': 'integer',
+          'description': 'Character index used to continue truncated content',
+          'default': 0,
+          'minimum': 0,
+        },
+        'raw': {
+          'type': 'boolean',
+          'description':
+              'Return raw source instead of compact, readable Markdown',
+          'default': false,
         },
       },
       'required': ['url'],
@@ -267,27 +371,15 @@ class KelivoFetchMcpServerEngine {
 
     return [
       {
-        'name': 'fetch_html',
+        'name': 'kelivo_fetch',
         'description':
-            'Fetch a web page for the full raw HTML source. Use ONLY when you need to parse specific DOM elements that will be lost in Markdown conversion. For most content extraction tasks, **prefer fetch_markdown** to avoid context bloat. Not for login-protected or paywalled pages.',
-        'inputSchema': schema(),
-      },
-      {
-        'name': 'fetch_markdown',
-        'description':
-            'Fetch a web page for clean Markdown. The preferred tool for articles, documentation, blog posts and tutorials. Not for login-protected or paywalled pages.',
-        'inputSchema': schema(),
-      },
-      {
-        'name': 'fetch_txt',
-        'description':
-            'Fetch a web page for plain text stripped of HTML tags, scripts and styles. Use when you only need readable text without structure, such as text-heavy but poorly-formatted pages, or when fetch_markdown outputs noisy content. Not for login-protected or paywalled pages.',
-        'inputSchema': schema(),
-      },
-      {
-        'name': 'fetch_json',
-        'description':
-            'Fetch a JSON document from a URL. Use only when the endpoint returns strict JSON, such as JSON config files or any JSON-based web service response. Not for login-protected or paywalled pages.',
+            'Fetch the public contents of a web page. Only fetch a URL that '
+            'already appears in the conversation: one provided by the user or '
+            'returned by a prior web_search, kelivo_fetch, or other tool. '
+            'Cannot access content that requires authentication, including private '
+            'documents or pages behind login walls. HTML is simplified to compact '
+            'Markdown with bounded output by default. Continue truncated content with '
+            'start_index; use raw=true only when exact source is required.',
         'inputSchema': schema(),
       },
     ];

--- a/test/core/services/mcp/kelivo_fetch/kelivo_fetch_server_test.dart
+++ b/test/core/services/mcp/kelivo_fetch/kelivo_fetch_server_test.dart
@@ -1,44 +1,192 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
-import 'package:html2md/html2md.dart' as html2md;
+
+import 'package:Cuplivo/core/services/mcp/kelivo_fetch/kelivo_fetch_server.dart';
 
 void main() {
-  group('fetch_markdown script/style ignore', () {
-    test('plain text without HTML tags passes through unchanged', () {
-      final md = html2md.convert('Hello world', ignore: ['script', 'style']);
-      expect(md, contains('Hello world'));
+  group('Kelivo fetch MCP', () {
+    late HttpServer httpServer;
+    late KelivoFetchMcpServerEngine engine;
+    late Uri baseUri;
+
+    setUp(() async {
+      httpServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      baseUri = Uri.parse('http://127.0.0.1:${httpServer.port}');
+      engine = KelivoFetchMcpServerEngine();
+      httpServer.listen((request) async {
+        if (request.uri.path == '/json') {
+          request.response.headers.contentType = ContentType.json;
+          request.response.write('''
+{
+  "items": [
+    1,
+    2
+  ]
+}
+''');
+        } else if (request.uri.path == '/unicode') {
+          request.response.headers.contentType = ContentType.text;
+          request.response.write('😀abc');
+        } else {
+          request.response.headers.contentType = ContentType.html;
+          request.response.write('''
+<!doctype html>
+<html>
+  <head><script>SCRIPT-NOISE-${List.filled(1000, 'x').join()}</script></head>
+  <body>
+    <nav>NAV-NOISE-${List.filled(1000, 'y').join()}</nav>
+    <main><h1>Useful title</h1><p>${List.filled(6500, 'a').join()}</p></main>
+    <footer>FOOTER-NOISE</footer>
+  </body>
+</html>
+''');
+        }
+        await request.response.close();
+      });
     });
 
-    test('script element content is stripped from markdown output', () {
-      const html = '<p>Hello</p><script>alert("xss")</script><p>World</p>';
-      final md = html2md.convert(html, ignore: ['script', 'style']);
-      expect(md, contains('Hello'));
-      expect(md, contains('World'));
-      expect(md, isNot(contains('alert')));
-      expect(md, isNot(contains('xss')));
+    tearDown(() async {
+      engine.close();
+      await httpServer.close(force: true);
     });
 
-    test('style element content is stripped from markdown output', () {
-      const html = '<p>Content</p><style>body{color:red}</style>';
-      final md = html2md.convert(html, ignore: ['style']);
-      expect(md, contains('Content'));
-      expect(md, isNot(contains('color:red')));
-      expect(md, isNot(contains('body{')));
+    test('advertises one compact, bounded fetch tool', () async {
+      final response =
+          await engine.handleMessage({
+                'jsonrpc': '2.0',
+                'id': 1,
+                'method': 'tools/list',
+              })
+              as Map<String, dynamic>;
+
+      final tools =
+          (response['result'] as Map<String, dynamic>)['tools'] as List;
+      expect(tools, hasLength(1));
+      final tool = (tools.single as Map).cast<String, dynamic>();
+      expect(tool['name'], 'kelivo_fetch');
+      expect(tool['description'], contains('HTML is simplified'));
+      expect(
+        tool['description'],
+        contains('already appears in the conversation'),
+      );
+      expect(tool['description'], contains('requires authentication'));
+
+      final schema = (tool['inputSchema'] as Map).cast<String, dynamic>();
+      final properties = (schema['properties'] as Map).cast<String, dynamic>();
+      expect(properties['url']['description'], contains('do not add www'));
+      expect(
+        properties['url']['description'],
+        contains('https://example.com is valid'),
+      );
+      expect(properties['max_length'], {
+        'type': 'integer',
+        'description': 'Maximum content characters to return',
+        'default': 5000,
+        'minimum': 1,
+        'maximum': 20000,
+      });
+      expect(properties['start_index'], containsPair('default', 0));
+      expect(properties['raw'], containsPair('default', false));
     });
 
-    test('both script and style elements are stripped simultaneously', () {
-      const html = '<script>js</script><p>Hello</p><style>css</style>';
-      final md = html2md.convert(html, ignore: ['script', 'style']);
-      expect(md, contains('Hello'));
-      expect(md, isNot(contains('js')));
-      expect(md, isNot(contains('css')));
+    test(
+      'simplifies HTML and limits default output to 5000 characters',
+      () async {
+        final result = await _callFetch(engine, baseUri.resolve('/html'));
+        final text = _resultText(result);
+
+        expect(text, contains('Useful title'));
+        expect(text, isNot(contains('SCRIPT-NOISE')));
+        expect(text, isNot(contains('NAV-NOISE')));
+        expect(text, isNot(contains('FOOTER-NOISE')));
+        expect(text, contains('start_index=5000'));
+        expect(text.split('\n\n[Content truncated').first, hasLength(5000));
+      },
+    );
+
+    test('continues a truncated response from start_index', () async {
+      final result = await _callFetch(
+        engine,
+        baseUri.resolve('/html'),
+        arguments: const {'start_index': 5000},
+      );
+      final text = _resultText(result);
+
+      expect(text, isNotEmpty);
+      expect(text, isNot(contains('Content truncated')));
+      expect(text, matches(RegExp(r'^a+$')));
     });
 
-    test('nested script inside body is stripped', () {
-      const html =
-          '<html><body><p>Visible</p><script>nested</script></body></html>';
-      final md = html2md.convert(html, ignore: ['script', 'style']);
-      expect(md, contains('Visible'));
-      expect(md, isNot(contains('nested')));
+    test('requires raw opt-in and still bounds raw HTML', () async {
+      final result = await _callFetch(
+        engine,
+        baseUri.resolve('/html'),
+        arguments: const {'raw': true, 'max_length': 200},
+      );
+      final text = _resultText(result);
+
+      expect(text, contains('<!doctype html>'));
+      expect(text, contains('SCRIPT-NOISE'));
+      expect(text.split('\n\n[Content truncated').first.length, 200);
+    });
+
+    test('compacts JSON before returning it', () async {
+      final result = await _callFetch(engine, baseUri.resolve('/json'));
+
+      expect(_resultText(result), '{"items":[1,2]}');
+    });
+
+    test('does not split Unicode surrogate pairs at a boundary', () async {
+      final first = await _callFetch(
+        engine,
+        baseUri.resolve('/unicode'),
+        arguments: const {'max_length': 1},
+      );
+      final continued = await _callFetch(
+        engine,
+        baseUri.resolve('/unicode'),
+        arguments: const {'max_length': 3, 'start_index': 2},
+      );
+
+      expect(_resultText(first), startsWith('😀'));
+      expect(_resultText(first), contains('start_index=2'));
+      expect(_resultText(continued), 'abc');
+    });
+
+    test('rejects attempts to exceed the hard output limit', () async {
+      final result = await _callFetch(
+        engine,
+        baseUri.resolve('/html'),
+        arguments: const {'max_length': 20001},
+      );
+
+      expect(result['isError'], isTrue);
+      expect(_resultText(result), contains('Invalid max_length'));
     });
   });
+}
+
+Future<Map<String, dynamic>> _callFetch(
+  KelivoFetchMcpServerEngine engine,
+  Uri url, {
+  Map<String, dynamic> arguments = const {},
+}) async {
+  final response =
+      await engine.handleMessage({
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'tools/call',
+            'params': {
+              'name': 'kelivo_fetch',
+              'arguments': {'url': url.toString(), ...arguments},
+            },
+          })
+          as Map<String, dynamic>;
+  return ((response['result'] as Map).cast<String, dynamic>());
+}
+
+String _resultText(Map<String, dynamic> result) {
+  final content = result['content'] as List;
+  return ((content.single as Map)['text'] as String);
 }


### PR DESCRIPTION
From upstream 92db9a4

Merge upstream improvement that consolidates fetch_html/markdown/txt/json into one kelivo_fetch tool with bounded output (default 5K, max 20K), start_index continuation, raw opt-in, and smart content detection (HTML→Markdown with noise stripping, JSON compaction, plain text).

Keeps cuplivo-next's server version (1.2.0) and auth warnings.