### PR TITLE
feat(skills): category support, master toggle, and chat-level entry

### DIFF
--- a/lib/desktop/skills_popover.dart
+++ b/lib/desktop/skills_popover.dart
@@ -1,0 +1,551 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../core/providers/assistant_provider.dart';
+import '../features/skills/skill_manager.dart';
+import '../icons/lucide_adapter.dart';
+import '../l10n/app_localizations.dart';
+import '../theme/app_font_weights.dart';
+
+Future<void> showDesktopSkillsPopover(
+  BuildContext context, {
+  required GlobalKey anchorKey,
+  required List<SkillMetadata> skills,
+  String? assistantId,
+  VoidCallback? onManageSkills,
+}) async {
+  final overlay = Overlay.maybeOf(context);
+  if (overlay == null) return;
+  final keyContext = anchorKey.currentContext;
+  if (keyContext == null) return;
+
+  final box = keyContext.findRenderObject() as RenderBox?;
+  if (box == null) return;
+  final offset = box.localToGlobal(Offset.zero);
+  final size = box.size;
+  final anchorRect = Rect.fromLTWH(
+    offset.dx,
+    offset.dy,
+    size.width,
+    size.height,
+  );
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (ctx) => _SkillsPopover(
+      anchorRect: anchorRect,
+      anchorWidth: size.width,
+      skills: skills,
+      assistantId: assistantId,
+      onManageSkills: onManageSkills,
+      onClose: () {
+        try {
+          entry.remove();
+        } catch (_) {}
+      },
+    ),
+  );
+  overlay.insert(entry);
+}
+
+class _SkillsPopover extends StatefulWidget {
+  const _SkillsPopover({
+    required this.anchorRect,
+    required this.anchorWidth,
+    required this.skills,
+    required this.assistantId,
+    required this.onManageSkills,
+    required this.onClose,
+  });
+
+  final Rect anchorRect;
+  final double anchorWidth;
+  final List<SkillMetadata> skills;
+  final String? assistantId;
+  final VoidCallback? onManageSkills;
+  final VoidCallback onClose;
+
+  @override
+  State<_SkillsPopover> createState() => _SkillsPopoverState();
+}
+
+class _SkillsPopoverState extends State<_SkillsPopover>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fadeIn;
+  Offset _offset = const Offset(0, 0.12);
+  bool _closing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 260),
+    );
+    _fadeIn = CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic);
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      setState(() => _offset = Offset.zero);
+      try {
+        await _controller.forward();
+      } catch (_) {}
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _close() async {
+    if (_closing) return;
+    _closing = true;
+    setState(() => _offset = const Offset(0, 1.0));
+    try {
+      await _controller.reverse();
+    } catch (_) {}
+    if (mounted) widget.onClose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screen = MediaQuery.of(context).size;
+    final width = (widget.anchorWidth - 16).clamp(260.0, 720.0);
+    final left =
+        (widget.anchorRect.left + (widget.anchorRect.width - width) / 2).clamp(
+          8.0,
+          screen.width - width - 8.0,
+        );
+    final clipHeight = widget.anchorRect.top.clamp(0.0, screen.height);
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: _close,
+          ),
+        ),
+        Positioned(
+          left: 0,
+          right: 0,
+          top: 0,
+          height: clipHeight,
+          child: ClipRect(
+            child: Stack(
+              children: [
+                Positioned(
+                  left: left,
+                  width: width,
+                  bottom: 0,
+                  child: FadeTransition(
+                    opacity: _fadeIn,
+                    child: AnimatedSlide(
+                      duration: const Duration(milliseconds: 260),
+                      curve: Curves.easeOutCubic,
+                      offset: _offset,
+                      child: _GlassPanel(
+                        borderRadius: const BorderRadius.vertical(
+                          top: Radius.circular(14),
+                        ),
+                        child: _SkillsPopoverContent(
+                          skills: widget.skills,
+                          assistantId: widget.assistantId,
+                          onManageSkills: widget.onManageSkills,
+                          onClose: _close,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GlassPanel extends StatelessWidget {
+  const _GlassPanel({required this.child, this.borderRadius});
+  final Widget child;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return ClipRRect(
+      borderRadius: borderRadius ?? BorderRadius.circular(14),
+      child: BackdropFilter(
+        filter: ui.ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: (isDark ? Colors.black : Colors.white).withValues(
+              alpha: isDark ? 0.28 : 0.56,
+            ),
+            border: Border(
+              top: BorderSide(
+                color: Colors.white.withValues(alpha: isDark ? 0.06 : 0.18),
+                width: 0.7,
+              ),
+              left: BorderSide(
+                color: Colors.white.withValues(alpha: isDark ? 0.04 : 0.12),
+                width: 0.6,
+              ),
+              right: BorderSide(
+                color: Colors.white.withValues(alpha: isDark ? 0.04 : 0.12),
+                width: 0.6,
+              ),
+            ),
+          ),
+          child: Material(type: MaterialType.transparency, child: child),
+        ),
+      ),
+    );
+  }
+}
+
+class _SkillsPopoverContent extends StatelessWidget {
+  const _SkillsPopoverContent({
+    required this.skills,
+    required this.assistantId,
+    required this.onManageSkills,
+    required this.onClose,
+  });
+
+  final List<SkillMetadata> skills;
+  final String? assistantId;
+  final VoidCallback? onManageSkills;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 420),
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _SkillsPopoverHeader(
+              onManageSkills: onManageSkills == null
+                  ? null
+                  : () {
+                      onClose();
+                      onManageSkills?.call();
+                    },
+            ),
+            if (skills.isEmpty)
+              _SkillsPopoverEmpty(onImport: onManageSkills, onClose: onClose)
+            else
+              for (final (group, groupSkills) in groupSkillsByCategory(
+                skills,
+              )) ...[
+                Padding(
+                  padding: const EdgeInsets.only(top: 6, bottom: 2),
+                  child: _GroupHeaderRow(
+                    title:
+                        group ??
+                        AppLocalizations.of(context)!.skillsUncategorizedGroup,
+                  ),
+                ),
+                for (final skill in groupSkills)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 1),
+                    child: _SkillsRowItem(
+                      name: skill.name,
+                      description: skill.description,
+                      assistantId: assistantId,
+                    ),
+                  ),
+              ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SkillsPopoverHeader extends StatefulWidget {
+  const _SkillsPopoverHeader({required this.onManageSkills});
+
+  final VoidCallback? onManageSkills;
+
+  @override
+  State<_SkillsPopoverHeader> createState() => _SkillsPopoverHeaderState();
+}
+
+class _SkillsPopoverHeaderState extends State<_SkillsPopoverHeader> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final hoverBg = (isDark ? Colors.white : Colors.black).withValues(
+      alpha: isDark ? 0.10 : 0.06,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Icon(
+            Lucide.Sparkles,
+            size: 16,
+            color: cs.onSurface.withValues(alpha: 0.85),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              l10n.skillsTitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: AppFontWeights.emphasis,
+                color: cs.onSurface.withValues(alpha: 0.9),
+                decoration: TextDecoration.none,
+              ),
+            ),
+          ),
+          if (widget.onManageSkills != null)
+            MouseRegion(
+              cursor: SystemMouseCursors.click,
+              onEnter: (_) => setState(() => _hovered = true),
+              onExit: (_) => setState(() => _hovered = false),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  widget.onManageSkills?.call();
+                },
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 120),
+                  height: 32,
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  decoration: BoxDecoration(
+                    color: _hovered ? hoverBg : Colors.transparent,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(Lucide.BookOpen, size: 14, color: cs.primary),
+                      const SizedBox(width: 5),
+                      Text(
+                        l10n.skillsSheetManageAction,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: AppFontWeights.medium,
+                          color: cs.primary,
+                          decoration: TextDecoration.none,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SkillsPopoverEmpty extends StatelessWidget {
+  const _SkillsPopoverEmpty({required this.onImport, required this.onClose});
+
+  final VoidCallback? onImport;
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Lucide.BookOpen,
+            size: 28,
+            color: cs.onSurface.withValues(alpha: 0.3),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.skillsEmptyMessage,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13,
+              color: cs.onSurface.withValues(alpha: 0.6),
+            ),
+          ),
+          if (onImport != null) ...[
+            const SizedBox(height: 10),
+            TextButton.icon(
+              onPressed: () {
+                onClose();
+                onImport?.call();
+              },
+              icon: const Icon(Lucide.Download, size: 15),
+              label: Text(l10n.skillsSheetImportAction),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _GroupHeaderRow extends StatelessWidget {
+  const _GroupHeaderRow({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 30,
+      child: Row(
+        children: [
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: AppFontWeights.emphasis,
+                color: cs.onSurface.withValues(alpha: 0.75),
+                decoration: TextDecoration.none,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SkillsRowItem extends StatefulWidget {
+  const _SkillsRowItem({
+    required this.name,
+    required this.description,
+    required this.assistantId,
+  });
+
+  final String name;
+  final String description;
+  final String? assistantId;
+
+  @override
+  State<_SkillsRowItem> createState() => _SkillsRowItemState();
+}
+
+class _SkillsRowItemState extends State<_SkillsRowItem> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final hoverBg = (isDark ? Colors.white : Colors.black).withValues(
+      alpha: isDark ? 0.12 : 0.10,
+    );
+    final ap = context.watch<AssistantProvider>();
+    final assistant = widget.assistantId != null
+        ? ap.getById(widget.assistantId!)
+        : ap.currentAssistant;
+    final enabled = assistant?.skillIds.contains(widget.name) ?? false;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          if (assistant == null) return;
+          final ids = assistant.skillIds.toSet();
+          if (enabled) {
+            ids.remove(widget.name);
+          } else {
+            ids.add(widget.name);
+          }
+          ap.updateAssistant(
+            assistant.copyWith(skillIds: ids.toList(growable: false)),
+          );
+        },
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: _hovered ? hoverBg : Colors.transparent,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Icon(
+                Lucide.BookOpen,
+                size: 16,
+                color: enabled
+                    ? cs.primary
+                    : cs.onSurface.withValues(alpha: 0.7),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: AppFontWeights.medium,
+                        color: enabled ? cs.primary : cs.onSurface,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                    if (widget.description.isNotEmpty) ...[
+                      const SizedBox(height: 1),
+                      Text(
+                        widget.description,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11.5,
+                          fontWeight: AppFontWeights.regular,
+                          color: cs.onSurface.withValues(alpha: 0.65),
+                          decoration: TextDecoration.none,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              if (enabled)
+                Icon(Lucide.Check, size: 14, color: cs.primary)
+              else
+                const SizedBox(width: 14),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/assistant/pages/assistant_settings_edit_skills_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_skills_tab.dart
@@ -61,28 +61,125 @@ class _SkillsTabState extends State<_SkillsTab> {
       children: [
         _iosSectionCard(
           children: [
-            for (int i = 0; i < _skills.length; i++) ...[
-              if (i > 0) _iosDivider(context),
-              _SkillRow(
-                name: _skills[i].name,
-                description: _skills[i].description,
-                enabled: assistant.skillIds.contains(_skills[i].name),
-                onChanged: (value) {
-                  final ids = assistant.skillIds.toSet();
-                  if (value) {
-                    ids.add(_skills[i].name);
-                  } else {
-                    ids.remove(_skills[i].name);
-                  }
-                  context.read<AssistantProvider>().updateAssistant(
-                    assistant.copyWith(skillIds: ids.toList(growable: false)),
-                  );
-                },
+            _SkillsMasterRow(
+              enabledCount: _skills
+                  .where((s) => assistant.skillIds.contains(s.name))
+                  .length,
+              total: _skills.length,
+              allEnabled:
+                  _skills.isNotEmpty &&
+                  _skills.every((s) => assistant.skillIds.contains(s.name)),
+              onChanged: (value) {
+                final ids = value
+                    ? _skills.map((s) => s.name).toSet()
+                    : <String>{};
+                context.read<AssistantProvider>().updateAssistant(
+                  assistant.copyWith(skillIds: ids.toList(growable: false)),
+                );
+              },
+            ),
+            _iosDivider(context),
+            for (final (group, skills) in groupSkillsByCategory(_skills)) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 10, 16, 2),
+                child: Text(
+                  group ?? l10n.skillsUncategorizedGroup,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: AppFontWeights.semibold,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                ),
               ),
+              for (int i = 0; i < skills.length; i++) ...[
+                if (i > 0) _iosDivider(context),
+                _SkillRow(
+                  name: skills[i].name,
+                  description: skills[i].description,
+                  enabled: assistant.skillIds.contains(skills[i].name),
+                  onChanged: (value) {
+                    final ids = assistant.skillIds.toSet();
+                    if (value) {
+                      ids.add(skills[i].name);
+                    } else {
+                      ids.remove(skills[i].name);
+                    }
+                    context.read<AssistantProvider>().updateAssistant(
+                      assistant.copyWith(skillIds: ids.toList(growable: false)),
+                    );
+                  },
+                ),
+              ],
             ],
           ],
         ),
       ],
+    );
+  }
+}
+
+class _SkillsMasterRow extends StatelessWidget {
+  const _SkillsMasterRow({
+    required this.enabledCount,
+    required this.total,
+    required this.allEnabled,
+    required this.onChanged,
+  });
+
+  final int enabledCount;
+  final int total;
+  final bool allEnabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return _TactileRow(
+      onTap: () => onChanged(!allEnabled),
+      builder: (pressed) {
+        final baseColor = cs.onSurface.withValues(alpha: 0.9);
+        return _AnimatedPressColor(
+          pressed: pressed,
+          base: baseColor,
+          builder: (color) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 36,
+                    child: Icon(Lucide.Sparkles, size: 20, color: color),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.skillsEnableAll,
+                          style: TextStyle(fontSize: 15, color: color),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          l10n.skillsEnabledCount(enabledCount, total),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: cs.onSurface.withValues(alpha: 0.6),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  IosSwitch(value: allEnabled, onChanged: onChanged),
+                ],
+              ),
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -33,6 +33,7 @@ import '../../../desktop/mcp_servers_popover.dart';
 import '../../../desktop/mini_map_popover.dart';
 import '../../../desktop/quick_phrase_popover.dart';
 import '../../../desktop/instruction_injection_popover.dart';
+import '../../../desktop/skills_popover.dart';
 import '../../../desktop/world_book_popover.dart';
 import '../../../desktop/document_processing_popover.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -50,6 +51,9 @@ import '../../quick_phrase/widgets/quick_phrase_menu.dart';
 import '../widgets/chat_input_bar.dart';
 import '../widgets/mini_map_sheet.dart';
 import '../widgets/instruction_injection_sheet.dart';
+import '../../skills/pages/skills_page.dart';
+import '../../skills/skill_manager.dart';
+import '../../skills/widgets/skills_sheet.dart';
 import '../widgets/world_book_sheet.dart';
 import '../widgets/document_processing_sheet.dart';
 import '../widgets/learning_prompt_sheet.dart';
@@ -1436,6 +1440,7 @@ class _HomePageState extends State<HomePage>
       onUploadFiles: _controller.onPickFiles,
       onToggleLearningMode: _openInstructionInjectionPopover,
       onOpenWorldBook: _openWorldBookPopover,
+      onOpenSkills: _openSkillsPopover,
       onLongPressLearning: _showLearningPromptSheet,
       onClearContext: _controller.clearContext,
       onCompressContext: _handleDesktopCompressContext,
@@ -1652,6 +1657,29 @@ class _HomePageState extends State<HomePage>
       );
     } else {
       await showInstructionInjectionSheet(context, assistantId: assistantId);
+    }
+  }
+
+  Future<void> _openSkillsPopover() async {
+    final isDesktop = PlatformUtils.isDesktop;
+    final assistantId = context.read<AssistantProvider>().currentAssistantId;
+    final skills = await SkillManager.listSkills();
+    if (!mounted) return;
+
+    if (isDesktop) {
+      await showDesktopSkillsPopover(
+        context,
+        anchorKey: _inputBarKey,
+        skills: skills,
+        assistantId: assistantId,
+        onManageSkills: () {
+          Navigator.of(
+            context,
+          ).push(MaterialPageRoute(builder: (_) => const SkillsPage()));
+        },
+      );
+    } else {
+      await showSkillsSheet(context, assistantId: assistantId);
     }
   }
 

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -89,11 +89,13 @@ class ChatInputBar extends StatefulWidget {
     this.onUploadFiles,
     this.onToggleLearningMode,
     this.onOpenWorldBook,
+    this.onOpenSkills,
     this.onClearContext,
     this.onCompressContext,
     this.onLongPressLearning,
     this.learningModeActive = false,
     this.worldBookActive = false,
+    this.skillsActive = false,
     this.showMoreButton = true,
     this.showQuickPhraseButton = false,
     this.onQuickPhrase,
@@ -147,11 +149,13 @@ class ChatInputBar extends StatefulWidget {
   final VoidCallback? onUploadFiles;
   final VoidCallback? onToggleLearningMode;
   final VoidCallback? onOpenWorldBook;
+  final VoidCallback? onOpenSkills;
   final VoidCallback? onClearContext;
   final VoidCallback? onCompressContext;
   final VoidCallback? onLongPressLearning;
   final bool learningModeActive;
   final bool worldBookActive;
+  final bool skillsActive;
   final bool showMoreButton;
   final bool showQuickPhraseButton;
   final VoidCallback? onQuickPhrase;
@@ -1601,6 +1605,25 @@ class _ChatInputBarState extends State<ChatInputBar>
                 icon: Lucide.BookOpen,
                 label: l10n.worldBookTitle,
                 onTap: lockTap(widget.onOpenWorldBook),
+              ),
+            ),
+          );
+        }
+
+        if (widget.onOpenSkills != null) {
+          actions.add(
+            _OverflowAction(
+              width: normalButtonW,
+              builder: () => _CompactIconButton(
+                tooltip: l10n.skillsTitle,
+                icon: Lucide.Sparkles,
+                active: widget.skillsActive,
+                onTap: lockTap(widget.onOpenSkills),
+              ),
+              menu: DesktopContextMenuItem(
+                icon: Lucide.Sparkles,
+                label: l10n.skillsTitle,
+                onTap: lockTap(widget.onOpenSkills),
               ),
             ),
           );

--- a/lib/features/home/widgets/chat_input_section.dart
+++ b/lib/features/home/widgets/chat_input_section.dart
@@ -60,6 +60,7 @@ class ChatInputSection extends StatelessWidget {
     this.onUploadFiles,
     this.onToggleLearningMode,
     this.onOpenWorldBook, // 新增世界书支持桌面端
+    this.onOpenSkills,
     this.onLongPressLearning,
     this.onClearContext,
     this.onCompressContext,
@@ -106,6 +107,7 @@ class ChatInputSection extends StatelessWidget {
   final VoidCallback? onUploadFiles;
   final VoidCallback? onToggleLearningMode;
   final VoidCallback? onOpenWorldBook;
+  final VoidCallback? onOpenSkills;
   final VoidCallback? onLongPressLearning;
   final VoidCallback? onClearContext;
   final VoidCallback? onCompressContext;
@@ -190,6 +192,7 @@ class ChatInputSection extends StatelessWidget {
       onUploadFiles: isTablet ? onUploadFiles : null,
       onToggleLearningMode: isTablet ? onToggleLearningMode : null,
       onOpenWorldBook: hasWorldBooks ? onOpenWorldBook : null,
+      onOpenSkills: isTablet ? onOpenSkills : null,
       onLongPressLearning: isTablet ? onLongPressLearning : null,
       learningModeActive: isTablet
           ? context
@@ -202,6 +205,14 @@ class ChatInputSection extends StatelessWidget {
                 .watch<WorldBookProvider>()
                 .activeBookIdsFor(assistantId)
                 .isNotEmpty
+          : false,
+      skillsActive: isTablet
+          ? (context
+                    .watch<AssistantProvider>()
+                    .currentAssistant
+                    ?.skillIds
+                    .isNotEmpty ??
+                false)
           : false,
       showMoreButton: !isTablet,
       onClearContext: isTablet ? onClearContext : null,

--- a/lib/features/skills/pages/skills_page.dart
+++ b/lib/features/skills/pages/skills_page.dart
@@ -131,6 +131,7 @@ class _SkillsPageState extends State<SkillsPage> {
       return;
     }
     await _refresh();
+    await _promptEnableImported([name]);
   }
 
   Future<void> _showImportChoice() async {
@@ -387,47 +388,72 @@ class _SkillsPageState extends State<SkillsPage> {
       builder: (ctx) {
         return StatefulBuilder(
           builder: (ctx, setDialogState) {
+            final allSelected = selected.length == skills.length;
             return AlertDialog(
               title: Text(l10n.skillsGitHubSelectTitle),
               content: SizedBox(
                 width: 400,
-                child: ListView.builder(
-                  shrinkWrap: true,
-                  itemCount: skills.length,
-                  itemBuilder: (_, i) {
-                    final skill = skills[i];
-                    return ListTile(
-                      leading: IosCheckbox(
-                        value: selected.contains(i),
-                        onChanged: (v) {
-                          setDialogState(() {
-                            if (v) {
-                              selected.add(i);
-                            } else {
-                              selected.remove(i);
-                            }
-                          });
-                        },
-                      ),
-                      title: Text(skill.name),
-                      subtitle: skill.description.isNotEmpty
-                          ? Text(
-                              skill.description,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            )
-                          : null,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _TactileSelectAllRow(
+                      label: allSelected
+                          ? l10n.skillsDeselectAll
+                          : l10n.skillsSelectAll,
+                      checked: allSelected,
                       onTap: () {
                         setDialogState(() {
-                          if (selected.contains(i)) {
-                            selected.remove(i);
-                          } else {
-                            selected.add(i);
+                          selected.clear();
+                          if (!allSelected) {
+                            selected.addAll(
+                              List.generate(skills.length, (i) => i),
+                            );
                           }
                         });
                       },
-                    );
-                  },
+                    ),
+                    const SizedBox(height: 4),
+                    Flexible(
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: skills.length,
+                        itemBuilder: (_, i) {
+                          final skill = skills[i];
+                          return ListTile(
+                            leading: IosCheckbox(
+                              value: selected.contains(i),
+                              onChanged: (v) {
+                                setDialogState(() {
+                                  if (v) {
+                                    selected.add(i);
+                                  } else {
+                                    selected.remove(i);
+                                  }
+                                });
+                              },
+                            ),
+                            title: Text(skill.name),
+                            subtitle: skill.description.isNotEmpty
+                                ? Text(
+                                    skill.description,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  )
+                                : null,
+                            onTap: () {
+                              setDialogState(() {
+                                if (selected.contains(i)) {
+                                  selected.remove(i);
+                                } else {
+                                  selected.add(i);
+                                }
+                              });
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                  ],
                 ),
               ),
               actions: [
@@ -451,9 +477,43 @@ class _SkillsPageState extends State<SkillsPage> {
     );
   }
 
+  Future<void> _promptEnableImported(List<String> names) async {
+    if (names.isEmpty || !mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    final assistant = context.read<AssistantProvider>().currentAssistant;
+    if (assistant == null) return;
+
+    final enabled = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.skillsEnableImportedTitle),
+        content: Text(
+          l10n.skillsEnableImportedMessage(names.length, assistant.name),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(l10n.skillsEnableImportedDismiss),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(l10n.skillsEnableImportedAction),
+          ),
+        ],
+      ),
+    );
+    if (enabled != true || !mounted) return;
+
+    final ids = {...assistant.skillIds, ...names};
+    await context.read<AssistantProvider>().updateAssistant(
+      assistant.copyWith(skillIds: ids.toList(growable: false)),
+    );
+  }
+
   Future<void> _importDiscoveredSkills(List<_DiscoveredSkill> skills) async {
     int imported = 0;
     int failed = 0;
+    final importedNames = <String>[];
 
     for (final skill in skills) {
       final error = await SkillManager.saveSkillWithFiles(
@@ -464,6 +524,7 @@ class _SkillsPageState extends State<SkillsPage> {
         failed++;
       } else {
         imported++;
+        importedNames.add(skill.name);
       }
     }
 
@@ -480,6 +541,7 @@ class _SkillsPageState extends State<SkillsPage> {
       );
     }
     await _refresh();
+    await _promptEnableImported(importedNames);
   }
 
   Future<void> _importFromFile() async {
@@ -511,6 +573,7 @@ class _SkillsPageState extends State<SkillsPage> {
     } else {
       int imported = 0;
       int failed = 0;
+      final importedNames = <String>[];
       try {
         final content = await File(path).readAsString();
         final name = _extractNameFromFrontmatter(content);
@@ -525,6 +588,7 @@ class _SkillsPageState extends State<SkillsPage> {
             failed++;
           } else {
             imported++;
+            importedNames.add(name);
           }
         }
       } catch (_) {
@@ -544,6 +608,7 @@ class _SkillsPageState extends State<SkillsPage> {
         );
       }
       await _refresh();
+      await _promptEnableImported(importedNames);
     }
   }
 
@@ -588,7 +653,7 @@ class _SkillsPageState extends State<SkillsPage> {
         title: Text(l10n.skillsTitle),
         actions: [
           IconButton(
-            icon: const Icon(Lucide.Upload),
+            icon: const Icon(Lucide.Download),
             tooltip: l10n.skillsImportChoiceTitle,
             onPressed: _showImportChoice,
           ),
@@ -616,36 +681,279 @@ class _SkillsPageState extends State<SkillsPage> {
             )
           : RefreshIndicator(
               onRefresh: () async => _refresh(),
-              child: ListView.builder(
+              child: ListView(
                 padding: const EdgeInsets.all(16),
-                itemCount: _skills.length,
-                itemBuilder: (ctx, i) {
-                  final skill = _skills[i];
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    child: ListTile(
-                      leading: Icon(Lucide.BookOpen, color: cs.primary),
-                      title: Text(
-                        skill.name,
-                        style: TextStyle(fontWeight: AppFontWeights.semibold),
-                      ),
-                      subtitle: skill.description.isNotEmpty
-                          ? Text(
-                              skill.description,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            )
-                          : null,
-                      trailing: IconButton(
-                        icon: const Icon(Lucide.Trash2),
-                        color: cs.error,
-                        onPressed: () => _deleteSkill(skill.name),
+                children: [
+                  for (final (group, skills) in groupSkillsByCategory(
+                    _skills,
+                  )) ...[
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(4, 12, 4, 6),
+                      child: Text(
+                        group ?? l10n.skillsUncategorizedGroup,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: AppFontWeights.semibold,
+                          color: cs.onSurface.withValues(alpha: 0.55),
+                        ),
                       ),
                     ),
-                  );
-                },
+                    for (final skill in skills)
+                      Card(
+                        margin: const EdgeInsets.only(bottom: 8),
+                        child: ListTile(
+                          leading: Icon(Lucide.BookOpen, color: cs.primary),
+                          title: Text(
+                            skill.name,
+                            style: TextStyle(
+                              fontWeight: AppFontWeights.semibold,
+                            ),
+                          ),
+                          subtitle: skill.description.isNotEmpty
+                              ? Text(
+                                  skill.description,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                )
+                              : null,
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  maxWidth: 120,
+                                ),
+                                child: _CategoryTag(
+                                  category: skill.category,
+                                  label:
+                                      skill.category ??
+                                      l10n.skillsUncategorizedGroup,
+                                  onTap: () => _editCategory(skill),
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(Lucide.Trash2),
+                                color: cs.error,
+                                onPressed: () => _deleteSkill(skill.name),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                  ],
+                ],
               ),
             ),
+    );
+  }
+
+  Future<void> _editCategory(SkillMetadata skill) async {
+    final l10n = AppLocalizations.of(context)!;
+    final controller = TextEditingController(text: skill.category ?? '');
+    final known =
+        _skills
+            .map((s) => s.category)
+            .whereType<String>()
+            .where((c) => c.isNotEmpty)
+            .toSet()
+            .toList()
+          ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            return AlertDialog(
+              title: Text(l10n.skillsEditCategoryTitle),
+              content: SizedBox(
+                width: 400,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextField(
+                      controller: controller,
+                      autofocus: true,
+                      decoration: InputDecoration(
+                        hintText: l10n.skillsCategoryHint,
+                        border: const OutlineInputBorder(),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                      ),
+                      style: const TextStyle(fontSize: 13),
+                      onChanged: (_) => setDialogState(() {}),
+                      onSubmitted: (_) =>
+                          Navigator.of(ctx).pop(controller.text.trim()),
+                    ),
+                    if (known.isNotEmpty) ...[
+                      const SizedBox(height: 12),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          for (final c in known)
+                            _CategorySuggestionPill(
+                              label: c,
+                              onTap: () {
+                                controller.text = c;
+                                setDialogState(() {});
+                              },
+                            ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(''),
+                  child: Text(l10n.skillsCategoryClear),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  child: Text(MaterialLocalizations.of(ctx).cancelButtonLabel),
+                ),
+                FilledButton(
+                  onPressed: () =>
+                      Navigator.of(ctx).pop(controller.text.trim()),
+                  child: Text(MaterialLocalizations.of(ctx).okButtonLabel),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (result == null || !mounted) return;
+    final newCategory = result.trim();
+    if (newCategory == (skill.category ?? '')) return;
+    final error = await SkillManager.updateCategory(
+      skill.name,
+      newCategory.isEmpty ? null : newCategory,
+    );
+    if (error != null) {
+      if (!mounted) return;
+      showAppSnackBar(context, message: _localizeSaveError(error, l10n));
+      return;
+    }
+    await _refresh();
+  }
+}
+
+class _CategoryTag extends StatelessWidget {
+  const _CategoryTag({
+    required this.category,
+    required this.label,
+    required this.onTap,
+  });
+  final String? category;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final hasCategory = category != null && category!.isNotEmpty;
+    final fg = hasCategory ? cs.primary : cs.onSurface.withValues(alpha: 0.45);
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: hasCategory
+              ? cs.primary.withValues(alpha: 0.08)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: hasCategory
+                ? cs.primary.withValues(alpha: 0.3)
+                : cs.outlineVariant.withValues(alpha: 0.5),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              hasCategory ? Lucide.Folder : Lucide.FolderOpen,
+              size: 11,
+              color: fg,
+            ),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(fontSize: 11, color: fg),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategorySuggestionPill extends StatelessWidget {
+  const _CategorySuggestionPill({required this.label, required this.onTap});
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: cs.primary.withValues(alpha: 0.25)),
+        ),
+        child: Text(label, style: TextStyle(fontSize: 12, color: cs.primary)),
+      ),
+    );
+  }
+}
+
+class _TactileSelectAllRow extends StatelessWidget {
+  const _TactileSelectAllRow({
+    required this.label,
+    required this.checked,
+    required this.onTap,
+  });
+  final String label;
+  final bool checked;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+        child: Row(
+          children: [
+            IosCheckbox(value: checked, onChanged: (_) => onTap()),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(fontSize: 14, color: cs.onSurface),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/features/skills/skill_manager.dart
+++ b/lib/features/skills/skill_manager.dart
@@ -8,12 +8,14 @@ import 'skill_paths.dart';
 class SkillMetadata {
   final String name;
   final String description;
+  final String? category;
   final String body;
 
   const SkillMetadata({
     required this.name,
     required this.description,
     required this.body,
+    this.category,
   });
 }
 
@@ -46,6 +48,25 @@ class SkillFileContent {
     required this.truncated,
     required this.size,
   });
+}
+
+/// Groups skills by their optional category, sorted A-Z with the
+/// uncategorized group (null/empty category) last.
+List<(String?, List<SkillMetadata>)> groupSkillsByCategory(
+  List<SkillMetadata> skills,
+) {
+  final groups = <String?, List<SkillMetadata>>{};
+  for (final skill in skills) {
+    (groups[skill.category] ??= []).add(skill);
+  }
+  final keys = groups.keys.toList()
+    ..sort((a, b) {
+      final aa = a ?? '';
+      final bb = b ?? '';
+      if (aa.isEmpty != bb.isEmpty) return aa.isEmpty ? 1 : -1;
+      return aa.toLowerCase().compareTo(bb.toLowerCase());
+    });
+  return [for (final key in keys) (key, groups[key]!)];
 }
 
 class SkillManager {
@@ -137,10 +158,12 @@ class SkillManager {
 
       final skillName = parsed.fields['name'] ?? name;
       final description = parsed.fields['description'] ?? '';
+      final category = parsed.fields['category']?.trim();
       skills.add(
         SkillMetadata(
           name: skillName,
           description: description,
+          category: (category == null || category.isEmpty) ? null : category,
           body: parsed.body,
         ),
       );
@@ -163,9 +186,11 @@ class SkillManager {
 
     final skillName = parsed.fields['name'] ?? name;
     final description = parsed.fields['description'] ?? '';
+    final category = parsed.fields['category']?.trim();
     return SkillMetadata(
       name: skillName,
       description: description,
+      category: (category == null || category.isEmpty) ? null : category,
       body: parsed.body,
     );
   }
@@ -296,6 +321,114 @@ class SkillManager {
     }
 
     return null;
+  }
+
+  /// Updates the optional `category` frontmatter field of an existing skill.
+  ///
+  /// A null or empty [category] removes the field (the skill then falls back
+  /// to the uncategorized group). Only SKILL.md is rewritten, in place, via a
+  /// same-directory temp file + atomic rename — auxiliary files in the skill
+  /// directory (references/, scripts/, images) are preserved.
+  static Future<SkillSaveError?> updateCategory(
+    String name,
+    String? category,
+  ) async {
+    final dirName = _dirNameFor(name);
+    if (dirName == null) {
+      return const SkillSaveError('name_invalid');
+    }
+
+    final root = await _getSkillsRoot();
+    final skillFilePath = SkillPaths.skillFilePath(root, dirName);
+    final content = await _readFileContent(skillFilePath);
+    if (content == null) {
+      return const SkillSaveError('io_error', {'detail': 'SKILL.md not found'});
+    }
+
+    final newCategory = category?.trim();
+    if (newCategory != null &&
+        (newCategory.contains('\n') || newCategory.contains('\r'))) {
+      return const SkillSaveError('io_error', {'detail': 'Invalid category'});
+    }
+
+    // Locate the frontmatter block in the original content and splice the
+    // rewritten block back in, preserving everything outside it (trailing
+    // newlines, body whitespace, CRLF line endings).
+    final start = content.indexOf('---');
+    if (start == -1 || content.substring(0, start).trim().isNotEmpty) {
+      return const SkillSaveError('invalid_frontmatter');
+    }
+    final end = content.indexOf('---', start + 3);
+    if (end == -1) {
+      return const SkillSaveError('invalid_frontmatter');
+    }
+
+    final raw = content.substring(start + 3, end);
+    final newRaw = _rewriteCategoryLine(raw, newCategory);
+    final newContent =
+        '${content.substring(0, start)}---$newRaw---'
+        '${content.substring(end + 3)}';
+
+    // Round-trip: YAML may silently mangle the value (e.g. `foo # bar`
+    // becomes the comment `foo`). Reject if it doesn't parse back.
+    final parsed = parseFrontmatter(newContent);
+    if (parsed == null) {
+      return const SkillSaveError('invalid_frontmatter');
+    }
+    final requested = (newCategory == null || newCategory.isEmpty)
+        ? null
+        : newCategory;
+    final parsedCategory = parsed.fields['category']?.trim();
+    if ((parsedCategory ?? '') != (requested ?? '')) {
+      return const SkillSaveError('invalid_frontmatter');
+    }
+
+    final tmpId = DateTime.now().microsecondsSinceEpoch;
+    final tmpFile = File('$skillFilePath.cat.$tmpId.tmp');
+    try {
+      await tmpFile.writeAsBytes(utf8.encode(newContent), flush: true);
+      await tmpFile.rename(skillFilePath);
+    } catch (e) {
+      try {
+        if (await tmpFile.exists()) {
+          await tmpFile.delete();
+        }
+      } catch (_) {}
+      return SkillSaveError('io_error', {
+        'detail': 'Failed to update SKILL.md: $e',
+      });
+    }
+    return null;
+  }
+
+  static String _rewriteCategoryLine(String raw, String? category) {
+    var text = raw;
+    if (text.endsWith('\n')) {
+      text = text.substring(0, text.length - 1);
+    }
+    final lines = text.split('\n');
+    final out = <String>[];
+    var replaced = false;
+    for (final line in lines) {
+      final trimmedStart = line.trimLeft();
+      if (trimmedStart.toLowerCase().startsWith('category:')) {
+        if (category == null || category.isEmpty) continue;
+        // Preserve the matched line's leading indentation and its \r so
+        // CRLF files stay CRLF.
+        final indent = line.substring(0, line.length - trimmedStart.length);
+        final carriageReturn = line.endsWith('\r') ? '\r' : '';
+        out.add('${indent}category: $category$carriageReturn');
+        replaced = true;
+      } else {
+        out.add(line);
+      }
+    }
+    if (!replaced && category != null && category.isNotEmpty) {
+      // Match the file's line-ending convention for the appended line.
+      final carriageReturn = lines.any((l) => l.endsWith('\r')) ? '\r' : '';
+      out.add('category: $category$carriageReturn');
+    }
+    return '${out.join('\n')}\n';
   }
 
   static Future<void> deleteSkill(String name) async {

--- a/lib/features/skills/widgets/skills_sheet.dart
+++ b/lib/features/skills/widgets/skills_sheet.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/assistant.dart';
+import '../../../core/providers/assistant_provider.dart';
+import '../../../core/services/haptics.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_switch.dart';
+import '../../../shared/widgets/ios_tactile.dart';
+import '../../../theme/app_font_weights.dart';
+import '../pages/skills_page.dart';
+import '../skill_manager.dart';
+
+/// Bottom sheet for toggling the current assistant's skills.
+///
+/// Mirrors the instruction-injection sheet entry point so skills are as
+/// discoverable as instruction prompts from the chat input bar.
+class SkillsSheet extends StatefulWidget {
+  const SkillsSheet({super.key, required this.assistantId});
+
+  final String? assistantId;
+
+  @override
+  State<SkillsSheet> createState() => _SkillsSheetState();
+}
+
+class _SkillsSheetState extends State<SkillsSheet> {
+  List<SkillMetadata> _skills = const [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final skills = await SkillManager.listSkills();
+    if (!mounted) return;
+    setState(() {
+      _skills = skills;
+      _loading = false;
+    });
+  }
+
+  void _toggle(Assistant assistant, String name, bool value) {
+    final ids = assistant.skillIds.toSet();
+    if (value) {
+      ids.add(name);
+    } else {
+      ids.remove(name);
+    }
+    context.read<AssistantProvider>().updateAssistant(
+      assistant.copyWith(skillIds: ids.toList(growable: false)),
+    );
+  }
+
+  void _openManagePage() {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const SkillsPage()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final ap = context.watch<AssistantProvider>();
+    final assistant = widget.assistantId != null
+        ? ap.getById(widget.assistantId!)
+        : ap.currentAssistant;
+
+    return SafeArea(
+      top: false,
+      child: DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.5,
+        maxChildSize: 0.85,
+        minChildSize: 0.45,
+        builder: (ctx, controller) {
+          return Column(
+            children: [
+              _SheetTopBar(
+                title: l10n.skillsTitle,
+                onBack: () => Navigator.of(ctx).maybePop(),
+                onManage: _openManagePage,
+              ),
+              const Divider(height: 1, thickness: 0.5),
+              Expanded(
+                child: _loading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _skills.isEmpty
+                    ? _SkillsEmptyState(onImport: _openManagePage)
+                    : assistant == null
+                    ? Center(
+                        child: Text(
+                          l10n.assistantEditPageNotFound,
+                          style: TextStyle(
+                            color: cs.onSurface.withValues(alpha: 0.6),
+                          ),
+                        ),
+                      )
+                    : ListView(
+                        controller: controller,
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                        children: [
+                          for (final (group, skills) in groupSkillsByCategory(
+                            _skills,
+                          )) ...[
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
+                              child: Text(
+                                group ?? l10n.skillsUncategorizedGroup,
+                                style: TextStyle(
+                                  fontSize: 12.5,
+                                  fontWeight: AppFontWeights.emphasis,
+                                  color: cs.onSurface.withValues(alpha: 0.55),
+                                ),
+                              ),
+                            ),
+                            for (final skill in skills)
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 6),
+                                child: _SkillSheetRow(
+                                  name: skill.name,
+                                  description: skill.description,
+                                  enabled: assistant.skillIds.contains(
+                                    skill.name,
+                                  ),
+                                  onChanged: (v) =>
+                                      _toggle(assistant, skill.name, v),
+                                ),
+                              ),
+                          ],
+                        ],
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SheetTopBar extends StatelessWidget {
+  const _SheetTopBar({
+    required this.title,
+    required this.onBack,
+    required this.onManage,
+  });
+
+  final String title;
+  final VoidCallback onBack;
+  final VoidCallback onManage;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 52,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            _NavIconButton(icon: Lucide.ArrowLeft, onTap: onBack),
+            Expanded(
+              child: Center(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: AppFontWeights.emphasis,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+            ),
+            Tooltip(
+              message: l10n.skillsSheetManageAction,
+              child: _NavIconButton(icon: Lucide.BookOpen, onTap: onManage),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NavIconButton extends StatelessWidget {
+  const _NavIconButton({required this.icon, required this.onTap});
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: 40,
+      height: 40,
+      child: IosCardPress(
+        borderRadius: BorderRadius.circular(12),
+        baseColor: Colors.transparent,
+        duration: const Duration(milliseconds: 200),
+        padding: EdgeInsets.zero,
+        onTap: () {
+          Haptics.light();
+          onTap();
+        },
+        child: Center(child: Icon(icon, size: 20, color: cs.onSurface)),
+      ),
+    );
+  }
+}
+
+class _SkillSheetRow extends StatelessWidget {
+  const _SkillSheetRow({
+    required this.name,
+    required this.description,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final String name;
+  final String description;
+  final bool enabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final iconColor = enabled
+        ? cs.primary
+        : cs.onSurface.withValues(alpha: 0.7);
+    return IosCardPress(
+      borderRadius: BorderRadius.circular(14),
+      baseColor: cs.surface,
+      duration: const Duration(milliseconds: 260),
+      onTap: () => onChanged(!enabled),
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Row(
+        children: [
+          Icon(Lucide.BookOpen, size: 20, color: iconColor),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: AppFontWeights.medium,
+                    color: cs.onSurface,
+                  ),
+                ),
+                if (description.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    description,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: cs.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          IosSwitch(value: enabled, onChanged: onChanged),
+        ],
+      ),
+    );
+  }
+}
+
+class _SkillsEmptyState extends StatelessWidget {
+  const _SkillsEmptyState({required this.onImport});
+
+  final VoidCallback onImport;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Lucide.BookOpen,
+              size: 36,
+              color: cs.onSurface.withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l10n.skillsEmptyMessage,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13.5,
+                color: cs.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: onImport,
+              icon: const Icon(Lucide.Download, size: 16),
+              label: Text(l10n.skillsSheetImportAction),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows the skills bottom sheet.
+///
+/// This is a convenience function to show the sheet with proper styling.
+Future<void> showSkillsSheet(
+  BuildContext context, {
+  required String? assistantId,
+}) async {
+  final cs = Theme.of(context).colorScheme;
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: cs.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (sheetCtx) {
+      return SkillsSheet(assistantId: assistantId);
+    },
+  );
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3095,6 +3095,40 @@
   "skillsDeleteConfirmDeleteButton": "Delete",
   "assistantEditPageSkillsTab": "Skills",
   "settingsPageSkills": "Skills",
+  "skillsUncategorizedGroup": "Uncategorized",
+  "skillsEditCategoryTitle": "Edit Category",
+  "skillsCategoryHint": "e.g. coding, writing, research",
+  "skillsCategoryClear": "No category",
+  "skillsEnableAll": "Enable all",
+  "skillsEnabledCount": "Enabled {enabled} of {total}",
+  "@skillsEnabledCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "skillsSelectAll": "Select all",
+  "skillsDeselectAll": "Deselect all",
+  "skillsEnableImportedTitle": "Enable skills?",
+  "skillsEnableImportedMessage": "Enable {count} imported skill(s) for \"{assistantName}\"?",
+  "@skillsEnableImportedMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "assistantName": {
+        "type": "String"
+      }
+    }
+  },
+  "skillsEnableImportedAction": "Enable",
+  "skillsEnableImportedDismiss": "Not now",
+  "skillsSheetManageAction": "Manage skills",
+  "skillsSheetImportAction": "Import skills",
   "responseTruncated": "Response was truncated ({reason}). The content may be incomplete.",
   "@responseTruncated": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -11918,6 +11918,90 @@ abstract class AppLocalizations {
   /// **'Skills'**
   String get settingsPageSkills;
 
+  /// No description provided for @skillsUncategorizedGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Uncategorized'**
+  String get skillsUncategorizedGroup;
+
+  /// No description provided for @skillsEditCategoryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Category'**
+  String get skillsEditCategoryTitle;
+
+  /// No description provided for @skillsCategoryHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. coding, writing, research'**
+  String get skillsCategoryHint;
+
+  /// No description provided for @skillsCategoryClear.
+  ///
+  /// In en, this message translates to:
+  /// **'No category'**
+  String get skillsCategoryClear;
+
+  /// No description provided for @skillsEnableAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable all'**
+  String get skillsEnableAll;
+
+  /// No description provided for @skillsEnabledCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Enabled {enabled} of {total}'**
+  String skillsEnabledCount(int enabled, int total);
+
+  /// No description provided for @skillsSelectAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Select all'**
+  String get skillsSelectAll;
+
+  /// No description provided for @skillsDeselectAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Deselect all'**
+  String get skillsDeselectAll;
+
+  /// No description provided for @skillsEnableImportedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable skills?'**
+  String get skillsEnableImportedTitle;
+
+  /// No description provided for @skillsEnableImportedMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable {count} imported skill(s) for \"{assistantName}\"?'**
+  String skillsEnableImportedMessage(int count, String assistantName);
+
+  /// No description provided for @skillsEnableImportedAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable'**
+  String get skillsEnableImportedAction;
+
+  /// No description provided for @skillsEnableImportedDismiss.
+  ///
+  /// In en, this message translates to:
+  /// **'Not now'**
+  String get skillsEnableImportedDismiss;
+
+  /// No description provided for @skillsSheetManageAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage skills'**
+  String get skillsSheetManageAction;
+
+  /// No description provided for @skillsSheetImportAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Import skills'**
+  String get skillsSheetImportAction;
+
   /// No description provided for @responseTruncated.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6534,6 +6534,52 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsPageSkills => 'Skills';
 
   @override
+  String get skillsUncategorizedGroup => 'Uncategorized';
+
+  @override
+  String get skillsEditCategoryTitle => 'Edit Category';
+
+  @override
+  String get skillsCategoryHint => 'e.g. coding, writing, research';
+
+  @override
+  String get skillsCategoryClear => 'No category';
+
+  @override
+  String get skillsEnableAll => 'Enable all';
+
+  @override
+  String skillsEnabledCount(int enabled, int total) {
+    return 'Enabled $enabled of $total';
+  }
+
+  @override
+  String get skillsSelectAll => 'Select all';
+
+  @override
+  String get skillsDeselectAll => 'Deselect all';
+
+  @override
+  String get skillsEnableImportedTitle => 'Enable skills?';
+
+  @override
+  String skillsEnableImportedMessage(int count, String assistantName) {
+    return 'Enable $count imported skill(s) for \"$assistantName\"?';
+  }
+
+  @override
+  String get skillsEnableImportedAction => 'Enable';
+
+  @override
+  String get skillsEnableImportedDismiss => 'Not now';
+
+  @override
+  String get skillsSheetManageAction => 'Manage skills';
+
+  @override
+  String get skillsSheetImportAction => 'Import skills';
+
+  @override
   String responseTruncated(String reason) {
     return 'Response was truncated ($reason). The content may be incomplete.';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6175,7 +6175,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get multiAIAddModelTooltip => '添加模型';
 
   @override
-  String get skillsTitle => '技能';
+  String get skillsTitle => 'skills';
 
   @override
   String get skillsImportManualTitle => '手动添加';
@@ -6187,7 +6187,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsImportFileLabel => '从文件导入';
 
   @override
-  String get skillsImportChoiceTitle => '导入技能';
+  String get skillsImportChoiceTitle => '导入 skills';
 
   @override
   String get skillsImportFromFile => '从文件导入';
@@ -6209,13 +6209,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '选择要导入的技能';
+  String get skillsGitHubSelectTitle => '选择要导入的 skills';
 
   @override
-  String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
+  String get skillsEmptyMessage => '暂无 skills。从文件导入或手动创建一个。';
 
   @override
-  String get skillsDeleteConfirmTitle => '删除技能';
+  String get skillsDeleteConfirmTitle => '删除 skills';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -6224,7 +6224,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已导入 $count 个技能';
+    return '已导入 $count 个 skills';
   }
 
   @override
@@ -6237,29 +6237,75 @@ class AppLocalizationsZh extends AppLocalizations {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
+  String get skillsNameInvalid => 'skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '保存技能失败：$detail';
+    return '保存 skills 失败：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '导入 $count 个技能失败';
+    return '导入 $count 个 skills 失败';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '删除';
 
   @override
-  String get assistantEditPageSkillsTab => '技能';
+  String get assistantEditPageSkillsTab => 'skills';
 
   @override
-  String get settingsPageSkills => '技能';
+  String get settingsPageSkills => 'skills';
+
+  @override
+  String get skillsUncategorizedGroup => '未分类';
+
+  @override
+  String get skillsEditCategoryTitle => '编辑分类';
+
+  @override
+  String get skillsCategoryHint => '例如：编程、写作、研究';
+
+  @override
+  String get skillsCategoryClear => '无分类';
+
+  @override
+  String get skillsEnableAll => '全部启用';
+
+  @override
+  String skillsEnabledCount(int enabled, int total) {
+    return '已启用 $enabled/$total';
+  }
+
+  @override
+  String get skillsSelectAll => '全选';
+
+  @override
+  String get skillsDeselectAll => '全不选';
+
+  @override
+  String get skillsEnableImportedTitle => '启用 skills？';
+
+  @override
+  String skillsEnableImportedMessage(int count, String assistantName) {
+    return '为“$assistantName”启用 $count 个已导入的 skills？';
+  }
+
+  @override
+  String get skillsEnableImportedAction => '启用';
+
+  @override
+  String get skillsEnableImportedDismiss => '暂不';
+
+  @override
+  String get skillsSheetManageAction => '管理 skills';
+
+  @override
+  String get skillsSheetImportAction => '导入 skills';
 
   @override
   String responseTruncated(String reason) {
@@ -12709,7 +12755,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get multiAIAddModelTooltip => '添加模型';
 
   @override
-  String get skillsTitle => '技能';
+  String get skillsTitle => 'skills';
 
   @override
   String get skillsImportManualTitle => '手动添加';
@@ -12721,7 +12767,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsImportFileLabel => '从文件导入';
 
   @override
-  String get skillsImportChoiceTitle => '导入技能';
+  String get skillsImportChoiceTitle => '导入 skills';
 
   @override
   String get skillsImportFromFile => '从文件导入';
@@ -12743,13 +12789,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '选择要导入的技能';
+  String get skillsGitHubSelectTitle => '选择要导入的 skills';
 
   @override
-  String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
+  String get skillsEmptyMessage => '暂无 skills。从文件导入或手动创建一个。';
 
   @override
-  String get skillsDeleteConfirmTitle => '删除技能';
+  String get skillsDeleteConfirmTitle => '删除 skills';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -12758,7 +12804,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已导入 $count 个技能';
+    return '已导入 $count 个 skills';
   }
 
   @override
@@ -12771,29 +12817,75 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
+  String get skillsNameInvalid => 'skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '保存技能失败：$detail';
+    return '保存 skills 失败：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '导入 $count 个技能失败';
+    return '导入 $count 个 skills 失败';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '删除';
 
   @override
-  String get assistantEditPageSkillsTab => '技能';
+  String get assistantEditPageSkillsTab => 'skills';
 
   @override
-  String get settingsPageSkills => '技能';
+  String get settingsPageSkills => 'skills';
+
+  @override
+  String get skillsUncategorizedGroup => '未分类';
+
+  @override
+  String get skillsEditCategoryTitle => '编辑分类';
+
+  @override
+  String get skillsCategoryHint => '例如：编程、写作、研究';
+
+  @override
+  String get skillsCategoryClear => '无分类';
+
+  @override
+  String get skillsEnableAll => '全部启用';
+
+  @override
+  String skillsEnabledCount(int enabled, int total) {
+    return '已启用 $enabled/$total';
+  }
+
+  @override
+  String get skillsSelectAll => '全选';
+
+  @override
+  String get skillsDeselectAll => '全不选';
+
+  @override
+  String get skillsEnableImportedTitle => '启用 skills？';
+
+  @override
+  String skillsEnableImportedMessage(int count, String assistantName) {
+    return '为“$assistantName”启用 $count 个已导入的 skills？';
+  }
+
+  @override
+  String get skillsEnableImportedAction => '启用';
+
+  @override
+  String get skillsEnableImportedDismiss => '暂不';
+
+  @override
+  String get skillsSheetManageAction => '管理 skills';
+
+  @override
+  String get skillsSheetImportAction => '导入 skills';
 
   @override
   String responseTruncated(String reason) {
@@ -19243,7 +19335,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get multiAIAddModelTooltip => '新增模型';
 
   @override
-  String get skillsTitle => '技能';
+  String get skillsTitle => 'skills';
 
   @override
   String get skillsImportManualTitle => '手動新增';
@@ -19255,7 +19347,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsImportFileLabel => '從檔案匯入';
 
   @override
-  String get skillsImportChoiceTitle => '匯入技能';
+  String get skillsImportChoiceTitle => '匯入 skills';
 
   @override
   String get skillsImportFromFile => '從檔案匯入';
@@ -19277,13 +19369,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsGitHubDownloadFailed => '下載儲存庫失敗。儲存庫可能不存在或為私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '選擇要匯入的技能';
+  String get skillsGitHubSelectTitle => '選擇要匯入的 skills';
 
   @override
-  String get skillsEmptyMessage => '暫無技能。從檔案匯入或手動建立一個。';
+  String get skillsEmptyMessage => '暫無 skills。從檔案匯入或手動建立一個。';
 
   @override
-  String get skillsDeleteConfirmTitle => '刪除技能';
+  String get skillsDeleteConfirmTitle => '刪除 skills';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -19292,7 +19384,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已匯入 $count 個技能';
+    return '已匯入 $count 個 skills';
   }
 
   @override
@@ -19305,29 +19397,75 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       'SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。';
 
   @override
-  String get skillsNameInvalid => '技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。';
+  String get skillsNameInvalid => 'skills 名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元資料必須包含 name 欄位。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '儲存技能失敗：$detail';
+    return '儲存 skills 失敗：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '匯入 $count 個技能失敗';
+    return '匯入 $count 個 skills 失敗';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '刪除';
 
   @override
-  String get assistantEditPageSkillsTab => '技能';
+  String get assistantEditPageSkillsTab => 'skills';
 
   @override
-  String get settingsPageSkills => '技能';
+  String get settingsPageSkills => 'skills';
+
+  @override
+  String get skillsUncategorizedGroup => '未分類';
+
+  @override
+  String get skillsEditCategoryTitle => '編輯分類';
+
+  @override
+  String get skillsCategoryHint => '例如：程式設計、寫作、研究';
+
+  @override
+  String get skillsCategoryClear => '無分類';
+
+  @override
+  String get skillsEnableAll => '全部啟用';
+
+  @override
+  String skillsEnabledCount(int enabled, int total) {
+    return '已啟用 $enabled/$total';
+  }
+
+  @override
+  String get skillsSelectAll => '全選';
+
+  @override
+  String get skillsDeselectAll => '全不選';
+
+  @override
+  String get skillsEnableImportedTitle => '啟用 skills？';
+
+  @override
+  String skillsEnableImportedMessage(int count, String assistantName) {
+    return '為「$assistantName」啟用 $count 個已匯入的 skills？';
+  }
+
+  @override
+  String get skillsEnableImportedAction => '啟用';
+
+  @override
+  String get skillsEnableImportedDismiss => '暫不';
+
+  @override
+  String get skillsSheetManageAction => '管理 skills';
+
+  @override
+  String get skillsSheetImportAction => '匯入 skills';
 
   @override
   String responseTruncated(String reason) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2482,20 +2482,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按钮的提示"
   },
-  "skillsTitle": "技能",
+  "skillsTitle": "skills",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
-  "skillsImportChoiceTitle": "导入技能",
+  "skillsImportChoiceTitle": "导入 skills",
   "skillsImportFromFile": "从文件导入",
   "skillsImportFromGitHub": "从 GitHub URL 导入",
   "skillsGitHubImportTitle": "从 GitHub 导入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
-  "skillsGitHubSelectTitle": "选择要导入的技能",
-  "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
-  "skillsDeleteConfirmTitle": "删除技能",
+  "skillsGitHubSelectTitle": "选择要导入的 skills",
+  "skillsEmptyMessage": "暂无 skills。从文件导入或手动创建一个。",
+  "skillsDeleteConfirmTitle": "删除 skills",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2504,7 +2504,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已导入 {count} 个技能",
+  "skillsImportSuccess": "已导入 {count} 个 skills",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2524,9 +2524,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
+  "skillsNameInvalid": "skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
-  "skillsSaveFailed": "保存技能失败：{detail}",
+  "skillsSaveFailed": "保存 skills 失败：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2534,7 +2534,7 @@
       }
     }
   },
-  "skillsImportFailed": "导入 {count} 个技能失败",
+  "skillsImportFailed": "导入 {count} 个 skills 失败",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2543,8 +2543,42 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "删除",
-  "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能",
+  "assistantEditPageSkillsTab": "skills",
+  "settingsPageSkills": "skills",
+  "skillsUncategorizedGroup": "未分类",
+  "skillsEditCategoryTitle": "编辑分类",
+  "skillsCategoryHint": "例如：编程、写作、研究",
+  "skillsCategoryClear": "无分类",
+  "skillsEnableAll": "全部启用",
+  "skillsEnabledCount": "已启用 {enabled}/{total}",
+  "@skillsEnabledCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "skillsSelectAll": "全选",
+  "skillsDeselectAll": "全不选",
+  "skillsEnableImportedTitle": "启用 skills？",
+  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的 skills？",
+  "@skillsEnableImportedMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "assistantName": {
+        "type": "String"
+      }
+    }
+  },
+  "skillsEnableImportedAction": "启用",
+  "skillsEnableImportedDismiss": "暂不",
+  "skillsSheetManageAction": "管理 skills",
+  "skillsSheetImportAction": "导入 skills",
   "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
   "@responseTruncated": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2454,20 +2454,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按钮的提示"
   },
-  "skillsTitle": "技能",
+  "skillsTitle": "skills",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
-  "skillsImportChoiceTitle": "导入技能",
+  "skillsImportChoiceTitle": "导入 skills",
   "skillsImportFromFile": "从文件导入",
   "skillsImportFromGitHub": "从 GitHub URL 导入",
   "skillsGitHubImportTitle": "从 GitHub 导入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
-  "skillsGitHubSelectTitle": "选择要导入的技能",
-  "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
-  "skillsDeleteConfirmTitle": "删除技能",
+  "skillsGitHubSelectTitle": "选择要导入的 skills",
+  "skillsEmptyMessage": "暂无 skills。从文件导入或手动创建一个。",
+  "skillsDeleteConfirmTitle": "删除 skills",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2476,7 +2476,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已导入 {count} 个技能",
+  "skillsImportSuccess": "已导入 {count} 个 skills",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2496,9 +2496,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
+  "skillsNameInvalid": "skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
-  "skillsSaveFailed": "保存技能失败：{detail}",
+  "skillsSaveFailed": "保存 skills 失败：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2506,7 +2506,7 @@
       }
     }
   },
-  "skillsImportFailed": "导入 {count} 个技能失败",
+  "skillsImportFailed": "导入 {count} 个 skills 失败",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2515,8 +2515,42 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "删除",
-  "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能",
+  "assistantEditPageSkillsTab": "skills",
+  "settingsPageSkills": "skills",
+  "skillsUncategorizedGroup": "未分类",
+  "skillsEditCategoryTitle": "编辑分类",
+  "skillsCategoryHint": "例如：编程、写作、研究",
+  "skillsCategoryClear": "无分类",
+  "skillsEnableAll": "全部启用",
+  "skillsEnabledCount": "已启用 {enabled}/{total}",
+  "@skillsEnabledCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "skillsSelectAll": "全选",
+  "skillsDeselectAll": "全不选",
+  "skillsEnableImportedTitle": "启用 skills？",
+  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的 skills？",
+  "@skillsEnableImportedMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "assistantName": {
+        "type": "String"
+      }
+    }
+  },
+  "skillsEnableImportedAction": "启用",
+  "skillsEnableImportedDismiss": "暂不",
+  "skillsSheetManageAction": "管理 skills",
+  "skillsSheetImportAction": "导入 skills",
   "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
   "@responseTruncated": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2482,20 +2482,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按鈕的提示"
   },
-  "skillsTitle": "技能",
+  "skillsTitle": "skills",
   "skillsImportManualTitle": "手動新增",
   "skillsImportManualHint": "貼上完整的 SKILL.md 內容（包含 YAML 前置元資料）",
   "skillsImportFileLabel": "從檔案匯入",
-  "skillsImportChoiceTitle": "匯入技能",
+  "skillsImportChoiceTitle": "匯入 skills",
   "skillsImportFromFile": "從檔案匯入",
   "skillsImportFromGitHub": "從 GitHub URL 匯入",
   "skillsGitHubImportTitle": "從 GitHub 匯入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "無效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下載儲存庫失敗。儲存庫可能不存在或為私有。",
-  "skillsGitHubSelectTitle": "選擇要匯入的技能",
-  "skillsEmptyMessage": "暫無技能。從檔案匯入或手動建立一個。",
-  "skillsDeleteConfirmTitle": "刪除技能",
+  "skillsGitHubSelectTitle": "選擇要匯入的 skills",
+  "skillsEmptyMessage": "暫無 skills。從檔案匯入或手動建立一個。",
+  "skillsDeleteConfirmTitle": "刪除 skills",
   "skillsDeleteConfirmMessage": "確定刪除 \"{name}\"？此操作不可復原。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2504,7 +2504,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已匯入 {count} 個技能",
+  "skillsImportSuccess": "已匯入 {count} 個 skills",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2524,9 +2524,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。",
-  "skillsNameInvalid": "技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。",
+  "skillsNameInvalid": "skills 名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元資料必須包含 name 欄位。",
-  "skillsSaveFailed": "儲存技能失敗：{detail}",
+  "skillsSaveFailed": "儲存 skills 失敗：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2534,7 +2534,7 @@
       }
     }
   },
-  "skillsImportFailed": "匯入 {count} 個技能失敗",
+  "skillsImportFailed": "匯入 {count} 個 skills 失敗",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2543,8 +2543,42 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "刪除",
-  "assistantEditPageSkillsTab": "技能",
-  "settingsPageSkills": "技能",
+  "assistantEditPageSkillsTab": "skills",
+  "settingsPageSkills": "skills",
+  "skillsUncategorizedGroup": "未分類",
+  "skillsEditCategoryTitle": "編輯分類",
+  "skillsCategoryHint": "例如：程式設計、寫作、研究",
+  "skillsCategoryClear": "無分類",
+  "skillsEnableAll": "全部啟用",
+  "skillsEnabledCount": "已啟用 {enabled}/{total}",
+  "@skillsEnabledCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "skillsSelectAll": "全選",
+  "skillsDeselectAll": "全不選",
+  "skillsEnableImportedTitle": "啟用 skills？",
+  "skillsEnableImportedMessage": "為「{assistantName}」啟用 {count} 個已匯入的 skills？",
+  "@skillsEnableImportedMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "assistantName": {
+        "type": "String"
+      }
+    }
+  },
+  "skillsEnableImportedAction": "啟用",
+  "skillsEnableImportedDismiss": "暫不",
+  "skillsSheetManageAction": "管理 skills",
+  "skillsSheetImportAction": "匯入 skills",
   "responseTruncated": "回答已被截斷（{reason}），內容可能不完整",
   "@responseTruncated": {
     "placeholders": {

--- a/test/features/skills/skill_manager_test.dart
+++ b/test/features/skills/skill_manager_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:Cuplivo/features/skills/skill_manager.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$root/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$root/tmp';
+}
+
+String _skillMd(String name, {String? category, String body = 'body text'}) {
+  final cat = category == null ? '' : 'category: $category\n';
+  return '---\nname: $name\n${cat}description: test skill\n---\n$body';
+}
+
+void main() {
+  late Directory root;
+
+  setUpAll(() async {
+    root = await Directory.systemTemp.createTemp('skills_test_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(root.path);
+  });
+
+  tearDownAll(() async {
+    if (await root.exists()) {
+      await root.delete(recursive: true);
+    }
+  });
+
+  group('SkillManager category parsing', () {
+    test('parseFrontmatter reads the category field', () {
+      final parsed = SkillManager.parseFrontmatter(
+        _skillMd('alpha', category: 'coding'),
+      );
+      expect(parsed?.fields['category'], 'coding');
+    });
+
+    test('parseFrontmatter returns null category when absent', () {
+      final parsed = SkillManager.parseFrontmatter(_skillMd('alpha'));
+      expect(parsed?.fields['category'], isNull);
+    });
+
+    test('listSkills exposes category and trims it', () async {
+      await SkillManager.saveSkill(
+        name: 'alpha',
+        content: _skillMd('alpha', category: '  coding  '),
+      );
+      await SkillManager.saveSkill(name: 'beta', content: _skillMd('beta'));
+      final skills = await SkillManager.listSkills();
+      final alpha = skills.firstWhere((s) => s.name == 'alpha');
+      final beta = skills.firstWhere((s) => s.name == 'beta');
+      expect(alpha.category, 'coding');
+      expect(beta.category, isNull);
+    });
+
+    test('readSkill exposes category', () async {
+      await SkillManager.saveSkill(
+        name: 'gamma',
+        content: _skillMd('gamma', category: 'research'),
+      );
+      final meta = await SkillManager.readSkill('gamma');
+      expect(meta?.category, 'research');
+    });
+  });
+
+  group('SkillManager.updateCategory', () {
+    test('adds a category to a skill without one', () async {
+      await SkillManager.saveSkill(name: 'delta', content: _skillMd('delta'));
+      expect(await SkillManager.updateCategory('delta', 'research'), isNull);
+      final skills = await SkillManager.listSkills();
+      expect(skills.firstWhere((s) => s.name == 'delta').category, 'research');
+    });
+
+    test('updates an existing category and preserves name/body', () async {
+      await SkillManager.saveSkill(
+        name: 'echo',
+        content: _skillMd('echo', category: 'old', body: 'keep me'),
+      );
+      expect(await SkillManager.updateCategory('echo', 'new'), isNull);
+      final meta = await SkillManager.readSkill('echo');
+      expect(meta?.name, 'echo');
+      expect(meta?.category, 'new');
+      expect(meta?.body, 'keep me');
+    });
+
+    test('clears the category when null is passed', () async {
+      await SkillManager.saveSkill(
+        name: 'foxtrot',
+        content: _skillMd('foxtrot', category: 'coding'),
+      );
+      expect(await SkillManager.updateCategory('foxtrot', null), isNull);
+      final meta = await SkillManager.readSkill('foxtrot');
+      expect(meta?.category, isNull);
+    });
+
+    test('clears the category when only whitespace is passed', () async {
+      await SkillManager.saveSkill(
+        name: 'golf',
+        content: _skillMd('golf', category: 'coding'),
+      );
+      expect(await SkillManager.updateCategory('golf', '   '), isNull);
+      final meta = await SkillManager.readSkill('golf');
+      expect(meta?.category, isNull);
+    });
+
+    test('rejects a category containing a newline', () async {
+      await SkillManager.saveSkill(name: 'hotel', content: _skillMd('hotel'));
+      final error = await SkillManager.updateCategory('hotel', 'a\nb');
+      expect(error, isNotNull);
+      expect(error?.code, 'io_error');
+      final meta = await SkillManager.readSkill('hotel');
+      expect(meta?.category, isNull);
+    });
+
+    test('returns an error for an unknown skill', () async {
+      final error = await SkillManager.updateCategory(
+        'missing-skill',
+        'coding',
+      );
+      expect(error, isNotNull);
+      expect(error?.code, 'io_error');
+    });
+
+    test('preserves auxiliary files in the skill directory', () async {
+      await SkillManager.saveSkillWithFiles(
+        name: 'india',
+        files: {
+          'SKILL.md': utf8.encode(_skillMd('india')),
+          'references/ref.md': utf8.encode('# ref'),
+          'scripts/run.sh': utf8.encode('#!/bin/sh'),
+        },
+      );
+      expect(await SkillManager.updateCategory('india', 'coding'), isNull);
+      final ref = await SkillManager.readSkillFile(
+        'india',
+        'references/ref.md',
+      );
+      expect(ref?.content, '# ref');
+      final script = await SkillManager.readSkillFile(
+        'india',
+        'scripts/run.sh',
+      );
+      expect(script?.content, '#!/bin/sh');
+      final meta = await SkillManager.readSkill('india');
+      expect(meta?.category, 'coding');
+    });
+
+    test('preserves body trailing newlines', () async {
+      await SkillManager.saveSkill(
+        name: 'juliet',
+        content: '${_skillMd('juliet', category: 'a')}\n\n',
+      );
+      expect(await SkillManager.updateCategory('juliet', 'b'), isNull);
+      final text = await File(
+        '${root.path}/skills/juliet/SKILL.md',
+      ).readAsString();
+      expect(text.endsWith('\n\n'), isTrue);
+      expect(text, contains('category: b\n'));
+    });
+
+    test('preserves CRLF line endings', () async {
+      const crlf =
+          '---\r\nname: kilo\r\ncategory: a\r\ndescription: test skill\r\n'
+          '---\r\nbody\r\n';
+      await SkillManager.saveSkill(name: 'kilo', content: crlf);
+      expect(await SkillManager.updateCategory('kilo', 'b'), isNull);
+      final text = await File(
+        '${root.path}/skills/kilo/SKILL.md',
+      ).readAsString();
+      expect(text, contains('category: b\r\n'));
+      final lines = text.split('\n');
+      for (final line in lines.take(lines.length - 1)) {
+        expect(
+          line.endsWith('\r'),
+          isTrue,
+          reason: 'mixed line ending in "$line"',
+        );
+      }
+    });
+
+    test('rejects a category YAML silently mangles', () async {
+      await SkillManager.saveSkill(name: 'lima', content: _skillMd('lima'));
+      final error = await SkillManager.updateCategory('lima', 'foo # bar');
+      expect(error, isNotNull);
+      expect(error?.code, 'invalid_frontmatter');
+      final meta = await SkillManager.readSkill('lima');
+      expect(meta?.category, isNull);
+    });
+  });
+
+  group('groupSkillsByCategory', () {
+    test('sorts groups A-Z and puts uncategorized last', () {
+      final skills = [
+        const SkillMetadata(name: 'c', description: '', body: ''),
+        const SkillMetadata(
+          name: 'a',
+          description: '',
+          body: '',
+          category: 'zeta',
+        ),
+        const SkillMetadata(
+          name: 'b',
+          description: '',
+          body: '',
+          category: 'alpha',
+        ),
+      ];
+      final groups = groupSkillsByCategory(skills);
+      expect(groups.map((g) => g.$1).toList(), ['alpha', 'zeta', null]);
+      expect(groups[0].$2.single.name, 'b');
+      expect(groups[1].$2.single.name, 'a');
+      expect(groups[2].$2.single.name, 'c');
+    });
+
+    test('returns a single uncategorized group for empty categories', () {
+      final skills = [
+        const SkillMetadata(name: 'a', description: '', body: ''),
+        const SkillMetadata(name: 'b', description: '', body: ''),
+      ];
+      final groups = groupSkillsByCategory(skills);
+      expect(groups.length, 1);
+      expect(groups.single.$1, isNull);
+      expect(groups.single.$2.map((s) => s.name), ['a', 'b']);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #126.

- rename zh UI term 技能 -> skills across zh/zh_Hans/zh_Hant ARB
- fix import button icon (Upload -> Download)
- optional category frontmatter with in-place atomic SKILL.md rewrite, round-trip validation, and click-to-edit tag in SkillsPage
- group skills by category in skills page, assistant tab, and chat sheet
- add per-assistant enable-all master toggle with enabled count
- add select-all/deselect-all in import dialog and post-import enable prompt
- add chat input-bar skills button with mobile sheet and desktop popover