### PR TITLE
fix(win-v): pass transit-mode probes through to prevent input regression

### DIFF
--- a/lib/desktop/windows_paste_fix.dart
+++ b/lib/desktop/windows_paste_fix.dart
@@ -70,8 +70,15 @@ class WindowsPasteFix {
 
   @visibleForTesting
   KeyData? rewrite(KeyData data) {
-    // Swallow all-zero garbage events that occur during focus transitions.
-    if (data.physical == 0 && data.logical == 0) return null;
+    // All-zero KeyData events are transit-mode probes sent by the Flutter
+    // engine. They must reach the framework's handleKeyData so that
+    // _transitMode is inferred as keyDataThenRawKeyData. Swallowing them
+    // here leaves _transitMode null, letting the raw channel set it to
+    // rawKeyData — after which every real KeyData forwarded by this
+    // wrapper hits the assertion:
+    //   'Should never encounter KeyData when transitMode is rawKeyData.'
+    // Pass them through unchanged.
+    if (data.physical == 0 && data.logical == 0) return data;
 
     // Normal hardware keys: pass through, reset state machine.
     if (data.physical != _junkPhysical) {

--- a/test/windows_paste_fix_test.dart
+++ b/test/windows_paste_fix_test.dart
@@ -72,10 +72,24 @@ void main() {
     });
   });
 
-  group('all-zero garbage events', () {
-    test('swallows all-zero event', () {
+  group('all-zero transit-mode probe events', () {
+    // The Flutter engine sends all-zero KeyData events as transit-mode
+    // probes. They MUST reach the framework's handleKeyData so that
+    // _transitMode is inferred as keyDataThenRawKeyData. Swallowing them
+    // here leaves _transitMode null, the raw channel then sets it to
+    // rawKeyData, and every subsequent real KeyData hits the assertion:
+    //   'Should never encounter KeyData when transitMode is rawKeyData.'
+    test('passes all-zero probe through unchanged', () {
       final key = makeKey(type: KeyEventType.down, physical: 0, logical: 0);
-      expect(fix.rewrite(key), isNull);
+      expect(fix.rewrite(key), same(key));
+    });
+
+    test('all-zero probe does not reset Win+V mid-sequence state', () {
+      fix.rewrite(ctrlDown(synthesized: false));
+      // Probe arrives mid-sequence (e.g. focus shift); must not break state.
+      fix.rewrite(makeKey(type: KeyEventType.down, physical: 0, logical: 0));
+      // Sequence should still continue at step 1 → expect Ctrl↑ swallow.
+      expect(fix.rewrite(ctrlUp(synthesized: true)), isNull);
     });
   });
 


### PR DESCRIPTION
Closes #134.

WindowsPasteFix.rewrite was swallowing all-zero KeyData events (physical=0, logical=0), treating them as focus-transition noise. These events are actually Flutter engine transit-mode probes: the framework's handleKeyData uses them to infer _transitMode.

Swallowing them left _transitMode null. When a real key arrived via the raw channel first, handleRawKeyMessage set _transitMode = rawKeyData. Every subsequent KeyData forwarded by the wrapper then hit the assertion 'Should never encounter KeyData when transitMode is rawKeyData' (hardware_keyboard.dart:1098). The exception was swallowed by zone.runGuarded, dropping key events and making the input field uneditable.

Pass the probes through unchanged so handleKeyData runs first and sets _transitMode = keyDataThenRawKeyData, matching the channel the Win+V junk events actually arrive on. The Win+V state machine is unaffected (probes have physical=0 != _junkPhysical but hit the all-zero early-return before that check, so _step is untouched).

Tests: replace the test encoding the old buggy swallow behavior with one asserting pass-through, plus a new test verifying a probe arriving mid-sequence does not reset the Win+V state machine.