### PR TITLE
feat: naive subsequence markdown copy + quote

### DIFF
--- a/docs/adr/0004-subsequence-markdown-copy.md
+++ b/docs/adr/0004-subsequence-markdown-copy.md
@@ -1,0 +1,65 @@
+# ADR-0004: Subsequence Matching for "Copy as Markdown"
+
+**Status:** Accepted (2026-07-26)
+
+## Context
+
+Users selecting rendered text in assistant messages get plain text on the
+clipboard. The raw markdown source contains syntax characters (`**`, `##`, `- `,
+`[text](url)`, fences) that are invisible in the rendered output. We want a
+"Copy as Markdown" context menu item that returns the corresponding source
+fragment, and a "Quote" button that inserts selected text into the chat input
+as a blockquote.
+
+Two algorithms were considered for the reverse-mapping from rendered plain text
+back to markdown source:
+
+1. **Stripped projection** — enumerate markdown syntax patterns, strip them to
+   produce a "simulated plain text," do substring search, reverse-map via a
+   position table. Fragile: must exhaustively handle `##`, `**`, `- `, `> `,
+   fences, links, images, HTML entities, tables. Missing one pattern causes
+   offset drift and wrong results.
+
+2. **Subsequence matching** — treat the selected plain text as a subsequence of
+   the raw source. Syntax characters are naturally skipped (they don't appear in
+   rendered text). Score matches by span length; return the tightest. No pattern
+   enumeration required.
+
+## Decision
+
+Use subsequence matching (option 2).
+
+- Simpler implementation, fewer assumptions about markdown syntax.
+- Tolerant of visual-only regex transforms (skipped chars widen span slightly
+  but don't break the match).
+- Bundled with "Quote" in the same PR due to shared `SelectionArea`
+  infrastructure (`onSelectionChanged`, `contextMenuBuilder`,
+  `_selectedPlainText`).
+
+## Rationale
+
+- The existing `SelectionArea` at `chat_message_widget.dart:1909` already wraps
+  assistant content. Adding `onSelectionChanged` and `contextMenuBuilder` is
+  purely additive — no breaking change.
+- Workflow: user selects rendered text → long-press/right-click → context menu
+  has "Copy as Markdown" and/or "Quote". No new gesture handlers or UI surfaces.
+- Visible text is sourced from `visualContent` (after `<think>` removal and
+  visual regex transforms), which is the same string the renderer consumes. The
+  subsequence match is built against this string for 100% alignment.
+
+## Consequences
+
+- The algorithm is a pure function in
+  `lib/utils/markdown_subsequence_match.dart`, trivially unit-testable.
+- If ambiguity becomes a user-facing problem (repeated text → wrong match),
+  upgrade path is to use `TextSelection.baseOffset` as a proximity hint.
+- Silent fallback to plain text on match failure — never worse than status quo.
+
+## Known Limitations (v1)
+
+1. Repeated text → first tightest match (may be wrong occurrence).
+2. Orphaned inline delimiters at selection boundaries.
+3. Multi-line prefix inconsistency (`> ` on intermediate lines).
+4. Table pipes included in source range.
+5. Reasoning section selections → silent fallback (match runs against
+   `visualContent`, which excludes thinking text).

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -25,6 +25,7 @@ import 'package:intl/intl.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/avatar_cache.dart';
 import '../../../utils/assistant_regex.dart';
+import '../../../utils/markdown_subsequence_match.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/providers/tts_provider.dart';
 import '../../../shared/widgets/markdown_with_highlight.dart';
@@ -713,6 +714,7 @@ class ChatMessageWidget extends StatefulWidget {
   final bool enableStreamingTextMotion;
   final List<String> suggestions;
   final ValueChanged<String>? onSuggestionTap;
+  final ValueChanged<String>? onQuoteSelection;
   final Future<void> Function(ToolUIPart part, AskUserResult result)?
   onRecoveredAskUserAnswer;
 
@@ -757,6 +759,7 @@ class ChatMessageWidget extends StatefulWidget {
     this.enableStreamingTextMotion = true,
     this.suggestions = const <String>[],
     this.onSuggestionTap,
+    this.onQuoteSelection,
     this.onRecoveredAskUserAnswer,
   });
 
@@ -768,6 +771,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
   final DateFormat _dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss');
   final ScrollController _reasoningScroll = ScrollController();
   bool _tickActive = false;
+  String? _selectedPlainText;
   // Local expand state for inline <think> card (defaults to expanded)
   bool? _inlineThinkExpanded;
   bool _inlineThinkManuallyToggled = false;
@@ -1908,6 +1912,76 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     return RepaintBoundary(
       child: SelectionArea(
         key: ValueKey('assistant_${widget.message.id}'),
+        onSelectionChanged: (selection) {
+          _selectedPlainText = selection?.plainText;
+        },
+        contextMenuBuilder: (context, selectableRegionState) {
+          final defaultItems = selectableRegionState.contextMenuButtonItems
+              .where((item) => item.type != ContextMenuButtonType.copy)
+              .toList();
+          if (widget.message.isStreaming) {
+            return AdaptiveTextSelectionToolbar.buttonItems(
+              anchors: selectableRegionState.contextMenuAnchors,
+              buttonItems: <ContextMenuButtonItem>[
+                ContextMenuButtonItem(
+                  label: AppLocalizations.of(
+                    context,
+                  )!.chatMessageWidgetCopyAsPlainText,
+                  onPressed: () {
+                    final selected = _selectedPlainText;
+                    if (selected == null || selected.trim().isEmpty) return;
+                    ContextMenuController.removeAny();
+                    selectableRegionState.clearSelection();
+                    Clipboard.setData(ClipboardData(text: selected));
+                  },
+                ),
+                ...defaultItems,
+              ],
+            );
+          }
+          return AdaptiveTextSelectionToolbar.buttonItems(
+            anchors: selectableRegionState.contextMenuAnchors,
+            buttonItems: <ContextMenuButtonItem>[
+              ContextMenuButtonItem(
+                label: AppLocalizations.of(
+                  context,
+                )!.chatMessageWidgetCopyAsMarkdown,
+                onPressed: () {
+                  final selected = _selectedPlainText;
+                  if (selected == null || selected.trim().isEmpty) return;
+                  ContextMenuController.removeAny();
+                  selectableRegionState.clearSelection();
+                  final matched = subsequenceMatch(visualContent, selected);
+                  Clipboard.setData(ClipboardData(text: matched ?? selected));
+                },
+              ),
+              ContextMenuButtonItem(
+                label: AppLocalizations.of(
+                  context,
+                )!.chatMessageWidgetCopyAsPlainText,
+                onPressed: () {
+                  final selected = _selectedPlainText;
+                  if (selected == null || selected.trim().isEmpty) return;
+                  ContextMenuController.removeAny();
+                  selectableRegionState.clearSelection();
+                  Clipboard.setData(ClipboardData(text: selected));
+                },
+              ),
+              if (widget.onQuoteSelection != null)
+                ContextMenuButtonItem(
+                  label: AppLocalizations.of(context)!.chatMessageWidgetQuote,
+                  onPressed: () {
+                    final selected = _selectedPlainText;
+                    if (selected == null || selected.trim().isEmpty) return;
+                    ContextMenuController.removeAny();
+                    selectableRegionState.clearSelection();
+                    widget.onQuoteSelection!.call(selected);
+                  },
+                ),
+              ...defaultItems,
+            ],
+          );
+        },
         child: DefaultTextStyle.merge(
           style: TextStyle(fontSize: baseAssistant, height: 1.5),
           child: assistantContent,

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -2310,6 +2310,25 @@ class HomePageController extends ChangeNotifier {
     notifyListeners();
   }
 
+  void insertQuote(String text) {
+    final lines = text.split('\n').map((line) => '> $line').join('\n');
+    final quoted = '$lines\n\n';
+
+    final currentText = _inputController.text;
+    final cursor = _inputController.selection.start;
+    final insertPos = (cursor >= 0 && cursor <= currentText.length)
+        ? cursor
+        : currentText.length;
+    final newText = currentText.replaceRange(insertPos, insertPos, quoted);
+    _inputController.value = _inputController.value.copyWith(
+      text: newText,
+      selection: TextSelection.collapsed(offset: insertPos + quoted.length),
+      composing: TextRange.empty,
+    );
+    _inputFocus.requestFocus();
+    notifyListeners();
+  }
+
   // ============================================================================
   // Public Methods - File Upload
   // ============================================================================

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1304,6 +1304,7 @@ class _HomePageState extends State<HomePage>
       ),
       onSpeakMessage: (message) => _controller.speakMessage(message),
       onSuggestionTap: (suggestion) => _controller.sendSuggestion(suggestion),
+      onQuoteSelection: (text) => _controller.insertQuote(text),
       onRecoveredAskUserAnswer: (message, part, result) =>
           _controller.submitRecoveredAskUserAnswer(message, part, result),
       onToggleSelection: (messageId, selected) {

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -44,6 +44,7 @@ typedef OnSelectMessages =
     void Function(int messageIndex, List<ChatMessage> messages);
 typedef OnSpeakMessage = Future<void> Function(ChatMessage message);
 typedef OnSuggestionTap = void Function(String suggestion);
+typedef OnQuoteSelection = void Function(String text);
 typedef OnRecoveredAskUserAnswer =
     Future<void> Function(
       ChatMessage message,
@@ -123,6 +124,7 @@ class MessageListView extends StatefulWidget {
     this.suggestions = const <String>[],
     this.afterMessageWidgets,
     this.onSuggestionTap,
+    this.onQuoteSelection,
     this.onRecoveredAskUserAnswer,
     this.onToggleSelection,
     this.onToggleReasoning,
@@ -192,6 +194,7 @@ class MessageListView extends StatefulWidget {
   final OnSelectMessages? onSelectMessages;
   final OnSpeakMessage? onSpeakMessage;
   final OnSuggestionTap? onSuggestionTap;
+  final OnQuoteSelection? onQuoteSelection;
   final OnRecoveredAskUserAnswer? onRecoveredAskUserAnswer;
   final void Function(String messageId, bool selected)? onToggleSelection;
   final void Function(String messageId)? onToggleReasoning;
@@ -922,6 +925,7 @@ class _MessageListViewState extends State<MessageListView> {
       isProcessingFiles: isProcessingFiles,
       suggestions: suggestions,
       onSuggestionTap: widget.onSuggestionTap,
+      onQuoteSelection: widget.onQuoteSelection,
       onRecoveredAskUserAnswer: widget.onRecoveredAskUserAnswer == null
           ? null
           : (part, result) =>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2895,5 +2895,8 @@
     }
   },
   "truncationReasonMaxTokens": "output length limit",
-  "truncationReasonContextExceeded": "context window exceeded"
+  "truncationReasonContextExceeded": "context window exceeded",
+  "chatMessageWidgetCopyAsMarkdown": "Copy as Markdown",
+  "chatMessageWidgetCopyAsPlainText": "Copy as Plain Text",
+  "chatMessageWidgetQuote": "Quote"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11077,6 +11077,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'context window exceeded'**
   String get truncationReasonContextExceeded;
+
+  /// No description provided for @chatMessageWidgetCopyAsMarkdown.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy as Markdown'**
+  String get chatMessageWidgetCopyAsMarkdown;
+
+  /// No description provided for @chatMessageWidgetCopyAsPlainText.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy as Plain Text'**
+  String get chatMessageWidgetCopyAsPlainText;
+
+  /// No description provided for @chatMessageWidgetQuote.
+  ///
+  /// In en, this message translates to:
+  /// **'Quote'**
+  String get chatMessageWidgetQuote;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6064,4 +6064,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get truncationReasonContextExceeded => 'context window exceeded';
+
+  @override
+  String get chatMessageWidgetCopyAsMarkdown => 'Copy as Markdown';
+
+  @override
+  String get chatMessageWidgetCopyAsPlainText => 'Copy as Plain Text';
+
+  @override
+  String get chatMessageWidgetQuote => 'Quote';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5816,6 +5816,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get truncationReasonContextExceeded => '上下文窗口超限';
+
+  @override
+  String get chatMessageWidgetCopyAsMarkdown => '复制为 Markdown';
+
+  @override
+  String get chatMessageWidgetCopyAsPlainText => '复制为纯文本';
+
+  @override
+  String get chatMessageWidgetQuote => '引用';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -11630,6 +11639,15 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get truncationReasonContextExceeded => '上下文窗口超限';
+
+  @override
+  String get chatMessageWidgetCopyAsMarkdown => '复制为 Markdown';
+
+  @override
+  String get chatMessageWidgetCopyAsPlainText => '复制为纯文本';
+
+  @override
+  String get chatMessageWidgetQuote => '引用';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -17444,4 +17462,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get truncationReasonContextExceeded => '上下文窗口超限';
+
+  @override
+  String get chatMessageWidgetCopyAsMarkdown => '複製為 Markdown';
+
+  @override
+  String get chatMessageWidgetCopyAsPlainText => '複製為純文字';
+
+  @override
+  String get chatMessageWidgetQuote => '引用';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2404,5 +2404,8 @@
     }
   },
   "truncationReasonMaxTokens": "输出长度限制",
-  "truncationReasonContextExceeded": "上下文窗口超限"
+  "truncationReasonContextExceeded": "上下文窗口超限",
+  "chatMessageWidgetCopyAsMarkdown": "复制为 Markdown",
+  "chatMessageWidgetCopyAsPlainText": "复制为纯文本",
+  "chatMessageWidgetQuote": "引用"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2376,5 +2376,8 @@
     }
   },
   "truncationReasonMaxTokens": "输出长度限制",
-  "truncationReasonContextExceeded": "上下文窗口超限"
+  "truncationReasonContextExceeded": "上下文窗口超限",
+  "chatMessageWidgetCopyAsMarkdown": "复制为 Markdown",
+  "chatMessageWidgetCopyAsPlainText": "复制为纯文本",
+  "chatMessageWidgetQuote": "引用"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2404,5 +2404,8 @@
     }
   },
   "truncationReasonMaxTokens": "輸出長度限制",
-  "truncationReasonContextExceeded": "上下文窗口超限"
+  "truncationReasonContextExceeded": "上下文窗口超限",
+  "chatMessageWidgetCopyAsMarkdown": "複製為 Markdown",
+  "chatMessageWidgetCopyAsPlainText": "複製為純文字",
+  "chatMessageWidgetQuote": "引用"
 }

--- a/lib/utils/markdown_subsequence_match.dart
+++ b/lib/utils/markdown_subsequence_match.dart
@@ -1,0 +1,92 @@
+/// Finds the tightest subsequence match of [query] in [source].
+///
+/// Walks [source] left-to-right for each candidate start position, greedily
+/// matching [query] characters in order. Returns the source fragment with the
+/// smallest span (end - start) that contains all query characters as a
+/// subsequence.
+///
+/// [query] is normalized before matching:
+/// - `\r\n` → `\n`, consecutive newlines folded into one
+/// - Zero-width / invisible characters stripped (\u200b–\u200f, \ufeff,
+///   \u00ad, \u2060–\u2064)
+/// - Bullet character `•` (U+2022) stripped
+///
+/// Returns `null` if [query] is empty, [source] is empty, or [query] is not a
+/// subsequence of [source].
+String? subsequenceMatch(String source, String query) {
+  if (query.isEmpty || source.isEmpty) return null;
+
+  final normalized = _normalizeQuery(query);
+  if (normalized.isEmpty) return null;
+  if (normalized.length > source.length) return null;
+
+  final srcLen = source.length;
+  final qryLen = normalized.length;
+
+  int? bestStart;
+  int? bestEnd;
+  int bestSpan = srcLen + 1;
+
+  for (int i = 0; i <= srcLen - qryLen; i++) {
+    if (qryLen >= bestSpan) break;
+
+    int qi = 0;
+    int si = i;
+    while (si < srcLen && qi < qryLen) {
+      if (source[si] == normalized[qi]) qi++;
+      si++;
+    }
+
+    if (qi == qryLen) {
+      final span = si - i;
+      if (span < bestSpan) {
+        bestSpan = span;
+        bestStart = i;
+        bestEnd = si;
+        if (span == qryLen) break;
+      }
+    }
+  }
+
+  if (bestStart == null || bestEnd == null) return null;
+
+  return source.substring(bestStart, bestEnd);
+}
+
+String _normalizeQuery(String raw) {
+  final buf = StringBuffer();
+  bool prevNewline = false;
+  for (int i = 0; i < raw.length; i++) {
+    var c = raw[i];
+    if (c == '\r') {
+      if (i + 1 < raw.length && raw[i + 1] == '\n') {
+        i++;
+      }
+      c = '\n';
+    }
+    if (c == '\n') {
+      if (!prevNewline) {
+        buf.write(c);
+        prevNewline = true;
+      }
+      continue;
+    }
+    prevNewline = false;
+    if (_isStripped(c)) continue;
+    buf.write(c);
+  }
+  return buf.toString();
+}
+
+bool _isStripped(String c) {
+  final cp = c.codeUnitAt(0);
+  return cp == 0x2022 || // bullet •
+      cp == 0x200b || // ZWSP
+      cp == 0x200c || // ZWNJ
+      cp == 0x200d || // ZWJ
+      cp == 0x200e || // LRM
+      cp == 0x200f || // RLM
+      cp == 0xfeff || // BOM
+      cp == 0x00ad || // soft hyphen
+      (cp >= 0x2060 && cp <= 0x2064); // invisible operators
+}

--- a/test/utils/markdown_subsequence_match_test.dart
+++ b/test/utils/markdown_subsequence_match_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/utils/markdown_subsequence_match.dart';
+
+void main() {
+  group('subsequenceMatch', () {
+    test('direct substring match returns the matching fragment', () {
+      final result = subsequenceMatch('hello world', 'world');
+      expect(result, 'world');
+    });
+
+    test('match skipping bold syntax', () {
+      // Tightest span includes trailing **, excludes leading **
+      final result = subsequenceMatch('**bold** text', 'bold text');
+      expect(result, 'bold** text');
+    });
+
+    test('match skipping heading prefix', () {
+      final result = subsequenceMatch('## Title', 'Title');
+      expect(result, 'Title');
+    });
+
+    test('match skipping link syntax', () {
+      // Tightest match lands inside [click here](url), excluding brackets
+      final result = subsequenceMatch('[click here](url)', 'click here');
+      expect(result, 'click here');
+    });
+
+    test('match across multiple inline spans', () {
+      // Internal delimiters preserved, outer ones excluded
+      final result = subsequenceMatch(
+        '**bold** and *italic*',
+        'bold and italic',
+      );
+      expect(result, 'bold** and *italic');
+    });
+
+    test('match code block content', () {
+      // Code fences are outside the span
+      final result = subsequenceMatch(
+        '```dart\nvoid main() {}\n```',
+        'void main() {}',
+      );
+      expect(result, 'void main() {}');
+    });
+
+    test('match across list items', () {
+      // First prefix excluded, intermediate prefix included
+      final result = subsequenceMatch(
+        '- item one\n- item two\n- item three',
+        'item one\nitem two',
+      );
+      expect(result, 'item one\n- item two');
+    });
+
+    test('tightest match wins', () {
+      // First occurrence "the" inside **the** has span 3 (tightest)
+      final result = subsequenceMatch('**the** cat and **the** dog', 'the');
+      expect(result, 'the');
+    });
+
+    test(
+      'tightest match prefers later exact substring over early loose match',
+      () {
+        final result = subsequenceMatch(
+          'the answer is 42. the question is unknown.',
+          'the question',
+        );
+        expect(result, 'the question');
+      },
+    );
+
+    test('returns null for empty query', () {
+      expect(subsequenceMatch('hello', ''), isNull);
+    });
+
+    test('returns null for empty source', () {
+      expect(subsequenceMatch('', 'hello'), isNull);
+    });
+
+    test('returns null when query longer than source', () {
+      expect(subsequenceMatch('abc', 'abcd'), isNull);
+    });
+
+    test('returns null when query is not a subsequence', () {
+      expect(subsequenceMatch('hello', 'xyz'), isNull);
+    });
+
+    test('matches single character at tightest position', () {
+      final result = subsequenceMatch('hello', 'e');
+      expect(result, 'e');
+    });
+
+    test('matches entire source', () {
+      final result = subsequenceMatch('hello world', 'hello world');
+      expect(result, 'hello world');
+    });
+
+    test('handles CJK', () {
+      final result = subsequenceMatch('你好世界', '世界');
+      expect(result, '世界');
+    });
+
+    test('match across blocks with newlines preserved', () {
+      final result = subsequenceMatch(
+        '# heading\n\n**bold** and `code`',
+        'heading\n\nbold and code',
+      );
+      expect(result, 'heading\n\n**bold** and `code');
+    });
+
+    // --- Normalization tests ---
+
+    test('folds \\r\\n to \\n', () {
+      final result = subsequenceMatch('- a\r\n- b', 'a\nb');
+      expect(result, 'a\r\n- b');
+    });
+
+    test('folds consecutive newlines in query', () {
+      // Source has a single newline between items; query has two
+      final result = subsequenceMatch('- a\n- b', 'a\n\nb');
+      expect(result, 'a\n- b');
+    });
+
+    test('strips ZWNJ (\\u200c) from query', () {
+      final result = subsequenceMatch('hello\u200c world', 'hello world');
+      expect(result, 'hello\u200c world');
+    });
+
+    test('strips bullet character from query', () {
+      // • stripped, leading space preserved in match
+      final result = subsequenceMatch('- item text', '• item text');
+      expect(result, ' item text');
+    });
+
+    test('strips ZWSP (\\u200b) from query', () {
+      final result = subsequenceMatch('hello', 'h\u200bello');
+      expect(result, 'hello');
+    });
+
+    test('returns null when normalization empties the query', () {
+      expect(subsequenceMatch('hello', '\u200b\u200c'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Inspired by Chevey339/kelivo#802, Fixes Chevey339/kelivo#771.

- Add `subsequenceMatch()` utility for reverse-mapping selected plain text back to markdown source (tightest-match algorithm)
- Add 'Copy as Markdown' and 'Copy as Plain Text' context menu items on assistant message `SelectionArea` (**replaces** default menu)
- Add 'Quote' action: inserts selected text as blockquote (> line) into input bar at cursor position
- Query normalization: fold `\r\n`/`\n\n`, strip ZWSP/ZWNJ/bullet/invisible
- Localized in en/zh/zh_Hans/zh_Hant
- ADR 0004 documenting algorithm choice
