### PR TITLE
fix: preset 折叠时清空上下文分隔线位置错误

### DIFF
--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1217,6 +1217,42 @@ class HomeViewModel extends ChangeNotifier {
     return remaining;
   }
 
+  /// Map a raw-space truncation index to a 0-based collapsed message index.
+  static int computeTruncCollapsedIndex({
+    required int truncRaw,
+    required List<ChatMessage> rawMessages,
+  }) {
+    if (truncRaw <= 0) return -1;
+    final seen = <String>{};
+    final int limit = truncRaw < rawMessages.length
+        ? truncRaw
+        : rawMessages.length;
+    int count = 0;
+    for (int i = 0; i < limit; i++) {
+      final gid = (rawMessages[i].groupId ?? rawMessages[i].id);
+      if (seen.add(gid)) count++;
+    }
+    return count - 1;
+  }
+
+  /// Adjust the collapsed truncation index when preset messages are folded.
+  ///
+  /// When presets are collapsed (hidden from the messages list passed to
+  /// [MessageListView]), the truncation index must shift left by [presetCount].
+  /// Returns -1 if the index falls within the hidden preset range or is
+  /// already negative.
+  static int adjustTruncIndexForPresetFolding({
+    required int truncIndex,
+    required int presetCount,
+    required bool showPresetToggle,
+    required bool presetsExpanded,
+  }) {
+    if (truncIndex < 0) return -1;
+    if (!showPresetToggle || presetsExpanded) return truncIndex;
+    final result = truncIndex - presetCount;
+    return result < 0 ? -1 : result;
+  }
+
   // ============================================================================
   // Title Generation
   // ============================================================================

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1104,19 +1104,11 @@ class _HomePageState extends State<HomePage>
 
   /// Map persisted truncateIndex (raw message count) to collapsed index.
   int _computeTruncCollapsedIndex() {
-    final int truncRaw = _controller.chatController.loadedWindowTruncateIndex();
-    if (truncRaw <= 0) return -1;
-    final rawMessages = _controller.messages;
-    final seen = <String>{};
-    final int limit = truncRaw < rawMessages.length
-        ? truncRaw
-        : rawMessages.length;
-    int count = 0;
-    for (int i = 0; i < limit; i++) {
-      final gid = (rawMessages[i].groupId ?? rawMessages[i].id);
-      if (seen.add(gid)) count++;
-    }
-    return count - 1;
+    final truncRaw = _controller.chatController.loadedWindowTruncateIndex();
+    return HomeViewModel.computeTruncCollapsedIndex(
+      truncRaw: truncRaw,
+      rawMessages: _controller.messages,
+    );
   }
 
   Widget _buildPresetToggleBar(
@@ -1231,13 +1223,12 @@ class _HomePageState extends State<HomePage>
       );
     }
 
-    int truncIndex = _computeTruncCollapsedIndex();
-    if (truncIndex >= 0) {
-      if (showPresetToggle && !_presetsExpanded) {
-        truncIndex -= presetCount;
-      }
-      truncIndex += 1; // headerWidget occupies ListView index 0
-    }
+    final truncIndex = HomeViewModel.adjustTruncIndexForPresetFolding(
+      truncIndex: _computeTruncCollapsedIndex(),
+      presetCount: presetCount,
+      showPresetToggle: showPresetToggle,
+      presetsExpanded: _presetsExpanded,
+    );
 
     final messageList = MessageListView(
       isProcessingFiles: _controller.isProcessingFiles,

--- a/test/features/home/controllers/home_view_model_truncation_index_test.dart
+++ b/test/features/home/controllers/home_view_model_truncation_index_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/features/home/controllers/home_view_model.dart';
+
+ChatMessage _m({
+  required String id,
+  required String role,
+  required String content,
+  String? groupId,
+  int version = 0,
+  bool isPreset = false,
+}) {
+  return ChatMessage(
+    id: id,
+    role: role,
+    content: content,
+    conversationId: 'c1',
+    groupId: groupId ?? id,
+    version: version,
+    isPreset: isPreset,
+  );
+}
+
+void main() {
+  group('HomeViewModel.computeTruncCollapsedIndex', () {
+    test('truncRaw <= 0 returns -1', () {
+      expect(
+        HomeViewModel.computeTruncCollapsedIndex(truncRaw: 0, rawMessages: []),
+        -1,
+      );
+      expect(
+        HomeViewModel.computeTruncCollapsedIndex(truncRaw: -1, rawMessages: []),
+        -1,
+      );
+    });
+
+    test('maps raw index directly for unique groups', () {
+      final msgs = [
+        _m(id: 'm0', role: 'user', content: 'a'),
+        _m(id: 'm1', role: 'assistant', content: 'b'),
+        _m(id: 'm2', role: 'user', content: 'c'),
+      ];
+
+      expect(
+        HomeViewModel.computeTruncCollapsedIndex(
+          truncRaw: 2,
+          rawMessages: msgs,
+        ),
+        1,
+      );
+    });
+
+    test('deduplicates versioned messages by groupId', () {
+      final msgs = [
+        _m(id: 'm0', role: 'user', content: 'a', groupId: 'g1'),
+        _m(id: 'm1', role: 'user', content: 'a2', groupId: 'g1', version: 1),
+        _m(id: 'm2', role: 'assistant', content: 'b', groupId: 'g2'),
+      ];
+
+      // truncRaw=3: includes m0, m1, m2 → 2 unique groups → returns 1
+      expect(
+        HomeViewModel.computeTruncCollapsedIndex(
+          truncRaw: 3,
+          rawMessages: msgs,
+        ),
+        1,
+      );
+    });
+
+    test('clamps truncRaw to rawMessages.length when larger', () {
+      final msgs = [
+        _m(id: 'm0', role: 'user', content: 'a'),
+        _m(id: 'm1', role: 'assistant', content: 'b'),
+      ];
+
+      // truncRaw=10 but only 2 messages → limit=2 → count=2 → returns 1
+      expect(
+        HomeViewModel.computeTruncCollapsedIndex(
+          truncRaw: 10,
+          rawMessages: msgs,
+        ),
+        1,
+      );
+    });
+  });
+
+  group('HomeViewModel.adjustTruncIndexForPresetFolding', () {
+    test('truncIndex < 0 returns -1', () {
+      expect(
+        HomeViewModel.adjustTruncIndexForPresetFolding(
+          truncIndex: -1,
+          presetCount: 3,
+          showPresetToggle: true,
+          presetsExpanded: false,
+        ),
+        -1,
+      );
+    });
+
+    test('no preset toggle returns truncIndex unchanged', () {
+      expect(
+        HomeViewModel.adjustTruncIndexForPresetFolding(
+          truncIndex: 4,
+          presetCount: 3,
+          showPresetToggle: false,
+          presetsExpanded: false,
+        ),
+        4,
+      );
+    });
+
+    test('presets expanded returns truncIndex unchanged', () {
+      expect(
+        HomeViewModel.adjustTruncIndexForPresetFolding(
+          truncIndex: 4,
+          presetCount: 3,
+          showPresetToggle: true,
+          presetsExpanded: true,
+        ),
+        4,
+      );
+    });
+
+    test('presets folded, truncIndex >= presetCount subtracts presetCount', () {
+      expect(
+        HomeViewModel.adjustTruncIndexForPresetFolding(
+          truncIndex: 4,
+          presetCount: 3,
+          showPresetToggle: true,
+          presetsExpanded: false,
+        ),
+        1,
+      );
+    });
+
+    test('presets folded, truncIndex < presetCount returns -1', () {
+      expect(
+        HomeViewModel.adjustTruncIndexForPresetFolding(
+          truncIndex: 1,
+          presetCount: 3,
+          showPresetToggle: true,
+          presetsExpanded: false,
+        ),
+        -1,
+      );
+    });
+
+    test(
+      'presets folded, exact boundary (truncIndex == presetCount) returns 0',
+      () {
+        expect(
+          HomeViewModel.adjustTruncIndexForPresetFolding(
+            truncIndex: 3,
+            presetCount: 3,
+            showPresetToggle: true,
+            presetsExpanded: false,
+          ),
+          0,
+        );
+      },
+    );
+
+    test(
+      'presets folded, truncIndex at last message returns correct index',
+      () {
+        // 5 collapsed messages: 3 presets, 2 real
+        // truncIndex=4 (last message index)
+        // after adjustment: 4-3 = 1 (last real message index in shortened list)
+        expect(
+          HomeViewModel.adjustTruncIndexForPresetFolding(
+            truncIndex: 4,
+            presetCount: 3,
+            showPresetToggle: true,
+            presetsExpanded: false,
+          ),
+          1,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixed a regression in #116.

- 移除 truncIndex += 1（错误地将消息列表索引误作 ListView 索引）
- 增加边界检查：预设折叠后 truncIndex 若落入预设范围则返回 -1
- 提取 computeTruncCollapsedIndex / adjustTruncIndexForPresetFolding 为 HomeViewModel 静态方法，便于单元测试
- 新增单元测试文件，覆盖 11 个场景