### PR TITLE
feat: handoff (subagent delegation) — fire-and-forget MCP tool

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -297,3 +297,44 @@
 - **deleted_records cap**: default 10 MB, user-configurable via discrete dropdown (mirrors log-max-size pattern), SharedPreferences key `trash_cap_mb_v1`. Options `[1, 5, 10, 25, 50, 100, 200, 500, 0]` MB (0 = unlimited).
 - **Eviction rule**: evict oldest by `createdAt`, NEVER self-evict the current write batch (identified by `batchId` column).
 - **deletion_markers cap**: unified 5000-row FIFO by `deletedAt`, not user-configurable.
+
+## Handoff (Sub-Agent Delegation)
+
+### Core Concepts
+
+- **Handoff**: A fire-and-forget delegation where one assistant (the source) launches another assistant (the target) in a new conversation with a task prompt. The source model receives only the new conversation's UUID as the tool result — no sub-agent output is collected. The sub-agent runs with full tool access (MCP, local, memory, search). The user navigates to the sub-conversation manually.
+- **`@kelivo/subagent`**: An in-memory MCP server (same pattern as `@kelivo/fetch`) that exposes one tool: `handoff(assistant, task)`. Auto-created at startup, non-deletable, toggleable via `isActive`. Per-assistant binding via `mcpServerIds` controls which assistants can delegate — don't bind the server, can't hand off. There is no dedicated `handoffDisabled` field.
+- **`HeadlessGenerationService`**: A root-level provider that owns sub-generations. Runs the full generation pipeline (system prompt, tools, streaming, persistence) detached from any page controller. Exposes `start()`, `isActive()`, `chunkStream()`, `cancel()`. Uses the `contextProvider` pattern to reuse `ToolHandlerService`. Cancellation goes through the existing `ChatApiService` token registry — no new cancel path.
+- **Discoverable**: A per-assistant boolean (`Assistant.discoverable`, default false). When true, the assistant appears as a valid handoff target in the `@kelivo/subagent` tool description. The target declares itself; the source does not maintain a target list.
+- **`handoffId`**: A per-assistant readable handle (`[a-z0-9-]`, max 32 chars, unique across all assistants). Used as the `assistant` parameter value in the handoff tool call. Required when `discoverable == true`. Validated at save time (same pattern as skill name validation).
+- **`handoffDescription`**: A per-assistant free-form string injected into the handoff tool's description at connection time. Tells the calling model when to delegate and what prompt format to use.
+- **`parentConversationId`**: A nullable column on `conversations`. Set when a conversation is created by a handoff. Enables bidirectional navigation bars. Orphan reference (parent deleted) → backward bar simply doesn't render.
+
+### Tool Semantics
+
+- **No enum, call-time validation**: The `assistant` parameter is a free-form string. The tool description lists available targets (built at connection time, may go stale). The handler validates at call time: no match or not discoverable → error string with available targets listed. Zero discoverable assistants → error string explaining the situation. The model self-corrects from the error (same pattern as MCP tool errors via `_renderToolErrorForModel`).
+- **Task-only context**: The sub-conversation receives exactly one user message: the `task` string. No history from the parent conversation is injected. The calling model is responsible for including all necessary context in the task.
+- **Recursion**: Allowed with no depth limit. A sub-agent that has `@kelivo/subagent` bound and can see discoverable assistants may hand off again. The user is watching (they navigated to the sub-conversation) and can cancel.
+- **Outer stream lifecycle**: After the handoff tool returns the UUID, the outer model generates a farewell message naturally. The outer stream is not cancelled. The farewell persists in the parent conversation.
+
+### UI
+
+- **Forward bar**: On the assistant message containing the handoff tool-call card, a tappable chip showing "{target assistant name} · {first 4 chars of child conversation ID}". Tap navigates to the child conversation.
+- **Backward bar**: On the first user message of a handoff-spawned conversation, a tappable chip showing "← {parent assistant name} · {first 4 chars of parent conversation ID}". Tap navigates to the parent. Edge case: if the first user message is deleted, the backward bar is not shown.
+- **Conversation list badge**: A small icon (e.g. `Lucide.CornerDownRight`) on conversation list tiles where `parentConversationId != null`.
+- **Page subscription**: On `switchConversationAnimated(convId)`, the page checks `HeadlessGenerationService.isActive(convId)`. If active, subscribes to `chunkStream(convId)` and drives the existing `StreamController` from those chunks. On navigate-away, unsubscribes (generation continues, persists to DB). On return, re-attaches or loads the finalized message.
+
+### Relationship to Existing Concepts
+
+- **Handoff vs Multi-AI Comparison**: Multi-AI sends the same prompt to N models in parallel within one conversation (subgroupId cards). Handoff creates a separate conversation with a different assistant and a model-formulated task. Multi-AI is comparison; Handoff is delegation.
+- **Handoff vs ProactiveCare**: ProactiveCare is scheduled autonomous generation by a single assistant (no tools, no user interaction during generation). Handoff is model-initiated delegation with full tools and user interaction (approval, ask_user) available in the sub-conversation.
+- **Handoff vs MCP tools**: Handoff IS an MCP tool (`@kelivo/subagent`), but its effect is to launch a full agent (another assistant with its own tools), not to perform a single atomic action. The MCP protocol is the delivery mechanism; the semantic is agent delegation.
+
+### Example Dialogue
+
+> **Dev:** "The user asked the orchestrator to research a topic AND write code. The orchestrator called `handoff` twice — once to `research-bot` and once to `code-helper`. Where do the results go?"
+> **Domain expert:** "Each handoff creates a separate conversation. The orchestrator's conversation gets two tool-call cards, each with a forward bar chip. The user navigates to each sub-conversation independently. The orchestrator never sees the sub-agents' output — it only got the UUIDs back. If you need the orchestrator to synthesize results, that's a future `startAndWait()` mode, not v1."
+
+### Flagged Ambiguities
+
+- "subagent" was used interchangeably with "handoff target" and "child assistant" — resolved: the feature is called **Handoff** (the act of delegation). The target is simply "the target assistant." There is no persistent "subagent" entity — the sub-conversation is a normal conversation with a `parentConversationId`.

--- a/docs/adr/0013-handoff-fire-and-forget-mcp.md
+++ b/docs/adr/0013-handoff-fire-and-forget-mcp.md
@@ -1,0 +1,19 @@
+# Handoff: Fire-and-Forget Delegation via In-Memory MCP Server
+
+Handoff lets one assistant delegate a task to another. We chose fire-and-forget semantics (no result collection) implemented as an in-memory MCP server (`@kelivo/subagent`), rather than synchronous delegation inside the outer model's tool loop.
+
+## Considered Options
+
+1. **Synchronous delegation (collect results).** The handoff tool handler awaits the sub-generation and returns the full text as the tool result. The outer model synthesizes. Rejected for v1: requires a nested `ToolHandlerService`, inner cancellation propagation, timeout bridging, and context-window management. Workload more than doubles. The upgrade path remains open — `HeadlessGenerationService.startAndWait()` can be added later without undoing the v1 shape.
+
+2. **Page-controller-driven generation.** The handoff handler calls back into the page-level `ChatActions.sendMessage()`. Rejected: couples the feature to the page lifecycle, leaves no room for background/isolate generation later.
+
+3. **Fire-and-forget via `HeadlessGenerationService` (chosen).** A root-level provider owns the sub-generation. The handoff tool handler creates a conversation, starts the generation detached, and returns the UUID. The user navigates manually. Full tool support (MCP, local, memory, search) works because the service reuses `ToolHandlerService` via the `contextProvider` pattern. Approval/ask_user widgets work because the user arrives at the sub-conversation and interacts inline.
+
+## Consequences
+
+- `@kelivo/subagent` is an in-memory MCP server (same pattern as `@kelivo/fetch`). Per-assistant binding via `mcpServerIds` replaces a dedicated `handoffDisabled` field — don't bind the server, can't delegate.
+- Three new fields on `Assistant` (`discoverable`, `handoffId`, `handoffDescription`) enable decentralized discovery. The target declares itself; the source doesn't maintain a list.
+- One new field on `Conversation` (`parentConversationId`) enables bidirectional navigation bars (forward on the handoff message, backward on the first user message).
+- The tool uses a free-form `assistant` string parameter validated at call time (no schema enum), eliminating the stale-cache problem inherent in MCP's connection-time `tools/list`.
+- Recursion is allowed with no depth limit. The user is watching and can cancel.

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -24,6 +24,7 @@ class ConversationRows extends Table {
       integer().withDefault(const Constant(0))();
   TextColumn get chatSuggestionsJson =>
       text().withDefault(const Constant('[]'))();
+  TextColumn get parentConversationId => text().nullable()();
 
   @override
   Set<Column<Object>> get primaryKey => {id};
@@ -141,6 +142,11 @@ class AssistantRows extends Table {
   // --- Time Injection ---
   BoolColumn get enableTimeInjection =>
       boolean().withDefault(const Constant(false))();
+
+  // --- Handoff / Delegation ---
+  BoolColumn get discoverable => boolean().withDefault(const Constant(false))();
+  TextColumn get handoffId => text().nullable()();
+  TextColumn get handoffDescription => text().nullable()();
 
   // --- Sort & Timestamp ---
   IntColumn get sortOrder => integer()();
@@ -288,7 +294,7 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 11;
+  int get schemaVersion => 12;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -383,6 +389,26 @@ class AppDatabase extends _$AppDatabase {
         } catch (_) {
           // Tables may already exist (migration replay / partial retry).
         }
+      }
+      if (from < 12) {
+        try {
+          await migrator.addColumn(
+            conversationRows,
+            conversationRows.parentConversationId,
+          );
+        } catch (_) {}
+        try {
+          await migrator.addColumn(assistantRows, assistantRows.discoverable);
+        } catch (_) {}
+        try {
+          await migrator.addColumn(assistantRows, assistantRows.handoffId);
+        } catch (_) {}
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.handoffDescription,
+          );
+        } catch (_) {}
       }
     },
   );

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -134,6 +134,17 @@ class $ConversationRowsTable extends ConversationRows
         requiredDuringInsert: false,
         defaultValue: const Constant('[]'),
       );
+  static const VerificationMeta _parentConversationIdMeta =
+      const VerificationMeta('parentConversationId');
+  @override
+  late final GeneratedColumn<String> parentConversationId =
+      GeneratedColumn<String>(
+        'parent_conversation_id',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -147,6 +158,7 @@ class $ConversationRowsTable extends ConversationRows
     summary,
     lastSummarizedMessageCount,
     chatSuggestionsJson,
+    parentConversationId,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -246,6 +258,15 @@ class $ConversationRowsTable extends ConversationRows
         ),
       );
     }
+    if (data.containsKey('parent_conversation_id')) {
+      context.handle(
+        _parentConversationIdMeta,
+        parentConversationId.isAcceptableOrUnknown(
+          data['parent_conversation_id']!,
+          _parentConversationIdMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -299,6 +320,10 @@ class $ConversationRowsTable extends ConversationRows
         DriftSqlType.string,
         data['${effectivePrefix}chat_suggestions_json'],
       )!,
+      parentConversationId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}parent_conversation_id'],
+      ),
     );
   }
 
@@ -320,6 +345,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
   final String? summary;
   final int lastSummarizedMessageCount;
   final String chatSuggestionsJson;
+  final String? parentConversationId;
   const ConversationRow({
     required this.id,
     required this.title,
@@ -332,6 +358,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     this.summary,
     required this.lastSummarizedMessageCount,
     required this.chatSuggestionsJson,
+    this.parentConversationId,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -353,6 +380,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       lastSummarizedMessageCount,
     );
     map['chat_suggestions_json'] = Variable<String>(chatSuggestionsJson);
+    if (!nullToAbsent || parentConversationId != null) {
+      map['parent_conversation_id'] = Variable<String>(parentConversationId);
+    }
     return map;
   }
 
@@ -373,6 +403,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           : Value(summary),
       lastSummarizedMessageCount: Value(lastSummarizedMessageCount),
       chatSuggestionsJson: Value(chatSuggestionsJson),
+      parentConversationId: parentConversationId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentConversationId),
     );
   }
 
@@ -399,6 +432,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       chatSuggestionsJson: serializer.fromJson<String>(
         json['chatSuggestionsJson'],
       ),
+      parentConversationId: serializer.fromJson<String?>(
+        json['parentConversationId'],
+      ),
     );
   }
   @override
@@ -418,6 +454,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
         lastSummarizedMessageCount,
       ),
       'chatSuggestionsJson': serializer.toJson<String>(chatSuggestionsJson),
+      'parentConversationId': serializer.toJson<String?>(parentConversationId),
     };
   }
 
@@ -433,6 +470,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     Value<String?> summary = const Value.absent(),
     int? lastSummarizedMessageCount,
     String? chatSuggestionsJson,
+    Value<String?> parentConversationId = const Value.absent(),
   }) => ConversationRow(
     id: id ?? this.id,
     title: title ?? this.title,
@@ -446,6 +484,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     lastSummarizedMessageCount:
         lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
     chatSuggestionsJson: chatSuggestionsJson ?? this.chatSuggestionsJson,
+    parentConversationId: parentConversationId.present
+        ? parentConversationId.value
+        : this.parentConversationId,
   );
   ConversationRow copyWithCompanion(ConversationRowsCompanion data) {
     return ConversationRow(
@@ -470,6 +511,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       chatSuggestionsJson: data.chatSuggestionsJson.present
           ? data.chatSuggestionsJson.value
           : this.chatSuggestionsJson,
+      parentConversationId: data.parentConversationId.present
+          ? data.parentConversationId.value
+          : this.parentConversationId,
     );
   }
 
@@ -486,7 +530,8 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ..write('versionSelectionsJson: $versionSelectionsJson, ')
           ..write('summary: $summary, ')
           ..write('lastSummarizedMessageCount: $lastSummarizedMessageCount, ')
-          ..write('chatSuggestionsJson: $chatSuggestionsJson')
+          ..write('chatSuggestionsJson: $chatSuggestionsJson, ')
+          ..write('parentConversationId: $parentConversationId')
           ..write(')'))
         .toString();
   }
@@ -504,6 +549,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     summary,
     lastSummarizedMessageCount,
     chatSuggestionsJson,
+    parentConversationId,
   );
   @override
   bool operator ==(Object other) =>
@@ -519,7 +565,8 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           other.versionSelectionsJson == this.versionSelectionsJson &&
           other.summary == this.summary &&
           other.lastSummarizedMessageCount == this.lastSummarizedMessageCount &&
-          other.chatSuggestionsJson == this.chatSuggestionsJson);
+          other.chatSuggestionsJson == this.chatSuggestionsJson &&
+          other.parentConversationId == this.parentConversationId);
 }
 
 class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
@@ -534,6 +581,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
   final Value<String?> summary;
   final Value<int> lastSummarizedMessageCount;
   final Value<String> chatSuggestionsJson;
+  final Value<String?> parentConversationId;
   final Value<int> rowid;
   const ConversationRowsCompanion({
     this.id = const Value.absent(),
@@ -547,6 +595,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     this.summary = const Value.absent(),
     this.lastSummarizedMessageCount = const Value.absent(),
     this.chatSuggestionsJson = const Value.absent(),
+    this.parentConversationId = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ConversationRowsCompanion.insert({
@@ -561,6 +610,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     this.summary = const Value.absent(),
     this.lastSummarizedMessageCount = const Value.absent(),
     this.chatSuggestionsJson = const Value.absent(),
+    this.parentConversationId = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        title = Value(title),
@@ -578,6 +628,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     Expression<String>? summary,
     Expression<int>? lastSummarizedMessageCount,
     Expression<String>? chatSuggestionsJson,
+    Expression<String>? parentConversationId,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -595,6 +646,8 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
         'last_summarized_message_count': lastSummarizedMessageCount,
       if (chatSuggestionsJson != null)
         'chat_suggestions_json': chatSuggestionsJson,
+      if (parentConversationId != null)
+        'parent_conversation_id': parentConversationId,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -611,6 +664,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     Value<String?>? summary,
     Value<int>? lastSummarizedMessageCount,
     Value<String>? chatSuggestionsJson,
+    Value<String?>? parentConversationId,
     Value<int>? rowid,
   }) {
     return ConversationRowsCompanion(
@@ -627,6 +681,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
       lastSummarizedMessageCount:
           lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
       chatSuggestionsJson: chatSuggestionsJson ?? this.chatSuggestionsJson,
+      parentConversationId: parentConversationId ?? this.parentConversationId,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -673,6 +728,11 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
         chatSuggestionsJson.value,
       );
     }
+    if (parentConversationId.present) {
+      map['parent_conversation_id'] = Variable<String>(
+        parentConversationId.value,
+      );
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -693,6 +753,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
           ..write('summary: $summary, ')
           ..write('lastSummarizedMessageCount: $lastSummarizedMessageCount, ')
           ..write('chatSuggestionsJson: $chatSuggestionsJson, ')
+          ..write('parentConversationId: $parentConversationId, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -2505,6 +2566,43 @@ class $AssistantRowsTable extends AssistantRows
     ),
     defaultValue: const Constant(false),
   );
+  static const VerificationMeta _discoverableMeta = const VerificationMeta(
+    'discoverable',
+  );
+  @override
+  late final GeneratedColumn<bool> discoverable = GeneratedColumn<bool>(
+    'discoverable',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("discoverable" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _handoffIdMeta = const VerificationMeta(
+    'handoffId',
+  );
+  @override
+  late final GeneratedColumn<String> handoffId = GeneratedColumn<String>(
+    'handoff_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _handoffDescriptionMeta =
+      const VerificationMeta('handoffDescription');
+  @override
+  late final GeneratedColumn<String> handoffDescription =
+      GeneratedColumn<String>(
+        'handoff_description',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _sortOrderMeta = const VerificationMeta(
     'sortOrder',
   );
@@ -2578,6 +2676,9 @@ class $AssistantRowsTable extends AssistantRows
     pdfMode,
     otherOfficeMode,
     enableTimeInjection,
+    discoverable,
+    handoffId,
+    handoffDescription,
     sortOrder,
     createdAt,
     updatedAt,
@@ -2910,6 +3011,30 @@ class $AssistantRowsTable extends AssistantRows
         ),
       );
     }
+    if (data.containsKey('discoverable')) {
+      context.handle(
+        _discoverableMeta,
+        discoverable.isAcceptableOrUnknown(
+          data['discoverable']!,
+          _discoverableMeta,
+        ),
+      );
+    }
+    if (data.containsKey('handoff_id')) {
+      context.handle(
+        _handoffIdMeta,
+        handoffId.isAcceptableOrUnknown(data['handoff_id']!, _handoffIdMeta),
+      );
+    }
+    if (data.containsKey('handoff_description')) {
+      context.handle(
+        _handoffDescriptionMeta,
+        handoffDescription.isAcceptableOrUnknown(
+          data['handoff_description']!,
+          _handoffDescriptionMeta,
+        ),
+      );
+    }
     if (data.containsKey('sort_order')) {
       context.handle(
         _sortOrderMeta,
@@ -3095,6 +3220,18 @@ class $AssistantRowsTable extends AssistantRows
         DriftSqlType.bool,
         data['${effectivePrefix}enable_time_injection'],
       )!,
+      discoverable: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}discoverable'],
+      )!,
+      handoffId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}handoff_id'],
+      ),
+      handoffDescription: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}handoff_description'],
+      ),
       sortOrder: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}sort_order'],
@@ -3155,6 +3292,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
   final String pdfMode;
   final String otherOfficeMode;
   final bool enableTimeInjection;
+  final bool discoverable;
+  final String? handoffId;
+  final String? handoffDescription;
   final int sortOrder;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -3197,6 +3337,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     required this.pdfMode,
     required this.otherOfficeMode,
     required this.enableTimeInjection,
+    required this.discoverable,
+    this.handoffId,
+    this.handoffDescription,
     required this.sortOrder,
     required this.createdAt,
     required this.updatedAt,
@@ -3268,6 +3411,13 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     map['pdf_mode'] = Variable<String>(pdfMode);
     map['other_office_mode'] = Variable<String>(otherOfficeMode);
     map['enable_time_injection'] = Variable<bool>(enableTimeInjection);
+    map['discoverable'] = Variable<bool>(discoverable);
+    if (!nullToAbsent || handoffId != null) {
+      map['handoff_id'] = Variable<String>(handoffId);
+    }
+    if (!nullToAbsent || handoffDescription != null) {
+      map['handoff_description'] = Variable<String>(handoffDescription);
+    }
     map['sort_order'] = Variable<int>(sortOrder);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
@@ -3331,6 +3481,13 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       pdfMode: Value(pdfMode),
       otherOfficeMode: Value(otherOfficeMode),
       enableTimeInjection: Value(enableTimeInjection),
+      discoverable: Value(discoverable),
+      handoffId: handoffId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(handoffId),
+      handoffDescription: handoffDescription == null && nullToAbsent
+          ? const Value.absent()
+          : Value(handoffDescription),
       sortOrder: Value(sortOrder),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
@@ -3403,6 +3560,11 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       enableTimeInjection: serializer.fromJson<bool>(
         json['enableTimeInjection'],
       ),
+      discoverable: serializer.fromJson<bool>(json['discoverable']),
+      handoffId: serializer.fromJson<String?>(json['handoffId']),
+      handoffDescription: serializer.fromJson<String?>(
+        json['handoffDescription'],
+      ),
       sortOrder: serializer.fromJson<int>(json['sortOrder']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
@@ -3458,6 +3620,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       'pdfMode': serializer.toJson<String>(pdfMode),
       'otherOfficeMode': serializer.toJson<String>(otherOfficeMode),
       'enableTimeInjection': serializer.toJson<bool>(enableTimeInjection),
+      'discoverable': serializer.toJson<bool>(discoverable),
+      'handoffId': serializer.toJson<String?>(handoffId),
+      'handoffDescription': serializer.toJson<String?>(handoffDescription),
       'sortOrder': serializer.toJson<int>(sortOrder),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
@@ -3503,6 +3668,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     String? pdfMode,
     String? otherOfficeMode,
     bool? enableTimeInjection,
+    bool? discoverable,
+    Value<String?> handoffId = const Value.absent(),
+    Value<String?> handoffDescription = const Value.absent(),
     int? sortOrder,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -3554,6 +3722,11 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     pdfMode: pdfMode ?? this.pdfMode,
     otherOfficeMode: otherOfficeMode ?? this.otherOfficeMode,
     enableTimeInjection: enableTimeInjection ?? this.enableTimeInjection,
+    discoverable: discoverable ?? this.discoverable,
+    handoffId: handoffId.present ? handoffId.value : this.handoffId,
+    handoffDescription: handoffDescription.present
+        ? handoffDescription.value
+        : this.handoffDescription,
     sortOrder: sortOrder ?? this.sortOrder,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
@@ -3661,6 +3834,13 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       enableTimeInjection: data.enableTimeInjection.present
           ? data.enableTimeInjection.value
           : this.enableTimeInjection,
+      discoverable: data.discoverable.present
+          ? data.discoverable.value
+          : this.discoverable,
+      handoffId: data.handoffId.present ? data.handoffId.value : this.handoffId,
+      handoffDescription: data.handoffDescription.present
+          ? data.handoffDescription.value
+          : this.handoffDescription,
       sortOrder: data.sortOrder.present ? data.sortOrder.value : this.sortOrder,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
@@ -3710,6 +3890,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           ..write('pdfMode: $pdfMode, ')
           ..write('otherOfficeMode: $otherOfficeMode, ')
           ..write('enableTimeInjection: $enableTimeInjection, ')
+          ..write('discoverable: $discoverable, ')
+          ..write('handoffId: $handoffId, ')
+          ..write('handoffDescription: $handoffDescription, ')
           ..write('sortOrder: $sortOrder, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt')
@@ -3757,6 +3940,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     pdfMode,
     otherOfficeMode,
     enableTimeInjection,
+    discoverable,
+    handoffId,
+    handoffDescription,
     sortOrder,
     createdAt,
     updatedAt,
@@ -3805,6 +3991,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           other.pdfMode == this.pdfMode &&
           other.otherOfficeMode == this.otherOfficeMode &&
           other.enableTimeInjection == this.enableTimeInjection &&
+          other.discoverable == this.discoverable &&
+          other.handoffId == this.handoffId &&
+          other.handoffDescription == this.handoffDescription &&
           other.sortOrder == this.sortOrder &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt);
@@ -3849,6 +4038,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
   final Value<String> pdfMode;
   final Value<String> otherOfficeMode;
   final Value<bool> enableTimeInjection;
+  final Value<bool> discoverable;
+  final Value<String?> handoffId;
+  final Value<String?> handoffDescription;
   final Value<int> sortOrder;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
@@ -3892,6 +4084,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.pdfMode = const Value.absent(),
     this.otherOfficeMode = const Value.absent(),
     this.enableTimeInjection = const Value.absent(),
+    this.discoverable = const Value.absent(),
+    this.handoffId = const Value.absent(),
+    this.handoffDescription = const Value.absent(),
     this.sortOrder = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
@@ -3936,6 +4131,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.pdfMode = const Value.absent(),
     this.otherOfficeMode = const Value.absent(),
     this.enableTimeInjection = const Value.absent(),
+    this.discoverable = const Value.absent(),
+    this.handoffId = const Value.absent(),
+    this.handoffDescription = const Value.absent(),
     required int sortOrder,
     required DateTime createdAt,
     required DateTime updatedAt,
@@ -3984,6 +4182,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Expression<String>? pdfMode,
     Expression<String>? otherOfficeMode,
     Expression<bool>? enableTimeInjection,
+    Expression<bool>? discoverable,
+    Expression<String>? handoffId,
+    Expression<String>? handoffDescription,
     Expression<int>? sortOrder,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
@@ -4040,6 +4241,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       if (otherOfficeMode != null) 'other_office_mode': otherOfficeMode,
       if (enableTimeInjection != null)
         'enable_time_injection': enableTimeInjection,
+      if (discoverable != null) 'discoverable': discoverable,
+      if (handoffId != null) 'handoff_id': handoffId,
+      if (handoffDescription != null) 'handoff_description': handoffDescription,
       if (sortOrder != null) 'sort_order': sortOrder,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
@@ -4086,6 +4290,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Value<String>? pdfMode,
     Value<String>? otherOfficeMode,
     Value<bool>? enableTimeInjection,
+    Value<bool>? discoverable,
+    Value<String?>? handoffId,
+    Value<String?>? handoffDescription,
     Value<int>? sortOrder,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
@@ -4134,6 +4341,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       pdfMode: pdfMode ?? this.pdfMode,
       otherOfficeMode: otherOfficeMode ?? this.otherOfficeMode,
       enableTimeInjection: enableTimeInjection ?? this.enableTimeInjection,
+      discoverable: discoverable ?? this.discoverable,
+      handoffId: handoffId ?? this.handoffId,
+      handoffDescription: handoffDescription ?? this.handoffDescription,
       sortOrder: sortOrder ?? this.sortOrder,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -4270,6 +4480,15 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     if (enableTimeInjection.present) {
       map['enable_time_injection'] = Variable<bool>(enableTimeInjection.value);
     }
+    if (discoverable.present) {
+      map['discoverable'] = Variable<bool>(discoverable.value);
+    }
+    if (handoffId.present) {
+      map['handoff_id'] = Variable<String>(handoffId.value);
+    }
+    if (handoffDescription.present) {
+      map['handoff_description'] = Variable<String>(handoffDescription.value);
+    }
     if (sortOrder.present) {
       map['sort_order'] = Variable<int>(sortOrder.value);
     }
@@ -4328,6 +4547,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
           ..write('pdfMode: $pdfMode, ')
           ..write('otherOfficeMode: $otherOfficeMode, ')
           ..write('enableTimeInjection: $enableTimeInjection, ')
+          ..write('discoverable: $discoverable, ')
+          ..write('handoffId: $handoffId, ')
+          ..write('handoffDescription: $handoffDescription, ')
           ..write('sortOrder: $sortOrder, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
@@ -6429,6 +6651,7 @@ typedef $$ConversationRowsTableCreateCompanionBuilder =
       Value<String?> summary,
       Value<int> lastSummarizedMessageCount,
       Value<String> chatSuggestionsJson,
+      Value<String?> parentConversationId,
       Value<int> rowid,
     });
 typedef $$ConversationRowsTableUpdateCompanionBuilder =
@@ -6444,6 +6667,7 @@ typedef $$ConversationRowsTableUpdateCompanionBuilder =
       Value<String?> summary,
       Value<int> lastSummarizedMessageCount,
       Value<String> chatSuggestionsJson,
+      Value<String?> parentConversationId,
       Value<int> rowid,
     });
 
@@ -6566,6 +6790,11 @@ class $$ConversationRowsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get parentConversationId => $composableBuilder(
+    column: $table.parentConversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   Expression<bool> messageRowsRefs(
     Expression<bool> Function($$MessageRowsTableFilterComposer f) f,
   ) {
@@ -6682,6 +6911,11 @@ class $$ConversationRowsTableOrderingComposer
     column: $table.chatSuggestionsJson,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get parentConversationId => $composableBuilder(
+    column: $table.parentConversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$ConversationRowsTableAnnotationComposer
@@ -6733,6 +6967,11 @@ class $$ConversationRowsTableAnnotationComposer
 
   GeneratedColumn<String> get chatSuggestionsJson => $composableBuilder(
     column: $table.chatSuggestionsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get parentConversationId => $composableBuilder(
+    column: $table.parentConversationId,
     builder: (column) => column,
   );
 
@@ -6833,6 +7072,7 @@ class $$ConversationRowsTableTableManager
                 Value<String?> summary = const Value.absent(),
                 Value<int> lastSummarizedMessageCount = const Value.absent(),
                 Value<String> chatSuggestionsJson = const Value.absent(),
+                Value<String?> parentConversationId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationRowsCompanion(
                 id: id,
@@ -6846,6 +7086,7 @@ class $$ConversationRowsTableTableManager
                 summary: summary,
                 lastSummarizedMessageCount: lastSummarizedMessageCount,
                 chatSuggestionsJson: chatSuggestionsJson,
+                parentConversationId: parentConversationId,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -6861,6 +7102,7 @@ class $$ConversationRowsTableTableManager
                 Value<String?> summary = const Value.absent(),
                 Value<int> lastSummarizedMessageCount = const Value.absent(),
                 Value<String> chatSuggestionsJson = const Value.absent(),
+                Value<String?> parentConversationId = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationRowsCompanion.insert(
                 id: id,
@@ -6874,6 +7116,7 @@ class $$ConversationRowsTableTableManager
                 summary: summary,
                 lastSummarizedMessageCount: lastSummarizedMessageCount,
                 chatSuggestionsJson: chatSuggestionsJson,
+                parentConversationId: parentConversationId,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
@@ -7906,6 +8149,9 @@ typedef $$AssistantRowsTableCreateCompanionBuilder =
       Value<String> pdfMode,
       Value<String> otherOfficeMode,
       Value<bool> enableTimeInjection,
+      Value<bool> discoverable,
+      Value<String?> handoffId,
+      Value<String?> handoffDescription,
       required int sortOrder,
       required DateTime createdAt,
       required DateTime updatedAt,
@@ -7951,6 +8197,9 @@ typedef $$AssistantRowsTableUpdateCompanionBuilder =
       Value<String> pdfMode,
       Value<String> otherOfficeMode,
       Value<bool> enableTimeInjection,
+      Value<bool> discoverable,
+      Value<String?> handoffId,
+      Value<String?> handoffDescription,
       Value<int> sortOrder,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
@@ -8153,6 +8402,21 @@ class $$AssistantRowsTableFilterComposer
 
   ColumnFilters<bool> get enableTimeInjection => $composableBuilder(
     column: $table.enableTimeInjection,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get discoverable => $composableBuilder(
+    column: $table.discoverable,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get handoffId => $composableBuilder(
+    column: $table.handoffId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get handoffDescription => $composableBuilder(
+    column: $table.handoffDescription,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -8372,6 +8636,21 @@ class $$AssistantRowsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get discoverable => $composableBuilder(
+    column: $table.discoverable,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get handoffId => $composableBuilder(
+    column: $table.handoffId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get handoffDescription => $composableBuilder(
+    column: $table.handoffDescription,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
     builder: (column) => ColumnOrderings(column),
@@ -8574,6 +8853,19 @@ class $$AssistantRowsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get discoverable => $composableBuilder(
+    column: $table.discoverable,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get handoffId =>
+      $composableBuilder(column: $table.handoffId, builder: (column) => column);
+
+  GeneratedColumn<String> get handoffDescription => $composableBuilder(
+    column: $table.handoffDescription,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<int> get sortOrder =>
       $composableBuilder(column: $table.sortOrder, builder: (column) => column);
 
@@ -8656,6 +8948,9 @@ class $$AssistantRowsTableTableManager
                 Value<String> pdfMode = const Value.absent(),
                 Value<String> otherOfficeMode = const Value.absent(),
                 Value<bool> enableTimeInjection = const Value.absent(),
+                Value<bool> discoverable = const Value.absent(),
+                Value<String?> handoffId = const Value.absent(),
+                Value<String?> handoffDescription = const Value.absent(),
                 Value<int> sortOrder = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
@@ -8699,6 +8994,9 @@ class $$AssistantRowsTableTableManager
                 pdfMode: pdfMode,
                 otherOfficeMode: otherOfficeMode,
                 enableTimeInjection: enableTimeInjection,
+                discoverable: discoverable,
+                handoffId: handoffId,
+                handoffDescription: handoffDescription,
                 sortOrder: sortOrder,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
@@ -8747,6 +9045,9 @@ class $$AssistantRowsTableTableManager
                 Value<String> pdfMode = const Value.absent(),
                 Value<String> otherOfficeMode = const Value.absent(),
                 Value<bool> enableTimeInjection = const Value.absent(),
+                Value<bool> discoverable = const Value.absent(),
+                Value<String?> handoffId = const Value.absent(),
+                Value<String?> handoffDescription = const Value.absent(),
                 required int sortOrder,
                 required DateTime createdAt,
                 required DateTime updatedAt,
@@ -8790,6 +9091,9 @@ class $$AssistantRowsTableTableManager
                 pdfMode: pdfMode,
                 otherOfficeMode: otherOfficeMode,
                 enableTimeInjection: enableTimeInjection,
+                discoverable: discoverable,
+                handoffId: handoffId,
+                handoffDescription: handoffDescription,
                 sortOrder: sortOrder,
                 createdAt: createdAt,
                 updatedAt: updatedAt,

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -987,6 +987,9 @@ class ChatDatabaseRepository {
           ?.toIso8601String(),
       'proactiveCarePrompt': row.proactiveCarePrompt,
       'proactiveCareDecisionPrompt': row.proactiveCareDecisionPrompt,
+      'discoverable': row.discoverable,
+      'handoffId': row.handoffId,
+      'handoffDescription': row.handoffDescription,
       'createdAt': row.createdAt.toIso8601String(),
       'updatedAt': row.updatedAt.toIso8601String(),
     });
@@ -1036,6 +1039,9 @@ class ChatDatabaseRepository {
       proactiveCarePrompt: Value(a.proactiveCarePrompt),
       proactiveCareDecisionPrompt: Value(a.proactiveCareDecisionPrompt),
       enableTimeInjection: Value(a.enableTimeInjection),
+      discoverable: Value(a.discoverable),
+      handoffId: Value(a.handoffId),
+      handoffDescription: Value(a.handoffDescription),
       sortOrder: sortOrder,
       createdAt: a.createdAt,
       updatedAt: a.updatedAt,
@@ -1071,6 +1077,7 @@ class ChatDatabaseRepository {
       summary: row.summary,
       lastSummarizedMessageCount: row.lastSummarizedMessageCount,
       chatSuggestions: _decodeStringList(row.chatSuggestionsJson),
+      parentConversationId: row.parentConversationId,
     );
   }
 
@@ -1113,6 +1120,7 @@ class ChatDatabaseRepository {
       chatSuggestions: _decodeStringList(
         row['chat_suggestions_json'] as String? ?? '[]',
       ),
+      parentConversationId: row['parent_conversation_id'] as String?,
     );
   }
 
@@ -1131,6 +1139,7 @@ class ChatDatabaseRepository {
         conversation.lastSummarizedMessageCount,
       ),
       chatSuggestionsJson: Value(jsonEncode(conversation.chatSuggestions)),
+      parentConversationId: Value(conversation.parentConversationId),
     );
   }
 

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -88,6 +88,10 @@ Do **not** store sensitive information, including:
   final String otherOfficeMode;
   // Time injection
   final bool enableTimeInjection;
+  // Handoff / delegation
+  final bool discoverable;
+  final String? handoffId;
+  final String? handoffDescription;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -130,6 +134,9 @@ Do **not** store sensitive information, including:
     this.pdfMode = 'extract',
     this.otherOfficeMode = 'direct',
     this.enableTimeInjection = false,
+    this.discoverable = false,
+    this.handoffId,
+    this.handoffDescription,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) : createdAt = createdAt ?? DateTime.now(),
@@ -175,6 +182,11 @@ Do **not** store sensitive information, including:
     String? pdfMode,
     String? otherOfficeMode,
     bool? enableTimeInjection,
+    bool? discoverable,
+    String? handoffId,
+    String? handoffDescription,
+    bool clearHandoffId = false,
+    bool clearHandoffDescription = false,
     DateTime? createdAt,
     DateTime? updatedAt,
     bool clearChatModel = false,
@@ -233,6 +245,11 @@ Do **not** store sensitive information, including:
       pdfMode: pdfMode ?? this.pdfMode,
       otherOfficeMode: otherOfficeMode ?? this.otherOfficeMode,
       enableTimeInjection: enableTimeInjection ?? this.enableTimeInjection,
+      discoverable: discoverable ?? this.discoverable,
+      handoffId: clearHandoffId ? null : (handoffId ?? this.handoffId),
+      handoffDescription: clearHandoffDescription
+          ? null
+          : (handoffDescription ?? this.handoffDescription),
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -277,6 +294,9 @@ Do **not** store sensitive information, including:
     'pdfMode': pdfMode,
     'otherOfficeMode': otherOfficeMode,
     'enableTimeInjection': enableTimeInjection,
+    'discoverable': discoverable,
+    'handoffId': handoffId,
+    'handoffDescription': handoffDescription,
     'createdAt': createdAt.toIso8601String(),
     'updatedAt': updatedAt.toIso8601String(),
   };
@@ -378,6 +398,9 @@ Do **not** store sensitive information, including:
     pdfMode: (json['pdfMode'] as String?) ?? 'extract',
     otherOfficeMode: (json['otherOfficeMode'] as String?) ?? 'direct',
     enableTimeInjection: json['enableTimeInjection'] as bool? ?? false,
+    discoverable: json['discoverable'] as bool? ?? false,
+    handoffId: json['handoffId'] as String?,
+    handoffDescription: json['handoffDescription'] as String?,
     createdAt: json['createdAt'] != null
         ? DateTime.parse(json['createdAt'] as String)
         : DateTime.now(),

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -19,6 +19,9 @@ class Conversation {
   // Owner assistant id; null for global/default
   String? assistantId;
 
+  // Parent conversation that spawned this one via handoff; null for normal
+  String? parentConversationId;
+
   // Truncate context starting at this index (-1 means no truncation)
   int truncateIndex;
 
@@ -43,6 +46,7 @@ class Conversation {
     this.isPinned = false,
     List<String>? mcpServerIds,
     this.assistantId,
+    this.parentConversationId,
     int? truncateIndex,
     Map<String, int>? versionSelections,
     this.summary,
@@ -67,6 +71,7 @@ class Conversation {
     bool? isPinned,
     List<String>? mcpServerIds,
     String? assistantId,
+    String? parentConversationId,
     int? truncateIndex,
     Map<String, int>? versionSelections,
     String? summary,
@@ -83,6 +88,7 @@ class Conversation {
       isPinned: isPinned ?? this.isPinned,
       mcpServerIds: mcpServerIds ?? this.mcpServerIds,
       assistantId: assistantId ?? this.assistantId,
+      parentConversationId: parentConversationId ?? this.parentConversationId,
       truncateIndex: truncateIndex ?? this.truncateIndex,
       versionSelections: versionSelections ?? this.versionSelections,
       summary: clearSummary ? null : (summary ?? this.summary),
@@ -102,6 +108,7 @@ class Conversation {
       'isPinned': isPinned,
       'mcpServerIds': mcpServerIds,
       'assistantId': assistantId,
+      'parentConversationId': parentConversationId,
       'truncateIndex': truncateIndex,
       'versionSelections': versionSelections,
       'summary': summary,
@@ -121,6 +128,7 @@ class Conversation {
       mcpServerIds:
           (json['mcpServerIds'] as List?)?.cast<String>() ?? <String>[],
       assistantId: json['assistantId'] as String?,
+      parentConversationId: json['parentConversationId'] as String?,
       truncateIndex: json['truncateIndex'] as int? ?? -1,
       versionSelections:
           (json['versionSelections'] as Map?)?.map(

--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:mcp_client/mcp_client.dart' as mcp;
 import '../services/mcp/kelivo_fetch/kelivo_fetch_server.dart';
 import '../services/mcp/stdio_command_resolver.dart';
@@ -9,6 +10,9 @@ import 'package:uuid/uuid.dart';
 
 import '../services/chat/chat_service.dart';
 import '../services/deleted_records_store.dart';
+import '../services/headless_generation_service.dart';
+import 'assistant_provider.dart';
+import '../services/mcp/kelivo_subagent/kelivo_subagent_server.dart';
 
 /// Transport type: SSE, Streamable HTTP, and STDIO (desktop-only).
 enum McpTransportType { sse, http, stdio, inmemory }
@@ -271,11 +275,19 @@ class McpProvider extends ChangeNotifier {
   static const String _prefsKey = 'mcp_servers_v1';
   static const String _prefsTimeoutKey = 'mcp_request_timeout_ms_v1';
 
-  McpProvider({this.chatService}) {
+  McpProvider({
+    this.chatService,
+    this.assistantProvider,
+    this.headlessGen,
+    required this.contextProvider,
+  }) {
     _load();
   }
 
   final ChatService? chatService;
+  final AssistantProvider? assistantProvider;
+  final HeadlessGenerationService? headlessGen;
+  final BuildContext Function() contextProvider;
 
   final Map<String, mcp.Client> _clients = {};
   final Map<String, McpStatus> _status = {}; // id -> status
@@ -319,8 +331,9 @@ class McpProvider extends ChangeNotifier {
         _servers = list;
       } catch (_) {}
     }
-    // Ensure built-in @kelivo/fetch is present by default
+    // Ensure built-in MCP servers are present by default
     _ensureBuiltinFetchServerPresent();
+    _ensureBuiltinSubagentServerPresent();
     // initialize statuses
     for (final s in _servers) {
       _status[s.id] = McpStatus.idle;
@@ -333,14 +346,40 @@ class McpProvider extends ChangeNotifier {
       // fire and forget
       unawaited(connect(s.id));
     }
+
+    // Refresh @kelivo/subagent tool definitions when assistants change
+    assistantProvider?.addListener(_onAssistantsChanged);
+  }
+
+  void _onAssistantsChanged() {
+    unawaited(refreshTools('kelivo_subagent'));
+  }
+
+  void _ensureBuiltinSubagentServerPresent() {
+    if (assistantProvider == null ||
+        chatService == null ||
+        headlessGen == null) {
+      return;
+    }
+    final exists = _servers.any(
+      (s) => s.id == 'kelivo_subagent' || s.name == '@kelivo/subagent',
+    );
+    if (exists) return;
+    _servers = [
+      ..._servers,
+      McpServerConfig(
+        id: 'kelivo_subagent',
+        enabled: true,
+        name: '@kelivo/subagent',
+        transport: McpTransportType.inmemory,
+        tools: const <McpToolConfig>[],
+      ),
+    ];
   }
 
   void _ensureBuiltinFetchServerPresent() {
     final exists = _servers.any(
-      (s) =>
-          s.transport == McpTransportType.inmemory ||
-          s.name == '@kelivo/fetch' ||
-          s.id == 'kelivo_fetch',
+      (s) => s.name == '@kelivo/fetch' || s.id == 'kelivo_fetch',
     );
     if (exists) return;
     final cfg = McpServerConfig(
@@ -836,8 +875,22 @@ class McpProvider extends ChangeNotifier {
 
       // In-memory builtin server path
       if (server.transport == McpTransportType.inmemory) {
-        final engine = KelivoFetchMcpServerEngine();
-        final transport = KelivoInMemoryClientTransport(engine);
+        final engine = switch (server.id) {
+          'kelivo_subagent' => KelivoSubagentMcpServerEngine(
+            assistants: assistantProvider!,
+            chatService: chatService!,
+            headlessGen: headlessGen!,
+            contextProvider: contextProvider,
+          ),
+          _ => KelivoFetchMcpServerEngine(),
+        };
+        final transport = switch (engine) {
+          KelivoSubagentMcpServerEngine e =>
+            KelivoSubagentInMemoryClientTransport(e),
+          _ => KelivoInMemoryClientTransport(
+            engine as KelivoFetchMcpServerEngine,
+          ),
+        };
         final client = mcp.McpClient.createClient(clientConfig);
         await client.connect(transport);
         _clients[id] = client;
@@ -1466,6 +1519,7 @@ class McpProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    assistantProvider?.removeListener(_onAssistantsChanged);
     // Clean up timers
     for (final t in _heartbeats.values) {
       t.cancel();

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -342,6 +342,8 @@ class ChatService extends ChangeNotifier {
   Future<Conversation> createConversation({
     String? title,
     String? assistantId,
+    List<String>? mcpServerIds,
+    String? parentConversationId,
   }) async {
     if (!_initialized) await init();
     _discardTemporaryConversation(_currentConversationId);
@@ -349,6 +351,8 @@ class ChatService extends ChangeNotifier {
     final conversation = Conversation(
       title: title ?? _defaultConversationTitle,
       assistantId: assistantId,
+      mcpServerIds: mcpServerIds,
+      parentConversationId: parentConversationId,
     );
 
     await _saveConversation(conversation);

--- a/lib/core/services/headless_generation_service.dart
+++ b/lib/core/services/headless_generation_service.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'package:flutter/widgets.dart';
+
+import '../providers/settings_provider.dart';
+import 'api/chat_api_service.dart';
+import 'chat/chat_service.dart';
+
+class HeadlessGenerationService extends ChangeNotifier {
+  HeadlessGenerationService({required this._chatService});
+
+  final ChatService _chatService;
+  final _chunkControllers = <String, StreamController<ChatStreamChunk>>{};
+  final _activeConversations = <String>{};
+
+  bool isActive(String conversationId) =>
+      _activeConversations.contains(conversationId);
+
+  Stream<ChatStreamChunk>? chunkStream(String conversationId) =>
+      _chunkControllers[conversationId]?.stream;
+
+  void start({
+    required String conversationId,
+    required String assistantId,
+    required List<Map<String, dynamic>> apiMessages,
+    required ProviderConfig config,
+    required String modelId,
+    List<Map<String, dynamic>>? toolDefs,
+    ToolCallHandler? onToolCall,
+    int? thinkingBudget,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    bool stream = true,
+    VoidCallback? onComplete,
+  }) {
+    unawaited(
+      _run(
+        conversationId: conversationId,
+        assistantId: assistantId,
+        apiMessages: apiMessages,
+        config: config,
+        modelId: modelId,
+        toolDefs: toolDefs,
+        onToolCall: onToolCall,
+        thinkingBudget: thinkingBudget,
+        temperature: temperature,
+        topP: topP,
+        maxTokens: maxTokens,
+        stream: stream,
+        onComplete: onComplete,
+      ),
+    );
+  }
+
+  Future<void> _run({
+    required String conversationId,
+    required String assistantId,
+    required List<Map<String, dynamic>> apiMessages,
+    required ProviderConfig config,
+    required String modelId,
+    List<Map<String, dynamic>>? toolDefs,
+    ToolCallHandler? onToolCall,
+    int? thinkingBudget,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    bool stream = true,
+    VoidCallback? onComplete,
+  }) async {
+    final controller = StreamController<ChatStreamChunk>.broadcast();
+    _chunkControllers[conversationId] = controller;
+    _activeConversations.add(conversationId);
+    notifyListeners();
+
+    String? assistantMessageId;
+    try {
+      final assistantMsg = await _chatService.addMessage(
+        conversationId: conversationId,
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+      assistantMessageId = assistantMsg.id;
+
+      final buf = StringBuffer();
+      var chunkCount = 0;
+      await for (final chunk in ChatApiService.sendMessageStream(
+        config: config,
+        modelId: modelId,
+        messages: apiMessages,
+        tools: toolDefs,
+        onToolCall: onToolCall,
+        thinkingBudget: thinkingBudget,
+        temperature: temperature,
+        topP: topP,
+        maxTokens: maxTokens,
+        stream: stream,
+        requestId: conversationId,
+      )) {
+        chunkCount++;
+        buf.write(chunk.content);
+        controller.add(chunk);
+      }
+
+      debugPrint(
+        '[HeadlessGen] stream done for $conversationId: '
+        'chunks=$chunkCount buf.length=${buf.length}',
+      );
+
+      await _chatService.updateMessage(
+        assistantMessageId,
+        content: buf.toString(),
+        isStreaming: false,
+      );
+      debugPrint(
+        '[HeadlessGen] message updated: id=$assistantMessageId '
+        'content.length=${buf.length} isStreaming=false',
+      );
+      onComplete?.call();
+    } catch (e) {
+      debugPrint('[HeadlessGen] error in $conversationId: $e');
+      if (assistantMessageId != null) {
+        await _chatService.updateMessage(
+          assistantMessageId,
+          content: 'Error: $e',
+          isStreaming: false,
+        );
+      }
+    } finally {
+      _activeConversations.remove(conversationId);
+      await controller.close();
+      _chunkControllers.remove(conversationId);
+      notifyListeners();
+    }
+  }
+
+  void cancel(String conversationId) {
+    ChatApiService.cancelRequest(conversationId);
+  }
+}

--- a/lib/core/services/mcp/kelivo_subagent/kelivo_subagent_server.dart
+++ b/lib/core/services/mcp/kelivo_subagent/kelivo_subagent_server.dart
@@ -1,0 +1,436 @@
+import 'dart:async';
+
+import 'package:mcp_client/mcp_client.dart' as mcp;
+
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import '../../../models/assistant.dart';
+import '../../../models/conversation.dart';
+import '../../../providers/assistant_provider.dart';
+import '../../../providers/settings_provider.dart';
+import '../../../../features/chat/utils/thinking_tag_parser.dart';
+import '../../../../features/home/services/message_builder_service.dart';
+import '../../../../features/home/services/tool_handler_service.dart';
+import '../../api/chat_api_service.dart';
+import '../../chat/chat_service.dart';
+import '../../headless_generation_service.dart';
+
+/// @kelivo/subagent — In-memory MCP server engine and transport (Flutter/Dart)
+class KelivoSubagentMcpServerEngine {
+  KelivoSubagentMcpServerEngine({
+    required this._assistants,
+    required this._chatService,
+    required this._headlessGen,
+    required this._contextProvider,
+  });
+
+  final AssistantProvider _assistants;
+  final ChatService _chatService;
+  final HeadlessGenerationService _headlessGen;
+  final BuildContext Function() _contextProvider;
+  bool _closed = false;
+
+  Future<dynamic> handleMessage(dynamic message) async {
+    if (_closed) return null;
+    if (message is List) {
+      final out = <dynamic>[];
+      for (final m in message) {
+        out.add(await _handleSingle(m));
+      }
+      return out;
+    }
+    return await _handleSingle(message);
+  }
+
+  Future<Map<String, dynamic>> _handleSingle(dynamic raw) async {
+    dynamic requestId;
+    try {
+      if (raw is! Map) {
+        return _error(null, code: -32600, message: 'Invalid Request');
+      }
+      final req = raw.cast<String, dynamic>();
+      requestId = req['id'];
+      final method = (req['method'] ?? '').toString();
+      final params = (req['params'] is Map)
+          ? (req['params'] as Map).cast<String, dynamic>()
+          : <String, dynamic>{};
+
+      switch (method) {
+        case mcp.McpProtocol.methodInitialize:
+          return _ok(
+            requestId,
+            result: {
+              'serverInfo': {'name': '@kelivo/subagent', 'version': '1.0.0'},
+              'protocolVersion': mcp.McpProtocol.defaultVersion,
+              'capabilities': {
+                'tools': {'listChanged': false},
+              },
+            },
+          );
+
+        case mcp.McpProtocol.methodListTools:
+          return _ok(requestId, result: {'tools': _toolDefinitions()});
+
+        case mcp.McpProtocol.methodCallTool:
+          final name = (params['name'] ?? '').toString();
+          final arguments = (params['arguments'] is Map)
+              ? (params['arguments'] as Map).cast<String, dynamic>()
+              : <String, dynamic>{};
+
+          if (name == 'kelivo_handoff') {
+            return _ok(requestId, result: await _handleHandoff(arguments));
+          }
+          return _error(
+            requestId,
+            code: -32101,
+            message: 'Tool not found: $name',
+          );
+
+        default:
+          if (requestId == null) return _noop();
+          return _error(
+            requestId,
+            code: -32601,
+            message: 'Method not found: $method',
+          );
+      }
+    } catch (e) {
+      return _error(requestId, code: -32603, message: 'Internal error: $e');
+    }
+  }
+
+  Future<Map<String, dynamic>> _handleHandoff(
+    Map<String, dynamic> arguments,
+  ) async {
+    final handoffId = (arguments['assistant'] ?? '').toString().trim();
+    final task = (arguments['task'] ?? '').toString().trim();
+
+    debugPrint(
+      '[Subagent] handoff request: assistant=$handoffId, '
+      'task=${task.length > 80 ? '${task.substring(0, 80)}...' : task}',
+    );
+
+    if (task.isEmpty) {
+      return _toolResult(isError: true, text: 'Error: task must not be empty.');
+    }
+
+    final matches = _assistants.assistants.where(
+      (a) => a.discoverable && a.handoffId == handoffId,
+    );
+    final target = matches.isNotEmpty ? matches.first : null;
+
+    if (target == null) {
+      final available = _assistants.assistants
+          .where(
+            (a) =>
+                a.discoverable &&
+                a.handoffId != null &&
+                a.handoffId!.isNotEmpty,
+          )
+          .map((a) => a.handoffId)
+          .join(', ');
+      return _toolResult(
+        isError: true,
+        text:
+            'Error: no discoverable assistant with id \'$handoffId\'. '
+            'Available: [${available.isEmpty ? 'none' : available}].',
+      );
+    }
+
+    final parentConversationId = _chatService.currentConversationId;
+
+    final conversation = await _chatService.createConversation(
+      assistantId: target.id,
+      mcpServerIds: target.mcpServerIds,
+      parentConversationId: parentConversationId,
+    );
+    await _chatService.addMessage(
+      conversationId: conversation.id,
+      role: 'user',
+      content: task,
+    );
+
+    debugPrint(
+      '[Subagent] conversation created: ${conversation.id} '
+      '(parent: $parentConversationId, assistant: ${target.name})',
+    );
+
+    unawaited(_startGeneration(conversation, target));
+
+    return _toolResult(
+      text: 'Handoff dispatched. Conversation: ${conversation.id}',
+    );
+  }
+
+  Future<void> _startGeneration(
+    Conversation conversation,
+    Assistant target,
+  ) async {
+    try {
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
+      final ctx = _contextProvider();
+      // ignore: use_build_context_synchronously
+      final settings = ctx.read<SettingsProvider>();
+      final providerKey =
+          target.chatModelProvider ?? settings.currentModelProvider ?? '';
+      final modelId = target.chatModelId ?? settings.currentModelId ?? '';
+      final config = settings.getProviderConfig(providerKey);
+
+      debugPrint(
+        '[Subagent] building pipeline for ${conversation.id} '
+        '(provider: $providerKey, model: $modelId)',
+      );
+
+      final messageBuilder = MessageBuilderService(
+        chatService: _chatService,
+        // ignore: use_build_context_synchronously (root context)
+        contextProvider: ctx,
+      );
+      final allMessages = _chatService.getMessages(conversation.id);
+      final apiMessages = messageBuilder.buildApiMessages(
+        messages: allMessages,
+        versionSelections: <String, int>{},
+        currentConversation: conversation,
+      );
+      await messageBuilder.processUserMessagesForApi(
+        apiMessages,
+        settings,
+        target,
+      );
+      messageBuilder.injectSystemPrompt(apiMessages, target, modelId);
+      await messageBuilder.injectMemoryAndRecentChats(
+        apiMessages,
+        target,
+        currentConversationId: conversation.id,
+      );
+      messageBuilder.injectInstructionPrompts(apiMessages, target.id);
+      await messageBuilder.injectWorldBookPrompts(apiMessages, target.id);
+      messageBuilder.injectSkillListPrompt(apiMessages, target.id);
+      messageBuilder.injectTimeNote(apiMessages, target);
+      messageBuilder.applyContextLimit(apiMessages, target);
+
+      // ignore: use_build_context_synchronously (root context)
+      final toolHandler = ToolHandlerService(contextProvider: ctx);
+      final toolDefs = toolHandler.buildToolDefinitions(
+        settings,
+        target,
+        providerKey,
+        modelId,
+        false,
+        isToolModel: (_, _) => true,
+      );
+      final onToolCall = toolDefs.isNotEmpty
+          ? toolHandler.buildToolCallHandler(settings, target)
+          : null;
+
+      debugPrint(
+        '[Subagent] starting generation for ${conversation.id} '
+        '(${apiMessages.length} messages, ${toolDefs.length} tools)',
+      );
+
+      _headlessGen.start(
+        conversationId: conversation.id,
+        assistantId: target.id,
+        apiMessages: apiMessages,
+        config: config,
+        modelId: modelId,
+        toolDefs: toolDefs.isEmpty ? null : toolDefs,
+        onToolCall: onToolCall,
+        thinkingBudget: target.thinkingBudget ?? settings.thinkingBudget,
+        temperature: target.temperature,
+        topP: target.topP,
+        maxTokens: target.maxTokens,
+        stream: target.streamOutput,
+        onComplete: () => _generateTitle(conversation.id, target),
+      );
+    } catch (e, st) {
+      debugPrint(
+        '[Subagent] generation failed for ${conversation.id}: $e\n$st',
+      );
+    }
+  }
+
+  void _generateTitle(String conversationId, Assistant assistant) {
+    unawaited(_generateTitleAsync(conversationId, assistant));
+  }
+
+  Future<void> _generateTitleAsync(
+    String conversationId,
+    Assistant assistant,
+  ) async {
+    try {
+      // ignore: use_build_context_synchronously (root context)
+      final ctx = _contextProvider();
+      // ignore: use_build_context_synchronously
+      final settings = ctx.read<SettingsProvider>();
+
+      final provKey =
+          settings.titleModelProvider ??
+          assistant.chatModelProvider ??
+          settings.currentModelProvider;
+      final mdlId =
+          settings.titleModelId ??
+          assistant.chatModelId ??
+          settings.currentModelId;
+      if (provKey == null || mdlId == null) return;
+      final cfg = settings.getProviderConfig(provKey);
+      final budget = settings.titleGenerationThinkingBudgetFor(
+        assistant.thinkingBudget,
+      );
+
+      final msgs = _chatService.getMessages(conversationId);
+      final joined = msgs
+          .where((m) => m.content.isNotEmpty)
+          .map(
+            (m) =>
+                '${m.role == 'assistant' ? 'Assistant' : 'User'}: ${m.content}',
+          )
+          .join('\n\n');
+      final content = joined.length > 3000 ? joined.substring(0, 3000) : joined;
+      final locale = Localizations.localeOf(ctx).toLanguageTag();
+
+      final prompt = settings.titlePrompt
+          .replaceAll('{locale}', locale)
+          .replaceAll('{content}', content);
+
+      final raw = (await ChatApiService.generateText(
+        config: cfg,
+        modelId: mdlId,
+        prompt: prompt,
+        thinkingBudget: budget,
+      )).trim();
+      final title = ThinkingTagParser.parseLegacyInlineBlocks(
+        raw,
+      ).visibleContent;
+      if (title.isNotEmpty) {
+        await _chatService.renameConversation(conversationId, title);
+        debugPrint('[Subagent] title generated for $conversationId: $title');
+      }
+    } catch (e) {
+      debugPrint('[Subagent] title generation failed for $conversationId: $e');
+    }
+  }
+
+  void close() {
+    _closed = true;
+  }
+
+  List<Map<String, dynamic>> _toolDefinitions() {
+    final targets = _assistants.assistants
+        .where(
+          (a) =>
+              a.discoverable && a.handoffId != null && a.handoffId!.isNotEmpty,
+        )
+        .toList();
+
+    final descBuffer = StringBuffer();
+    descBuffer.write(
+      'Delegate a task to another specialized assistant. '
+      'A new conversation is created with full tool access. '
+      'The user can navigate to it from the conversation list.\n',
+    );
+    if (targets.isEmpty) {
+      descBuffer.write(
+        'No assistants are currently available. '
+        'Ask the user to enable "discoverable" on a target assistant.',
+      );
+    } else {
+      descBuffer.write('Available targets:\n');
+      for (final t in targets) {
+        descBuffer.write(
+          '- ${t.handoffId}: ${t.handoffDescription ?? t.name}\n',
+        );
+      }
+    }
+
+    return [
+      {
+        'name': 'kelivo_handoff',
+        'description': descBuffer.toString(),
+        'inputSchema': {
+          'type': 'object',
+          'properties': {
+            'assistant': {
+              'type': 'string',
+              'description': 'The handoff ID of the target assistant',
+            },
+            'task': {
+              'type': 'string',
+              'description':
+                  'The complete task prompt for the target assistant. '
+                  'Include all necessary context — the target has no access '
+                  'to this conversation\'s history.',
+            },
+          },
+          'required': ['assistant', 'task'],
+        },
+      },
+    ];
+  }
+
+  Map<String, dynamic> _ok(dynamic id, {required Map<String, dynamic> result}) {
+    return {'jsonrpc': '2.0', if (id != null) 'id': id, 'result': result};
+  }
+
+  Map<String, dynamic> _error(
+    dynamic id, {
+    required int code,
+    required String message,
+  }) {
+    return {
+      'jsonrpc': '2.0',
+      if (id != null) 'id': id,
+      'error': {'code': code, 'message': message},
+    };
+  }
+
+  Map<String, dynamic> _noop() => {'jsonrpc': '2.0'};
+
+  Map<String, dynamic> _toolResult({String text = '', bool isError = false}) {
+    return {
+      'content': [
+        {'type': 'text', 'text': text},
+      ],
+      if (isError) 'isError': true,
+    };
+  }
+}
+
+class KelivoSubagentInMemoryClientTransport implements mcp.ClientTransport {
+  final KelivoSubagentMcpServerEngine _server;
+  final _messageController = StreamController<dynamic>.broadcast();
+  final _closeCompleter = Completer<void>();
+  bool _closed = false;
+
+  KelivoSubagentInMemoryClientTransport(this._server);
+
+  @override
+  Stream<dynamic> get onMessage => _messageController.stream;
+
+  @override
+  Future<void> get onClose => _closeCompleter.future;
+
+  @override
+  void send(dynamic message) {
+    if (_closed) return;
+    Future.microtask(() async {
+      final resp = await _server.handleMessage(message);
+      if (_closed) return;
+      if (resp != null) {
+        _messageController.add(resp);
+      }
+    });
+  }
+
+  @override
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    try {
+      _server.close();
+    } catch (_) {}
+    if (!_messageController.isClosed) _messageController.close();
+    if (!_closeCompleter.isCompleted) _closeCompleter.complete();
+  }
+}

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -628,6 +628,9 @@ class ProactiveCareHeadlessChatStore {
       'regexRules': jsonDecode(row['regex_rules_json'] as String),
       'enableProactiveCare': (row['enable_proactive_care'] as int) != 0,
       'enableTimeInjection': (row['enable_time_injection'] as int) != 0,
+      'discoverable': (row['discoverable'] as int? ?? 0) != 0,
+      'handoffId': row['handoff_id'] as String?,
+      'handoffDescription': row['handoff_description'] as String?,
       'proactiveCareNextMessageAt': _dateTimeFromSqlNullable(
         row['proactive_care_next_message_at'],
       )?.toIso8601String(),

--- a/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
@@ -13,6 +13,9 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
   late final TextEditingController _thinkingCtrl;
   late final TextEditingController _maxTokensCtrl;
   late final TextEditingController _backgroundCtrl;
+  late final TextEditingController _handoffIdCtrl;
+  late final TextEditingController _handoffDescCtrl;
+  String? _handoffIdError;
 
   @override
   void initState() {
@@ -25,6 +28,8 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
     );
     _maxTokensCtrl = TextEditingController(text: a.maxTokens?.toString() ?? '');
     _backgroundCtrl = TextEditingController(text: a.background ?? '');
+    _handoffIdCtrl = TextEditingController(text: a.handoffId ?? '');
+    _handoffDescCtrl = TextEditingController(text: a.handoffDescription ?? '');
   }
 
   @override
@@ -37,6 +42,8 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
       _thinkingCtrl.text = a.thinkingBudget?.toString() ?? '';
       _maxTokensCtrl.text = a.maxTokens?.toString() ?? '';
       _backgroundCtrl.text = a.background ?? '';
+      _handoffIdCtrl.text = a.handoffId ?? '';
+      _handoffDescCtrl.text = a.handoffDescription ?? '';
     }
   }
 
@@ -46,6 +53,8 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
     _thinkingCtrl.dispose();
     _maxTokensCtrl.dispose();
     _backgroundCtrl.dispose();
+    _handoffIdCtrl.dispose();
+    _handoffDescCtrl.dispose();
     super.dispose();
   }
 
@@ -548,6 +557,133 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
               ],
             ),
           ),
+        ),
+        // Handoff / Delegation section
+        const SizedBox(height: 16),
+        _iosSectionCard(
+          children: [
+            _iosSwitchRow(
+              context,
+              icon: Lucide.ArrowRight,
+              label: l10n.assistantEditHandoffDiscoverable,
+              value: a.discoverable,
+              onChanged: (v) => context
+                  .read<AssistantProvider>()
+                  .updateAssistant(a.copyWith(discoverable: v)),
+            ),
+            if (a.discoverable) ...[
+              _iosDivider(context),
+              // Handoff ID
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.assistantEditHandoffId,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: cs.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    TextField(
+                      controller: _handoffIdCtrl,
+                      decoration: InputDecoration(
+                        hintText: 'research-bot',
+                        errorText: _handoffIdError,
+                        filled: true,
+                        fillColor: isDark
+                            ? Colors.white10
+                            : const Color(0xFFF2F3F5),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.4),
+                          ),
+                        ),
+                      ),
+                      onChanged: (v) {
+                        final sanitized = v.toLowerCase().replaceAll(
+                          RegExp(r'[^a-z0-9-]'),
+                          '',
+                        );
+                        final l10n = AppLocalizations.of(context)!;
+                        if (sanitized != v.toLowerCase()) {
+                          setState(
+                            () => _handoffIdError =
+                                l10n.assistantEditHandoffIdInvalid,
+                          );
+                        } else {
+                          final dup = context
+                              .read<AssistantProvider>()
+                              .assistants
+                              .any(
+                                (o) =>
+                                    o.id != a.id &&
+                                    o.handoffId == sanitized &&
+                                    sanitized.isNotEmpty,
+                              );
+                          setState(
+                            () => _handoffIdError = dup
+                                ? l10n.assistantEditHandoffIdUnique
+                                : null,
+                          );
+                        }
+                        context.read<AssistantProvider>().updateAssistant(
+                          a.copyWith(handoffId: sanitized),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              _iosDivider(context),
+              // Handoff Description
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.assistantEditHandoffDescription,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: cs.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    TextField(
+                      controller: _handoffDescCtrl,
+                      maxLines: 3,
+                      decoration: InputDecoration(
+                        hintText: l10n.assistantEditHandoffDescription,
+                        filled: true,
+                        fillColor: isDark
+                            ? Colors.white10
+                            : const Color(0xFFF2F3F5),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.4),
+                          ),
+                        ),
+                      ),
+                      onChanged: (v) => context
+                          .read<AssistantProvider>()
+                          .updateAssistant(a.copyWith(handoffDescription: v)),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
         ),
       ],
     );

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -1741,6 +1741,9 @@ class _DesktopAssistantBasicPaneState
     extends State<_DesktopAssistantBasicPane> {
   late final TextEditingController _nameCtrl;
   late final TextEditingController _maxTokensCtrl;
+  late final TextEditingController _handoffIdCtrl;
+  late final TextEditingController _handoffDescCtrl;
+  String? _handoffIdError;
   bool _hoverChatModel = false;
   bool _hoverBgChooser = false;
   final GlobalKey _avatarKey = GlobalKey();
@@ -1751,6 +1754,8 @@ class _DesktopAssistantBasicPaneState
     final a = context.read<AssistantProvider>().getById(widget.assistantId)!;
     _nameCtrl = TextEditingController(text: a.name);
     _maxTokensCtrl = TextEditingController(text: a.maxTokens?.toString() ?? '');
+    _handoffIdCtrl = TextEditingController(text: a.handoffId ?? '');
+    _handoffDescCtrl = TextEditingController(text: a.handoffDescription ?? '');
   }
 
   @override
@@ -1760,6 +1765,8 @@ class _DesktopAssistantBasicPaneState
       final a = context.read<AssistantProvider>().getById(widget.assistantId)!;
       _nameCtrl.text = a.name;
       _maxTokensCtrl.text = a.maxTokens?.toString() ?? '';
+      _handoffIdCtrl.text = a.handoffId ?? '';
+      _handoffDescCtrl.text = a.handoffDescription ?? '';
     }
   }
 
@@ -1767,6 +1774,8 @@ class _DesktopAssistantBasicPaneState
   void dispose() {
     _nameCtrl.dispose();
     _maxTokensCtrl.dispose();
+    _handoffIdCtrl.dispose();
+    _handoffDescCtrl.dispose();
     super.dispose();
   }
 
@@ -2529,6 +2538,129 @@ class _DesktopAssistantBasicPaneState
                     ClipRRect(
                       borderRadius: BorderRadius.circular(10),
                       child: _BackgroundPreview(path: a.background!),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            sectionDivider(),
+            // Handoff / Delegation
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.assistantEditHandoffSectionTitle,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: AppFontWeights.semibold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  simpleSwitchRow(
+                    label: l10n.assistantEditHandoffDiscoverable,
+                    value: a.discoverable,
+                    onChanged: (v) => context
+                        .read<AssistantProvider>()
+                        .updateAssistant(a.copyWith(discoverable: v)),
+                  ),
+                  if (a.discoverable) ...[
+                    sectionDivider(),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8, bottom: 8),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            l10n.assistantEditHandoffId,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: cs.onSurface.withValues(alpha: 0.7),
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          TextField(
+                            controller: _handoffIdCtrl,
+                            decoration: InputDecoration(
+                              hintText: 'research-bot',
+                              errorText: _handoffIdError,
+                              filled: true,
+                              fillColor: isDark
+                                  ? Colors.white10
+                                  : const Color(0xFFF2F3F5),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: cs.outlineVariant.withValues(
+                                    alpha: 0.4,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            onChanged: (v) {
+                              final sanitized = v.toLowerCase().replaceAll(
+                                RegExp(r'[^a-z0-9-]'),
+                                '',
+                              );
+                              if (sanitized != v.toLowerCase()) {
+                                setState(
+                                  () => _handoffIdError =
+                                      l10n.assistantEditHandoffIdInvalid,
+                                );
+                              } else {
+                                final dup = ap.assistants.any(
+                                  (o) =>
+                                      o.id != a.id &&
+                                      o.handoffId == sanitized &&
+                                      sanitized.isNotEmpty,
+                                );
+                                setState(
+                                  () => _handoffIdError = dup
+                                      ? l10n.assistantEditHandoffIdUnique
+                                      : null,
+                                );
+                              }
+                              context.read<AssistantProvider>().updateAssistant(
+                                a.copyWith(handoffId: sanitized),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            l10n.assistantEditHandoffDescription,
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: cs.onSurface.withValues(alpha: 0.7),
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          TextField(
+                            controller: _handoffDescCtrl,
+                            maxLines: 3,
+                            decoration: InputDecoration(
+                              hintText: l10n.assistantEditHandoffDescription,
+                              filled: true,
+                              fillColor: isDark
+                                  ? Colors.white10
+                                  : const Color(0xFFF2F3F5),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide(
+                                  color: cs.outlineVariant.withValues(
+                                    alpha: 0.4,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            onChanged: (v) => context
+                                .read<AssistantProvider>()
+                                .updateAssistant(
+                                  a.copyWith(handoffDescription: v),
+                                ),
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ],

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import '../../../core/services/storage/message_locate_bus.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'dart:ui' as ui;
@@ -4260,6 +4261,16 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
             ),
           );
 
+    // Handoff forward bar
+    final Widget? handoffChip = _buildHandoffForwardChip(context, fg, cs);
+    final Widget? mergedContent = (content != null && handoffChip != null)
+        ? Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [content, const SizedBox(height: 4), handoffChip],
+          )
+        : handoffChip ?? content;
+
     final extra = approvalRequest != null
         ? Row(
             mainAxisSize: MainAxisSize.min,
@@ -4308,8 +4319,60 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
               color: fg.muted,
             )
           : Icon(Lucide.ChevronRight, size: 16, color: fg.muted),
-      content: content,
-      contentVisible: content != null && (!_isAskUser || askUserExpanded),
+      content: mergedContent,
+      contentVisible: mergedContent != null && (!_isAskUser || askUserExpanded),
+    );
+  }
+
+  Widget? _buildHandoffForwardChip(
+    BuildContext context,
+    _ChatSurfaceForegroundPalette fg,
+    ColorScheme cs,
+  ) {
+    if (widget.part.toolName != 'kelivo_handoff' || widget.part.loading) {
+      return null;
+    }
+    final contentRaw = widget.part.content?.trim() ?? '';
+    if (contentRaw.isEmpty) return null;
+
+    // Parse conversation UUID from result "Handoff complete. Conversation: uuid"
+    final uuidMatch = RegExp(r'([a-f0-9\-]{36})').firstMatch(contentRaw);
+    if (uuidMatch == null) return null;
+    final convId = uuidMatch.group(1)!;
+    final prefix = convId.substring(0, 4);
+
+    // Resolve target assistant name from arguments['assistant']
+    final handoffId = (widget.part.arguments['assistant'] ?? '').toString();
+    final assistants = context.read<AssistantProvider>();
+    final target = assistants.assistants.where((a) => a.handoffId == handoffId);
+    final targetName = target.isNotEmpty ? target.first.name : handoffId;
+
+    return IosCardPress(
+      onTap: () =>
+          MessageLocateBus.instance.fire(conversationId: convId, messageId: ''),
+      borderRadius: BorderRadius.circular(999),
+      baseColor: Colors.transparent,
+      pressedScale: 0.97,
+      padding: EdgeInsets.zero,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.2)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Lucide.ArrowRight, size: 14, color: cs.primary),
+            const SizedBox(width: 6),
+            Text(
+              '$targetName · $prefix',
+              style: TextStyle(fontSize: 12, color: cs.primary),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -20,6 +20,7 @@ import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/memory_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/headless_generation_service.dart';
 import '../../../core/services/tts/tts_text_selection.dart';
 import '../../../core/services/haptics.dart';
 import '../../../core/services/proactive_care_alarm_service.dart';
@@ -150,6 +151,8 @@ class HomePageController extends ChangeNotifier {
   late scroll_ctrl.ChatScrollController _scrollCtrl;
 
   McpProvider? _mcpProvider;
+  HeadlessGenerationService? _headlessGen;
+  bool _wasCurrentHeadlessActive = false;
   StreamSubscription<ChatAction>? _chatActionSub;
   StreamSubscription<MessageLocateTarget>? _locateSub;
   ReceivePort? _proactiveCarePort;
@@ -290,7 +293,8 @@ class HomePageController extends ChangeNotifier {
   bool get isCurrentConversationLoading {
     final cid = currentConversation?.id;
     if (cid == null) return false;
-    return loadingConversationIds.contains(cid);
+    return loadingConversationIds.contains(cid) ||
+        (_headlessGen?.isActive(cid) ?? false);
   }
 
   QueuedChatInput? get currentQueuedInput => _viewModel.currentQueuedInput;
@@ -563,6 +567,13 @@ class HomePageController extends ChangeNotifier {
       _mcpProvider = _context.read<McpProvider>();
       _mcpProvider!.addListener(_onMcpChanged);
     } catch (_) {}
+    try {
+      _headlessGen = _context.read<HeadlessGenerationService>();
+      _headlessGen!.addListener(_onHeadlessGenChanged);
+      debugPrint('[HeadlessGen] listener attached');
+    } catch (e) {
+      debugPrint('[HeadlessGen] listener FAILED: $e');
+    }
   }
 
   void _setupKeyboardListeners() {}
@@ -1086,6 +1097,10 @@ class HomePageController extends ChangeNotifier {
 
   Future<void> cancelStreaming() async {
     debugPrint('[CancelTrace] HomePageController.cancelStreaming ENTER');
+    final cid = currentConversation?.id;
+    if (cid != null && (_headlessGen?.isActive(cid) ?? false)) {
+      _headlessGen!.cancel(cid);
+    }
     await _viewModel.cancelStreaming();
     notifyListeners();
     debugPrint('[CancelTrace] HomePageController.cancelStreaming EXIT');
@@ -2627,6 +2642,17 @@ class HomePageController extends ChangeNotifier {
     // Kept for potential future use
   }
 
+  void _onHeadlessGenChanged() {
+    final cid = currentConversation?.id;
+    if (cid == null) return;
+    final isNowActive = _headlessGen?.isActive(cid) ?? false;
+    if (_wasCurrentHeadlessActive && !isNowActive) {
+      _chatController.setCurrentConversation(currentConversation);
+    }
+    _wasCurrentHeadlessActive = isNowActive;
+    notifyListeners();
+  }
+
   // ============================================================================
   // Disposal
   // ============================================================================
@@ -2637,6 +2663,7 @@ class HomePageController extends ChangeNotifier {
     IsolateNameServer.removePortNameMapping(proactiveCareMainPortName);
     _convoFadeController.dispose();
     _mcpProvider?.removeListener(_onMcpChanged);
+    _headlessGen?.removeListener(_onHeadlessGenChanged);
     _scrollCtrl.dispose();
     try {
       _chatActionSub?.cancel();

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -10,8 +10,12 @@ import 'package:scrollview_observer/scrollview_observer.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/storage/message_locate_bus.dart';
+import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_checkbox.dart';
+import '../../../shared/widgets/ios_tactile.dart';
 import '../../chat/widgets/chat_message_widget.dart';
 import '../../chat/widgets/message_more_sheet.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
@@ -783,7 +787,7 @@ class _MessageListViewState extends State<MessageListView> {
     required List<String> suggestions,
     bool enableStreamingTextMotion = true,
   }) {
-    return ChatMessageWidget(
+    final chatWidget = ChatMessageWidget(
       message: message,
       enableStreamingTextMotion: enableStreamingTextMotion,
       versionIndex: selectedIdx,
@@ -930,6 +934,76 @@ class _MessageListViewState extends State<MessageListView> {
           ? null
           : (part, result) =>
                 widget.onRecoveredAskUserAnswer!(message, part, result),
+    );
+
+    // Backward bar for handoff-spawned conversations
+    if (message.role == 'user' && index == 0) {
+      final backwardChip = _buildHandoffBackwardChip(context, message);
+      if (backwardChip != null) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [backwardChip, const SizedBox(height: 8), chatWidget],
+        );
+      }
+    }
+    return chatWidget;
+  }
+
+  Widget? _buildHandoffBackwardChip(BuildContext context, ChatMessage message) {
+    final ChatService chatService;
+    final AssistantProvider assistants;
+    try {
+      chatService = context.read<ChatService>();
+      assistants = context.read<AssistantProvider>();
+    } catch (_) {
+      return null;
+    }
+    final conv = chatService.getConversation(message.conversationId);
+    final parentConvId = conv?.parentConversationId;
+    if (parentConvId == null || parentConvId.isEmpty) return null;
+
+    final parentConv = chatService.getConversation(parentConvId);
+    if (parentConv == null) return null;
+
+    final parentAssistant = parentConv.assistantId != null
+        ? assistants.getById(parentConv.assistantId!)
+        : null;
+    final parentName = parentAssistant?.name ?? 'Assistant';
+    final parentPrefix = parentConvId.length >= 4
+        ? parentConvId.substring(0, 4)
+        : parentConvId;
+
+    final cs = Theme.of(context).colorScheme;
+
+    return IosCardPress(
+      onTap: () => MessageLocateBus.instance.fire(
+        conversationId: parentConvId,
+        messageId: '',
+      ),
+      borderRadius: BorderRadius.circular(999),
+      baseColor: Colors.transparent,
+      pressedScale: 0.97,
+      padding: EdgeInsets.zero,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.2)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Lucide.ArrowLeft, size: 14, color: cs.primary),
+            const SizedBox(width: 6),
+            Text(
+              '$parentName · $parentPrefix',
+              style: TextStyle(fontSize: 12, color: cs.primary),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/widgets/side_drawer.dart
+++ b/lib/features/home/widgets/side_drawer.dart
@@ -3913,12 +3913,34 @@ class _ChatTileState extends State<_ChatTile> {
                   const SizedBox(width: 8),
                   _LoadingDot(),
                 ],
+                ..._buildHandoffBadgeWidget(context),
               ],
             ),
           ),
         ),
       ),
     );
+  }
+
+  List<Widget> _buildHandoffBadgeWidget(BuildContext context) {
+    try {
+      final chatService = context.read<ChatService>();
+      final conv = chatService.getConversation(widget.chat.id);
+      if (conv?.parentConversationId == null) return const [];
+      final cs = Theme.of(context).colorScheme;
+      return [
+        Padding(
+          padding: const EdgeInsets.only(left: 6),
+          child: Icon(
+            Lucide.ArrowRight,
+            size: 12,
+            color: cs.primary.withValues(alpha: 0.6),
+          ),
+        ),
+      ];
+    } catch (_) {
+      return const [];
+    }
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3077,5 +3077,16 @@
   "chatMessageWidgetCopyAsMarkdown": "Copy as Markdown",
   "chatMessageWidgetCopyAsPlainText": "Copy as Plain Text",
   "chatMessageWidgetQuote": "Quote",
-  "chatMessageWidgetSpeak": "Speak"
+  "chatMessageWidgetSpeak": "Speak",
+  "handoffForwardChip": "→ {assistantName} · {convIdPrefix}",
+  "handoffBackwardChip": "← {assistantName} · {convIdPrefix}",
+  "handoffBadgeTooltip": "Spawned from handoff",
+  "assistantEditHandoffSectionTitle": "Handoff / Delegation",
+  "assistantEditHandoffDiscoverable": "Discoverable by other assistants",
+  "assistantEditHandoffId": "Handoff ID",
+  "assistantEditHandoffDescription": "Description for other assistants",
+  "assistantEditHandoffIdInvalid": "Only lowercase letters, digits, and hyphens are allowed",
+  "assistantEditHandoffIdUnique": "This Handoff ID is already in use",
+  "handoffForwardChipTooltip": "Open the spawned conversation",
+  "handoffBackwardChipTooltip": "Back to the parent conversation"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11773,6 +11773,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Speak'**
   String get chatMessageWidgetSpeak;
+
+  /// No description provided for @handoffForwardChip.
+  ///
+  /// In en, this message translates to:
+  /// **'→ {assistantName} · {convIdPrefix}'**
+  String handoffForwardChip(Object assistantName, Object convIdPrefix);
+
+  /// No description provided for @handoffBackwardChip.
+  ///
+  /// In en, this message translates to:
+  /// **'← {assistantName} · {convIdPrefix}'**
+  String handoffBackwardChip(Object assistantName, Object convIdPrefix);
+
+  /// No description provided for @handoffBadgeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Spawned from handoff'**
+  String get handoffBadgeTooltip;
+
+  /// No description provided for @assistantEditHandoffSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Handoff / Delegation'**
+  String get assistantEditHandoffSectionTitle;
+
+  /// No description provided for @assistantEditHandoffDiscoverable.
+  ///
+  /// In en, this message translates to:
+  /// **'Discoverable by other assistants'**
+  String get assistantEditHandoffDiscoverable;
+
+  /// No description provided for @assistantEditHandoffId.
+  ///
+  /// In en, this message translates to:
+  /// **'Handoff ID'**
+  String get assistantEditHandoffId;
+
+  /// No description provided for @assistantEditHandoffDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Description for other assistants'**
+  String get assistantEditHandoffDescription;
+
+  /// No description provided for @assistantEditHandoffIdInvalid.
+  ///
+  /// In en, this message translates to:
+  /// **'Only lowercase letters, digits, and hyphens are allowed'**
+  String get assistantEditHandoffIdInvalid;
+
+  /// No description provided for @assistantEditHandoffIdUnique.
+  ///
+  /// In en, this message translates to:
+  /// **'This Handoff ID is already in use'**
+  String get assistantEditHandoffIdUnique;
+
+  /// No description provided for @handoffForwardChipTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Open the spawned conversation'**
+  String get handoffForwardChipTooltip;
+
+  /// No description provided for @handoffBackwardChipTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to the parent conversation'**
+  String get handoffBackwardChipTooltip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6448,4 +6448,45 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chatMessageWidgetSpeak => 'Speak';
+
+  @override
+  String handoffForwardChip(Object assistantName, Object convIdPrefix) {
+    return '→ $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String handoffBackwardChip(Object assistantName, Object convIdPrefix) {
+    return '← $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String get handoffBadgeTooltip => 'Spawned from handoff';
+
+  @override
+  String get assistantEditHandoffSectionTitle => 'Handoff / Delegation';
+
+  @override
+  String get assistantEditHandoffDiscoverable =>
+      'Discoverable by other assistants';
+
+  @override
+  String get assistantEditHandoffId => 'Handoff ID';
+
+  @override
+  String get assistantEditHandoffDescription =>
+      'Description for other assistants';
+
+  @override
+  String get assistantEditHandoffIdInvalid =>
+      'Only lowercase letters, digits, and hyphens are allowed';
+
+  @override
+  String get assistantEditHandoffIdUnique =>
+      'This Handoff ID is already in use';
+
+  @override
+  String get handoffForwardChipTooltip => 'Open the spawned conversation';
+
+  @override
+  String get handoffBackwardChipTooltip => 'Back to the parent conversation';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6188,6 +6188,43 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get chatMessageWidgetSpeak => '朗读';
+
+  @override
+  String handoffForwardChip(Object assistantName, Object convIdPrefix) {
+    return '→ $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String handoffBackwardChip(Object assistantName, Object convIdPrefix) {
+    return '← $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String get handoffBadgeTooltip => '从交接创建';
+
+  @override
+  String get assistantEditHandoffSectionTitle => '交接 / 委派';
+
+  @override
+  String get assistantEditHandoffDiscoverable => '可被其他助手发现';
+
+  @override
+  String get assistantEditHandoffId => '交接标识';
+
+  @override
+  String get assistantEditHandoffDescription => '对其他助手描述此助手的用途';
+
+  @override
+  String get assistantEditHandoffIdInvalid => '只允许小写字母、数字和连字符';
+
+  @override
+  String get assistantEditHandoffIdUnique => '此交接标识已被使用';
+
+  @override
+  String get handoffForwardChipTooltip => '打开创建的新对话';
+
+  @override
+  String get handoffBackwardChipTooltip => '返回上一级对话';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -12374,6 +12411,43 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get chatMessageWidgetSpeak => '朗读';
+
+  @override
+  String handoffForwardChip(Object assistantName, Object convIdPrefix) {
+    return '→ $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String handoffBackwardChip(Object assistantName, Object convIdPrefix) {
+    return '← $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String get handoffBadgeTooltip => '从交接创建';
+
+  @override
+  String get assistantEditHandoffSectionTitle => '交接 / 委派';
+
+  @override
+  String get assistantEditHandoffDiscoverable => '可被其他助手发现';
+
+  @override
+  String get assistantEditHandoffId => '交接标识';
+
+  @override
+  String get assistantEditHandoffDescription => '对其他助手描述此助手的用途';
+
+  @override
+  String get assistantEditHandoffIdInvalid => '只允许小写字母、数字和连字符';
+
+  @override
+  String get assistantEditHandoffIdUnique => '此交接标识已被使用';
+
+  @override
+  String get handoffForwardChipTooltip => '打开创建的新对话';
+
+  @override
+  String get handoffBackwardChipTooltip => '返回上一级对话';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -18560,4 +18634,41 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get chatMessageWidgetSpeak => '朗讀';
+
+  @override
+  String handoffForwardChip(Object assistantName, Object convIdPrefix) {
+    return '→ $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String handoffBackwardChip(Object assistantName, Object convIdPrefix) {
+    return '← $assistantName · $convIdPrefix';
+  }
+
+  @override
+  String get handoffBadgeTooltip => '從交接創建';
+
+  @override
+  String get assistantEditHandoffSectionTitle => '交接 / 委派';
+
+  @override
+  String get assistantEditHandoffDiscoverable => '可被其他助手發現';
+
+  @override
+  String get assistantEditHandoffId => '交接標識';
+
+  @override
+  String get assistantEditHandoffDescription => '對其他助手描述此助手的用途';
+
+  @override
+  String get assistantEditHandoffIdInvalid => '只允許小寫字母、數字和連字符';
+
+  @override
+  String get assistantEditHandoffIdUnique => '此交接標識已被使用';
+
+  @override
+  String get handoffForwardChipTooltip => '打開創建的新對話';
+
+  @override
+  String get handoffBackwardChipTooltip => '返回上一級對話';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2527,5 +2527,16 @@
   "chatMessageWidgetCopyAsMarkdown": "复制为 Markdown",
   "chatMessageWidgetCopyAsPlainText": "复制为纯文本",
   "chatMessageWidgetQuote": "引用",
-  "chatMessageWidgetSpeak": "朗读"
+  "chatMessageWidgetSpeak": "朗读",
+  "handoffForwardChip": "→ {assistantName} · {convIdPrefix}",
+  "handoffBackwardChip": "← {assistantName} · {convIdPrefix}",
+  "handoffBadgeTooltip": "从交接创建",
+  "assistantEditHandoffSectionTitle": "交接 / 委派",
+  "assistantEditHandoffDiscoverable": "可被其他助手发现",
+  "assistantEditHandoffId": "交接标识",
+  "assistantEditHandoffDescription": "对其他助手描述此助手的用途",
+  "assistantEditHandoffIdInvalid": "只允许小写字母、数字和连字符",
+  "assistantEditHandoffIdUnique": "此交接标识已被使用",
+  "handoffForwardChipTooltip": "打开创建的新对话",
+  "handoffBackwardChipTooltip": "返回上一级对话"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2499,5 +2499,16 @@
   "chatMessageWidgetCopyAsMarkdown": "复制为 Markdown",
   "chatMessageWidgetCopyAsPlainText": "复制为纯文本",
   "chatMessageWidgetQuote": "引用",
-  "chatMessageWidgetSpeak": "朗读"
+  "chatMessageWidgetSpeak": "朗读",
+  "handoffForwardChip": "→ {assistantName} · {convIdPrefix}",
+  "handoffBackwardChip": "← {assistantName} · {convIdPrefix}",
+  "handoffBadgeTooltip": "从交接创建",
+  "assistantEditHandoffSectionTitle": "交接 / 委派",
+  "assistantEditHandoffDiscoverable": "可被其他助手发现",
+  "assistantEditHandoffId": "交接标识",
+  "assistantEditHandoffDescription": "对其他助手描述此助手的用途",
+  "assistantEditHandoffIdInvalid": "只允许小写字母、数字和连字符",
+  "assistantEditHandoffIdUnique": "此交接标识已被使用",
+  "handoffForwardChipTooltip": "打开创建的新对话",
+  "handoffBackwardChipTooltip": "返回上一级对话"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2527,5 +2527,16 @@
   "chatMessageWidgetCopyAsMarkdown": "複製為 Markdown",
   "chatMessageWidgetCopyAsPlainText": "複製為純文字",
   "chatMessageWidgetQuote": "引用",
-  "chatMessageWidgetSpeak": "朗讀"
+  "chatMessageWidgetSpeak": "朗讀",
+  "handoffForwardChip": "→ {assistantName} · {convIdPrefix}",
+  "handoffBackwardChip": "← {assistantName} · {convIdPrefix}",
+  "handoffBadgeTooltip": "從交接創建",
+  "assistantEditHandoffSectionTitle": "交接 / 委派",
+  "assistantEditHandoffDiscoverable": "可被其他助手發現",
+  "assistantEditHandoffId": "交接標識",
+  "assistantEditHandoffDescription": "對其他助手描述此助手的用途",
+  "assistantEditHandoffIdInvalid": "只允許小寫字母、數字和連字符",
+  "assistantEditHandoffIdUnique": "此交接標識已被使用",
+  "handoffForwardChipTooltip": "打開創建的新對話",
+  "handoffBackwardChipTooltip": "返回上一級對話"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,7 @@ import 'core/providers/hotkey_provider.dart';
 import 'core/services/chat/chat_service.dart';
 import 'core/services/trash_restore_coordinator.dart';
 import 'core/services/mcp/mcp_tool_service.dart';
+import 'core/services/headless_generation_service.dart';
 import 'core/services/logging/flutter_logger.dart';
 import 'features/home/services/ask_user_interaction_service.dart';
 import 'features/home/services/tool_approval_service.dart';
@@ -141,13 +142,22 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => ChatService()),
         ChangeNotifierProvider(create: (_) => McpToolService()),
         ChangeNotifierProvider(
-          create: (ctx) => McpProvider(chatService: ctx.read<ChatService>()),
+          create: (ctx) =>
+              AssistantProvider(chatService: ctx.read<ChatService>()),
         ),
         ChangeNotifierProvider(create: (_) => ToolApprovalService()),
         ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
         ChangeNotifierProvider(
           create: (ctx) =>
-              AssistantProvider(chatService: ctx.read<ChatService>()),
+              HeadlessGenerationService(chatService: ctx.read<ChatService>()),
+        ),
+        ChangeNotifierProvider(
+          create: (ctx) => McpProvider(
+            chatService: ctx.read<ChatService>(),
+            assistantProvider: ctx.read<AssistantProvider>(),
+            headlessGen: ctx.read<HeadlessGenerationService>(),
+            contextProvider: () => navigatorKey.currentContext!,
+          ),
         ),
         ChangeNotifierProvider(create: (_) => TagProvider()),
         ChangeNotifierProvider(create: (_) => TtsProvider()),

--- a/test/features/home/services/assistant_search_test.dart
+++ b/test/features/home/services/assistant_search_test.dart
@@ -69,7 +69,11 @@ void main() {
             ChangeNotifierProvider<AssistantProvider>(
               create: (_) => AssistantProvider(),
             ),
-            ChangeNotifierProvider<McpProvider>(create: (_) => McpProvider()),
+            ChangeNotifierProvider<McpProvider>(
+              create: (_) => McpProvider(
+                contextProvider: () => throw UnimplementedError(),
+              ),
+            ),
             ChangeNotifierProvider<McpToolService>(
               create: (_) => McpToolService(),
             ),

--- a/test/features/home/services/memory_mode_test.dart
+++ b/test/features/home/services/memory_mode_test.dart
@@ -368,7 +368,10 @@ class _ToolHandlerTestScope extends StatelessWidget {
         ChangeNotifierProvider<AssistantProvider>(
           create: (_) => AssistantProvider(),
         ),
-        ChangeNotifierProvider<McpProvider>(create: (_) => McpProvider()),
+        ChangeNotifierProvider<McpProvider>(
+          create: (_) =>
+              McpProvider(contextProvider: () => throw UnimplementedError()),
+        ),
         ChangeNotifierProvider<McpToolService>(create: (_) => McpToolService()),
         ChangeNotifierProvider<MemoryProvider>(create: (_) => MemoryProvider()),
       ],

--- a/test/features/home/services/tool_handler_service_test.dart
+++ b/test/features/home/services/tool_handler_service_test.dart
@@ -239,7 +239,10 @@ class _ToolHandlerTestScope extends StatelessWidget {
         ChangeNotifierProvider<AssistantProvider>(
           create: (_) => AssistantProvider(),
         ),
-        ChangeNotifierProvider<McpProvider>(create: (_) => McpProvider()),
+        ChangeNotifierProvider<McpProvider>(
+          create: (_) =>
+              McpProvider(contextProvider: () => throw UnimplementedError()),
+        ),
         ChangeNotifierProvider<McpToolService>(create: (_) => McpToolService()),
         ChangeNotifierProvider<MemoryProvider>(
           create: (_) => memoryProvider ?? MemoryProvider(),


### PR DESCRIPTION
Part 1/2 of #39.

- Add @kelivo/subagent in-memory MCP server with kelivo_handoff tool
- Per-assistant discoverable/handoffId/handoffDescription fields (DB v12)
- conversations.parentConversationId for backward navigation
- HeadlessGenerationService: fire-and-forget stream runner with onComplete callback, error handling, and title generation
- Full message pipeline (memory, worldbook, skills, tools) via MessageBuilderService + ToolHandlerService in subagent engine
- UI: forward chip on handoff tool-call card, backward chip on first user message of spawned conversation, badge in conversation list
- UI: chat page watches HeadlessGenerationService for stop button and message reload on completion
- McpProvider: contextProvider via navigatorKey.currentContext, auto-refresh subagent tool definitions on assistant changes
- Settings UI: Handoff/Delegation section (mobile + desktop)
- Fix: DB repository mappers persist handoff fields across restarts
- Fix: await updateMessage before notifyListeners (race condition)
- Fix: error path saves isStreaming=false to prevent stuck state
- 11 ARB keys across 4 locales, ADR-0013, CONTEXT.md section