### PR TITLE
feat: preset messages with collapse UI and isPreset field

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -63,6 +63,7 @@ class MessageRows extends Table {
   IntColumn get cachedTokens => integer().nullable()();
   IntColumn get durationMs => integer().nullable()();
   IntColumn get messageOrder => integer()();
+  BoolColumn get isPreset => boolean().withDefault(const Constant(false))();
 
   @override
   Set<Column<Object>> get primaryKey => {id};
@@ -238,7 +239,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -312,6 +313,11 @@ class AppDatabase extends _$AppDatabase {
         await customStatement(
           "UPDATE assistant_rows SET skill_ids_json = '[]' WHERE skill_ids_json IS NULL",
         );
+      }
+      if (from < 8) {
+        try {
+          await migrator.addColumn(messageRows, messageRows.isPreset);
+        } catch (_) {}
       }
     },
   );

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -952,6 +952,21 @@ class $MessageRowsTable extends MessageRows
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _isPresetMeta = const VerificationMeta(
+    'isPreset',
+  );
+  @override
+  late final GeneratedColumn<bool> isPreset = GeneratedColumn<bool>(
+    'is_preset',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_preset" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -976,6 +991,7 @@ class $MessageRowsTable extends MessageRows
     cachedTokens,
     durationMs,
     messageOrder,
+    isPreset,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1166,6 +1182,12 @@ class $MessageRowsTable extends MessageRows
     } else if (isInserting) {
       context.missing(_messageOrderMeta);
     }
+    if (data.containsKey('is_preset')) {
+      context.handle(
+        _isPresetMeta,
+        isPreset.isAcceptableOrUnknown(data['is_preset']!, _isPresetMeta),
+      );
+    }
     return context;
   }
 
@@ -1263,6 +1285,10 @@ class $MessageRowsTable extends MessageRows
         DriftSqlType.int,
         data['${effectivePrefix}message_order'],
       )!,
+      isPreset: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_preset'],
+      )!,
     );
   }
 
@@ -1295,6 +1321,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
   final int? cachedTokens;
   final int? durationMs;
   final int messageOrder;
+  final bool isPreset;
   const MessageRow({
     required this.id,
     required this.conversationId,
@@ -1318,6 +1345,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
     this.cachedTokens,
     this.durationMs,
     required this.messageOrder,
+    required this.isPreset,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -1372,6 +1400,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
       map['duration_ms'] = Variable<int>(durationMs);
     }
     map['message_order'] = Variable<int>(messageOrder);
+    map['is_preset'] = Variable<bool>(isPreset);
     return map;
   }
 
@@ -1427,6 +1456,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
           ? const Value.absent()
           : Value(durationMs),
       messageOrder: Value(messageOrder),
+      isPreset: Value(isPreset),
     );
   }
 
@@ -1464,6 +1494,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
       cachedTokens: serializer.fromJson<int?>(json['cachedTokens']),
       durationMs: serializer.fromJson<int?>(json['durationMs']),
       messageOrder: serializer.fromJson<int>(json['messageOrder']),
+      isPreset: serializer.fromJson<bool>(json['isPreset']),
     );
   }
   @override
@@ -1494,6 +1525,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
       'cachedTokens': serializer.toJson<int?>(cachedTokens),
       'durationMs': serializer.toJson<int?>(durationMs),
       'messageOrder': serializer.toJson<int>(messageOrder),
+      'isPreset': serializer.toJson<bool>(isPreset),
     };
   }
 
@@ -1520,6 +1552,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
     Value<int?> cachedTokens = const Value.absent(),
     Value<int?> durationMs = const Value.absent(),
     int? messageOrder,
+    bool? isPreset,
   }) => MessageRow(
     id: id ?? this.id,
     conversationId: conversationId ?? this.conversationId,
@@ -1553,6 +1586,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
     cachedTokens: cachedTokens.present ? cachedTokens.value : this.cachedTokens,
     durationMs: durationMs.present ? durationMs.value : this.durationMs,
     messageOrder: messageOrder ?? this.messageOrder,
+    isPreset: isPreset ?? this.isPreset,
   );
   MessageRow copyWithCompanion(MessageRowsCompanion data) {
     return MessageRow(
@@ -1608,6 +1642,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
       messageOrder: data.messageOrder.present
           ? data.messageOrder.value
           : this.messageOrder,
+      isPreset: data.isPreset.present ? data.isPreset.value : this.isPreset,
     );
   }
 
@@ -1635,7 +1670,8 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
           ..write('completionTokens: $completionTokens, ')
           ..write('cachedTokens: $cachedTokens, ')
           ..write('durationMs: $durationMs, ')
-          ..write('messageOrder: $messageOrder')
+          ..write('messageOrder: $messageOrder, ')
+          ..write('isPreset: $isPreset')
           ..write(')'))
         .toString();
   }
@@ -1664,6 +1700,7 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
     cachedTokens,
     durationMs,
     messageOrder,
+    isPreset,
   ]);
   @override
   bool operator ==(Object other) =>
@@ -1690,7 +1727,8 @@ class MessageRow extends DataClass implements Insertable<MessageRow> {
           other.completionTokens == this.completionTokens &&
           other.cachedTokens == this.cachedTokens &&
           other.durationMs == this.durationMs &&
-          other.messageOrder == this.messageOrder);
+          other.messageOrder == this.messageOrder &&
+          other.isPreset == this.isPreset);
 }
 
 class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
@@ -1716,6 +1754,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
   final Value<int?> cachedTokens;
   final Value<int?> durationMs;
   final Value<int> messageOrder;
+  final Value<bool> isPreset;
   final Value<int> rowid;
   const MessageRowsCompanion({
     this.id = const Value.absent(),
@@ -1740,6 +1779,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
     this.cachedTokens = const Value.absent(),
     this.durationMs = const Value.absent(),
     this.messageOrder = const Value.absent(),
+    this.isPreset = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   MessageRowsCompanion.insert({
@@ -1765,6 +1805,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
     this.cachedTokens = const Value.absent(),
     this.durationMs = const Value.absent(),
     required int messageOrder,
+    this.isPreset = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        conversationId = Value(conversationId),
@@ -1795,6 +1836,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
     Expression<int>? cachedTokens,
     Expression<int>? durationMs,
     Expression<int>? messageOrder,
+    Expression<bool>? isPreset,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -1822,6 +1864,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
       if (cachedTokens != null) 'cached_tokens': cachedTokens,
       if (durationMs != null) 'duration_ms': durationMs,
       if (messageOrder != null) 'message_order': messageOrder,
+      if (isPreset != null) 'is_preset': isPreset,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -1849,6 +1892,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
     Value<int?>? cachedTokens,
     Value<int?>? durationMs,
     Value<int>? messageOrder,
+    Value<bool>? isPreset,
     Value<int>? rowid,
   }) {
     return MessageRowsCompanion(
@@ -1875,6 +1919,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
       cachedTokens: cachedTokens ?? this.cachedTokens,
       durationMs: durationMs ?? this.durationMs,
       messageOrder: messageOrder ?? this.messageOrder,
+      isPreset: isPreset ?? this.isPreset,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -1952,6 +1997,9 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
     if (messageOrder.present) {
       map['message_order'] = Variable<int>(messageOrder.value);
     }
+    if (isPreset.present) {
+      map['is_preset'] = Variable<bool>(isPreset.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -1983,6 +2031,7 @@ class MessageRowsCompanion extends UpdateCompanion<MessageRow> {
           ..write('cachedTokens: $cachedTokens, ')
           ..write('durationMs: $durationMs, ')
           ..write('messageOrder: $messageOrder, ')
+          ..write('isPreset: $isPreset, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -6160,6 +6209,7 @@ typedef $$MessageRowsTableCreateCompanionBuilder =
       Value<int?> cachedTokens,
       Value<int?> durationMs,
       required int messageOrder,
+      Value<bool> isPreset,
       Value<int> rowid,
     });
 typedef $$MessageRowsTableUpdateCompanionBuilder =
@@ -6186,6 +6236,7 @@ typedef $$MessageRowsTableUpdateCompanionBuilder =
       Value<int?> cachedTokens,
       Value<int?> durationMs,
       Value<int> messageOrder,
+      Value<bool> isPreset,
       Value<int> rowid,
     });
 
@@ -6367,6 +6418,11 @@ class $$MessageRowsTableFilterComposer
 
   ColumnFilters<int> get messageOrder => $composableBuilder(
     column: $table.messageOrder,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isPreset => $composableBuilder(
+    column: $table.isPreset,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -6560,6 +6616,11 @@ class $$MessageRowsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get isPreset => $composableBuilder(
+    column: $table.isPreset,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$ConversationRowsTableOrderingComposer get conversationId {
     final $$ConversationRowsTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -6683,6 +6744,9 @@ class $$MessageRowsTableAnnotationComposer
     column: $table.messageOrder,
     builder: (column) => column,
   );
+
+  GeneratedColumn<bool> get isPreset =>
+      $composableBuilder(column: $table.isPreset, builder: (column) => column);
 
   $$ConversationRowsTableAnnotationComposer get conversationId {
     final $$ConversationRowsTableAnnotationComposer composer = $composerBuilder(
@@ -6816,6 +6880,7 @@ class $$MessageRowsTableTableManager
                 Value<int?> cachedTokens = const Value.absent(),
                 Value<int?> durationMs = const Value.absent(),
                 Value<int> messageOrder = const Value.absent(),
+                Value<bool> isPreset = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MessageRowsCompanion(
                 id: id,
@@ -6840,6 +6905,7 @@ class $$MessageRowsTableTableManager
                 cachedTokens: cachedTokens,
                 durationMs: durationMs,
                 messageOrder: messageOrder,
+                isPreset: isPreset,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -6866,6 +6932,7 @@ class $$MessageRowsTableTableManager
                 Value<int?> cachedTokens = const Value.absent(),
                 Value<int?> durationMs = const Value.absent(),
                 required int messageOrder,
+                Value<bool> isPreset = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MessageRowsCompanion.insert(
                 id: id,
@@ -6890,6 +6957,7 @@ class $$MessageRowsTableTableManager
                 cachedTokens: cachedTokens,
                 durationMs: durationMs,
                 messageOrder: messageOrder,
+                isPreset: isPreset,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -1145,6 +1145,7 @@ class ChatDatabaseRepository {
       completionTokens: row.completionTokens,
       cachedTokens: row.cachedTokens,
       durationMs: row.durationMs,
+      isPreset: row.isPreset,
     );
   }
 
@@ -1176,6 +1177,7 @@ class ChatDatabaseRepository {
       completionTokens: row['completion_tokens'] as int?,
       cachedTokens: row['cached_tokens'] as int?,
       durationMs: row['duration_ms'] as int?,
+      isPreset: row['is_preset'] == 1,
     );
   }
 
@@ -1219,6 +1221,7 @@ class ChatDatabaseRepository {
       completionTokens: Value(message.completionTokens),
       cachedTokens: Value(message.cachedTokens),
       durationMs: Value(message.durationMs),
+      isPreset: Value(message.isPreset),
       messageOrder: messageOrder,
     );
   }

--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -49,6 +49,8 @@ class ChatMessage {
 
   final int? durationMs;
 
+  final bool isPreset;
+
   factory ChatMessage({
     String? id,
     required String role,
@@ -71,6 +73,7 @@ class ChatMessage {
     int? completionTokens,
     int? cachedTokens,
     int? durationMs,
+    bool isPreset = false,
   }) {
     final resolvedId = id ?? const Uuid().v4();
     return ChatMessage._(
@@ -95,6 +98,7 @@ class ChatMessage {
       completionTokens: completionTokens,
       cachedTokens: cachedTokens,
       durationMs: durationMs,
+      isPreset: isPreset,
     );
   }
 
@@ -120,6 +124,7 @@ class ChatMessage {
     this.completionTokens,
     this.cachedTokens,
     this.durationMs,
+    this.isPreset = false,
   });
 
   // Sentinel for copyWith — not passed vs explicitly null.
@@ -147,6 +152,7 @@ class ChatMessage {
     Object? completionTokens = sentinel,
     Object? cachedTokens = sentinel,
     Object? durationMs = sentinel,
+    Object? isPreset = sentinel,
   }) {
     return ChatMessage(
       id: identical(id, sentinel) ? this.id : id as String,
@@ -200,6 +206,9 @@ class ChatMessage {
       durationMs: identical(durationMs, sentinel)
           ? this.durationMs
           : durationMs as int?,
+      isPreset: identical(isPreset, sentinel)
+          ? this.isPreset
+          : isPreset as bool,
     );
   }
 
@@ -226,6 +235,7 @@ class ChatMessage {
       'completionTokens': completionTokens,
       'cachedTokens': cachedTokens,
       'durationMs': durationMs,
+      'isPreset': isPreset,
     };
   }
 
@@ -256,6 +266,7 @@ class ChatMessage {
       completionTokens: json['completionTokens'] as int?,
       cachedTokens: json['cachedTokens'] as int?,
       durationMs: json['durationMs'] as int?,
+      isPreset: json['isPreset'] as bool? ?? false,
     );
   }
 }

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -928,6 +928,7 @@ class ChatService extends ChangeNotifier {
     String? groupId,
     String? subgroupId,
     int? version,
+    bool isPreset = false,
   }) async {
     if (!_initialized) await init();
 
@@ -971,6 +972,7 @@ class ChatService extends ChangeNotifier {
       groupId: groupId,
       subgroupId: subgroupId,
       version: version,
+      isPreset: isPreset,
     );
 
     if (!temporary) {
@@ -1298,6 +1300,7 @@ class ChatService extends ChangeNotifier {
         reasoningFinishedAt: src.reasoningFinishedAt,
         translation: src.translation,
         reasoningSegmentsJson: src.reasoningSegmentsJson,
+        isPreset: src.isPreset,
       );
       await _repo.putMessage(clone, messageOrder: ids.length);
       ids.add(clone.id);
@@ -1455,6 +1458,33 @@ class ChatService extends ChangeNotifier {
     await _saveConversation(c);
     notifyListeners();
     return c;
+  }
+
+  /// Maps a raw-space [truncateIndex] (count of all raw messages) to the
+  /// equivalent skip count in collapsed space (version-collapsed groups).
+  /// Returns 0 when no truncation is active or the result is non-positive.
+  static int rawToCollapsedSkip({
+    required List<ChatMessage> rawMessages,
+    required List<ChatMessage> collapsedMessages,
+    required int truncateIndex,
+  }) {
+    if (truncateIndex <= 0 || truncateIndex > rawMessages.length) return 0;
+    final firstIndexByGroup = <String, int>{};
+    for (var i = 0; i < rawMessages.length; i++) {
+      final gid = rawMessages[i].groupId ?? rawMessages[i].id;
+      firstIndexByGroup.putIfAbsent(gid, () => i);
+    }
+    var skip = 0;
+    for (final m in collapsedMessages) {
+      final gid = m.groupId ?? m.id;
+      final firstIdx = firstIndexByGroup[gid];
+      if (firstIdx != null && firstIdx < truncateIndex) {
+        skip++;
+      } else {
+        break;
+      }
+    }
+    return skip;
   }
 
   Future<void> deleteMessage(String messageId) async {

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -11,6 +11,7 @@ import '../models/chat_message.dart';
 import '../models/conversation.dart';
 import '../providers/settings_provider.dart';
 import 'api/chat_api_service.dart';
+import 'chat/chat_service.dart';
 import 'chat/prompt_transformer.dart';
 import 'instruction_injection_store.dart';
 import 'logging/flutter_logger.dart';
@@ -285,8 +286,13 @@ class ProactiveCareMessageFlow {
       conversation.versionSelections,
     );
     final tIndex = conversation.truncateIndex;
-    final effective = (tIndex >= 0 && tIndex <= collapsed.length)
-        ? collapsed.sublist(tIndex)
+    final collapsedSkip = ChatService.rawToCollapsedSkip(
+      rawMessages: messages,
+      collapsedMessages: collapsed,
+      truncateIndex: tIndex,
+    );
+    final effective = collapsedSkip > 0
+        ? collapsed.sublist(collapsedSkip)
         : collapsed;
     return <Map<String, dynamic>>[
       for (final m in effective)

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1099,6 +1099,16 @@ class HomePageController extends ChangeNotifier {
   }
 
   Future<void> createNewConversationAnimated() async {
+    // Guardrail: block rapid creation if conversation has only preset messages
+    if (_shouldBlockNewConversation) {
+      final l10n = AppLocalizations.of(_context)!;
+      showAppSnackBar(
+        _context,
+        message: l10n.homePagePresetConversationBlocked,
+        type: NotificationType.warning,
+      );
+      return;
+    }
     try {
       await _viewModel.flushCurrentConversationProgress();
     } catch (_) {}
@@ -1120,6 +1130,13 @@ class HomePageController extends ChangeNotifier {
         _inputFocus.requestFocus();
       });
     }
+  }
+
+  bool get _shouldBlockNewConversation {
+    final a = _context.read<AssistantProvider>().currentAssistant;
+    if (a == null || a.presetMessages.isEmpty) return false;
+    if (currentConversation == null) return false;
+    return _chatController.messages.every((m) => m.isPreset);
   }
 
   Future<void> _createNewConversation() async {

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -892,10 +892,11 @@ class HomeViewModel extends ChangeNotifier {
             conversationId: currentConversation!.id,
             role: role,
             content: content,
+            isPreset: true,
           );
-          _chatController.reloadMessages();
-          notifyListeners();
         }
+        _chatController.reloadMessages();
+        notifyListeners();
       }
     } catch (_) {}
 
@@ -1450,7 +1451,13 @@ class HomeViewModel extends ChangeNotifier {
     final mdlId = settings.suggestionModelId;
     if (provKey == null || mdlId == null) return;
 
-    final msgs = collapseVersions(_chatService.getMessages(convo.id));
+    final rawMsgs = _chatService.getMessages(convo.id);
+    final msgs = collapseVersions(rawMsgs);
+    final collapsedTruncateIndex = ChatService.rawToCollapsedSkip(
+      rawMessages: rawMsgs,
+      collapsedMessages: msgs,
+      truncateIndex: convo.truncateIndex,
+    );
     final lastAssistant = msgs.cast<ChatMessage?>().lastWhere(
       (m) =>
           m != null &&
@@ -1475,7 +1482,7 @@ class HomeViewModel extends ChangeNotifier {
         providerKey: provKey,
         modelId: mdlId,
         messages: msgs,
-        truncateIndex: convo.truncateIndex,
+        truncateIndex: collapsedTruncateIndex,
         locale: locale,
         thinkingBudget: budget,
       );

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -438,6 +438,7 @@ class _HomePageState extends State<HomePage>
   final GlobalKey _selectionMiniMapKey = GlobalKey();
   final GlobalKey _selectionActionBarKey = GlobalKey();
   bool _scrollNavHovering = false;
+  bool _presetsExpanded = false;
   StreamSubscription<String>? _processTextSub;
 
   // ============================================================================
@@ -1118,6 +1119,65 @@ class _HomePageState extends State<HomePage>
     return count - 1;
   }
 
+  Widget _buildPresetToggleBar(
+    BuildContext context, {
+    required int presetCount,
+    required bool isExpanded,
+    required VoidCallback onToggle,
+  }) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      child: IosCardPress(
+        onTap: onToggle,
+        borderRadius: BorderRadius.circular(10),
+        baseColor: Colors.transparent,
+        pressedBlendStrength: 0.05,
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          children: [
+            Expanded(
+              child: Divider(
+                color: cs.outlineVariant.withValues(alpha: 0.5),
+                height: 1,
+                thickness: 1,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    isExpanded ? Lucide.ChevronDown : Lucide.ChevronRight,
+                    size: 16,
+                    color: cs.onSurface.withValues(alpha: 0.6),
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    l10n.homePagePresetMessagesCount(presetCount),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: cs.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: Divider(
+                color: cs.outlineVariant.withValues(alpha: 0.5),
+                height: 1,
+                thickness: 1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildMessageListView(
     BuildContext context, {
     required double topContentPadding,
@@ -1136,8 +1196,26 @@ class _HomePageState extends State<HomePage>
     final suggestionsEnabled =
         settings.suggestionModelProvider != null &&
         settings.suggestionModelId != null;
+
+    // Filter preset messages and build collapse toggle
+    final allMessages = _controller.chatController.collapsedMessages;
+    final presetCount = allMessages.takeWhile((m) => m.isPreset).length;
+    final showPresetToggle = presetCount > 0;
+    final messages = !_presetsExpanded && showPresetToggle
+        ? allMessages.skip(presetCount).toList()
+        : allMessages;
+
+    Widget? presetHeaderWidget;
+    if (showPresetToggle) {
+      presetHeaderWidget = _buildPresetToggleBar(
+        context,
+        presetCount: presetCount,
+        isExpanded: _presetsExpanded,
+        onToggle: () => setState(() => _presetsExpanded = !_presetsExpanded),
+      );
+    }
+
     // Build inline multi-AI card widgets keyed by anchor user message ID
-    final messages = _controller.chatController.collapsedMessages;
     final afterMessageWidgets = <String, Widget>{};
     for (final anchorId in _controller.multiAIEngine.anchorMessageIds) {
       final subgrouped = _controller.multiAIEngine.getMessagesForAnchor(
@@ -1153,14 +1231,23 @@ class _HomePageState extends State<HomePage>
       );
     }
 
+    int truncIndex = _computeTruncCollapsedIndex();
+    if (truncIndex >= 0) {
+      if (showPresetToggle && !_presetsExpanded) {
+        truncIndex -= presetCount;
+      }
+      truncIndex += 1; // headerWidget occupies ListView index 0
+    }
+
     final messageList = MessageListView(
       isProcessingFiles: _controller.isProcessingFiles,
       scrollController: _scrollController,
       observerController: _controller.scrollCtrl.observerController,
       messages: messages,
+      headerWidget: presetHeaderWidget,
       byGroup: _controller.chatController.groupedMessages,
       versionSelections: _controller.versionSelections,
-      truncCollapsedIndex: _computeTruncCollapsedIndex(),
+      truncCollapsedIndex: truncIndex,
       reasoning: _controller.reasoning,
       reasoningSegments: _controller.reasoningSegments,
       contentSplits: _controller.contentSplits,

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -134,6 +134,7 @@ class MessageListView extends StatefulWidget {
     this.hasMoreAfter = false,
     this.onLoadMoreAfter,
     this.hideMoreActions,
+    this.headerWidget,
   });
 
   final ScrollController scrollController;
@@ -211,6 +212,10 @@ class MessageListView extends StatefulWidget {
   final bool Function()? onLoadMoreBefore;
   final bool hasMoreAfter;
   final bool Function()? onLoadMoreAfter;
+
+  /// An optional widget rendered as the first item in the list.
+  /// When provided, [messages] indices are shifted by 1.
+  final Widget? headerWidget;
 
   @override
   State<MessageListView> createState() => _MessageListViewState();
@@ -292,6 +297,7 @@ class _MessageListViewState extends State<MessageListView> {
         return ValueListenableBuilder<bool>(
           valueListenable: widget.isProcessingFiles,
           builder: (context, isProcessing, child) {
+            final hasHeader = widget.headerWidget != null;
             final list = ListView.builder(
               controller: widget.scrollController,
               padding: EdgeInsets.fromLTRB(
@@ -301,15 +307,23 @@ class _MessageListViewState extends State<MessageListView> {
                 widget.bottomContentPadding +
                     (widget.isPinnedIndicatorActive ? 12 : 0),
               ),
-              itemCount: widget.messages.length,
+              itemCount: hasHeader
+                  ? widget.messages.length + 1
+                  : widget.messages.length,
               keyboardDismissBehavior: _keyboardDismissBehavior,
               itemBuilder: (context, index) {
-                if (index < 0 || index >= widget.messages.length) {
+                // headerWidget occupies index 0; message index = index - 1
+                if (hasHeader && index == 0) {
+                  return widget.headerWidget!;
+                }
+                final adjustedIndex = hasHeader ? index - 1 : index;
+                if (adjustedIndex < 0 ||
+                    adjustedIndex >= widget.messages.length) {
                   return const SizedBox.shrink();
                 }
                 return _buildMessageItem(
                   context,
-                  index: index,
+                  index: adjustedIndex,
                   isProcessingFiles: isProcessing,
                 );
               },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -328,6 +328,15 @@
   "homePageSelectMessagesToShare": "Please select messages to share",
   "homePageDone": "Done",
   "homePageDropToUpload": "Drop files to upload",
+  "homePagePresetMessagesCount": "{count} preset messages",
+  "@homePagePresetMessagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetConversationBlocked": "Send a message first before creating a new conversation",
   "assistantEditPageTitle": "Assistant",
   "assistantEditPageNotFound": "Assistant not found",
   "assistantEditPageBasicTab": "Basic",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1367,6 +1367,18 @@ abstract class AppLocalizations {
   /// **'Drop files to upload'**
   String get homePageDropToUpload;
 
+  /// No description provided for @homePagePresetMessagesCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} preset messages'**
+  String homePagePresetMessagesCount(int count);
+
+  /// No description provided for @homePagePresetConversationBlocked.
+  ///
+  /// In en, this message translates to:
+  /// **'Send a message first before creating a new conversation'**
+  String get homePagePresetConversationBlocked;
+
   /// No description provided for @assistantEditPageTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -687,6 +687,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homePageDropToUpload => 'Drop files to upload';
 
   @override
+  String homePagePresetMessagesCount(int count) {
+    return '$count preset messages';
+  }
+
+  @override
+  String get homePagePresetConversationBlocked =>
+      'Send a message first before creating a new conversation';
+
+  @override
   String get assistantEditPageTitle => 'Assistant';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -675,6 +675,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homePageDropToUpload => '将文件拖拽到此处上传';
 
   @override
+  String homePagePresetMessagesCount(int count) {
+    return '$count 条预设消息';
+  }
+
+  @override
+  String get homePagePresetConversationBlocked => '请先发送消息后再创建新对话';
+
+  @override
   String get assistantEditPageTitle => '助手';
 
   @override
@@ -6481,6 +6489,14 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get homePageDropToUpload => '将文件拖拽到此处上传';
 
   @override
+  String homePagePresetMessagesCount(int count) {
+    return '$count 条预设消息';
+  }
+
+  @override
+  String get homePagePresetConversationBlocked => '请先发送消息后再创建新对话';
+
+  @override
   String get assistantEditPageTitle => '助手';
 
   @override
@@ -12285,6 +12301,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get homePageDropToUpload => '將檔案拖曳到此處以上傳';
+
+  @override
+  String homePagePresetMessagesCount(int count) {
+    return '$count 條預設訊息';
+  }
+
+  @override
+  String get homePagePresetConversationBlocked => '請先傳送訊息後再建立新對話';
 
   @override
   String get assistantEditPageTitle => '助理';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -646,6 +646,15 @@
   "homePageSelectMessagesToShare": "请选择要分享的消息",
   "homePageDone": "完成",
   "homePageDropToUpload": "将文件拖拽到此处上传",
+  "homePagePresetMessagesCount": "{count} 条预设消息",
+  "@homePagePresetMessagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetConversationBlocked": "请先发送消息后再创建新对话",
   "chatHistoryPageTitle": "聊天历史",
   "chatHistoryPageSearchTooltip": "搜索",
   "chatHistoryPageDeleteAllTooltip": "删除未置顶",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -679,6 +679,15 @@
   "homePageDone": "完成",
   "homePageProcessingFiles": "正在解析文件……",
   "homePageDropToUpload": "将文件拖拽到此处上传",
+  "homePagePresetMessagesCount": "{count} 条预设消息",
+  "@homePagePresetMessagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetConversationBlocked": "请先发送消息后再创建新对话",
   "chatHistoryPageTitle": "聊天历史",
   "chatHistoryPageSearchTooltip": "搜索",
   "chatHistoryPageDeleteAllTooltip": "删除未置顶",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -649,6 +649,15 @@
   "homePageDone": "完成",
   "homePageProcessingFiles": "正在解析檔案……",
   "homePageDropToUpload": "將檔案拖曳到此處以上傳",
+  "homePagePresetMessagesCount": "{count} 條預設訊息",
+  "@homePagePresetMessagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetConversationBlocked": "請先傳送訊息後再建立新對話",
   "chatHistoryPageTitle": "聊天歷史",
   "chatHistoryPageSearchTooltip": "搜尋",
   "chatHistoryPageDeleteAllTooltip": "刪除未置頂",


### PR DESCRIPTION
Closes #85.

- Add isPreset column to MessageRows (DB schema v8, migration)
- Collapse preset messages behind a toggle bar in chat list
- Guardrail: block new-conversation when only presets exist
- Fix: reloadMessages outside preset injection loop (window truncation)
- l10n: add preset messages count and blocked hint in 4 languages
- Regenerate drift & l10n artifacts