### PR TITLE
feat: beautify request body in log viewer — split messages from config

### DIFF
--- a/lib/features/settings/logs/request_body_beautifier.dart
+++ b/lib/features/settings/logs/request_body_beautifier.dart
@@ -1,0 +1,610 @@
+import 'dart:convert';
+
+/// Normalized role for a conversation turn shown in the beautified request body.
+enum TurnRole { system, user, assistant, tool }
+
+/// A single part within a turn. Turns are interleaved lists of text and
+/// non-text parts (tool calls, images, thinking, etc.) in their original order.
+sealed class TurnPart {}
+
+class TextPart extends TurnPart {
+  final String text;
+  TextPart(this.text);
+}
+
+class ImagePart extends TurnPart {
+  /// Filename if known (e.g. from OpenAI ``file`` parts), ``null`` otherwise.
+  final String? filename;
+
+  /// Remote URL if the image is a plain URL (not base64), ``null`` otherwise.
+  final String? url;
+
+  /// MIME type if known, ``null`` otherwise.
+  final String? mime;
+
+  /// Whether the payload is base64-encoded inline data.
+  final bool isBase64;
+
+  /// Decoded byte length of the base64 payload (0 if unknown / not base64).
+  final int byteLength;
+
+  ImagePart({
+    this.filename,
+    this.url,
+    this.mime,
+    this.isBase64 = false,
+    this.byteLength = 0,
+  });
+
+  /// Compact display label: ``filename/url/mime (base64) · size``.
+  String get displayLabel {
+    final head = filename ?? url ?? mime ?? 'image';
+    final base64Tag = isBase64 ? ' (base64)' : '';
+    if (byteLength > 0) {
+      return '$head$base64Tag · ${_describeBytes(byteLength)}';
+    }
+    return '$head$base64Tag';
+  }
+}
+
+class FilePart extends TurnPart {
+  final String filename;
+  FilePart(this.filename);
+}
+
+class ToolCallPart extends TurnPart {
+  final String name;
+
+  /// Pretty-printed JSON arguments (or raw string if not JSON).
+  final String arguments;
+  ToolCallPart(this.name, this.arguments);
+}
+
+class ToolResultPart extends TurnPart {
+  final String name;
+
+  /// Pretty-printed JSON output (or raw string if not JSON).
+  final String output;
+  ToolResultPart(this.name, this.output);
+}
+
+class ThinkingPart extends TurnPart {
+  final String content;
+  ThinkingPart(this.content);
+}
+
+class RedactedThinkingPart extends TurnPart {
+  final int byteLength;
+  RedactedThinkingPart(this.byteLength);
+}
+
+/// One normalized conversation turn rendered as a left-border-accented block.
+class BeautifiedTurn {
+  final TurnRole role;
+  final List<TurnPart> parts;
+  const BeautifiedTurn(this.role, this.parts);
+}
+
+/// Result of beautifying a request body: colored turns on top, remaining
+/// config fields pretty-printed below.
+class BeautifiedBody {
+  final List<BeautifiedTurn> turns;
+
+  /// Pretty-printed JSON of the non-message fields. Empty string if none.
+  final String configJson;
+  const BeautifiedBody(this.turns, this.configJson);
+}
+
+/// Tries to parse [rawBody] into a [BeautifiedBody].
+///
+/// Returns `null` if the body is not valid JSON, not a JSON object, or does
+/// not match any of the four supported LLM protocol structures.
+BeautifiedBody? tryBeautify(String rawBody) {
+  final trimmed = rawBody.trim();
+  if (trimmed.isEmpty) return null;
+
+  final dynamic decoded;
+  try {
+    decoded = jsonDecode(trimmed);
+  } catch (_) {
+    return null;
+  }
+  if (decoded is! Map<String, dynamic>) return null;
+
+  // Detection order: unique structural keys first.
+  if (decoded.containsKey('input')) return _parseOpenAIResponses(decoded);
+  if (decoded.containsKey('contents')) return _parseGemini(decoded);
+  if (decoded.containsKey('messages')) {
+    if (decoded['system'] is String || decoded['system'] is List) {
+      return _parseClaude(decoded);
+    }
+    return _parseOpenAIChat(decoded);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-protocol parsers
+// ---------------------------------------------------------------------------
+
+BeautifiedBody _parseOpenAIChat(Map<String, dynamic> body) {
+  final turns = <BeautifiedTurn>[];
+  final messages = body['messages'] as List<dynamic>? ?? const [];
+
+  for (final msg in messages) {
+    if (msg is! Map<String, dynamic>) continue;
+    final role = _normalizeRole(msg['role'] as String?);
+    final parts = <TurnPart>[];
+
+    final content = msg['content'];
+
+    // Tool-role messages: content IS the tool result, no separate text part.
+    if (role == TurnRole.tool) {
+      final toolName = (msg['name'] as String?) ?? 'tool';
+      final resultStr = content is String ? content : _prettyOrRaw(content);
+      parts.add(ToolResultPart(toolName, resultStr));
+    } else if (content is String && content.isNotEmpty) {
+      parts.add(TextPart(content));
+    } else if (content is List) {
+      for (final part in content) {
+        if (part is! Map<String, dynamic>) continue;
+        final p = _parseOpenAIChatContentPart(part);
+        if (p != null) parts.add(p);
+      }
+    }
+
+    // Assistant tool calls.
+    if (msg['tool_calls'] is List) {
+      for (final tc in (msg['tool_calls'] as List)) {
+        if (tc is! Map<String, dynamic>) continue;
+        final fn = tc['function'] as Map<String, dynamic>?;
+        parts.add(
+          ToolCallPart(
+            (fn?['name'] as String?) ?? 'unknown',
+            _prettyOrRaw(fn?['arguments']),
+          ),
+        );
+      }
+    }
+
+    // Some vendors echo reasoning on messages (typically assistant).
+    // Two formats: reasoning_content (string) and reasoning_details (list
+    // of {type: "reasoning.text", text: "..."} chunks from OpenRouter-style
+    // streaming).
+    final reasoning = msg['reasoning_content'];
+    if (reasoning is String && reasoning.isNotEmpty) {
+      parts.add(ThinkingPart(reasoning));
+    }
+    final reasoningDetails = msg['reasoning_details'];
+    if (reasoningDetails is List) {
+      final text = reasoningDetails
+          .whereType<Map<String, dynamic>>()
+          .map((d) => d['text'] as String?)
+          .where((t) => t != null && t.isNotEmpty)
+          .join();
+      if (text.isNotEmpty) parts.add(ThinkingPart(text));
+    }
+
+    if (parts.isNotEmpty) turns.add(BeautifiedTurn(role, parts));
+  }
+
+  return BeautifiedBody(turns, _remainingJson(body, const {'messages'}));
+}
+
+BeautifiedBody _parseClaude(Map<String, dynamic> body) {
+  final turns = <BeautifiedTurn>[];
+
+  // Claude system prompt is a top-level string (or a list of blocks).
+  final system = body['system'];
+  if (system is String && system.isNotEmpty) {
+    turns.add(BeautifiedTurn(TurnRole.system, [TextPart(system)]));
+  } else if (system is List) {
+    final text = system
+        .whereType<Map<String, dynamic>>()
+        .where((b) => b['type'] == 'text')
+        .map((b) => b['text'] as String?)
+        .where((t) => t != null && t.isNotEmpty)
+        .join('\n');
+    if (text.isNotEmpty) {
+      turns.add(BeautifiedTurn(TurnRole.system, [TextPart(text)]));
+    }
+  }
+
+  final messages = body['messages'] as List<dynamic>? ?? const [];
+  for (final msg in messages) {
+    if (msg is! Map<String, dynamic>) continue;
+    final role = _normalizeRole(msg['role'] as String?);
+    final parts = <TurnPart>[];
+
+    final content = msg['content'];
+    if (content is String && content.isNotEmpty) {
+      parts.add(TextPart(content));
+    } else if (content is List) {
+      for (final block in content) {
+        if (block is! Map<String, dynamic>) continue;
+        final p = _parseClaudeContentBlock(block);
+        if (p != null) parts.add(p);
+      }
+    }
+
+    if (parts.isNotEmpty) turns.add(BeautifiedTurn(role, parts));
+  }
+
+  return BeautifiedBody(
+    turns,
+    _remainingJson(body, const {'messages', 'system'}),
+  );
+}
+
+BeautifiedBody _parseGemini(Map<String, dynamic> body) {
+  final turns = <BeautifiedTurn>[];
+
+  // Gemini system instruction is a top-level object with parts.
+  final sysInstr = body['systemInstruction'];
+  if (sysInstr is Map<String, dynamic>) {
+    final text = _extractGeminiText(sysInstr['parts']);
+    if (text.isNotEmpty) {
+      turns.add(BeautifiedTurn(TurnRole.system, [TextPart(text)]));
+    }
+  }
+
+  final contents = body['contents'] as List<dynamic>? ?? const [];
+  for (final entry in contents) {
+    if (entry is! Map<String, dynamic>) continue;
+    final role = _normalizeRole(entry['role'] as String?);
+    final parts = <TurnPart>[];
+
+    final partsList = entry['parts'] as List<dynamic>? ?? const [];
+    for (final part in partsList) {
+      if (part is! Map<String, dynamic>) continue;
+      final p = _parseGeminiPart(part);
+      if (p != null) parts.add(p);
+    }
+
+    if (parts.isNotEmpty) turns.add(BeautifiedTurn(role, parts));
+  }
+
+  return BeautifiedBody(
+    turns,
+    _remainingJson(body, const {'contents', 'systemInstruction'}),
+  );
+}
+
+BeautifiedBody _parseOpenAIResponses(Map<String, dynamic> body) {
+  final turns = <BeautifiedTurn>[];
+
+  // OpenAI Responses: system prompt is a top-level "instructions" string.
+  final instructions = body['instructions'];
+  if (instructions is String && instructions.isNotEmpty) {
+    turns.add(BeautifiedTurn(TurnRole.system, [TextPart(instructions)]));
+  }
+
+  // "input" can be a simple string or an array of items.
+  final input = body['input'];
+  if (input is String && input.isNotEmpty) {
+    turns.add(BeautifiedTurn(TurnRole.user, [TextPart(input)]));
+  } else if (input is List) {
+    for (final item in input) {
+      if (item is! Map<String, dynamic>) continue;
+      final type = item['type'] as String?;
+
+      if (type == 'function_call') {
+        turns.add(
+          BeautifiedTurn(TurnRole.assistant, [
+            ToolCallPart(
+              (item['name'] as String?) ?? 'unknown',
+              _prettyOrRaw(item['arguments']),
+            ),
+          ]),
+        );
+        continue;
+      }
+      if (type == 'function_call_output') {
+        turns.add(
+          BeautifiedTurn(TurnRole.tool, [
+            ToolResultPart(
+              (item['call_id'] as String?) ?? 'tool',
+              _prettyOrRaw(item['output']),
+            ),
+          ]),
+        );
+        continue;
+      }
+
+      // Message item: has role + content.
+      final role = _normalizeRole(item['role'] as String?);
+      final parts = <TurnPart>[];
+      final content = item['content'];
+      if (content is String && content.isNotEmpty) {
+        parts.add(TextPart(content));
+      } else if (content is List) {
+        for (final part in content) {
+          if (part is! Map<String, dynamic>) continue;
+          final p = _parseOpenAIResponsesContentPart(part);
+          if (p != null) parts.add(p);
+        }
+      }
+
+      // Vendor-echoed reasoning (OpenRouter-style reasoning_details).
+      final reasoningDetails = item['reasoning_details'];
+      if (reasoningDetails is List) {
+        final text = reasoningDetails
+            .whereType<Map<String, dynamic>>()
+            .map((d) => d['text'] as String?)
+            .where((t) => t != null && t.isNotEmpty)
+            .join();
+        if (text.isNotEmpty) parts.add(ThinkingPart(text));
+      }
+
+      if (parts.isNotEmpty) turns.add(BeautifiedTurn(role, parts));
+    }
+  }
+
+  return BeautifiedBody(
+    turns,
+    _remainingJson(body, const {'input', 'instructions'}),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Content-part parsers (per protocol)
+// ---------------------------------------------------------------------------
+
+TurnPart? _parseOpenAIChatContentPart(Map<String, dynamic> part) {
+  switch (part['type'] as String?) {
+    case 'text':
+      final t = part['text'] as String?;
+      if (t != null && t.isNotEmpty) return TextPart(t);
+      return null;
+    case 'image_url':
+      final url = (part['image_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String) {
+        if (url.startsWith('data:')) {
+          final info = _parseDataUrl(url);
+          return ImagePart(
+            mime: info?.mime,
+            isBase64: true,
+            byteLength: info?.byteLength ?? 0,
+          );
+        }
+        return ImagePart(url: url);
+      }
+      return null;
+    case 'video_url':
+      final url = (part['video_url'] as Map<String, dynamic>?)?['url'];
+      if (url is String && url.startsWith('data:')) {
+        final info = _parseDataUrl(url);
+        return ImagePart(
+          mime: info?.mime,
+          isBase64: true,
+          byteLength: info?.byteLength ?? 0,
+        );
+      }
+      return ImagePart(url: url is String ? url : null);
+    case 'file':
+      final file = part['file'] as Map<String, dynamic>?;
+      final filename = (file?['filename'] as String?) ?? 'file';
+      return FilePart(filename);
+    default:
+      return null;
+  }
+}
+
+TurnPart? _parseClaudeContentBlock(Map<String, dynamic> block) {
+  switch (block['type'] as String?) {
+    case 'text':
+      final t = block['text'] as String?;
+      if (t != null && t.isNotEmpty) return TextPart(t);
+      return null;
+    case 'image':
+      final source = block['source'] as Map<String, dynamic>?;
+      final mediaType = (source?['media_type'] as String?) ?? 'image';
+      final data = source?['data'] as String?;
+      return ImagePart(
+        mime: mediaType,
+        isBase64: true,
+        byteLength: data != null ? _base64ByteLength(data) : 0,
+      );
+    case 'tool_use':
+      return ToolCallPart(
+        (block['name'] as String?) ?? 'unknown',
+        _prettyOrRaw(block['input']),
+      );
+    case 'tool_result':
+      final content = block['content'];
+      if (content is String) {
+        return ToolResultPart(
+          (block['tool_use_id'] as String?) ?? 'tool',
+          content,
+        );
+      }
+      if (content is List) {
+        // Nested content blocks: extract text, summarize non-text.
+        final texts = <String>[];
+        for (final sub in content) {
+          if (sub is! Map<String, dynamic>) continue;
+          if (sub['type'] == 'text' && sub['text'] is String) {
+            texts.add(sub['text'] as String);
+          } else {
+            texts.add('[${sub['type'] ?? 'block'}]');
+          }
+        }
+        return ToolResultPart(
+          (block['tool_use_id'] as String?) ?? 'tool',
+          texts.join('\n'),
+        );
+      }
+      return ToolResultPart(
+        (block['tool_use_id'] as String?) ?? 'tool',
+        _prettyOrRaw(content),
+      );
+    case 'thinking':
+      final t = block['thinking'] as String?;
+      if (t != null && t.isNotEmpty) return ThinkingPart(t);
+      return null;
+    case 'redacted_thinking':
+      final data = block['data'] as String?;
+      return RedactedThinkingPart(data != null ? _base64ByteLength(data) : 0);
+    default:
+      return null;
+  }
+}
+
+TurnPart? _parseGeminiPart(Map<String, dynamic> part) {
+  // Text part.
+  if (part['text'] is String) {
+    final t = part['text'] as String;
+    if (t.isNotEmpty) return TextPart(t);
+    return null;
+  }
+  // Inline data (base64).
+  final inlineData = part['inline_data'] as Map<String, dynamic>?;
+  if (inlineData != null) {
+    final mime = (inlineData['mime_type'] as String?) ?? 'data';
+    final data = inlineData['data'] as String?;
+    return ImagePart(
+      mime: mime,
+      isBase64: true,
+      byteLength: data != null ? _base64ByteLength(data) : 0,
+    );
+  }
+  // File data (URI reference).
+  final fileData = part['file_data'] as Map<String, dynamic>?;
+  if (fileData != null) {
+    final uri = (fileData['file_uri'] as String?) ?? 'file';
+    return FilePart(uri);
+  }
+  // Function call (model turn).
+  final fnCall = part['functionCall'] as Map<String, dynamic>?;
+  if (fnCall != null) {
+    return ToolCallPart(
+      (fnCall['name'] as String?) ?? 'unknown',
+      _prettyOrRaw(fnCall['args']),
+    );
+  }
+  // Function response (user turn).
+  final fnResp = part['functionResponse'] as Map<String, dynamic>?;
+  if (fnResp != null) {
+    return ToolResultPart(
+      (fnResp['name'] as String?) ?? 'tool',
+      _prettyOrRaw(fnResp['response']),
+    );
+  }
+  return null;
+}
+
+TurnPart? _parseOpenAIResponsesContentPart(Map<String, dynamic> part) {
+  switch (part['type'] as String?) {
+    case 'input_text':
+    case 'output_text':
+      final t = part['text'] as String?;
+      if (t != null && t.isNotEmpty) return TextPart(t);
+      return null;
+    case 'input_image':
+      final url = part['image_url'] as String?;
+      if (url != null && url.startsWith('data:')) {
+        final info = _parseDataUrl(url);
+        return ImagePart(
+          mime: info?.mime,
+          isBase64: true,
+          byteLength: info?.byteLength ?? 0,
+        );
+      }
+      return ImagePart(url: url);
+    case 'input_file':
+      final filename = (part['filename'] as String?) ?? 'file';
+      return FilePart(filename);
+    default:
+      return null;
+  }
+}
+
+String _extractGeminiText(dynamic parts) {
+  if (parts is! List) return '';
+  return parts
+      .whereType<Map<String, dynamic>>()
+      .map((p) => p['text'] as String?)
+      .where((t) => t != null && t.isNotEmpty)
+      .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+TurnRole _normalizeRole(String? role) {
+  switch (role) {
+    case 'system':
+    case 'developer':
+      return TurnRole.system;
+    case 'user':
+      return TurnRole.user;
+    case 'assistant':
+    case 'model':
+      return TurnRole.assistant;
+    case 'tool':
+    case 'function':
+      return TurnRole.tool;
+    default:
+      return TurnRole.user;
+  }
+}
+
+/// Pretty-prints a JSON value. If [value] is a JSON string (stringified JSON),
+/// it is decoded first. Falls back to the raw string representation.
+String _prettyOrRaw(dynamic value) {
+  if (value == null) return '';
+  if (value is String) {
+    if (value.isEmpty) return '';
+    try {
+      return const JsonEncoder.withIndent('  ').convert(jsonDecode(value));
+    } catch (_) {
+      return value;
+    }
+  }
+  try {
+    return const JsonEncoder.withIndent('  ').convert(value);
+  } catch (_) {
+    return value.toString();
+  }
+}
+
+/// Builds a pretty-printed JSON string of all non-message fields.
+String _remainingJson(Map<String, dynamic> body, Set<String> messageKeys) {
+  final config = Map<String, dynamic>.from(body)
+    ..removeWhere((k, _) => messageKeys.contains(k));
+  if (config.isEmpty) return '';
+  return const JsonEncoder.withIndent('  ').convert(config);
+}
+
+/// Parses a data: URL into structured image metadata.
+({String mime, int byteLength})? _parseDataUrl(String dataUrl) {
+  final commaIdx = dataUrl.indexOf(',');
+  if (commaIdx < 0) return null;
+  final header = dataUrl.substring(0, commaIdx);
+  final mimeMatch = RegExp(r'^data:([^;,]+)').firstMatch(header);
+  final mime = mimeMatch?.group(1) ?? 'data';
+  if (!header.contains('base64')) return (mime: mime, byteLength: 0);
+  final payload = dataUrl.substring(commaIdx + 1);
+  return (mime: mime, byteLength: _base64ByteLength(payload));
+}
+
+/// Estimates the decoded byte length of a base64 string.
+int _base64ByteLength(String base64Str) {
+  final cleaned = base64Str.replaceAll(RegExp(r'[^A-Za-z0-9+/=]'), '');
+  if (cleaned.isEmpty) return 0;
+  final padding = '=' * (cleaned.length % 4 == 0 ? 0 : 4 - cleaned.length % 4);
+  try {
+    return base64.decode(cleaned + padding).length;
+  } catch (_) {
+    // Fallback estimate: 3 bytes per 4 base64 chars.
+    return (cleaned.length * 3 ~/ 4).clamp(0, 99999999);
+  }
+}
+
+/// Human-readable byte size.
+String _describeBytes(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+}

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -15,6 +15,7 @@ import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/app_directories.dart';
 import '../../../core/providers/settings_provider.dart';
+import '../logs/request_body_beautifier.dart';
 import '../logs/request_log_parser.dart';
 import '../../../theme/app_font_weights.dart';
 
@@ -1078,10 +1079,26 @@ String _fmtDuration(Duration d) {
   return '${m}m ${s}s';
 }
 
-class _RequestLogDetailPage extends StatelessWidget {
+class _RequestLogDetailPage extends StatefulWidget {
   const _RequestLogDetailPage({required this.entry});
 
   final RequestLogEntry entry;
+
+  @override
+  State<_RequestLogDetailPage> createState() => _RequestLogDetailPageState();
+}
+
+class _RequestLogDetailPageState extends State<_RequestLogDetailPage> {
+  bool _beautifyBody = true;
+  BeautifiedBody? _beautified;
+
+  @override
+  void initState() {
+    super.initState();
+    _beautified = widget.entry.requestBody == null
+        ? null
+        : tryBeautify(widget.entry.requestBody!);
+  }
 
   String _prettyJson(String text) {
     final v = text.trim();
@@ -1128,6 +1145,7 @@ class _RequestLogDetailPage extends StatelessWidget {
     final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
 
+    final entry = widget.entry;
     final uri = entry.uri;
     final url = uri?.toString() ?? (entry.rawUrl ?? '');
 
@@ -1169,6 +1187,10 @@ class _RequestLogDetailPage extends StatelessWidget {
         : ((entry.statusCode != null && entry.statusCode! >= 400)
               ? <String>['HTTP ${entry.statusCode}']
               : const <String>[]);
+
+    // Beautification toggle availability.
+    final canBeautify = _beautified != null;
+    final showBeautified = _beautifyBody && canBeautify;
 
     return Scaffold(
       appBar: AppBar(
@@ -1250,13 +1272,33 @@ class _RequestLogDetailPage extends StatelessWidget {
             _SectionCard(
               icon: Lucide.ArrowUp,
               title: l10n.logViewerSectionRequestBody,
-              trailing: IosIconButton(
-                icon: Lucide.Copy,
-                size: 18,
-                padding: const EdgeInsets.all(6),
-                onTap: () => _copy(context, reqBodyText),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IosIconButton(
+                    icon: Lucide.Sparkles,
+                    size: 18,
+                    padding: const EdgeInsets.all(6),
+                    enabled: canBeautify,
+                    onTap: canBeautify
+                        ? () => setState(() => _beautifyBody = !_beautifyBody)
+                        : null,
+                    color: showBeautified
+                        ? cs.primary
+                        : cs.onSurface.withValues(alpha: 0.78),
+                    semanticLabel: l10n.logViewerBeautifyToggle,
+                  ),
+                  IosIconButton(
+                    icon: Lucide.Copy,
+                    size: 18,
+                    padding: const EdgeInsets.all(6),
+                    onTap: () => _copy(context, reqBodyText),
+                  ),
+                ],
               ),
-              child: _CodeBlock(text: reqBodyText, tone: _CodeTone.neutral),
+              child: showBeautified && _beautified != null
+                  ? _BeautifiedBodyView(beautified: _beautified!)
+                  : _CodeBlock(text: reqBodyText, tone: _CodeTone.neutral),
             ),
           ],
           if (resHeaders != null && resHeaders.isNotEmpty) ...[
@@ -1980,6 +2022,261 @@ class _SettingTile extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Beautified request body rendering
+// ---------------------------------------------------------------------------
+
+/// Role color pair (light, dark).
+class _RoleColor {
+  const _RoleColor(this.label, this.light, this.dark);
+  final String label;
+  final Color light;
+  final Color dark;
+
+  Color color(bool isDark) => isDark ? dark : light;
+}
+
+const _roleColors = <TurnRole, _RoleColor>{
+  TurnRole.system: _RoleColor('SYSTEM', Color(0xFFCA8A04), Color(0xFFFACC15)),
+  TurnRole.user: _RoleColor('USER', Color(0xFF2563EB), Color(0xFF60A5FA)),
+  TurnRole.assistant: _RoleColor(
+    'ASSISTANT',
+    Color(0xFF16A34A),
+    Color(0xFF86EFAC),
+  ),
+  TurnRole.tool: _RoleColor('TOOL', Color(0xFF8B5CF6), Color(0xFFA78BFA)),
+};
+
+/// Renders a [BeautifiedBody]: colored turn blocks on top, config JSON below.
+class _BeautifiedBodyView extends StatelessWidget {
+  const _BeautifiedBodyView({required this.beautified});
+
+  final BeautifiedBody beautified;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final children = <Widget>[];
+
+    for (var i = 0; i < beautified.turns.length; i++) {
+      if (i > 0) children.add(const SizedBox(height: 8));
+      children.add(_TurnBlock(turn: beautified.turns[i]));
+    }
+
+    if (beautified.configJson.isNotEmpty) {
+      if (children.isNotEmpty) children.add(const SizedBox(height: 14));
+      children.add(_SectionLabel(text: l10n.logViewerRequestConfig));
+      children.add(const SizedBox(height: 6));
+      children.add(
+        _CodeBlock(text: beautified.configJson, tone: _CodeTone.neutral),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.text});
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Text(
+      text,
+      style: TextStyle(
+        fontSize: 11,
+        fontWeight: AppFontWeights.heavy,
+        letterSpacing: 0.4,
+        color: cs.onSurface.withValues(alpha: 0.50),
+      ),
+    );
+  }
+}
+
+/// One conversation turn rendered with a colored left border and role label.
+class _TurnBlock extends StatelessWidget {
+  const _TurnBlock({required this.turn});
+  final BeautifiedTurn turn;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    final rc = _roleColors[turn.role]!;
+    final color = rc.color(isDark);
+
+    final children = <Widget>[
+      Text(
+        rc.label,
+        style: TextStyle(
+          fontSize: 10.5,
+          fontWeight: AppFontWeights.heavy,
+          letterSpacing: 0.5,
+          color: color,
+        ),
+      ),
+      const SizedBox(height: 6),
+    ];
+
+    for (var i = 0; i < turn.parts.length; i++) {
+      if (i > 0) children.add(const SizedBox(height: 6));
+      children.add(_buildPart(turn.parts[i], cs, isDark));
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: isDark ? 0.06 : 0.04),
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(8),
+          topRight: Radius.circular(8),
+          bottomRight: Radius.circular(8),
+        ),
+        border: Border(left: BorderSide(color: color, width: 3)),
+      ),
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: children,
+      ),
+    );
+  }
+
+  Widget _buildPart(TurnPart part, ColorScheme cs, bool isDark) {
+    switch (part) {
+      case TextPart(:final text):
+        return SelectableText(
+          text,
+          style: TextStyle(
+            fontSize: 12.5,
+            height: 1.4,
+            color: cs.onSurface.withValues(alpha: 0.88),
+          ),
+        );
+      case ImagePart(:final displayLabel):
+        return SelectableText(
+          displayLabel,
+          style: TextStyle(
+            fontSize: 12,
+            height: 1.4,
+            color: cs.onSurface.withValues(alpha: 0.60),
+          ),
+        );
+      case FilePart(:final filename):
+        return SelectableText(
+          filename,
+          style: TextStyle(
+            fontSize: 12,
+            height: 1.4,
+            color: cs.onSurface.withValues(alpha: 0.60),
+          ),
+        );
+      case ToolCallPart(:final name, :final arguments):
+        return _LabeledContent(
+          label: 'tool_call: $name',
+          content: arguments,
+          cs: cs,
+          isDark: isDark,
+        );
+      case ToolResultPart(:final name, :final output):
+        return _LabeledContent(
+          label: 'tool_result: $name',
+          content: output,
+          cs: cs,
+          isDark: isDark,
+        );
+      case ThinkingPart(:final content):
+        return _LabeledContent(
+          label: 'thinking',
+          content: content,
+          cs: cs,
+          isDark: isDark,
+          italic: true,
+          muted: true,
+        );
+      case RedactedThinkingPart(:final byteLength):
+        return Text(
+          'redacted_thinking: $byteLength bytes',
+          style: TextStyle(
+            fontSize: 12,
+            height: 1.4,
+            color: cs.onSurface.withValues(alpha: 0.45),
+          ),
+        );
+    }
+  }
+}
+
+/// A label + optional content block (for tool calls, tool results, thinking).
+class _LabeledContent extends StatelessWidget {
+  const _LabeledContent({
+    required this.label,
+    required this.content,
+    required this.cs,
+    required this.isDark,
+    this.italic = false,
+    this.muted = false,
+  });
+
+  final String label;
+  final String content;
+  final ColorScheme cs;
+  final bool isDark;
+  final bool italic;
+  final bool muted;
+
+  @override
+  Widget build(BuildContext context) {
+    if (content.isEmpty) {
+      return Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: AppFontWeights.semibold,
+          color: cs.onSurface.withValues(alpha: muted ? 0.45 : 0.62),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: AppFontWeights.semibold,
+            color: cs.onSurface.withValues(alpha: muted ? 0.45 : 0.62),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Container(
+          padding: const EdgeInsets.fromLTRB(10, 6, 10, 6),
+          decoration: BoxDecoration(
+            color: cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: SelectableText(
+            content,
+            style: TextStyle(
+              fontSize: 11,
+              height: 1.35,
+              fontFamily: 'monospace',
+              fontStyle: italic ? FontStyle.italic : null,
+              color: cs.onSurface.withValues(alpha: muted ? 0.56 : 0.80),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2298,6 +2298,8 @@
   "logViewerSectionParameters": "Parameters",
   "logViewerSectionRequestHeaders": "Request Headers",
   "logViewerSectionRequestBody": "Request Body",
+  "logViewerBeautifyToggle": "Beautify",
+  "logViewerRequestConfig": "Configuration",
   "logViewerSectionResponseHeaders": "Response Headers",
   "logViewerSectionResponseBody": "Response Body",
   "logViewerSectionWarnings": "Warnings",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9920,6 +9920,18 @@ abstract class AppLocalizations {
   /// **'Request Body'**
   String get logViewerSectionRequestBody;
 
+  /// No description provided for @logViewerBeautifyToggle.
+  ///
+  /// In en, this message translates to:
+  /// **'Beautify'**
+  String get logViewerBeautifyToggle;
+
+  /// No description provided for @logViewerRequestConfig.
+  ///
+  /// In en, this message translates to:
+  /// **'Configuration'**
+  String get logViewerRequestConfig;
+
   /// No description provided for @logViewerSectionResponseHeaders.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5373,6 +5373,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logViewerSectionRequestBody => 'Request Body';
 
   @override
+  String get logViewerBeautifyToggle => 'Beautify';
+
+  @override
+  String get logViewerRequestConfig => 'Configuration';
+
+  @override
   String get logViewerSectionResponseHeaders => 'Response Headers';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5161,6 +5161,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get logViewerSectionRequestBody => '请求体';
 
   @override
+  String get logViewerBeautifyToggle => '美化显示';
+
+  @override
+  String get logViewerRequestConfig => '配置参数';
+
+  @override
   String get logViewerSectionResponseHeaders => '响应头';
 
   @override
@@ -11049,6 +11055,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get logViewerSectionRequestBody => '请求体';
 
   @override
+  String get logViewerBeautifyToggle => '美化显示';
+
+  @override
+  String get logViewerRequestConfig => '配置参数';
+
+  @override
   String get logViewerSectionResponseHeaders => '响应头';
 
   @override
@@ -16935,6 +16947,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get logViewerSectionRequestBody => '請求本文';
+
+  @override
+  String get logViewerBeautifyToggle => '美化顯示';
+
+  @override
+  String get logViewerRequestConfig => '設定參數';
 
   @override
   String get logViewerSectionResponseHeaders => '回應標頭';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1882,6 +1882,8 @@
   "logViewerSectionParameters": "参数",
   "logViewerSectionRequestHeaders": "请求头",
   "logViewerSectionRequestBody": "请求体",
+  "logViewerBeautifyToggle": "美化显示",
+  "logViewerRequestConfig": "配置参数",
   "logViewerSectionResponseHeaders": "响应头",
   "logViewerSectionResponseBody": "响应体",
   "logViewerSectionWarnings": "警告",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1873,6 +1873,8 @@
   "logViewerSectionParameters": "参数",
   "logViewerSectionRequestHeaders": "请求头",
   "logViewerSectionRequestBody": "请求体",
+  "logViewerBeautifyToggle": "美化显示",
+  "logViewerRequestConfig": "配置参数",
   "logViewerSectionResponseHeaders": "响应头",
   "logViewerSectionResponseBody": "响应体",
   "logViewerSectionWarnings": "警告",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1881,6 +1881,8 @@
   "logViewerSectionParameters": "參數",
   "logViewerSectionRequestHeaders": "請求標頭",
   "logViewerSectionRequestBody": "請求本文",
+  "logViewerBeautifyToggle": "美化顯示",
+  "logViewerRequestConfig": "設定參數",
   "logViewerSectionResponseHeaders": "回應標頭",
   "logViewerSectionResponseBody": "回應本文",
   "logViewerSectionWarnings": "警告",

--- a/test/features/settings/logs/request_body_beautifier_test.dart
+++ b/test/features/settings/logs/request_body_beautifier_test.dart
@@ -1,0 +1,624 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/features/settings/logs/request_body_beautifier.dart';
+
+void main() {
+  group('tryBeautify', () {
+    group('failure cases', () {
+      test('returns null for empty string', () {
+        expect(tryBeautify(''), isNull);
+        expect(tryBeautify('   '), isNull);
+      });
+
+      test('returns null for invalid JSON', () {
+        expect(tryBeautify('not json'), isNull);
+        expect(tryBeautify('{broken'), isNull);
+        expect(tryBeautify('base64: SGVsbG8='), isNull);
+      });
+
+      test('returns null for JSON that is not an object', () {
+        expect(tryBeautify('[1, 2, 3]'), isNull);
+        expect(tryBeautify('"hello"'), isNull);
+        expect(tryBeautify('42'), isNull);
+      });
+
+      test('returns null for unknown protocol structure', () {
+        expect(tryBeautify('{"foo": "bar", "baz": [1, 2]}'), isNull);
+      });
+    });
+
+    group('OpenAI Chat Completions', () {
+      test('parses system + user + assistant with text content', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'messages': [
+            {'role': 'system', 'content': 'You are helpful.'},
+            {'role': 'user', 'content': 'Hello'},
+            {'role': 'assistant', 'content': 'Hi there!'},
+          ],
+          'temperature': 0.7,
+          'stream': true,
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        expect(result.turns[0].role, TurnRole.system);
+        expect((result.turns[0].parts[0] as TextPart).text, 'You are helpful.');
+
+        expect(result.turns[1].role, TurnRole.user);
+        expect((result.turns[1].parts[0] as TextPart).text, 'Hello');
+
+        expect(result.turns[2].role, TurnRole.assistant);
+        expect((result.turns[2].parts[0] as TextPart).text, 'Hi there!');
+
+        final config = jsonDecode(result.configJson) as Map<String, dynamic>;
+        expect(config['model'], 'gpt-4o');
+        expect(config['temperature'], 0.7);
+        expect(config['stream'], true);
+        expect(config.containsKey('messages'), isFalse);
+      });
+
+      test('parses tool_calls with stringified JSON arguments', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'messages': [
+            {'role': 'user', 'content': 'What is the weather?'},
+            {
+              'role': 'assistant',
+              'content': null,
+              'tool_calls': [
+                {
+                  'id': 'call_1',
+                  'type': 'function',
+                  'function': {
+                    'name': 'get_weather',
+                    'arguments': '{"city": "Beijing"}',
+                  },
+                },
+              ],
+            },
+            {
+              'role': 'tool',
+              'tool_call_id': 'call_1',
+              'name': 'get_weather',
+              'content': '{"temp": 22}',
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        // Assistant turn with tool_call part.
+        final assistantParts = result.turns[1].parts;
+        expect(assistantParts.length, 1);
+        final toolCall = assistantParts[0] as ToolCallPart;
+        expect(toolCall.name, 'get_weather');
+        expect(toolCall.arguments, contains('Beijing'));
+
+        // Tool turn with tool_result part.
+        final toolParts = result.turns[2].parts;
+        expect(toolParts.length, 1);
+        final toolResult = toolParts[0] as ToolResultPart;
+        expect(toolResult.name, 'get_weather');
+        expect(toolResult.output, contains('22'));
+      });
+
+      test('parses multipart content with image_url', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'messages': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'text', 'text': 'What is this?'},
+                {
+                  'type': 'image_url',
+                  'image_url': {'url': 'https://example.com/img.png'},
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 1);
+        expect(result.turns[0].role, TurnRole.user);
+        expect(result.turns[0].parts.length, 2);
+        expect((result.turns[0].parts[0] as TextPart).text, 'What is this?');
+        final img = result.turns[0].parts[1] as ImagePart;
+        expect(img.url, 'https://example.com/img.png');
+        expect(img.isBase64, isFalse);
+      });
+
+      test('handles data: URL image', () {
+        final body = jsonEncode({
+          'messages': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'text', 'text': 'Look'},
+                {
+                  'type': 'image_url',
+                  'image_url': {'url': 'data:image/png;base64,SGVsbG8='},
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        final imagePart = result!.turns[0].parts[1] as ImagePart;
+        expect(imagePart.isBase64, isTrue);
+        expect(imagePart.mime, 'image/png');
+        expect(imagePart.displayLabel, contains('image/png'));
+        expect(imagePart.displayLabel, contains('(base64)'));
+        expect(imagePart.displayLabel, contains('B'));
+      });
+    });
+
+    group('Claude', () {
+      test('parses system string + messages with text blocks', () {
+        final body = jsonEncode({
+          'model': 'claude-3',
+          'max_tokens': 1024,
+          'system': 'You are Claude.',
+          'messages': [
+            {'role': 'user', 'content': 'Hi'},
+            {'role': 'assistant', 'content': 'Hello!'},
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        expect(result.turns[0].role, TurnRole.system);
+        expect((result.turns[0].parts[0] as TextPart).text, 'You are Claude.');
+
+        expect(result.turns[1].role, TurnRole.user);
+        expect((result.turns[1].parts[0] as TextPart).text, 'Hi');
+
+        expect(result.turns[2].role, TurnRole.assistant);
+
+        final config = jsonDecode(result.configJson) as Map<String, dynamic>;
+        expect(config['model'], 'claude-3');
+        expect(config['max_tokens'], 1024);
+        expect(config.containsKey('system'), isFalse);
+        expect(config.containsKey('messages'), isFalse);
+      });
+
+      test('parses tool_use and tool_result blocks', () {
+        final body = jsonEncode({
+          'model': 'claude-3',
+          'max_tokens': 1024,
+          'system': 'You are Claude.',
+          'messages': [
+            {'role': 'user', 'content': 'What is the weather?'},
+            {
+              'role': 'assistant',
+              'content': [
+                {'type': 'text', 'text': 'Let me check.'},
+                {
+                  'type': 'tool_use',
+                  'id': 'toolu_1',
+                  'name': 'get_weather',
+                  'input': {'city': 'Beijing'},
+                },
+              ],
+            },
+            {
+              'role': 'user',
+              'content': [
+                {
+                  'type': 'tool_result',
+                  'tool_use_id': 'toolu_1',
+                  'content': 'Sunny, 22C',
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 4); // system + user + assistant + user
+
+        final assistantParts = result.turns[2].parts;
+        expect(assistantParts.length, 2);
+        expect(assistantParts[0] is TextPart, isTrue);
+        expect(assistantParts[1] is ToolCallPart, isTrue);
+
+        final userParts = result.turns[3].parts;
+        expect(userParts.length, 1);
+        expect(userParts[0] is ToolResultPart, isTrue);
+        final toolResult = userParts[0] as ToolResultPart;
+        expect(toolResult.output, 'Sunny, 22C');
+      });
+
+      test('parses thinking and redacted_thinking blocks', () {
+        final body = jsonEncode({
+          'model': 'claude-3',
+          'max_tokens': 1024,
+          'system': 'You are Claude.',
+          'messages': [
+            {
+              'role': 'assistant',
+              'content': [
+                {'type': 'thinking', 'thinking': 'I should...'},
+                {'type': 'redacted_thinking', 'data': 'SGVsbG8='},
+                {'type': 'text', 'text': 'Here is my answer.'},
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 2); // system + assistant
+
+        final parts = result.turns[1].parts;
+        expect(parts.length, 3);
+        expect(parts[0] is ThinkingPart, isTrue);
+        expect(parts[1] is RedactedThinkingPart, isTrue);
+        expect(parts[2] is TextPart, isTrue);
+      });
+
+      test('handles system as list of blocks', () {
+        final body = jsonEncode({
+          'model': 'claude-3',
+          'max_tokens': 1024,
+          'system': [
+            {'type': 'text', 'text': 'System rule 1.'},
+            {'type': 'text', 'text': 'System rule 2.'},
+          ],
+          'messages': [],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 1);
+        expect(result.turns[0].role, TurnRole.system);
+        expect(
+          (result.turns[0].parts[0] as TextPart).text,
+          'System rule 1.\nSystem rule 2.',
+        );
+      });
+    });
+
+    group('Gemini', () {
+      test('parses systemInstruction + contents with text parts', () {
+        final body = jsonEncode({
+          'contents': [
+            {
+              'role': 'user',
+              'parts': [
+                {'text': 'Hello'},
+              ],
+            },
+            {
+              'role': 'model',
+              'parts': [
+                {'text': 'Hi!'},
+              ],
+            },
+          ],
+          'systemInstruction': {
+            'parts': [
+              {'text': 'Be helpful.'},
+            ],
+          },
+          'generationConfig': {'temperature': 0.7},
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        expect(result.turns[0].role, TurnRole.system);
+        expect((result.turns[0].parts[0] as TextPart).text, 'Be helpful.');
+
+        expect(result.turns[1].role, TurnRole.user);
+        expect(result.turns[2].role, TurnRole.assistant);
+
+        final config = jsonDecode(result.configJson) as Map<String, dynamic>;
+        expect(config.containsKey('generationConfig'), isTrue);
+        expect(config.containsKey('contents'), isFalse);
+        expect(config.containsKey('systemInstruction'), isFalse);
+      });
+
+      test('parses functionCall and functionResponse parts', () {
+        final body = jsonEncode({
+          'contents': [
+            {
+              'role': 'model',
+              'parts': [
+                {'text': 'Let me check.'},
+                {
+                  'functionCall': {
+                    'name': 'get_weather',
+                    'args': {'city': 'Beijing'},
+                  },
+                },
+              ],
+            },
+            {
+              'role': 'user',
+              'parts': [
+                {
+                  'functionResponse': {
+                    'name': 'get_weather',
+                    'response': {'temp': 22},
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 2);
+
+        final modelParts = result.turns[0].parts;
+        expect(modelParts.length, 2);
+        expect(modelParts[0] is TextPart, isTrue);
+        expect(modelParts[1] is ToolCallPart, isTrue);
+
+        final userParts = result.turns[1].parts;
+        expect(userParts.length, 1);
+        expect(userParts[0] is ToolResultPart, isTrue);
+      });
+
+      test('handles inline_data with size estimation', () {
+        // 12 bytes -> base64 of "Hello World!" = SGVsbG8gV29ybGQh
+        final body = jsonEncode({
+          'contents': [
+            {
+              'role': 'user',
+              'parts': [
+                {
+                  'inline_data': {
+                    'mime_type': 'image/png',
+                    'data': 'SGVsbG8gV29ybGQh',
+                  },
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        final imagePart = result!.turns[0].parts[0] as ImagePart;
+        expect(imagePart.isBase64, isTrue);
+        expect(imagePart.mime, 'image/png');
+        expect(imagePart.displayLabel, contains('image/png'));
+        expect(imagePart.displayLabel, contains('(base64)'));
+        expect(imagePart.displayLabel, contains('B'));
+      });
+    });
+
+    group('OpenAI Responses', () {
+      test('parses instructions + input as array', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'instructions': 'You are helpful.',
+          'input': [
+            {
+              'role': 'user',
+              'content': [
+                {'type': 'input_text', 'text': 'Hello'},
+              ],
+            },
+            {
+              'type': 'message',
+              'role': 'assistant',
+              'content': [
+                {'type': 'output_text', 'text': 'Hi!'},
+              ],
+            },
+          ],
+          'temperature': 0.7,
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        expect(result.turns[0].role, TurnRole.system);
+        expect((result.turns[0].parts[0] as TextPart).text, 'You are helpful.');
+
+        expect(result.turns[1].role, TurnRole.user);
+        expect(result.turns[2].role, TurnRole.assistant);
+
+        final config = jsonDecode(result.configJson) as Map<String, dynamic>;
+        expect(config['model'], 'gpt-4o');
+        expect(config.containsKey('input'), isFalse);
+        expect(config.containsKey('instructions'), isFalse);
+      });
+
+      test('parses input as simple string', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'input': 'Just a simple prompt',
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 1);
+        expect(result.turns[0].role, TurnRole.user);
+        expect(
+          (result.turns[0].parts[0] as TextPart).text,
+          'Just a simple prompt',
+        );
+      });
+
+      test('parses function_call and function_call_output items', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'input': [
+            {'role': 'user', 'content': 'What is the weather?'},
+            {
+              'type': 'function_call',
+              'call_id': 'call_1',
+              'name': 'get_weather',
+              'arguments': '{"city": "Beijing"}',
+            },
+            {
+              'type': 'function_call_output',
+              'call_id': 'call_1',
+              'output': '{"temp": 22}',
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 3);
+
+        expect(result.turns[0].role, TurnRole.user);
+        expect(result.turns[1].role, TurnRole.assistant);
+        expect(result.turns[2].role, TurnRole.tool);
+
+        expect(result.turns[1].parts[0] is ToolCallPart, isTrue);
+        expect(result.turns[2].parts[0] is ToolResultPart, isTrue);
+      });
+    });
+
+    group('edge cases', () {
+      test('empty messages array produces empty turns', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'messages': [],
+          'temperature': 0.7,
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns, isEmpty);
+        expect(result.configJson, isNotEmpty);
+      });
+
+      test('malformed messages entries are skipped', () {
+        final body = jsonEncode({
+          'model': 'gpt-4o',
+          'messages': [
+            'not a map',
+            {'role': 'user', 'content': 'valid'},
+            42,
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 1);
+        expect(result.turns[0].role, TurnRole.user);
+      });
+
+      test(
+        'Claude without system is detected as Claude if system key absent',
+        () {
+          // When Claude has no system prompt, "system" key may be omitted.
+          // This should fall through to OpenAI Chat detection.
+          final body = jsonEncode({
+            'model': 'claude-3',
+            'max_tokens': 1024,
+            'messages': [
+              {'role': 'user', 'content': 'Hi'},
+              {'role': 'assistant', 'content': 'Hello!'},
+            ],
+          });
+
+          final result = tryBeautify(body);
+          expect(result, isNotNull);
+          // Detected as OpenAI Chat (fallback), which is fine - both use
+          // "messages" and the rendering is the same.
+          expect(result!.turns.length, 2);
+        },
+      );
+
+      test('config JSON is empty when only message fields present', () {
+        final body = jsonEncode({
+          'messages': [
+            {'role': 'user', 'content': 'Hi'},
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 1);
+        expect(result.configJson, isEmpty);
+      });
+
+      test('developer role is mapped to system', () {
+        final body = jsonEncode({
+          'messages': [
+            {'role': 'developer', 'content': 'You are a coding expert.'},
+            {'role': 'user', 'content': 'Write a function'},
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 2);
+        expect(result.turns[0].role, TurnRole.system);
+        expect(
+          (result.turns[0].parts[0] as TextPart).text,
+          'You are a coding expert.',
+        );
+      });
+
+      test('reasoning_details list is concatenated into ThinkingPart', () {
+        final body = jsonEncode({
+          'messages': [
+            {'role': 'user', 'content': 'Hi'},
+            {
+              'role': 'assistant',
+              'content': '\n\n',
+              'tool_calls': [
+                {
+                  'id': 'call_1',
+                  'type': 'function',
+                  'function': {
+                    'name': 'search_web',
+                    'arguments': '{"query":"test"}',
+                  },
+                },
+              ],
+              'reasoning_details': [
+                {
+                  'type': 'reasoning.text',
+                  'text': '思考',
+                  'format': 'unknown',
+                  'index': 0,
+                },
+                {
+                  'type': 'reasoning.text',
+                  'text': '过程',
+                  'format': 'unknown',
+                  'index': 0,
+                },
+              ],
+            },
+          ],
+        });
+
+        final result = tryBeautify(body);
+        expect(result, isNotNull);
+        expect(result!.turns.length, 2);
+
+        final assistantParts = result.turns[1].parts;
+        // Expect: ToolCallPart + ThinkingPart (order: tool_calls first, then reasoning).
+        final thinking = assistantParts.whereType<ThinkingPart>().toList();
+        expect(thinking.length, 1);
+        expect(thinking[0].content, '思考过程');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Add a per-entry toggle (Sparkles icon) in the Request Body section of the log detail page. When enabled, parse the JSON body and split it into:

- Message-type turns rendered as colored left-border blocks (SYSTEM amber, USER blue, ASSISTANT green, TOOL violet), with interleaved secondary items for non-text parts (tool calls, images, thinking blocks).
- Non-message config fields rendered as a pretty-printed JSON blob below.

Supports four LLM protocols via structure-based detection:
- OpenAI Chat Completions (messages)
- OpenAI Responses (input + instructions)
- Google Gemini (contents + systemInstruction)
- Claude/Anthropic (messages + system)

Copy button always copies the raw pretty-printed JSON regardless of toggle. Toggle is disabled (greyed out) when the body cannot be beautified.

New files:
- lib/features/settings/logs/request_body_beautifier.dart (pure Dart logic)
- test/features/settings/logs/request_body_beautifier_test.dart (22 tests)

l10n: logViewerBeautifyToggle, logViewerRequestConfig across 4 ARB files.