### PR TITLE
feat: add multi-key rotation to search feature

### DIFF
--- a/lib/core/services/api_key_manager.dart
+++ b/lib/core/services/api_key_manager.dart
@@ -13,26 +13,33 @@ class ApiKeyManager {
   factory ApiKeyManager() => _instance;
   ApiKeyManager._internal();
 
-  final Map<String, int> _roundRobinIndexMap = {}; // providerId -> index
+  final Map<String, int> _roundRobinIndexMap = {}; // scopeId -> index
   final Map<String, int> _keyUsageMap = {}; // keyId -> total uses (ephemeral)
 
   KeySelectionResult selectForProvider(ProviderConfig provider) {
-    final keys = List<ApiKeyConfig>.from(
-      (provider.apiKeys ?? const <ApiKeyConfig>[]).where((k) => k.isEnabled),
+    return selectFromKeys(
+      provider.apiKeys ?? const [],
+      provider.keyManagement ?? const KeyManagementConfig(),
+      provider.id,
     );
-    if (keys.isEmpty) return const KeySelectionResult(null, 'no_keys');
+  }
 
-    // Filter by status and cooldown
+  KeySelectionResult selectFromKeys(
+    List<ApiKeyConfig> keys,
+    KeyManagementConfig config,
+    String scopeId,
+  ) {
+    final enabled = List<ApiKeyConfig>.from(keys.where((k) => k.isEnabled));
+    if (enabled.isEmpty) return const KeySelectionResult(null, 'no_keys');
+
     final now = DateTime.now().millisecondsSinceEpoch;
-    final cooldownMs =
-        (provider.keyManagement?.failureRecoveryTimeMinutes ?? 5) * 60 * 1000;
-    final available = keys.where((k) {
+    final cooldownMs = config.failureRecoveryTimeMinutes * 60 * 1000;
+    final available = enabled.where((k) {
       if (k.status == ApiKeyStatus.disabled) return false;
       if (k.status == ApiKeyStatus.error) {
         final since = now - (k.updatedAt);
         if (since < cooldownMs) return false;
       }
-      // Only select keys marked active; error keys are filtered by cooldown above and disabled are skipped.
       return k.status == ApiKeyStatus.active;
     }).toList();
 
@@ -40,8 +47,7 @@ class ApiKeyManager {
       return const KeySelectionResult(null, 'no_available_keys');
     }
 
-    final strategy =
-        provider.keyManagement?.strategy ?? LoadBalanceStrategy.roundRobin;
+    final strategy = config.strategy;
     ApiKeyConfig chosen;
     switch (strategy) {
       case LoadBalanceStrategy.priority:
@@ -59,12 +65,10 @@ class ApiKeyManager {
         break;
       case LoadBalanceStrategy.roundRobin:
         final cur =
-            _roundRobinIndexMap[provider.id] ??
-            (provider.keyManagement?.roundRobinIndex ?? 0);
+            _roundRobinIndexMap[scopeId] ?? (config.roundRobinIndex ?? 0);
         final idx = cur % available.length;
         chosen = available[idx];
-        final next = (idx + 1) % available.length;
-        _roundRobinIndexMap[provider.id] = next;
+        _roundRobinIndexMap[scopeId] = (idx + 1) % available.length;
         break;
     }
 
@@ -73,6 +77,20 @@ class ApiKeyManager {
 
   ApiKeyConfig updateKeyStatus(
     ProviderConfig provider,
+    ApiKeyConfig key,
+    bool success, {
+    String? error,
+  }) {
+    return updateKeyStatusFromConfig(
+      provider.keyManagement ?? const KeyManagementConfig(),
+      key,
+      success,
+      error: error,
+    );
+  }
+
+  ApiKeyConfig updateKeyStatusFromConfig(
+    KeyManagementConfig config,
     ApiKeyConfig key,
     bool success, {
     String? error,
@@ -89,7 +107,7 @@ class ApiKeyManager {
       status: success
           ? ApiKeyStatus.active
           : (key.usage.consecutiveFailures + 1) >=
-                (provider.keyManagement?.maxFailuresBeforeDisable ?? 3)
+                (config.maxFailuresBeforeDisable)
           ? ApiKeyStatus.error
           : key.status,
       lastError: success ? null : (error ?? key.lastError),
@@ -102,4 +120,6 @@ class ApiKeyManager {
   void recordKeyUsage(String keyId, bool success) {
     _keyUsageMap[keyId] = (_keyUsageMap[keyId] ?? 0) + 1;
   }
+
+  int? getRoundRobinIndex(String scopeId) => _roundRobinIndexMap[scopeId];
 }

--- a/lib/core/services/search/providers/bing_search_service.dart
+++ b/lib/core/services/search/providers/bing_search_service.dart
@@ -22,6 +22,7 @@ class BingSearchService extends SearchService<BingLocalOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required BingLocalOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final encodedQuery = Uri.encodeComponent(query);

--- a/lib/core/services/search/providers/bocha_search_service.dart
+++ b/lib/core/services/search/providers/bocha_search_service.dart
@@ -22,6 +22,7 @@ class BochaSearchService extends SearchService<BochaOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required BochaOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = <String, dynamic>{
@@ -43,7 +44,8 @@ class BochaSearchService extends SearchService<BochaOptions> {
           .post(
             Uri.parse('https://api.bochaai.com/v1/web-search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: jsonEncode(body),

--- a/lib/core/services/search/providers/brave_search_service.dart
+++ b/lib/core/services/search/providers/brave_search_service.dart
@@ -22,6 +22,7 @@ class BraveSearchService extends SearchService<BraveOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required BraveOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final encodedQuery = Uri.encodeComponent(query);
@@ -33,7 +34,7 @@ class BraveSearchService extends SearchService<BraveOptions> {
             Uri.parse(url),
             headers: {
               'Accept': 'application/json',
-              'X-Subscription-Token': serviceOptions.apiKey,
+              'X-Subscription-Token': apiKeyOverride ?? serviceOptions.apiKey,
             },
           )
           .timeout(Duration(milliseconds: commonOptions.timeout));

--- a/lib/core/services/search/providers/duckduckgo_search_service.dart
+++ b/lib/core/services/search/providers/duckduckgo_search_service.dart
@@ -21,6 +21,7 @@ class DuckDuckGoSearchService extends SearchService<DuckDuckGoOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required DuckDuckGoOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     final ddgs = DDGS(timeout: Duration(milliseconds: commonOptions.timeout));
     final region = serviceOptions.region.trim().isNotEmpty

--- a/lib/core/services/search/providers/exa_search_service.dart
+++ b/lib/core/services/search/providers/exa_search_service.dart
@@ -22,6 +22,7 @@ class ExaSearchService extends SearchService<ExaOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required ExaOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -34,7 +35,8 @@ class ExaSearchService extends SearchService<ExaOptions> {
           .post(
             Uri.parse(serviceOptions.resolvedUrl),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: body,

--- a/lib/core/services/search/providers/grok_search_service.dart
+++ b/lib/core/services/search/providers/grok_search_service.dart
@@ -28,9 +28,10 @@ class GrokSearchService extends SearchService<GrokOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required GrokOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
-      if (serviceOptions.apiKey.trim().isEmpty) {
+      if ((apiKeyOverride ?? serviceOptions.apiKey).trim().isEmpty) {
         throw Exception('Grok API key is required');
       }
 
@@ -56,7 +57,8 @@ class GrokSearchService extends SearchService<GrokOptions> {
           .post(
             Uri.parse(serviceOptions.resolvedUrl),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey.trim()}',
+              'Authorization':
+                  'Bearer ${(apiKeyOverride ?? serviceOptions.apiKey).trim()}',
               'Content-Type': 'application/json',
             },
             body: jsonEncode(body),

--- a/lib/core/services/search/providers/jina_search_service.dart
+++ b/lib/core/services/search/providers/jina_search_service.dart
@@ -22,6 +22,7 @@ class JinaSearchService extends SearchService<JinaOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required JinaOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({'q': query});
@@ -30,7 +31,8 @@ class JinaSearchService extends SearchService<JinaOptions> {
           .post(
             Uri.parse('https://s.jina.ai/'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Accept': 'application/json',
               'Content-Type': 'application/json',
               // Speed up and reduce payload: omit page content in response

--- a/lib/core/services/search/providers/linkup_search_service.dart
+++ b/lib/core/services/search/providers/linkup_search_service.dart
@@ -22,6 +22,7 @@ class LinkUpSearchService extends SearchService<LinkUpOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required LinkUpOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -35,7 +36,8 @@ class LinkUpSearchService extends SearchService<LinkUpOptions> {
           .post(
             Uri.parse('https://api.linkup.so/v1/search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: body,

--- a/lib/core/services/search/providers/metaso_search_service.dart
+++ b/lib/core/services/search/providers/metaso_search_service.dart
@@ -22,6 +22,7 @@ class MetasoSearchService extends SearchService<MetasoOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required MetasoOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -35,7 +36,8 @@ class MetasoSearchService extends SearchService<MetasoOptions> {
           .post(
             Uri.parse('https://metaso.cn/api/v1/search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Accept': 'application/json',
               'Content-Type': 'application/json',
             },

--- a/lib/core/services/search/providers/ollama_search_service.dart
+++ b/lib/core/services/search/providers/ollama_search_service.dart
@@ -22,6 +22,7 @@ class OllamaSearchService extends SearchService<OllamaOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required OllamaOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -33,7 +34,8 @@ class OllamaSearchService extends SearchService<OllamaOptions> {
           .post(
             Uri.parse('https://ollama.com/api/web_search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: body,

--- a/lib/core/services/search/providers/perplexity_search_service.dart
+++ b/lib/core/services/search/providers/perplexity_search_service.dart
@@ -22,6 +22,7 @@ class PerplexitySearchService extends SearchService<PerplexityOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required PerplexityOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = <String, dynamic>{
@@ -45,7 +46,8 @@ class PerplexitySearchService extends SearchService<PerplexityOptions> {
           .post(
             Uri.parse('https://api.perplexity.ai/search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: jsonEncode(body),

--- a/lib/core/services/search/providers/querit_search_service.dart
+++ b/lib/core/services/search/providers/querit_search_service.dart
@@ -31,9 +31,10 @@ class QueritSearchService extends SearchService<QueritOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required QueritOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
-      final apiKey = serviceOptions.apiKey.trim();
+      final apiKey = (apiKeyOverride ?? serviceOptions.apiKey).trim();
       if (apiKey.isEmpty) {
         throw Exception('Querit API key is required');
       }

--- a/lib/core/services/search/providers/searxng_search_service.dart
+++ b/lib/core/services/search/providers/searxng_search_service.dart
@@ -22,6 +22,7 @@ class SearXNGSearchService extends SearchService<SearXNGOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required SearXNGOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       if (serviceOptions.url.isEmpty) {

--- a/lib/core/services/search/providers/serper_search_service.dart
+++ b/lib/core/services/search/providers/serper_search_service.dart
@@ -31,6 +31,7 @@ class SerperSearchService extends SearchService<SerperOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required SerperOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = <String, dynamic>{
@@ -46,7 +47,7 @@ class SerperSearchService extends SearchService<SerperOptions> {
           .post(
             Uri.parse(endpoint),
             headers: {
-              'X-API-KEY': serviceOptions.apiKey,
+              'X-API-KEY': apiKeyOverride ?? serviceOptions.apiKey,
               'Content-Type': 'application/json',
             },
             body: jsonEncode(body),

--- a/lib/core/services/search/providers/tavily_search_service.dart
+++ b/lib/core/services/search/providers/tavily_search_service.dart
@@ -22,6 +22,7 @@ class TavilySearchService extends SearchService<TavilyOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required TavilyOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -33,7 +34,8 @@ class TavilySearchService extends SearchService<TavilyOptions> {
           .post(
             Uri.parse(serviceOptions.resolvedUrl),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: body,

--- a/lib/core/services/search/providers/zhipu_search_service.dart
+++ b/lib/core/services/search/providers/zhipu_search_service.dart
@@ -22,6 +22,7 @@ class ZhipuSearchService extends SearchService<ZhipuOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required ZhipuOptions serviceOptions,
+    String? apiKeyOverride,
   }) async {
     try {
       final body = jsonEncode({
@@ -34,7 +35,8 @@ class ZhipuSearchService extends SearchService<ZhipuOptions> {
           .post(
             Uri.parse('https://open.bigmodel.cn/api/paas/v4/web_search'),
             headers: {
-              'Authorization': 'Bearer ${serviceOptions.apiKey}',
+              'Authorization':
+                  'Bearer ${apiKeyOverride ?? serviceOptions.apiKey}',
               'Content-Type': 'application/json',
             },
             body: body,

--- a/lib/core/services/search/search_service.dart
+++ b/lib/core/services/search/search_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../models/api_keys.dart';
 // Import statements for service implementations
 import 'providers/bing_search_service.dart';
 import 'providers/tavily_search_service.dart';
@@ -27,6 +28,7 @@ abstract class SearchService<T extends SearchServiceOptions> {
     required String query,
     required SearchCommonOptions commonOptions,
     required T serviceOptions,
+    String? apiKeyOverride,
   });
 
   // Factory method to get service instance based on options type
@@ -67,6 +69,13 @@ abstract class SearchService<T extends SearchServiceOptions> {
       default:
         return BingSearchService() as SearchService;
     }
+  }
+
+  /// Whether this service type uses API keys (keyless services don't show key UI).
+  static bool serviceUsesKeys(SearchServiceOptions options) {
+    return options is! BingLocalOptions &&
+        options is! DuckDuckGoOptions &&
+        options is! SearXNGOptions;
   }
 }
 
@@ -145,10 +154,66 @@ class SearchCommonOptions {
 // Base class for service-specific options
 abstract class SearchServiceOptions {
   final String id;
+  final List<ApiKeyConfig> apiKeys;
+  final KeyManagementConfig? keyManagement;
 
-  const SearchServiceOptions({required this.id});
+  const SearchServiceOptions({
+    required this.id,
+    this.apiKeys = const [],
+    this.keyManagement,
+  });
+
+  /// Resolves the first active key for backward-compatible single-key access.
+  /// Provider implementations (TavilySearchService, etc.) call this getter
+  /// and never see the list. Rotation happens in SearchToolService.
+  String get apiKey {
+    if (apiKeys.isEmpty) return '';
+    final enabled = apiKeys.where((k) => k.isEnabled).toList();
+    if (enabled.isEmpty) return apiKeys.first.key;
+    return enabled.first.key;
+  }
 
   Map<String, dynamic> toJson();
+
+  /// Dual-read: prefers new `apiKeys` list, falls back to legacy `apiKey` string.
+  static List<ApiKeyConfig> readKeys(Map<String, dynamic> json) {
+    if (json['apiKeys'] != null) {
+      return (json['apiKeys'] as List)
+          .map((e) => ApiKeyConfig.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    final legacy = json['apiKey'] as String?;
+    if (legacy != null && legacy.isNotEmpty) {
+      return [ApiKeyConfig.create(legacy)];
+    }
+    return [];
+  }
+
+  /// Dual-write: writes the full `apiKeys` list AND the first active key as
+  /// legacy `apiKey` string for backward compat with older versions.
+  static void writeKeys(
+    Map<String, dynamic> json,
+    List<ApiKeyConfig> keys, {
+    KeyManagementConfig? keyManagement,
+  }) {
+    json['apiKeys'] = keys.map((k) => k.toJson()).toList();
+    final active = keys.where((k) => k.isEnabled);
+    json['apiKey'] = active.isNotEmpty
+        ? active.first.key
+        : (keys.isNotEmpty ? keys.first.key : '');
+    if (keyManagement != null) {
+      json['keyManagement'] = keyManagement.toJson();
+    }
+  }
+
+  static KeyManagementConfig? readKeyManagement(Map<String, dynamic> json) {
+    if (json['keyManagement'] != null) {
+      return KeyManagementConfig.fromJson(
+        json['keyManagement'] as Map<String, dynamic>,
+      );
+    }
+    return null;
+  }
 
   static SearchServiceOptions fromJson(Map<String, dynamic> json) {
     final type = json['type'] as String;
@@ -199,7 +264,12 @@ abstract class SearchServiceOptions {
 class BingLocalOptions extends SearchServiceOptions {
   final String acceptLanguage;
 
-  BingLocalOptions({required super.id, this.acceptLanguage = 'en-US,en;q=0.9'});
+  BingLocalOptions({
+    required super.id,
+    super.apiKeys,
+    super.keyManagement,
+    this.acceptLanguage = 'en-US,en;q=0.9',
+  });
 
   @override
   Map<String, dynamic> toJson() => {
@@ -211,6 +281,8 @@ class BingLocalOptions extends SearchServiceOptions {
   factory BingLocalOptions.fromJson(Map<String, dynamic> json) =>
       BingLocalOptions(
         id: json['id'],
+        apiKeys: SearchServiceOptions.readKeys(json),
+        keyManagement: SearchServiceOptions.readKeyManagement(json),
         acceptLanguage: json['acceptLanguage'] ?? 'en-US,en;q=0.9',
       );
 }
@@ -218,10 +290,14 @@ class BingLocalOptions extends SearchServiceOptions {
 class TavilyOptions extends SearchServiceOptions {
   static const String defaultUrl = 'https://api.tavily.com/search';
 
-  final String apiKey;
   final String url;
 
-  TavilyOptions({required super.id, required this.apiKey, this.url = ''});
+  TavilyOptions({
+    required super.id,
+    super.apiKeys,
+    super.keyManagement,
+    this.url = '',
+  });
 
   String get resolvedUrl {
     final trimmed = url.trim();
@@ -229,16 +305,20 @@ class TavilyOptions extends SearchServiceOptions {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'tavily',
-    'id': id,
-    'apiKey': apiKey,
-    'url': url.trim(),
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'tavily',
+      'id': id,
+      'url': url.trim(),
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory TavilyOptions.fromJson(Map<String, dynamic> json) => TavilyOptions(
     id: json['id'],
-    apiKey: json['apiKey'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     url: json['url'] ?? '',
   );
 }
@@ -246,10 +326,14 @@ class TavilyOptions extends SearchServiceOptions {
 class ExaOptions extends SearchServiceOptions {
   static const String defaultUrl = 'https://api.exa.ai/search';
 
-  final String apiKey;
   final String url;
 
-  ExaOptions({required super.id, required this.apiKey, this.url = ''});
+  ExaOptions({
+    required super.id,
+    super.apiKeys,
+    super.keyManagement,
+    this.url = '',
+  });
 
   String get resolvedUrl {
     final trimmed = url.trim();
@@ -257,34 +341,35 @@ class ExaOptions extends SearchServiceOptions {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'exa',
-    'id': id,
-    'apiKey': apiKey,
-    'url': url.trim(),
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'exa', 'id': id, 'url': url.trim()};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory ExaOptions.fromJson(Map<String, dynamic> json) => ExaOptions(
     id: json['id'],
-    apiKey: json['apiKey'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     url: json['url'] ?? '',
   );
 }
 
 class ZhipuOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  ZhipuOptions({required super.id, required this.apiKey});
+  ZhipuOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'zhipu',
-    'id': id,
-    'apiKey': apiKey,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'zhipu', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory ZhipuOptions.fromJson(Map<String, dynamic> json) =>
-      ZhipuOptions(id: json['id'], apiKey: json['apiKey']);
+  factory ZhipuOptions.fromJson(Map<String, dynamic> json) => ZhipuOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class SearXNGOptions extends SearchServiceOptions {
@@ -296,6 +381,8 @@ class SearXNGOptions extends SearchServiceOptions {
 
   SearXNGOptions({
     required super.id,
+    super.apiKeys,
+    super.keyManagement,
     required this.url,
     this.engines = '',
     this.language = '',
@@ -316,6 +403,8 @@ class SearXNGOptions extends SearchServiceOptions {
 
   factory SearXNGOptions.fromJson(Map<String, dynamic> json) => SearXNGOptions(
     id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     url: json['url'],
     engines: json['engines'] ?? '',
     language: json['language'] ?? '',
@@ -325,85 +414,99 @@ class SearXNGOptions extends SearchServiceOptions {
 }
 
 class LinkUpOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  LinkUpOptions({required super.id, required this.apiKey});
+  LinkUpOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'linkup',
-    'id': id,
-    'apiKey': apiKey,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'linkup', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory LinkUpOptions.fromJson(Map<String, dynamic> json) =>
-      LinkUpOptions(id: json['id'], apiKey: json['apiKey']);
+  factory LinkUpOptions.fromJson(Map<String, dynamic> json) => LinkUpOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class BraveOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  BraveOptions({required super.id, required this.apiKey});
+  BraveOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'brave',
-    'id': id,
-    'apiKey': apiKey,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'brave', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory BraveOptions.fromJson(Map<String, dynamic> json) =>
-      BraveOptions(id: json['id'], apiKey: json['apiKey']);
+  factory BraveOptions.fromJson(Map<String, dynamic> json) => BraveOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class MetasoOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  MetasoOptions({required super.id, required this.apiKey});
+  MetasoOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'metaso',
-    'id': id,
-    'apiKey': apiKey,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'metaso', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory MetasoOptions.fromJson(Map<String, dynamic> json) =>
-      MetasoOptions(id: json['id'], apiKey: json['apiKey']);
+  factory MetasoOptions.fromJson(Map<String, dynamic> json) => MetasoOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class OllamaOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  OllamaOptions({required super.id, required this.apiKey});
+  OllamaOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'ollama',
-    'id': id,
-    'apiKey': apiKey,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'ollama', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory OllamaOptions.fromJson(Map<String, dynamic> json) =>
-      OllamaOptions(id: json['id'], apiKey: json['apiKey']);
+  factory OllamaOptions.fromJson(Map<String, dynamic> json) => OllamaOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class JinaOptions extends SearchServiceOptions {
-  final String apiKey;
-
-  JinaOptions({required super.id, required this.apiKey});
+  JinaOptions({required super.id, super.apiKeys, super.keyManagement});
 
   @override
-  Map<String, dynamic> toJson() => {'type': 'jina', 'id': id, 'apiKey': apiKey};
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{'type': 'jina', 'id': id};
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
-  factory JinaOptions.fromJson(Map<String, dynamic> json) =>
-      JinaOptions(id: json['id'], apiKey: json['apiKey']);
+  factory JinaOptions.fromJson(Map<String, dynamic> json) => JinaOptions(
+    id: json['id'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
+  );
 }
 
 class DuckDuckGoOptions extends SearchServiceOptions {
   final String region;
 
-  DuckDuckGoOptions({required super.id, this.region = 'us-en'});
+  DuckDuckGoOptions({
+    required super.id,
+    super.apiKeys,
+    super.keyManagement,
+    this.region = 'us-en',
+  });
 
   @override
   Map<String, dynamic> toJson() => {
@@ -413,37 +516,46 @@ class DuckDuckGoOptions extends SearchServiceOptions {
   };
 
   factory DuckDuckGoOptions.fromJson(Map<String, dynamic> json) =>
-      DuckDuckGoOptions(id: json['id'], region: json['region'] ?? 'us-en');
+      DuckDuckGoOptions(
+        id: json['id'],
+        apiKeys: SearchServiceOptions.readKeys(json),
+        keyManagement: SearchServiceOptions.readKeyManagement(json),
+        region: json['region'] ?? 'us-en',
+      );
 }
 
 class PerplexityOptions extends SearchServiceOptions {
-  final String apiKey;
   final String? country; // ISO 3166-1 alpha-2
   final List<String>? searchDomainFilter; // domains/URLs
   final int? maxTokensPerPage; // default 1024
 
   PerplexityOptions({
     required super.id,
-    required this.apiKey,
+    super.apiKeys,
+    super.keyManagement,
     this.country,
     this.searchDomainFilter,
     this.maxTokensPerPage,
   });
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'perplexity',
-    'id': id,
-    'apiKey': apiKey,
-    if (country != null) 'country': country,
-    if (searchDomainFilter != null) 'searchDomainFilter': searchDomainFilter,
-    if (maxTokensPerPage != null) 'maxTokensPerPage': maxTokensPerPage,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'perplexity',
+      'id': id,
+      if (country != null) 'country': country,
+      if (searchDomainFilter != null) 'searchDomainFilter': searchDomainFilter,
+      if (maxTokensPerPage != null) 'maxTokensPerPage': maxTokensPerPage,
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory PerplexityOptions.fromJson(Map<String, dynamic> json) =>
       PerplexityOptions(
         id: json['id'],
-        apiKey: json['apiKey'],
+        apiKeys: SearchServiceOptions.readKeys(json),
+        keyManagement: SearchServiceOptions.readKeyManagement(json),
         country: json['country'],
         searchDomainFilter: (json['searchDomainFilter'] as List?)
             ?.map((e) => e.toString())
@@ -453,8 +565,6 @@ class PerplexityOptions extends SearchServiceOptions {
 }
 
 class BochaOptions extends SearchServiceOptions {
-  final String apiKey;
-  // Optional parameters supported by Bocha API
   final String? freshness; // e.g., 'noLimit', 'week', 'month', etc.
   final bool summary; // whether to include textual summary
   final String? include; // e.g., 'qq.com|m.163.com'
@@ -462,7 +572,8 @@ class BochaOptions extends SearchServiceOptions {
 
   BochaOptions({
     required super.id,
-    required this.apiKey,
+    super.apiKeys,
+    super.keyManagement,
     this.freshness,
     this.summary = true,
     this.include,
@@ -470,19 +581,23 @@ class BochaOptions extends SearchServiceOptions {
   });
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'bocha',
-    'id': id,
-    'apiKey': apiKey,
-    if (freshness != null) 'freshness': freshness,
-    'summary': summary,
-    if (include != null) 'include': include,
-    if (exclude != null) 'exclude': exclude,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'bocha',
+      'id': id,
+      if (freshness != null) 'freshness': freshness,
+      'summary': summary,
+      if (include != null) 'include': include,
+      if (exclude != null) 'exclude': exclude,
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory BochaOptions.fromJson(Map<String, dynamic> json) => BochaOptions(
     id: json['id'],
-    apiKey: json['apiKey'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     freshness: json['freshness'],
     summary: (json['summary'] ?? true) as bool,
     include: json['include'],
@@ -491,7 +606,6 @@ class BochaOptions extends SearchServiceOptions {
 }
 
 class SerperOptions extends SearchServiceOptions {
-  final String apiKey;
   final String gl;
   final String hl;
   final String tbs;
@@ -499,7 +613,8 @@ class SerperOptions extends SearchServiceOptions {
 
   SerperOptions({
     required super.id,
-    required this.apiKey,
+    super.apiKeys,
+    super.keyManagement,
     this.gl = '',
     this.hl = '',
     this.tbs = '',
@@ -507,19 +622,23 @@ class SerperOptions extends SearchServiceOptions {
   });
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'serper',
-    'id': id,
-    'apiKey': apiKey,
-    'gl': gl.trim(),
-    'hl': hl.trim(),
-    'tbs': tbs.trim(),
-    'page': page,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'serper',
+      'id': id,
+      'gl': gl.trim(),
+      'hl': hl.trim(),
+      'tbs': tbs.trim(),
+      'page': page,
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory SerperOptions.fromJson(Map<String, dynamic> json) => SerperOptions(
     id: json['id'],
-    apiKey: json['apiKey'],
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     gl: json['gl'] ?? '',
     hl: json['hl'] ?? '',
     tbs: json['tbs'] ?? '',
@@ -534,7 +653,6 @@ class GrokOptions extends SearchServiceOptions {
   static const String defaultSystemPrompt =
       "You are a helpful search assistant. Search the web to find accurate and up-to-date information for the user's query. Provide a comprehensive answer with citations.";
 
-  final String apiKey;
   final String model;
   final String reasoningEffort;
   final String customUrl;
@@ -542,7 +660,8 @@ class GrokOptions extends SearchServiceOptions {
 
   GrokOptions({
     required super.id,
-    required this.apiKey,
+    super.apiKeys,
+    super.keyManagement,
     this.model = defaultModel,
     String? reasoningEffort,
     this.customUrl = defaultUrl,
@@ -571,19 +690,23 @@ class GrokOptions extends SearchServiceOptions {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'grok',
-    'id': id,
-    'apiKey': apiKey,
-    'model': model.trim(),
-    'reasoningEffort': reasoningEffort.trim(),
-    'customUrl': customUrl.trim(),
-    'systemPrompt': systemPrompt,
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'grok',
+      'id': id,
+      'model': model.trim(),
+      'reasoningEffort': reasoningEffort.trim(),
+      'customUrl': customUrl.trim(),
+      'systemPrompt': systemPrompt,
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory GrokOptions.fromJson(Map<String, dynamic> json) => GrokOptions(
     id: json['id'],
-    apiKey: json['apiKey'] ?? '',
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     model: json['model'] ?? defaultModel,
     reasoningEffort: json['reasoningEffort'],
     customUrl: json['customUrl'] ?? defaultUrl,
@@ -592,7 +715,6 @@ class GrokOptions extends SearchServiceOptions {
 }
 
 class QueritOptions extends SearchServiceOptions {
-  final String apiKey;
   final String sitesInclude;
   final String sitesExclude;
   final String timeRange;
@@ -601,7 +723,8 @@ class QueritOptions extends SearchServiceOptions {
 
   QueritOptions({
     required super.id,
-    required this.apiKey,
+    super.apiKeys,
+    super.keyManagement,
     this.sitesInclude = '',
     this.sitesExclude = '',
     this.timeRange = '',
@@ -610,20 +733,24 @@ class QueritOptions extends SearchServiceOptions {
   });
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': 'querit',
-    'id': id,
-    'apiKey': apiKey,
-    'sitesInclude': sitesInclude.trim(),
-    'sitesExclude': sitesExclude.trim(),
-    'timeRange': timeRange.trim(),
-    'countries': countries.trim(),
-    'languages': languages.trim(),
-  };
+  Map<String, dynamic> toJson() {
+    final json = <String, dynamic>{
+      'type': 'querit',
+      'id': id,
+      'sitesInclude': sitesInclude.trim(),
+      'sitesExclude': sitesExclude.trim(),
+      'timeRange': timeRange.trim(),
+      'countries': countries.trim(),
+      'languages': languages.trim(),
+    };
+    SearchServiceOptions.writeKeys(json, apiKeys, keyManagement: keyManagement);
+    return json;
+  }
 
   factory QueritOptions.fromJson(Map<String, dynamic> json) => QueritOptions(
     id: json['id'],
-    apiKey: json['apiKey'] ?? '',
+    apiKeys: SearchServiceOptions.readKeys(json),
+    keyManagement: SearchServiceOptions.readKeyManagement(json),
     sitesInclude: json['sitesInclude'] ?? '',
     sitesExclude: json['sitesExclude'] ?? '',
     timeRange: json['timeRange'] ?? '',

--- a/lib/core/services/search/search_tool_service.dart
+++ b/lib/core/services/search/search_tool_service.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'package:uuid/uuid.dart';
+import '../../models/api_keys.dart';
+import '../api_key_manager.dart';
 import 'search_service.dart';
 import '../../providers/settings_provider.dart';
 
@@ -61,27 +63,164 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
     String query,
     SettingsProvider settings,
   ) async {
-    try {
-      // Get selected search service
-      final services = settings.searchServices;
-      if (services.isEmpty) {
-        return jsonEncode({'error': 'No search services configured'});
+    final services = settings.searchServices;
+    if (services.isEmpty) {
+      return jsonEncode({'error': 'No search services configured'});
+    }
+
+    final selectedIndex = settings.searchServiceSelected.clamp(
+      0,
+      services.length - 1,
+    );
+    final serviceOptions = services[selectedIndex];
+    final service = SearchService.getService(serviceOptions);
+    final manager = ApiKeyManager();
+
+    // Keyless services (BingLocal, DuckDuckGo, SearXNG) — call directly.
+    if (serviceOptions.apiKeys.isEmpty) {
+      return _searchDirect(query, settings, service, serviceOptions);
+    }
+
+    // Keyed services: rotate keys on failure, retry transparently.
+    final config = serviceOptions.keyManagement ?? const KeyManagementConfig();
+    final result = await _searchWithRotation(
+      query,
+      settings,
+      service,
+      serviceOptions,
+      manager,
+      config,
+    );
+
+    // Persist updated key status/usage and roundRobinIndex back to settings.
+    await _persistKeyUpdates(
+      settings,
+      selectedIndex,
+      serviceOptions,
+      manager,
+      config,
+    );
+
+    return result;
+  }
+
+  /// Direct search for keyless services.
+  static Future<String> _searchDirect(
+    String query,
+    SettingsProvider settings,
+    SearchService service,
+    SearchServiceOptions serviceOptions,
+  ) async {
+    final result = await _trySearch(query, settings, service, serviceOptions);
+    if (result != null) return result;
+    return jsonEncode({'error': 'Search failed'});
+  }
+
+  /// Rotates keys on failure, retries transparently, and writes updated key
+  /// status/usage back to [serviceOptions.apiKeys] in-place.
+  ///
+  /// Note: there is currently no UI for strategy / auto-disable / cooldown
+  /// settings, so [keys] is captured once and is stale across retries. This is
+  /// acceptable because roundRobin (the implicit default) tolerates stale keys
+  /// thanks to the in-memory index map. If strategy/cooldown UI is added later,
+  /// the stale‑keys problem must be fixed (write updated configs back into the
+  /// list before calling selectFromKeys on subsequent attempts).
+  static Future<String> _searchWithRotation(
+    String query,
+    SettingsProvider settings,
+    SearchService service,
+    SearchServiceOptions serviceOptions,
+    ApiKeyManager manager,
+    KeyManagementConfig config,
+  ) async {
+    final keys = serviceOptions.apiKeys.where((k) => k.isEnabled).toList();
+    if (keys.isEmpty) {
+      return _searchDirect(query, settings, service, serviceOptions);
+    }
+
+    for (var attempt = 0; attempt < keys.length; attempt++) {
+      final selection = manager.selectFromKeys(keys, config, serviceOptions.id);
+      if (selection.key == null) break;
+
+      final result = await _trySearch(
+        query,
+        settings,
+        service,
+        serviceOptions,
+        apiKeyOverride: selection.key!.key,
+      );
+      if (result != null) {
+        final updated = manager.updateKeyStatusFromConfig(
+          config,
+          selection.key!,
+          true,
+        );
+        _replaceApiKey(serviceOptions.apiKeys, updated);
+        return result;
       }
 
-      final selectedIndex = settings.searchServiceSelected.clamp(
-        0,
-        services.length - 1,
+      final updated = manager.updateKeyStatusFromConfig(
+        config,
+        selection.key!,
+        false,
+        error: 'search_failed',
       );
-      final service = SearchService.getService(services[selectedIndex]);
+      _replaceApiKey(serviceOptions.apiKeys, updated);
+    }
+    return jsonEncode({'error': 'All search keys failed'});
+  }
 
-      // Execute search
+  /// Replaces an [ApiKeyConfig] in [list] by matching [id].
+  static void _replaceApiKey(List<ApiKeyConfig> list, ApiKeyConfig updated) {
+    final idx = list.indexWhere((k) => k.id == updated.id);
+    if (idx >= 0) list[idx] = updated;
+  }
+
+  /// Persists updated key status/usage and roundRobinIndex back to settings.
+  ///
+  /// Currently only roundRobinIndex is persisted because strategy/cooldown/
+  /// auto‑disable are not exposed via UI — roundRobin is the de‑facto default,
+  /// so writing back the index is sufficient. If strategy/cooldown UI is added
+  /// later, also write back disabled/error key statuses so they survive restart.
+  static Future<void> _persistKeyUpdates(
+    SettingsProvider settings,
+    int selectedIndex,
+    SearchServiceOptions serviceOptions,
+    ApiKeyManager manager,
+    KeyManagementConfig config,
+  ) async {
+    // Single-key configs: rotation has no effect on future selection, skip write.
+    if (serviceOptions.apiKeys.length <= 1) return;
+    final roundRobinIndex = manager.getRoundRobinIndex(serviceOptions.id);
+    final services = List<SearchServiceOptions>.from(settings.searchServices);
+
+    if (roundRobinIndex != null &&
+        config.strategy == LoadBalanceStrategy.roundRobin) {
+      final updatedConfig = config.copyWith(roundRobinIndex: roundRobinIndex);
+      final json = serviceOptions.toJson();
+      json['keyManagement'] = updatedConfig.toJson();
+      services[selectedIndex] = SearchServiceOptions.fromJson(json);
+    }
+
+    await settings.setSearchServices(services);
+  }
+
+  /// Returns the encoded result on success, or null on failure.
+  static Future<String?> _trySearch(
+    String query,
+    SettingsProvider settings,
+    SearchService service,
+    SearchServiceOptions serviceOptions, {
+    String? apiKeyOverride,
+  }) async {
+    try {
       final result = await service.search(
         query: query,
         commonOptions: settings.searchCommonOptions,
-        serviceOptions: services[selectedIndex],
+        serviceOptions: serviceOptions,
+        apiKeyOverride: apiKeyOverride,
       );
 
-      // Add unique IDs to each result item
       final itemsWithIds = result.items.asMap().entries.map((entry) {
         final item = entry.value;
         return SearchResultItem(
@@ -93,13 +232,12 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
         );
       }).toList();
 
-      // Return formatted result
       return jsonEncode({
         if (result.answer != null) 'answer': result.answer,
         'items': itemsWithIds.map((item) => item.toJson()).toList(),
       });
     } catch (e) {
-      return jsonEncode({'error': 'Search failed: $e'});
+      return null;
     }
   }
 }

--- a/lib/desktop/setting/search_services_pane.dart
+++ b/lib/desktop/setting/search_services_pane.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../core/models/api_keys.dart';
 import '../../icons/lucide_adapter.dart' as lucide;
 import '../../l10n/app_localizations.dart';
 import '../../core/providers/settings_provider.dart';
@@ -1060,11 +1061,18 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
 
   SearchServiceOptions _createService() {
     final id = const Uuid().v4().substring(0, 8);
+
+    List<ApiKeyConfig> makeKeys() {
+      final key = _controllers['apiKey']?.text;
+      if (key == null || key.isEmpty) return [];
+      return [ApiKeyConfig.create(key)];
+    }
+
     switch (_selectedType) {
       case 'tavily':
         return TavilyOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           url: _controllers['tavilyUrl']!.text.trim(),
         );
       case 'duckduckgo':
@@ -1076,11 +1084,11 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
       case 'exa':
         return ExaOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           url: _controllers['exaUrl']!.text.trim(),
         );
       case 'zhipu':
-        return ZhipuOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return ZhipuOptions(id: id, apiKeys: makeKeys());
       case 'searxng':
         return SearXNGOptions(
           id: id,
@@ -1091,24 +1099,24 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
           password: _controllers['password']!.text,
         );
       case 'linkup':
-        return LinkUpOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return LinkUpOptions(id: id, apiKeys: makeKeys());
       case 'brave':
-        return BraveOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return BraveOptions(id: id, apiKeys: makeKeys());
       case 'metaso':
-        return MetasoOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return MetasoOptions(id: id, apiKeys: makeKeys());
       case 'jina':
-        return JinaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return JinaOptions(id: id, apiKeys: makeKeys());
       case 'ollama':
-        return OllamaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return OllamaOptions(id: id, apiKeys: makeKeys());
       case 'perplexity':
-        return PerplexityOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return PerplexityOptions(id: id, apiKeys: makeKeys());
       case 'bocha':
-        return BochaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return BochaOptions(id: id, apiKeys: makeKeys());
       case 'serper':
         final page = int.tryParse(_controllers['page']!.text.trim());
         return SerperOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           gl: _controllers['gl']!.text.trim(),
           hl: _controllers['hl']!.text.trim(),
           tbs: _controllers['tbs']!.text.trim(),
@@ -1117,7 +1125,7 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
       case 'querit':
         return QueritOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           sitesInclude: _controllers['sitesInclude']!.text.trim(),
           sitesExclude: _controllers['sitesExclude']!.text.trim(),
           timeRange: _controllers['timeRange']!.text.trim(),
@@ -1127,7 +1135,7 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
       case 'grok':
         return GrokOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           model: _controllers['model']!.text.trim(),
           reasoningEffort: _controllers['reasoningEffort']!.text,
           customUrl: _controllers['customUrl']!.text.trim(),
@@ -1149,46 +1157,30 @@ class _EditServiceDialog extends StatefulWidget {
 
 class _EditServiceDialogState extends State<_EditServiceDialog> {
   final Map<String, TextEditingController> _controllers = {};
+  late List<ApiKeyConfig> _editKeys;
+
   @override
   void initState() {
     super.initState();
+    _editKeys = List.from(widget.service.apiKeys);
     _initControllers();
   }
 
   void _initControllers() {
     final s = widget.service;
     if (s is TavilyOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['url'] = TextEditingController(text: s.url);
     } else if (s is DuckDuckGoOptions) {
       _controllers['region'] = TextEditingController(text: s.region);
     } else if (s is ExaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['url'] = TextEditingController(text: s.url);
-    } else if (s is ZhipuOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
     } else if (s is SearXNGOptions) {
       _controllers['url'] = TextEditingController(text: s.url);
       _controllers['engines'] = TextEditingController(text: s.engines);
       _controllers['language'] = TextEditingController(text: s.language);
       _controllers['username'] = TextEditingController(text: s.username);
       _controllers['password'] = TextEditingController(text: s.password);
-    } else if (s is LinkUpOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is BraveOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is MetasoOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is OllamaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is JinaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is PerplexityOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
-    } else if (s is BochaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
     } else if (s is SerperOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['gl'] = TextEditingController(text: s.gl);
       _controllers['hl'] = TextEditingController(text: s.hl);
       _controllers['tbs'] = TextEditingController(text: s.tbs);
@@ -1196,7 +1188,6 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
         text: s.page == 1 ? '' : s.page.toString(),
       );
     } else if (s is QueritOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['sitesInclude'] = TextEditingController(
         text: s.sitesInclude,
       );
@@ -1207,7 +1198,6 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
       _controllers['countries'] = TextEditingController(text: s.countries);
       _controllers['languages'] = TextEditingController(text: s.languages);
     } else if (s is GrokOptions) {
-      _controllers['apiKey'] = TextEditingController(text: s.apiKey);
       _controllers['model'] = TextEditingController(text: s.model);
       _controllers['reasoningEffort'] = TextEditingController(
         text: s.reasoningEffort,
@@ -1276,6 +1266,19 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
                 filled: true,
                 dense: true,
                 onTap: () {
+                  if (_editKeys.isEmpty &&
+                      widget.service is! BingLocalOptions &&
+                      widget.service is! DuckDuckGoOptions &&
+                      widget.service is! SearXNGOptions) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          l10n.searchServicesEditDialogApiKeyRequired,
+                        ),
+                      ),
+                    );
+                    return;
+                  }
                   final updated = _updateService();
                   Navigator.of(context).pop(updated);
                 },
@@ -1292,13 +1295,11 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     final s = widget.service;
     InputDecoration deco(String hint) =>
         _deskInputDecoration(context).copyWith(hintText: hint);
+
+    final fields = <Widget>[];
+
     if (s is TavilyOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco(l10n.searchServicesDialogApiKey),
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         TextField(
           controller: _controllers['url'],
           decoration: _deskInputDecoration(context).copyWith(
@@ -1306,14 +1307,9 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
             hintText: TavilyOptions.defaultUrl,
           ),
         ),
-      ];
+      ]);
     } else if (s is ExaOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco('API Key'),
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         TextField(
           controller: _controllers['url'],
           decoration: _deskInputDecoration(context).copyWith(
@@ -1321,28 +1317,9 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
             hintText: ExaOptions.defaultUrl,
           ),
         ),
-      ];
-    } else if (s is ZhipuOptions ||
-        s is LinkUpOptions ||
-        s is BraveOptions ||
-        s is MetasoOptions ||
-        s is JinaOptions ||
-        s is OllamaOptions ||
-        s is PerplexityOptions ||
-        s is BochaOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco('API Key'),
-        ),
-      ];
+      ]);
     } else if (s is GrokOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco('API Key'),
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         TextField(
           controller: _controllers['model'],
           decoration: _deskInputDecoration(context).copyWith(
@@ -1373,14 +1350,9 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
           minLines: 3,
           maxLines: 5,
         ),
-      ];
+      ]);
     } else if (s is SerperOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco('API Key'),
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         TextField(
           controller: _controllers['gl'],
           decoration: deco(l10n.searchServicesDialogCountryOptional),
@@ -1401,14 +1373,9 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
           decoration: deco(l10n.searchServicesDialogPageOptional),
           keyboardType: TextInputType.number,
         ),
-      ];
+      ]);
     } else if (s is QueritOptions) {
-      return [
-        TextField(
-          controller: _controllers['apiKey'],
-          decoration: deco(l10n.searchServicesDialogApiKey),
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         TextField(
           controller: _controllers['sitesInclude'],
           decoration: deco(l10n.searchServicesDialogSitesIncludeOptional),
@@ -1433,16 +1400,16 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
           controller: _controllers['languages'],
           decoration: deco(l10n.searchServicesDialogLanguagesOptional),
         ),
-      ];
+      ]);
     } else if (s is DuckDuckGoOptions) {
-      return [
+      fields.addAll([
         TextField(
           controller: _controllers['region'],
           decoration: deco(l10n.searchServicesEditDialogRegionOptional),
         ),
-      ];
+      ]);
     } else if (s is SearXNGOptions) {
-      return [
+      fields.addAll([
         TextField(
           controller: _controllers['url'],
           decoration: deco(l10n.searchServicesEditDialogInstanceUrl),
@@ -1468,9 +1435,109 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
           decoration: deco(l10n.searchServicesAddDialogPasswordOptional),
           obscureText: true,
         ),
-      ];
+      ]);
     }
-    return [];
+
+    if (SearchService.serviceUsesKeys(s)) {
+      if (fields.isNotEmpty) fields.add(const SizedBox(height: 12));
+      fields.addAll(_buildKeyManagement());
+    }
+    return fields;
+  }
+
+  List<Widget> _buildKeyManagement() {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+
+    final rows = <Widget>[];
+    for (int i = 0; i < _editKeys.length; i++) {
+      final k = _editKeys[i];
+      final idx = i;
+      rows.add(
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          decoration: BoxDecoration(
+            color: cs.surfaceContainerHighest.withValues(alpha: 0.25),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      k.name ?? '${l10n.searchServicesDialogApiKey} ${idx + 1}',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: cs.onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      k.key.length > 24
+                          ? '${k.key.substring(0, 24)}...'
+                          : k.key,
+                      style: TextStyle(fontSize: 13, color: cs.onSurface),
+                    ),
+                  ],
+                ),
+              ),
+              IosSwitch(
+                value: k.isEnabled,
+                onChanged: (v) {
+                  setState(() => _editKeys[idx] = k.copyWith(isEnabled: v));
+                },
+              ),
+              const SizedBox(width: 6),
+              _SmallIconBtn(
+                icon: lucide.Lucide.Trash2,
+                onTap: () => setState(() => _editKeys.removeAt(idx)),
+              ),
+            ],
+          ),
+        ),
+      );
+      rows.add(const SizedBox(height: 8));
+    }
+
+    rows.add(_SmallIconBtn(icon: lucide.Lucide.Plus, onTap: () => _addKey()));
+
+    return [const SizedBox(height: 4), ...rows];
+  }
+
+  Future<void> _addKey() async {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: cs.surface,
+        title: Text(l10n.searchServicesDialogAddKey),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: l10n.searchServicesDialogApiKey,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(l10n.searchServicesEditDialogCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: Text(l10n.searchServicesEditDialogSave),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result != null && result.isNotEmpty && mounted) {
+      setState(() => _editKeys.add(ApiKeyConfig.create(result)));
+    }
   }
 
   SearchServiceOptions _updateService() {
@@ -1478,7 +1545,7 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     if (s is TavilyOptions) {
       return TavilyOptions(
         id: s.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         url: _controllers['url']!.text.trim(),
       );
     }
@@ -1492,12 +1559,12 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     if (s is ExaOptions) {
       return ExaOptions(
         id: s.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         url: _controllers['url']!.text.trim(),
       );
     }
     if (s is ZhipuOptions) {
-      return ZhipuOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return ZhipuOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is SearXNGOptions) {
       return SearXNGOptions(
@@ -1510,31 +1577,31 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
       );
     }
     if (s is LinkUpOptions) {
-      return LinkUpOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return LinkUpOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is BraveOptions) {
-      return BraveOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return BraveOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is MetasoOptions) {
-      return MetasoOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return MetasoOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is JinaOptions) {
-      return JinaOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return JinaOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is OllamaOptions) {
-      return OllamaOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return OllamaOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is PerplexityOptions) {
-      return PerplexityOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return PerplexityOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is BochaOptions) {
-      return BochaOptions(id: s.id, apiKey: _controllers['apiKey']!.text);
+      return BochaOptions(id: s.id, apiKeys: _editKeys);
     }
     if (s is SerperOptions) {
       final page = int.tryParse(_controllers['page']!.text.trim());
       return SerperOptions(
         id: s.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         gl: _controllers['gl']!.text.trim(),
         hl: _controllers['hl']!.text.trim(),
         tbs: _controllers['tbs']!.text.trim(),
@@ -1544,7 +1611,7 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     if (s is QueritOptions) {
       return QueritOptions(
         id: s.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         sitesInclude: (_controllers['sitesInclude']?.text ?? '').trim(),
         sitesExclude: (_controllers['sitesExclude']?.text ?? '').trim(),
         timeRange: (_controllers['timeRange']?.text ?? '').trim(),
@@ -1555,7 +1622,7 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     if (s is GrokOptions) {
       return GrokOptions(
         id: s.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         model: _controllers['model']!.text.trim(),
         reasoningEffort: _controllers['reasoningEffort']!.text,
         customUrl: _controllers['customUrl']!.text.trim(),

--- a/lib/features/search/pages/search_services_page.dart
+++ b/lib/features/search/pages/search_services_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:uuid/uuid.dart';
+import '../../../core/models/api_keys.dart';
 import '../../../core/services/search/search_service.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
@@ -1197,6 +1198,12 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
     final uuid = const Uuid();
     final id = uuid.v4().substring(0, 8);
 
+    List<ApiKeyConfig> makeKeys() {
+      final key = _controllers['apiKey']?.text;
+      if (key == null || key.isEmpty) return [];
+      return [ApiKeyConfig.create(key)];
+    }
+
     switch (_selectedType) {
       case 'bing_local':
         return BingLocalOptions(id: id);
@@ -1209,17 +1216,17 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
       case 'tavily':
         return TavilyOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           url: _controllers['tavilyUrl']!.text.trim(),
         );
       case 'exa':
         return ExaOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           url: _controllers['exaUrl']!.text.trim(),
         );
       case 'zhipu':
-        return ZhipuOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return ZhipuOptions(id: id, apiKeys: makeKeys());
       case 'searxng':
         return SearXNGOptions(
           id: id,
@@ -1230,24 +1237,24 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
           password: _controllers['password']!.text,
         );
       case 'linkup':
-        return LinkUpOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return LinkUpOptions(id: id, apiKeys: makeKeys());
       case 'brave':
-        return BraveOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return BraveOptions(id: id, apiKeys: makeKeys());
       case 'metaso':
-        return MetasoOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return MetasoOptions(id: id, apiKeys: makeKeys());
       case 'jina':
-        return JinaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return JinaOptions(id: id, apiKeys: makeKeys());
       case 'ollama':
-        return OllamaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return OllamaOptions(id: id, apiKeys: makeKeys());
       case 'perplexity':
-        return PerplexityOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return PerplexityOptions(id: id, apiKeys: makeKeys());
       case 'bocha':
-        return BochaOptions(id: id, apiKey: _controllers['apiKey']!.text);
+        return BochaOptions(id: id, apiKeys: makeKeys());
       case 'serper':
         final pageText = (_controllers['page']?.text ?? '').trim();
         return SerperOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           gl: (_controllers['gl']?.text ?? '').trim(),
           hl: (_controllers['hl']?.text ?? '').trim(),
           tbs: (_controllers['tbs']?.text ?? '').trim(),
@@ -1256,7 +1263,7 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
       case 'querit':
         return QueritOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           sitesInclude: (_controllers['sitesInclude']?.text ?? '').trim(),
           sitesExclude: (_controllers['sitesExclude']?.text ?? '').trim(),
           timeRange: (_controllers['timeRange']?.text ?? '').trim(),
@@ -1266,7 +1273,7 @@ class _AddServiceBottomSheetState extends State<_AddServiceBottomSheet> {
       case 'grok':
         return GrokOptions(
           id: id,
-          apiKey: _controllers['apiKey']!.text,
+          apiKeys: makeKeys(),
           model: _controllers['model']!.text.trim(),
           reasoningEffort: _controllers['reasoningEffort']!.text,
           customUrl: _controllers['customUrl']!.text.trim(),
@@ -1292,45 +1299,30 @@ class _EditServiceSheet extends StatefulWidget {
 class _EditServiceSheetState extends State<_EditServiceSheet> {
   final _formKey = GlobalKey<FormState>();
   final Map<String, TextEditingController> _controllers = {};
+  late List<ApiKeyConfig> _editKeys;
 
   @override
   void initState() {
     super.initState();
+    _editKeys = List.from(widget.service.apiKeys);
     _initControllers();
   }
 
   void _initControllers() {
     final service = widget.service;
     if (service is TavilyOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['url'] = TextEditingController(text: service.url);
     } else if (service is DuckDuckGoOptions) {
       _controllers['region'] = TextEditingController(text: service.region);
     } else if (service is ExaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['url'] = TextEditingController(text: service.url);
-    } else if (service is ZhipuOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
     } else if (service is SearXNGOptions) {
       _controllers['url'] = TextEditingController(text: service.url);
       _controllers['engines'] = TextEditingController(text: service.engines);
       _controllers['language'] = TextEditingController(text: service.language);
       _controllers['username'] = TextEditingController(text: service.username);
       _controllers['password'] = TextEditingController(text: service.password);
-    } else if (service is LinkUpOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
-    } else if (service is BraveOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
-    } else if (service is MetasoOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
-    } else if (service is OllamaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
-    } else if (service is JinaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
-    } else if (service is BochaOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
     } else if (service is SerperOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['gl'] = TextEditingController(text: service.gl);
       _controllers['hl'] = TextEditingController(text: service.hl);
       _controllers['tbs'] = TextEditingController(text: service.tbs);
@@ -1338,7 +1330,6 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
         text: service.page == 1 ? '' : service.page.toString(),
       );
     } else if (service is QueritOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['sitesInclude'] = TextEditingController(
         text: service.sitesInclude,
       );
@@ -1355,7 +1346,6 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
         text: service.languages,
       );
     } else if (service is GrokOptions) {
-      _controllers['apiKey'] = TextEditingController(text: service.apiKey);
       _controllers['model'] = TextEditingController(text: service.model);
       _controllers['reasoningEffort'] = TextEditingController(
         text: service.reasoningEffort,
@@ -1433,6 +1423,19 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
               child: FilledButton(
                 onPressed: () {
                   if (_formKey.currentState!.validate()) {
+                    if (_editKeys.isEmpty &&
+                        widget.service is! BingLocalOptions &&
+                        widget.service is! DuckDuckGoOptions &&
+                        widget.service is! SearXNGOptions) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            l10n.searchServicesEditDialogApiKeyRequired,
+                          ),
+                        ),
+                      );
+                      return;
+                    }
                     final updated = _updateService();
                     widget.onSave(updated);
                     Navigator.of(context).pop();
@@ -1507,86 +1510,36 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
       );
     }
 
+    final fields = <Widget>[];
+
     if (service is BingLocalOptions) {
-      return [Text(l10n.searchServicesEditDialogBingLocalNoConfig)];
+      fields.add(Text(l10n.searchServicesEditDialogBingLocalNoConfig));
     } else if (service is DuckDuckGoOptions) {
-      return [
+      fields.addAll([
         buildTextField(
           key: 'region',
           label: l10n.searchServicesEditDialogRegionOptional,
           hint: 'us-en',
         ),
-      ];
+      ]);
     } else if (service is TavilyOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: l10n.searchServicesDialogApiKey,
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         buildTextField(
           key: 'url',
           label: l10n.searchServicesFieldCustomUrlOptional,
           hint: TavilyOptions.defaultUrl,
         ),
-      ];
+      ]);
     } else if (service is ExaOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: 'API Key',
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         buildTextField(
           key: 'url',
           label: l10n.searchServicesFieldCustomUrlOptional,
           hint: ExaOptions.defaultUrl,
         ),
-      ];
-    } else if (service is ZhipuOptions ||
-        service is LinkUpOptions ||
-        service is BraveOptions ||
-        service is MetasoOptions ||
-        service is OllamaOptions ||
-        service is JinaOptions ||
-        service is BochaOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: 'API Key',
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-      ];
+      ]);
     } else if (service is SerperOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: 'API Key',
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         buildTextField(
           key: 'gl',
           label: l10n.searchServicesDialogCountryOptional,
@@ -1620,20 +1573,9 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
             return null;
           },
         ),
-      ];
+      ]);
     } else if (service is QueritOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: l10n.searchServicesDialogApiKey,
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         buildTextField(
           key: 'sitesInclude',
           label: l10n.searchServicesDialogSitesIncludeOptional,
@@ -1663,20 +1605,9 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
           label: l10n.searchServicesDialogLanguagesOptional,
           hint: l10n.searchServicesDialogLanguagesHint,
         ),
-      ];
+      ]);
     } else if (service is GrokOptions) {
-      return [
-        buildTextField(
-          key: 'apiKey',
-          label: 'API Key',
-          validator: (value) {
-            if (value == null || value.isEmpty) {
-              return l10n.searchServicesEditDialogApiKeyRequired;
-            }
-            return null;
-          },
-        ),
-        const SizedBox(height: 12),
+      fields.addAll([
         buildTextField(
           key: 'model',
           label: l10n.searchServicesDialogModel,
@@ -1701,9 +1632,9 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
           minLines: 3,
           maxLines: 5,
         ),
-      ];
+      ]);
     } else if (service is SearXNGOptions) {
-      return [
+      fields.addAll([
         buildTextField(
           key: 'url',
           label: l10n.searchServicesEditDialogInstanceUrl,
@@ -1737,10 +1668,158 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
           label: l10n.searchServicesEditDialogPasswordOptional,
           obscureText: true,
         ),
-      ];
+      ]);
     }
 
-    return [];
+    if (SearchService.serviceUsesKeys(service)) {
+      if (fields.isNotEmpty) fields.add(const SizedBox(height: 12));
+      fields.addAll(_buildKeyManagement());
+    }
+    return fields;
+  }
+
+  List<Widget> _buildKeyManagement() {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    final rows = <Widget>[];
+    for (int i = 0; i < _editKeys.length; i++) {
+      final k = _editKeys[i];
+      final idx = i;
+      rows.add(
+        Container(
+          decoration: BoxDecoration(
+            color: cs.surfaceContainerHighest.withValues(
+              alpha: isDark ? 0.18 : 0.5,
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        k.name ??
+                            '${l10n.searchServicesDialogApiKey} ${idx + 1}',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: cs.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        k.key.length > 20
+                            ? '${k.key.substring(0, 20)}...'
+                            : k.key,
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: cs.onSurface,
+                          fontWeight: AppFontWeights.medium,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                IosSwitch(
+                  value: k.isEnabled,
+                  onChanged: (v) {
+                    setState(() {
+                      _editKeys[idx] = k.copyWith(isEnabled: v);
+                    });
+                  },
+                ),
+                const SizedBox(width: 4),
+                GestureDetector(
+                  onTap: () {
+                    setState(() => _editKeys.removeAt(idx));
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(4),
+                    child: Icon(Lucide.X, size: 16, color: cs.error),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      rows.add(const SizedBox(height: 8));
+    }
+
+    rows.add(
+      Container(
+        decoration: BoxDecoration(
+          color: cs.surfaceContainerHighest.withValues(
+            alpha: isDark ? 0.18 : 0.5,
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => _addKey(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+            child: Row(
+              children: [
+                Icon(Lucide.Plus, size: 16, color: cs.primary),
+                const SizedBox(width: 8),
+                Text(
+                  l10n.searchServicesDialogAddKey,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: cs.primary,
+                    fontWeight: AppFontWeights.semibold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    return [const SizedBox(height: 12), ...rows];
+  }
+
+  Future<void> _addKey() async {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: cs.surface,
+        title: Text(l10n.searchServicesDialogAddKey),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: l10n.searchServicesDialogApiKey,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(l10n.searchServicesEditDialogCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: Text(l10n.searchServicesEditDialogSave),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result != null && result.isNotEmpty && mounted) {
+      setState(() {
+        _editKeys.add(ApiKeyConfig.create(result));
+      });
+    }
   }
 
   SearchServiceOptions _updateService() {
@@ -1749,7 +1828,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     if (service is TavilyOptions) {
       return TavilyOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         url: _controllers['url']!.text.trim(),
       );
     } else if (service is DuckDuckGoOptions) {
@@ -1761,11 +1840,11 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     } else if (service is ExaOptions) {
       return ExaOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         url: _controllers['url']!.text.trim(),
       );
     } else if (service is ZhipuOptions) {
-      return ZhipuOptions(id: service.id, apiKey: _controllers['apiKey']!.text);
+      return ZhipuOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is SearXNGOptions) {
       return SearXNGOptions(
         id: service.id,
@@ -1776,28 +1855,19 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
         password: _controllers['password']!.text,
       );
     } else if (service is LinkUpOptions) {
-      return LinkUpOptions(
-        id: service.id,
-        apiKey: _controllers['apiKey']!.text,
-      );
+      return LinkUpOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is BraveOptions) {
-      return BraveOptions(id: service.id, apiKey: _controllers['apiKey']!.text);
+      return BraveOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is MetasoOptions) {
-      return MetasoOptions(
-        id: service.id,
-        apiKey: _controllers['apiKey']!.text,
-      );
+      return MetasoOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is OllamaOptions) {
-      return OllamaOptions(
-        id: service.id,
-        apiKey: _controllers['apiKey']!.text,
-      );
+      return OllamaOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is JinaOptions) {
-      return JinaOptions(id: service.id, apiKey: _controllers['apiKey']!.text);
+      return JinaOptions(id: service.id, apiKeys: _editKeys);
     } else if (service is PerplexityOptions) {
       return PerplexityOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         country: service.country,
         searchDomainFilter: service.searchDomainFilter,
         maxTokensPerPage: service.maxTokensPerPage,
@@ -1805,7 +1875,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     } else if (service is BochaOptions) {
       return BochaOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         freshness: service.freshness,
         summary: service.summary,
         include: service.include,
@@ -1815,7 +1885,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
       final pageText = (_controllers['page']?.text ?? '').trim();
       return SerperOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         gl: (_controllers['gl']?.text ?? '').trim(),
         hl: (_controllers['hl']?.text ?? '').trim(),
         tbs: (_controllers['tbs']?.text ?? '').trim(),
@@ -1824,7 +1894,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     } else if (service is QueritOptions) {
       return QueritOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         sitesInclude: (_controllers['sitesInclude']?.text ?? '').trim(),
         sitesExclude: (_controllers['sitesExclude']?.text ?? '').trim(),
         timeRange: (_controllers['timeRange']?.text ?? '').trim(),
@@ -1834,7 +1904,7 @@ class _EditServiceSheetState extends State<_EditServiceSheet> {
     } else if (service is GrokOptions) {
       return GrokOptions(
         id: service.id,
-        apiKey: _controllers['apiKey']!.text,
+        apiKeys: _editKeys,
         model: _controllers['model']!.text.trim(),
         reasoningEffort: _controllers['reasoningEffort']!.text,
         customUrl: _controllers['customUrl']!.text.trim(),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1745,6 +1745,7 @@
   "searchServicesEditDialogApiKeyRequired": "API Key is required",
   "searchServicesEditDialogInstanceUrl": "Instance URL",
   "searchServicesEditDialogUrlRequired": "URL is required",
+  "searchServicesDialogAddKey": "Add Key",
   "searchServicesEditDialogEnginesOptional": "Engines (optional)",
   "searchServicesEditDialogLanguageOptional": "Language (optional)",
   "searchServicesEditDialogUsernameOptional": "Username (optional)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7454,6 +7454,12 @@ abstract class AppLocalizations {
   /// **'URL is required'**
   String get searchServicesEditDialogUrlRequired;
 
+  /// No description provided for @searchServicesDialogAddKey.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Key'**
+  String get searchServicesDialogAddKey;
+
   /// No description provided for @searchServicesEditDialogEnginesOptional.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4003,6 +4003,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get searchServicesEditDialogUrlRequired => 'URL is required';
 
   @override
+  String get searchServicesDialogAddKey => 'Add Key';
+
+  @override
   String get searchServicesEditDialogEnginesOptional => 'Engines (optional)';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3869,6 +3869,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get searchServicesEditDialogUrlRequired => 'URL 必填';
 
   @override
+  String get searchServicesDialogAddKey => '添加密钥';
+
+  @override
   String get searchServicesEditDialogEnginesOptional => '搜索引擎（可选）';
 
   @override
@@ -10052,6 +10055,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get searchServicesEditDialogUrlRequired => 'URL 必填';
 
   @override
+  String get searchServicesDialogAddKey => '添加密钥';
+
+  @override
   String get searchServicesEditDialogEnginesOptional => '搜索引擎（可选）';
 
   @override
@@ -16231,6 +16237,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get searchServicesEditDialogUrlRequired => 'URL 必填';
+
+  @override
+  String get searchServicesDialogAddKey => '新增金鑰';
 
   @override
   String get searchServicesEditDialogEnginesOptional => '搜尋引擎（可選）';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1335,6 +1335,7 @@
   "searchServicesEditDialogApiKeyRequired": "API Key 必填",
   "searchServicesEditDialogInstanceUrl": "实例 URL",
   "searchServicesEditDialogUrlRequired": "URL 必填",
+  "searchServicesDialogAddKey": "添加密钥",
   "searchServicesEditDialogEnginesOptional": "搜索引擎（可选）",
   "searchServicesEditDialogLanguageOptional": "语言（可选）",
   "searchServicesEditDialogUsernameOptional": "用户名（可选）",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1355,6 +1355,7 @@
   "searchServicesEditDialogApiKeyRequired": "API Key 必填",
   "searchServicesEditDialogInstanceUrl": "实例 URL",
   "searchServicesEditDialogUrlRequired": "URL 必填",
+  "searchServicesDialogAddKey": "添加密钥",
   "searchServicesEditDialogEnginesOptional": "搜索引擎（可选）",
   "searchServicesEditDialogLanguageOptional": "语言（可选）",
   "searchServicesEditDialogUsernameOptional": "用户名（可选）",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1322,6 +1322,7 @@
   "searchServicesEditDialogApiKeyRequired": "API Key 必填",
   "searchServicesEditDialogInstanceUrl": "實例 URL",
   "searchServicesEditDialogUrlRequired": "URL 必填",
+  "searchServicesDialogAddKey": "新增金鑰",
   "searchServicesEditDialogEnginesOptional": "搜尋引擎（可選）",
   "searchServicesEditDialogLanguageOptional": "語言（可選）",
   "searchServicesEditDialogUsernameOptional": "使用者名稱（可選）",

--- a/test/core/services/search/grok_search_service_test.dart
+++ b/test/core/services/search/grok_search_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:Cuplivo/core/models/api_keys.dart';
 import 'package:Cuplivo/core/services/search/providers/grok_search_service.dart';
 import 'package:Cuplivo/core/services/search/search_service.dart';
 import 'package:Cuplivo/utils/brand_assets.dart';
@@ -12,7 +13,7 @@ void main() {
     test('serializes options and resolves factory/icon mapping', () {
       final options = GrokOptions(
         id: 'grok-1',
-        apiKey: 'xai-test',
+        apiKeys: [ApiKeyConfig.create('xai-test')],
         model: 'grok-test',
         reasoningEffort: 'medium',
         customUrl: 'https://example.com/responses',
@@ -81,7 +82,7 @@ void main() {
         commonOptions: const SearchCommonOptions(resultSize: 1, timeout: 1000),
         serviceOptions: GrokOptions(
           id: 'grok-1',
-          apiKey: 'xai-test',
+          apiKeys: [ApiKeyConfig.create('xai-test')],
           model: 'grok-test',
           customUrl: 'https://example.com/responses',
           systemPrompt: 'Search carefully.',
@@ -138,7 +139,7 @@ void main() {
         commonOptions: const SearchCommonOptions(timeout: 1000),
         serviceOptions: GrokOptions(
           id: 'grok-1',
-          apiKey: 'xai-test',
+          apiKeys: [ApiKeyConfig.create('xai-test')],
           model: 'grok-4-1-fast-non-reasoning',
           reasoningEffort: 'none',
         ),
@@ -174,7 +175,10 @@ void main() {
       await service.search(
         query: 'kelivo',
         commonOptions: const SearchCommonOptions(timeout: 1000),
-        serviceOptions: GrokOptions(id: 'grok-1', apiKey: 'xai-test'),
+        serviceOptions: GrokOptions(
+          id: 'grok-1',
+          apiKeys: [ApiKeyConfig.create('xai-test')],
+        ),
       );
 
       final body = jsonDecode(captured!.body) as Map<String, dynamic>;
@@ -219,7 +223,10 @@ void main() {
             resultSize: 1,
             timeout: 1000,
           ),
-          serviceOptions: GrokOptions(id: 'grok-1', apiKey: 'xai-test'),
+          serviceOptions: GrokOptions(
+            id: 'grok-1',
+            apiKeys: [ApiKeyConfig.create('xai-test')],
+          ),
         );
 
         expect(result.answer, 'Kelivo is a Flutter chat client.');
@@ -243,7 +250,7 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: GrokOptions(id: 'grok-1', apiKey: ''),
+          serviceOptions: GrokOptions(id: 'grok-1', apiKeys: []),
         ),
         throwsA(
           isA<Exception>().having(
@@ -265,7 +272,10 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: GrokOptions(id: 'grok-1', apiKey: 'xai-test'),
+          serviceOptions: GrokOptions(
+            id: 'grok-1',
+            apiKeys: [ApiKeyConfig.create('xai-test')],
+          ),
         ),
         throwsA(
           isA<Exception>().having(

--- a/test/core/services/search/querit_search_service_test.dart
+++ b/test/core/services/search/querit_search_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:Cuplivo/core/models/api_keys.dart';
 import 'package:Cuplivo/core/services/search/providers/querit_search_service.dart';
 import 'package:Cuplivo/core/services/search/search_service.dart';
 import 'package:Cuplivo/utils/brand_assets.dart';
@@ -12,7 +13,7 @@ void main() {
     test('serializes options and resolves factory/icon mapping', () {
       final options = QueritOptions(
         id: 'querit-1',
-        apiKey: 'querit-test',
+        apiKeys: [ApiKeyConfig.create('querit-test')],
         sitesInclude: 'example.com',
         sitesExclude: 'excluded.example',
         timeRange: 'd7',
@@ -78,7 +79,7 @@ void main() {
         commonOptions: const SearchCommonOptions(resultSize: 1, timeout: 1000),
         serviceOptions: QueritOptions(
           id: 'querit-1',
-          apiKey: 'querit-test',
+          apiKeys: [ApiKeyConfig.create('querit-test')],
           sitesInclude: 'example.com, docs.example.com',
           sitesExclude: 'excluded.example',
           timeRange: 'd7',
@@ -136,7 +137,10 @@ void main() {
       final result = await service.search(
         query: 'kelivo',
         commonOptions: const SearchCommonOptions(resultSize: 5, timeout: 1000),
-        serviceOptions: QueritOptions(id: 'querit-1', apiKey: 'querit-test'),
+        serviceOptions: QueritOptions(
+          id: 'querit-1',
+          apiKeys: [ApiKeyConfig.create('querit-test')],
+        ),
       );
 
       expect(jsonDecode(captured!.body), {'query': 'kelivo', 'count': 5});
@@ -168,7 +172,10 @@ void main() {
       final result = await service.search(
         query: 'kelivo',
         commonOptions: const SearchCommonOptions(timeout: 1000),
-        serviceOptions: QueritOptions(id: 'querit-1', apiKey: 'querit-test'),
+        serviceOptions: QueritOptions(
+          id: 'querit-1',
+          apiKeys: [ApiKeyConfig.create('querit-test')],
+        ),
       );
 
       expect(result.items.single.title, 'https://example.com/kelivo');
@@ -188,7 +195,7 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: QueritOptions(id: 'querit-1', apiKey: ''),
+          serviceOptions: QueritOptions(id: 'querit-1', apiKeys: []),
         ),
         throwsA(
           isA<Exception>().having(
@@ -210,7 +217,10 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: QueritOptions(id: 'querit-1', apiKey: 'querit-test'),
+          serviceOptions: QueritOptions(
+            id: 'querit-1',
+            apiKeys: [ApiKeyConfig.create('querit-test')],
+          ),
         ),
         throwsA(
           isA<Exception>().having(
@@ -236,7 +246,10 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: QueritOptions(id: 'querit-1', apiKey: 'querit-test'),
+          serviceOptions: QueritOptions(
+            id: 'querit-1',
+            apiKeys: [ApiKeyConfig.create('querit-test')],
+          ),
         ),
         throwsA(
           isA<Exception>().having(

--- a/test/core/services/search/serper_search_service_test.dart
+++ b/test/core/services/search/serper_search_service_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:Cuplivo/core/models/api_keys.dart';
 import 'package:Cuplivo/core/services/search/providers/serper_search_service.dart';
 import 'package:Cuplivo/core/services/search/search_service.dart';
 import 'package:Cuplivo/utils/brand_assets.dart';
@@ -12,7 +13,7 @@ void main() {
     test('serializes options and resolves factory/icon mapping', () {
       final options = SerperOptions(
         id: 'serper-1',
-        apiKey: 'sk-test',
+        apiKeys: [ApiKeyConfig.create('sk-test')],
         gl: 'cn',
         hl: 'zh-cn',
         tbs: 'qdr:d',
@@ -63,7 +64,7 @@ void main() {
         commonOptions: const SearchCommonOptions(resultSize: 1, timeout: 1000),
         serviceOptions: SerperOptions(
           id: 'serper-1',
-          apiKey: 'sk-test',
+          apiKeys: [ApiKeyConfig.create('sk-test')],
           gl: 'cn',
           hl: 'zh-cn',
           tbs: 'qdr:d',
@@ -99,7 +100,10 @@ void main() {
       final result = await service.search(
         query: 'kelivo',
         commonOptions: const SearchCommonOptions(timeout: 1000),
-        serviceOptions: SerperOptions(id: 'serper-1', apiKey: 'sk-test'),
+        serviceOptions: SerperOptions(
+          id: 'serper-1',
+          apiKeys: [ApiKeyConfig.create('sk-test')],
+        ),
       );
 
       expect(jsonDecode(captured!.body), {'q': 'kelivo'});
@@ -115,7 +119,10 @@ void main() {
         () => service.search(
           query: 'kelivo',
           commonOptions: const SearchCommonOptions(timeout: 1000),
-          serviceOptions: SerperOptions(id: 'serper-1', apiKey: 'sk-test'),
+          serviceOptions: SerperOptions(
+            id: 'serper-1',
+            apiKeys: [ApiKeyConfig.create('sk-test')],
+          ),
         ),
         throwsA(
           isA<Exception>().having(


### PR DESCRIPTION
Fixes Chevey339/kelivo#217, Fixes Chevey339/kelivo#623.

- Refactor ApiKeyManager: selectFromKeys, updateKeyStatusFromConfig, getRoundRobinIndex
- Add apiKeys/keyManagement fields to SearchServiceOptions + all 16 subclasses
- Add rotation logic in SearchToolService with transparent retry on failure
- Write back key status/usage and roundRobinIndex after rotation
- Fix stale-keys list in rotation loop (previously not written back)
- Fix: skip SharedPreferences write for single-key configs
- Fix: add apiKeyOverride parameter to all provider search methods
- Fix: serialize/deserialize keyManagement in all subclass toJson/fromJson
- Fix: add empty-keys validation guard in mobile and desktop edit dialogs
- Fix: obscureText for SearXNG password, remove dead apiKey controllers
- Add searchServicesDialogAddKey l10n key in all 4 ARB files