### PR TITLE
feat(proactive-care): use background tool calls for care-time decision

### DIFF
--- a/lib/core/services/proactive_care_decision_tools.dart
+++ b/lib/core/services/proactive_care_decision_tools.dart
@@ -1,0 +1,72 @@
+/// Tool names and OpenAI-shaped function definitions for the proactive care
+/// ("Ta的来信") decision flow. Mirrors DirectorTools (group chat).
+class ProactiveCareDecisionTools {
+  ProactiveCareDecisionTools._();
+
+  static const updateTime = 'update_care_time';
+  static const keepTime = 'keep_care_time';
+
+  static List<Map<String, dynamic>> definitions() {
+    return [
+      {
+        'type': 'function',
+        'function': {
+          'name': updateTime,
+          'description':
+              'Change the next proactive care message time to a new time.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'next_care_time': {
+                'type': 'string',
+                'description':
+                    'ISO 8601 local time, e.g. 2026-08-04T09:30:00. '
+                    'Must be later than the current system time.',
+              },
+            },
+            'required': ['next_care_time'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': keepTime,
+          'description':
+              'Keep the currently scheduled next care time unchanged.',
+          'parameters': {'type': 'object', 'properties': {}},
+        },
+      },
+    ];
+  }
+
+  /// Validates update_care_time args with the exact semantics of the removed
+  /// JSON decision parser: ISO-8601 parse, UTC→local, strictly after [now].
+  /// Any invalid/missing/past input → null (= keep current time).
+  static DateTime? parseUpdateTimeArgs(
+    Map<String, dynamic> args, {
+    required DateTime now,
+  }) {
+    final raw = args['next_care_time'];
+    if (raw is! String || raw.trim().isEmpty) return null;
+    final parsed = DateTime.tryParse(raw.trim());
+    if (parsed == null) return null;
+    final local = parsed.isUtc ? parsed.toLocal() : parsed;
+    if (!local.isAfter(now)) return null;
+    return local;
+  }
+
+  /// Lenient tool-name matching, mirrors DirectorRunner._parseTool.
+  static String _normalize(String name) =>
+      name.trim().toLowerCase().replaceAll('-', '_');
+
+  static bool isUpdateTime(String name) {
+    final n = _normalize(name);
+    return n == updateTime || n.endsWith(updateTime);
+  }
+
+  static bool isKeepTime(String name) {
+    final n = _normalize(name);
+    return n == keepTime || n.endsWith(keepTime);
+  }
+}

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
 
@@ -16,9 +17,28 @@ import 'chat/prompt_transformer.dart';
 import 'instruction_injection_store.dart';
 import 'logging/flutter_logger.dart';
 import 'memory_store.dart';
+import 'proactive_care_decision_tools.dart';
 import 'proactive_care_service.dart';
 
 const String _logTag = 'ProactiveCareFlow';
+
+/// Stream source signature for the decision flow (injectable for tests).
+/// Subset of [ChatApiService.sendMessageStream], same idea as
+/// DirectorStreamSender.
+typedef ProactiveCareDecisionSender =
+    Stream<ChatStreamChunk> Function({
+      required ProviderConfig config,
+      required String modelId,
+      required List<Map<String, dynamic>> messages,
+      List<Map<String, dynamic>>? tools,
+      ToolCallHandler? onToolCall,
+      int? thinkingBudget,
+      double? temperature,
+      double? topP,
+      int? maxTokens,
+      bool stream,
+      String? requestId,
+    });
 
 /// Snapshot of localized strings needed by the proactive care background
 /// isolate, which has no BuildContext / AppLocalizations. The main isolate
@@ -99,6 +119,11 @@ class ProactiveCareModelConfig {
 /// killed). Only data loading and persistence differ between the two paths:
 /// the main isolate uses providers + ChatService, the background isolate uses
 /// SQLite via [ProactiveCareHeadlessChatStore].
+///
+/// The decision flow (Pipeline ①) uses the same transport as normal chat
+/// ([ChatApiService.sendMessageStream]) with provider-default
+/// `tool_choice: auto` (not `required`), so DeepSeek and other
+/// OpenAI-compatible hosts that reject forced tools still work.
 class ProactiveCareMessageFlow {
   const ProactiveCareMessageFlow._();
 
@@ -445,9 +470,11 @@ class ProactiveCareMessageFlow {
     return buf.toString().trim();
   }
 
+  static const Duration _decisionTimeout = Duration(seconds: 45);
+
   /// Silently asks the decision model for the next proactive care time
-  /// (Pipeline ①). Returns null when the model declines, fails, or returns
-  /// an invalid/past time.
+  /// (Pipeline ①) via tool calls. Returns null when the model keeps the
+  /// current time, declines, fails, or returns an invalid/past time.
   static Future<DateTime?> decideNextCareTime({
     required ProviderConfig config,
     required String modelId,
@@ -456,8 +483,10 @@ class ProactiveCareMessageFlow {
     required List<Map<String, dynamic>> history,
     required String decisionPrompt,
     int? fallbackThinkingBudget,
+    ProactiveCareDecisionSender? sendMessageStream,
   }) async {
     if (history.isEmpty) return null;
+    final send = sendMessageStream ?? ChatApiService.sendMessageStream;
     final now = DateTime.now();
 
     String personaPrompt = '';
@@ -492,29 +521,159 @@ class ProactiveCareMessageFlow {
       personaPrompt: personaPrompt,
       memoriesBlock: memoriesBlock,
     );
+    final tools = ProactiveCareDecisionTools.definitions();
+    final baseRequestId =
+        'proactive-care-decision-${assistant.id}-${DateTime.now().microsecondsSinceEpoch}';
+
+    final first = await _callDecisionOnce(
+      send: send,
+      config: config,
+      modelId: modelId,
+      messages: apiMessages,
+      tools: tools,
+      assistant: assistant,
+      fallbackThinkingBudget: fallbackThinkingBudget,
+      now: now,
+      requestId: baseRequestId,
+    );
+    if (first.decided) return first.time;
+
+    // One Director-style retry with an explicit tool-only directive.
+    final retryMessages = List<Map<String, dynamic>>.from(apiMessages)
+      ..add({
+        'role': 'user',
+        'content':
+            '你必须只通过调用工具给出决策：修改时间调用 update_care_time'
+            '（参数 next_care_time 为 ISO 8601 格式的未来时间），'
+            '保持不变调用 keep_care_time。不要输出自由文本。',
+      });
+    final second = await _callDecisionOnce(
+      send: send,
+      config: config,
+      modelId: modelId,
+      messages: retryMessages,
+      tools: tools,
+      assistant: assistant,
+      fallbackThinkingBudget: fallbackThinkingBudget,
+      now: now,
+      requestId: '$baseRequestId-retry',
+    );
+    if (second.decided) return second.time;
+
+    FlutterLogger.log(
+      'Decision finished without a tool call; keeping current time',
+      tag: _logTag,
+    );
+    return null;
+  }
+
+  /// One decision attempt. `decided == true` means a recognized tool call
+  /// settled the outcome (`time` may still be null = keep current time);
+  /// `decided == false` means the attempt produced no decision (free text,
+  /// error, timeout) and the caller may retry.
+  static Future<({bool decided, DateTime? time})> _callDecisionOnce({
+    required ProactiveCareDecisionSender send,
+    required ProviderConfig config,
+    required String modelId,
+    required List<Map<String, dynamic>> messages,
+    required List<Map<String, dynamic>> tools,
+    required Assistant assistant,
+    required int? fallbackThinkingBudget,
+    required DateTime now,
+    required String requestId,
+  }) async {
+    var decided = false;
+    DateTime? decisionTime;
+    final completer = Completer<DateTime?>();
+    StreamSubscription<ChatStreamChunk>? sub;
+
+    void finish(DateTime? time) {
+      if (decided) return;
+      decided = true;
+      decisionTime = time;
+      if (!completer.isCompleted) completer.complete(time);
+      // The first recognized tool call IS the decision. Cancel the stream so
+      // the provider cannot start follow-up tool rounds (Director pattern).
+      unawaited(sub?.cancel());
+      ChatApiService.cancelRequest(requestId);
+    }
+
+    void maybeDecide(String name, Map<String, dynamic> args) {
+      if (decided) return;
+      if (ProactiveCareDecisionTools.isKeepTime(name)) {
+        finish(null);
+      } else if (ProactiveCareDecisionTools.isUpdateTime(name)) {
+        final time = ProactiveCareDecisionTools.parseUpdateTimeArgs(
+          args,
+          now: now,
+        );
+        if (time == null) {
+          FlutterLogger.log(
+            'Decision update_care_time args invalid/past: $args',
+            tag: _logTag,
+          );
+        }
+        finish(time); // invalid/past → null → keep current time (final)
+      }
+      // Unknown tool names: stay undecided; neutral result keeps stream going.
+    }
+
+    Future<String> onToolCall(
+      String name,
+      Map<String, dynamic> args, {
+      String? toolCallId,
+    }) async {
+      maybeDecide(name, args);
+      // Keep the result neutral — never 'ignored' (models retry-loop on it).
+      return jsonEncode({'ok': true});
+    }
 
     try {
-      final buf = StringBuffer();
-      await for (final chunk in ChatApiService.sendMessageStream(
+      final stream = send(
         config: config,
         modelId: modelId,
-        messages: apiMessages,
+        messages: messages,
+        tools: tools,
+        onToolCall: onToolCall,
         thinkingBudget: assistant.thinkingBudget ?? fallbackThinkingBudget,
         temperature: assistant.temperature,
         topP: assistant.topP,
         maxTokens: assistant.maxTokens,
         stream: false,
-      )) {
-        buf.write(chunk.content);
-      }
-      return ProactiveCareService.parseDecision(
-        buf.toString(),
-        now: DateTime.now(),
+        requestId: requestId,
+      );
+
+      sub = stream.listen(
+        (chunk) {
+          if (decided) return;
+          final calls = chunk.toolCalls;
+          if (calls == null || calls.isEmpty) return;
+          for (final c in calls) {
+            maybeDecide(c.name, Map<String, dynamic>.from(c.arguments));
+            if (decided) break;
+          }
+        },
+        onError: (Object e) {
+          if (!completer.isCompleted) completer.completeError(e);
+        },
+        onDone: () {
+          if (!completer.isCompleted) completer.complete(null);
+        },
+        cancelOnError: true,
+      );
+
+      await completer.future.timeout(
+        _decisionTimeout,
+        onTimeout: () {
+          unawaited(sub?.cancel());
+          ChatApiService.cancelRequest(requestId);
+          throw TimeoutException('proactive care decision timeout');
+        },
       );
     } catch (e) {
-      FlutterLogger.log('Decision request failed: $e', tag: _logTag);
-      return null;
+      FlutterLogger.log('Decision call failed: $e', tag: _logTag);
     }
+    return (decided: decided, time: decisionTime);
   }
 }
 

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -529,6 +529,14 @@ class ProactiveCareMessageFlow {
     final baseRequestId =
         'proactive-care-decision-${assistant.id}-${DateTime.now().microsecondsSinceEpoch}';
 
+    void logSettled(String attempt, DateTime? time) {
+      FlutterLogger.log(
+        'Decision settled ($attempt, model: $modelId): '
+        '${time?.toIso8601String() ?? 'keep current time'}',
+        tag: _logTag,
+      );
+    }
+
     final first = await _callDecisionOnce(
       send: send,
       config: config,
@@ -541,11 +549,7 @@ class ProactiveCareMessageFlow {
       requestId: baseRequestId,
     );
     if (first.decided) {
-      FlutterLogger.log(
-        'Decision settled: '
-        '${first.time?.toIso8601String() ?? 'keep current time'}',
-        tag: _logTag,
-      );
+      logSettled('attempt 1', first.time);
       return first.time;
     }
 
@@ -567,11 +571,7 @@ class ProactiveCareMessageFlow {
       requestId: '$baseRequestId-retry',
     );
     if (second.decided) {
-      FlutterLogger.log(
-        'Decision settled: '
-        '${second.time?.toIso8601String() ?? 'keep current time'}',
-        tag: _logTag,
-      );
+      logSettled('retry', second.time);
       return second.time;
     }
 

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -475,6 +475,9 @@ class ProactiveCareMessageFlow {
   /// Silently asks the decision model for the next proactive care time
   /// (Pipeline ①) via tool calls. Returns null when the model keeps the
   /// current time, declines, fails, or returns an invalid/past time.
+  ///
+  /// [decisionTimeout] bounds each attempt's stream (tests inject a tiny
+  /// value); defaults to [_decisionTimeout].
   static Future<DateTime?> decideNextCareTime({
     required ProviderConfig config,
     required String modelId,
@@ -484,6 +487,7 @@ class ProactiveCareMessageFlow {
     required String decisionPrompt,
     int? fallbackThinkingBudget,
     ProactiveCareDecisionSender? sendMessageStream,
+    Duration decisionTimeout = _decisionTimeout,
   }) async {
     if (history.isEmpty) return null;
     final send = sendMessageStream ?? ChatApiService.sendMessageStream;
@@ -533,19 +537,23 @@ class ProactiveCareMessageFlow {
       tools: tools,
       assistant: assistant,
       fallbackThinkingBudget: fallbackThinkingBudget,
-      now: now,
+      timeout: decisionTimeout,
       requestId: baseRequestId,
     );
-    if (first.decided) return first.time;
+    if (first.decided) {
+      FlutterLogger.log(
+        'Decision settled: '
+        '${first.time?.toIso8601String() ?? 'keep current time'}',
+        tag: _logTag,
+      );
+      return first.time;
+    }
 
     // One Director-style retry with an explicit tool-only directive.
     final retryMessages = List<Map<String, dynamic>>.from(apiMessages)
       ..add({
         'role': 'user',
-        'content':
-            '你必须只通过调用工具给出决策：修改时间调用 update_care_time'
-            '（参数 next_care_time 为 ISO 8601 格式的未来时间），'
-            '保持不变调用 keep_care_time。不要输出自由文本。',
+        'content': ProactiveCareService.builtinDecisionToolOnlyDirective,
       });
     final second = await _callDecisionOnce(
       send: send,
@@ -555,13 +563,21 @@ class ProactiveCareMessageFlow {
       tools: tools,
       assistant: assistant,
       fallbackThinkingBudget: fallbackThinkingBudget,
-      now: now,
+      timeout: decisionTimeout,
       requestId: '$baseRequestId-retry',
     );
-    if (second.decided) return second.time;
+    if (second.decided) {
+      FlutterLogger.log(
+        'Decision settled: '
+        '${second.time?.toIso8601String() ?? 'keep current time'}',
+        tag: _logTag,
+      );
+      return second.time;
+    }
 
     FlutterLogger.log(
-      'Decision finished without a tool call; keeping current time',
+      'Decision finished without a tool call (model: $modelId); '
+      'keeping current time',
       tag: _logTag,
     );
     return null;
@@ -579,7 +595,7 @@ class ProactiveCareMessageFlow {
     required List<Map<String, dynamic>> tools,
     required Assistant assistant,
     required int? fallbackThinkingBudget,
-    required DateTime now,
+    required Duration timeout,
     required String requestId,
   }) async {
     var decided = false;
@@ -603,13 +619,16 @@ class ProactiveCareMessageFlow {
       if (ProactiveCareDecisionTools.isKeepTime(name)) {
         finish(null);
       } else if (ProactiveCareDecisionTools.isUpdateTime(name)) {
+        // Validate against a fresh clock: the request-level `now` (time
+        // footer) can be stale by the time a tool call arrives.
         final time = ProactiveCareDecisionTools.parseUpdateTimeArgs(
           args,
-          now: now,
+          now: DateTime.now(),
         );
         if (time == null) {
           FlutterLogger.log(
-            'Decision update_care_time args invalid/past: $args',
+            'Decision ${ProactiveCareDecisionTools.updateTime} args '
+            'invalid/past: $args',
             tag: _logTag,
           );
         }
@@ -663,7 +682,7 @@ class ProactiveCareMessageFlow {
       );
 
       await completer.future.timeout(
-        _decisionTimeout,
+        timeout,
         onTimeout: () {
           unawaited(sub?.cancel());
           ChatApiService.cancelRequest(requestId);

--- a/lib/core/services/proactive_care_service.dart
+++ b/lib/core/services/proactive_care_service.dart
@@ -1,4 +1,5 @@
 import '../models/assistant_memory.dart';
+import 'proactive_care_decision_tools.dart';
 
 /// Pure logic for the proactive care ("Ta的来信") decision flow.
 ///
@@ -12,8 +13,17 @@ class ProactiveCareService {
   /// decision request (LLM only). Mirrors DirectorContextBuilder's
   /// tool-only reminder.
   static const String builtinDecisionToolReminder =
-      '请只通过调用工具给出决策：需要修改时间时调用 update_care_time，'
-      '保持不变时调用 keep_care_time。不要输出其他内容。';
+      '请只通过调用工具给出决策：需要修改时间时调用 '
+      '${ProactiveCareDecisionTools.updateTime}，'
+      '保持不变时调用 ${ProactiveCareDecisionTools.keepTime}。不要输出其他内容。';
+
+  /// Built-in tool-only retry directive appended as an extra user message
+  /// when the first decision attempt produced no tool call (LLM only).
+  static const String builtinDecisionToolOnlyDirective =
+      '你必须只通过调用工具给出决策：修改时间调用 '
+      '${ProactiveCareDecisionTools.updateTime}'
+      '（参数 next_care_time 为 ISO 8601 格式的未来时间），'
+      '保持不变调用 ${ProactiveCareDecisionTools.keepTime}。不要输出自由文本。';
 
   /// Prefix before the assistant persona in the decision request (LLM only).
   static const String personaReferencePrefix = '以下是供你参考的助手人设';

--- a/lib/core/services/proactive_care_service.dart
+++ b/lib/core/services/proactive_care_service.dart
@@ -1,25 +1,19 @@
-import 'dart:convert';
-
 import '../models/assistant_memory.dart';
 
 /// Pure logic for the proactive care ("Ta的来信") decision flow.
 ///
 /// After each completed assistant reply, the full conversation context plus
 /// the decision prompt built here is sent silently to the decision model.
-/// The model answers with a JSON decision that may update the assistant's
-/// next proactive message time.
+/// The model answers by calling one of the decision tools
+/// (`update_care_time` / `keep_care_time`); see
+/// `ProactiveCareDecisionTools`.
 class ProactiveCareService {
-  /// Built-in JSON output rules for the decision request (LLM only).
-  ///
-  /// Time fields are appended separately via [buildDecisionTimeFooter] after
-  /// the chat history.
-  static const String builtinDecisionJsonRules = '''
-【输出要求】
-你必须严格以 JSON 格式输出，不要包含任何额外文字：
-{
-  "should_update": true或false,
-  "next_care_time": "ISO 8601格式的时间字符串，如2026-06-12T10:00:00"
-}''';
+  /// Built-in tool-only reminder appended to the final user message of the
+  /// decision request (LLM only). Mirrors DirectorContextBuilder's
+  /// tool-only reminder.
+  static const String builtinDecisionToolReminder =
+      '请只通过调用工具给出决策：需要修改时间时调用 update_care_time，'
+      '保持不变时调用 keep_care_time。不要输出其他内容。';
 
   /// Prefix before the assistant persona in the decision request (LLM only).
   static const String personaReferencePrefix = '以下是供你参考的助手人设';
@@ -47,12 +41,13 @@ class ProactiveCareService {
 
   /// Assembles the full silent decision API message list (Pipeline ①):
   ///
-  /// 1. `system`: user decision prompt + JSON output rules (no times)
+  /// 1. `system`: user decision prompt (when non-empty)
   /// 2. `user` (optional): persona reference prefix + assistant system prompt
   /// 3. `user` (optional): memories reference prefix + memory block
   /// 4. `user`: chat history header (when [history] is non-empty)
   /// 5. ...[history] (user/assistant turns, unchanged)
-  /// 6. `user`: next care time + current system time (always last)
+  /// 6. `user`: next care time + current system time + tool reminder
+  ///    (always last)
   static List<Map<String, dynamic>> buildDecisionApiMessages({
     required String decisionPrompt,
     required DateTime? currentNextCareTime,
@@ -63,11 +58,10 @@ class ProactiveCareService {
   }) {
     final messages = <Map<String, dynamic>>[];
 
-    final systemParts = <String>[
-      if (decisionPrompt.trim().isNotEmpty) decisionPrompt.trim(),
-      builtinDecisionJsonRules.trim(),
-    ];
-    messages.add({'role': 'system', 'content': systemParts.join('\n\n')});
+    final prompt = decisionPrompt.trim();
+    if (prompt.isNotEmpty) {
+      messages.add({'role': 'system', 'content': prompt});
+    }
 
     final persona = personaPrompt.trim();
     if (persona.isNotEmpty) {
@@ -92,10 +86,9 @@ class ProactiveCareService {
 
     messages.add({
       'role': 'user',
-      'content': buildDecisionTimeFooter(
-        now: now,
-        currentNextCareTime: currentNextCareTime,
-      ),
+      'content':
+          '${buildDecisionTimeFooter(now: now, currentNextCareTime: currentNextCareTime)}'
+          '\n\n$builtinDecisionToolReminder',
     });
 
     return messages;
@@ -136,43 +129,5 @@ class ProactiveCareService {
     final head = carePrompt.trim();
     if (head.isEmpty) return time;
     return '$head\n\n$time';
-  }
-
-  /// Parses the LLM decision reply.
-  ///
-  /// Returns the new next-care time only when `should_update` is true and
-  /// `next_care_time` parses to a time later than [now] (mirroring the date
-  /// picker constraint that past times are not allowed). Returns null in all
-  /// other cases (invalid JSON, should_update=false, past/invalid time).
-  static DateTime? parseDecision(String raw, {required DateTime now}) {
-    final jsonText = _extractJsonObject(raw);
-    if (jsonText == null) return null;
-
-    Object? decoded;
-    try {
-      decoded = jsonDecode(jsonText);
-    } catch (_) {
-      return null;
-    }
-    if (decoded is! Map) return null;
-
-    if (decoded['should_update'] != true) return null;
-    final rawTime = decoded['next_care_time'];
-    if (rawTime is! String || rawTime.trim().isEmpty) return null;
-    final parsed = DateTime.tryParse(rawTime.trim());
-    if (parsed == null) return null;
-
-    final local = parsed.isUtc ? parsed.toLocal() : parsed;
-    if (!local.isAfter(now)) return null;
-    return local;
-  }
-
-  /// Extracts the first balanced top-level `{...}` block, tolerating
-  /// markdown code fences and surrounding prose.
-  static String? _extractJsonObject(String raw) {
-    final start = raw.indexOf('{');
-    final end = raw.lastIndexOf('}');
-    if (start < 0 || end <= start) return null;
-    return raw.substring(start, end + 1);
   }
 }

--- a/test/core/services/proactive_care_decision_test.dart
+++ b/test/core/services/proactive_care_decision_test.dart
@@ -1,0 +1,518 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+import 'package:Cuplivo/core/services/proactive_care_decision_tools.dart';
+import 'package:Cuplivo/core/services/proactive_care_message_flow.dart';
+import 'package:Cuplivo/core/services/proactive_care_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Queued fake transport: one [StreamController] per send attempt, so the
+/// retry path gets its own stream. Modeled on the director retry test fake.
+class _FakeDecisionTransport {
+  final List<StreamController<ChatStreamChunk>> _pending = [];
+  final List<bool> subscriptionCancelled = [];
+  final List<List<Map<String, dynamic>>> capturedMessages = [];
+  final List<List<Map<String, dynamic>>?> capturedTools = [];
+  final List<ToolCallHandler?> capturedHandlers = [];
+  final List<String?> capturedRequestIds = [];
+  int sendCount = 0;
+
+  StreamController<ChatStreamChunk> enqueue() {
+    final index = _pending.length;
+    final controller = StreamController<ChatStreamChunk>();
+    controller.onCancel = () => subscriptionCancelled[index] = true;
+    _pending.add(controller);
+    subscriptionCancelled.add(false);
+    return controller;
+  }
+
+  Stream<ChatStreamChunk> send({
+    required ProviderConfig config,
+    required String modelId,
+    required List<Map<String, dynamic>> messages,
+    List<Map<String, dynamic>>? tools,
+    ToolCallHandler? onToolCall,
+    int? thinkingBudget,
+    double? temperature,
+    double? topP,
+    int? maxTokens,
+    bool stream = true,
+    String? requestId,
+  }) {
+    final index = sendCount++;
+    capturedMessages.add(messages);
+    capturedTools.add(tools);
+    capturedHandlers.add(onToolCall);
+    capturedRequestIds.add(requestId);
+    return _pending[index].stream;
+  }
+
+  Future<void> closeAll() async {
+    for (final controller in _pending) {
+      await controller.close();
+    }
+  }
+}
+
+/// Tomorrow 09:30 with no microseconds, so ISO-8601 round-trips exactly and
+/// it is always strictly after the flow's internal `now`.
+DateTime futureTime() {
+  final now = DateTime.now();
+  return DateTime(now.year, now.month, now.day + 1, 9, 30);
+}
+
+ChatStreamChunk toolChunk(
+  String name,
+  Map<String, dynamic> arguments, {
+  String id = 't1',
+}) {
+  return ChatStreamChunk(
+    content: '',
+    isDone: false,
+    totalTokens: 0,
+    toolCalls: <ToolCallInfo>[
+      ToolCallInfo(id: id, name: name, arguments: arguments),
+    ],
+  );
+}
+
+ChatStreamChunk updateChunk(DateTime time, {String id = 't1', String? name}) {
+  return toolChunk(
+    name ?? ProactiveCareDecisionTools.updateTime,
+    <String, dynamic>{'next_care_time': time.toIso8601String()},
+    id: id,
+  );
+}
+
+void main() {
+  late _FakeDecisionTransport transport;
+
+  setUp(() {
+    transport = _FakeDecisionTransport();
+  });
+
+  tearDown(() async {
+    await transport.closeAll();
+  });
+
+  Future<DateTime?> decide({List<Map<String, dynamic>>? history}) {
+    return ProactiveCareMessageFlow.decideNextCareTime(
+      config: ProviderConfig.defaultsFor('TestProvider'),
+      modelId: 'test-model',
+      assistant: Assistant(id: 'a1', name: 'Alpha'),
+      userNickname: 'tester',
+      history:
+          history ??
+          const <Map<String, dynamic>>[
+            {'role': 'user', 'content': 'hi'},
+            {'role': 'assistant', 'content': 'hello'},
+          ],
+      decisionPrompt: 'test',
+      sendMessageStream: transport.send,
+    );
+  }
+
+  group('decision flow', () {
+    test(
+      '1: valid future time via chunk toolCalls returns the exact time',
+      () async {
+        final controller = transport.enqueue();
+        final time = futureTime();
+
+        final future = decide();
+        controller.add(updateChunk(time));
+        final result = await future.timeout(const Duration(seconds: 5));
+
+        expect(result, time);
+        expect(transport.sendCount, 1);
+
+        await pumpEventQueue();
+        expect(transport.subscriptionCancelled[0], isTrue);
+
+        final tools = transport.capturedTools[0];
+        expect(tools, isNotNull);
+        expect(tools, hasLength(2));
+        for (final def in tools!) {
+          expect(def['type'], 'function');
+        }
+        expect(
+          Map<String, dynamic>.from(tools[0]['function'] as Map)['name'],
+          ProactiveCareDecisionTools.updateTime,
+        );
+        expect(
+          Map<String, dynamic>.from(tools[1]['function'] as Map)['name'],
+          ProactiveCareDecisionTools.keepTime,
+        );
+
+        // Message wiring: system prompt first, tool reminder last.
+        expect(transport.capturedMessages[0].first, {
+          'role': 'system',
+          'content': 'test',
+        });
+        expect(
+          transport.capturedMessages[0].last['content'] as String,
+          endsWith(ProactiveCareService.builtinDecisionToolReminder),
+        );
+        expect(
+          transport.capturedRequestIds[0],
+          startsWith('proactive-care-decision-a1-'),
+        );
+      },
+    );
+
+    test(
+      '2: decision via onToolCall handler returns the time neutrally',
+      () async {
+        transport.enqueue();
+        final time = futureTime();
+
+        final future = decide();
+        final handler = transport.capturedHandlers[0];
+        expect(handler, isNotNull);
+        final resultString = await handler!(
+          ProactiveCareDecisionTools.updateTime,
+          <String, dynamic>{'next_care_time': time.toIso8601String()},
+          toolCallId: 't1',
+        );
+        expect(
+          (jsonDecode(resultString) as Map<String, dynamic>)['ok'],
+          isTrue,
+        );
+        expect(resultString, isNot(contains('ignored')));
+
+        final result = await future.timeout(const Duration(seconds: 5));
+        expect(result, time);
+        expect(transport.sendCount, 1);
+
+        await pumpEventQueue();
+        expect(transport.subscriptionCancelled[0], isTrue);
+      },
+    );
+
+    test('3: UTC input is converted to local time', () async {
+      final controller = transport.enqueue();
+      final utc = DateTime.now().toUtc().add(const Duration(days: 1));
+
+      final future = decide();
+      controller.add(updateChunk(utc));
+      final result = await future.timeout(const Duration(seconds: 5));
+
+      expect(result, isNotNull);
+      expect(result!.isUtc, isFalse);
+      expect(result.toUtc(), utc);
+    });
+
+    test('4: past time is final (null, no retry)', () async {
+      final controller = transport.enqueue();
+      final past = DateTime.now().subtract(const Duration(hours: 1));
+
+      final future = decide();
+      controller.add(updateChunk(past));
+      final result = await future.timeout(const Duration(seconds: 5));
+
+      expect(result, isNull);
+      expect(transport.sendCount, 1);
+    });
+
+    test('5: malformed time arg is final (null, no retry)', () async {
+      final controller = transport.enqueue();
+
+      final future = decide();
+      controller.add(
+        toolChunk(
+          ProactiveCareDecisionTools.updateTime,
+          const <String, dynamic>{'next_care_time': 'not-a-date'},
+        ),
+      );
+      final result = await future.timeout(const Duration(seconds: 5));
+
+      expect(result, isNull);
+      expect(transport.sendCount, 1);
+    });
+
+    test(
+      '6: missing or empty next_care_time is final (null, no retry)',
+      () async {
+        final first = transport.enqueue();
+        final firstFuture = decide();
+        first.add(
+          toolChunk(
+            ProactiveCareDecisionTools.updateTime,
+            const <String, dynamic>{},
+          ),
+        );
+        expect(await firstFuture.timeout(const Duration(seconds: 5)), isNull);
+        expect(transport.sendCount, 1);
+
+        final second = transport.enqueue();
+        final secondFuture = decide();
+        second.add(
+          toolChunk(
+            ProactiveCareDecisionTools.updateTime,
+            const <String, dynamic>{'next_care_time': ''},
+          ),
+        );
+        expect(await secondFuture.timeout(const Duration(seconds: 5)), isNull);
+        expect(transport.sendCount, 2);
+      },
+    );
+
+    test('7: keep_care_time returns null and cancels without retry', () async {
+      final controller = transport.enqueue();
+
+      final future = decide();
+      controller.add(
+        toolChunk(
+          ProactiveCareDecisionTools.keepTime,
+          const <String, dynamic>{},
+        ),
+      );
+      final result = await future.timeout(const Duration(seconds: 5));
+
+      expect(result, isNull);
+      expect(transport.sendCount, 1);
+
+      await pumpEventQueue();
+      expect(transport.subscriptionCancelled[0], isTrue);
+    });
+
+    test('8: free text on both attempts returns null and retry appends the '
+        'tool-only directive', () async {
+      final first = transport.enqueue();
+      final second = transport.enqueue();
+
+      final future = decide();
+      first.add(
+        ChatStreamChunk(
+          content: 'I think we should wait a bit longer.',
+          isDone: false,
+          totalTokens: 0,
+        ),
+      );
+      await first.close();
+      second.add(
+        ChatStreamChunk(
+          content: 'Still no tools, sorry.',
+          isDone: false,
+          totalTokens: 0,
+        ),
+      );
+      await second.close();
+
+      final result = await future.timeout(const Duration(seconds: 5));
+      expect(result, isNull);
+      expect(transport.sendCount, 2);
+
+      final retryLast = transport.capturedMessages[1].last;
+      expect(retryLast['role'], 'user');
+      expect(retryLast['content'] as String, contains('update_care_time'));
+      expect(retryLast['content'] as String, contains('keep_care_time'));
+      expect(
+        transport.capturedRequestIds[1],
+        '${transport.capturedRequestIds[0]}-retry',
+      );
+    });
+
+    test('9: first stream error retries and returns the retry time', () async {
+      final first = transport.enqueue();
+      final second = transport.enqueue();
+      final time = futureTime();
+
+      final future = decide();
+      first.addError(Exception('network down'));
+      second.add(updateChunk(time));
+
+      final result = await future.timeout(const Duration(seconds: 5));
+      expect(result, time);
+      expect(transport.sendCount, 2);
+    });
+
+    test('10: follow-up handler calls after a decision stay neutral', () async {
+      transport.enqueue();
+      final time = futureTime();
+
+      final future = decide();
+      final handler = transport.capturedHandlers[0]!;
+      await handler(ProactiveCareDecisionTools.updateTime, <String, dynamic>{
+        'next_care_time': time.toIso8601String(),
+      }, toolCallId: 't1');
+      final result = await future.timeout(const Duration(seconds: 5));
+      expect(result, time);
+
+      // Provider keeps sending follow-up calls before the cancel lands.
+      final followUpKeep = await handler(
+        ProactiveCareDecisionTools.keepTime,
+        const <String, dynamic>{},
+        toolCallId: 't2',
+      );
+      final followUpUpdate = await handler(
+        ProactiveCareDecisionTools.updateTime,
+        <String, dynamic>{
+          'next_care_time': time.add(const Duration(days: 1)).toIso8601String(),
+        },
+        toolCallId: 't3',
+      );
+      expect(followUpKeep, isNot(contains('ignored')));
+      expect(followUpUpdate, isNot(contains('ignored')));
+      expect((jsonDecode(followUpKeep) as Map<String, dynamic>)['ok'], isTrue);
+      expect(
+        (jsonDecode(followUpUpdate) as Map<String, dynamic>)['ok'],
+        isTrue,
+      );
+      expect(transport.sendCount, 1);
+    });
+
+    test('11: lenient tool-name matching accepts Update-Care-Time', () async {
+      final controller = transport.enqueue();
+      final time = futureTime();
+
+      final future = decide();
+      controller.add(updateChunk(time, name: 'Update-Care-Time'));
+      final result = await future.timeout(const Duration(seconds: 5));
+
+      expect(result, time);
+      expect(transport.sendCount, 1);
+    });
+
+    test('12: empty history returns null without sending', () async {
+      final result = await decide(
+        history: const <Map<String, dynamic>>[],
+      ).timeout(const Duration(seconds: 5));
+      expect(result, isNull);
+      expect(transport.sendCount, 0);
+    });
+
+    test(
+      '15: unknown tool name stays undecided, later valid call settles',
+      () async {
+        final controller = transport.enqueue();
+        final time = futureTime();
+
+        var completed = false;
+        final future = decide();
+        unawaited(future.then((_) => completed = true));
+
+        controller.add(
+          toolChunk('some_unknown_tool', const <String, dynamic>{'x': 1}),
+        );
+        await pumpEventQueue();
+        expect(completed, isFalse);
+
+        controller.add(updateChunk(time, id: 't2'));
+        final result = await future.timeout(const Duration(seconds: 5));
+        expect(result, time);
+        expect(transport.sendCount, 1);
+      },
+    );
+
+    test('16: both attempts error returns null after two sends', () async {
+      final first = transport.enqueue();
+      final second = transport.enqueue();
+
+      final future = decide();
+      first.addError(Exception('first down'));
+      second.addError(Exception('second down'));
+
+      final result = await future.timeout(const Duration(seconds: 5));
+      expect(result, isNull);
+      expect(transport.sendCount, 2);
+    });
+
+    test(
+      '17: handler and chunk double delivery decides once, first wins',
+      () async {
+        final controller = transport.enqueue();
+        final time = futureTime();
+
+        final future = decide();
+        final handler = transport.capturedHandlers[0]!;
+        await handler(
+          ProactiveCareDecisionTools.keepTime,
+          const <String, dynamic>{},
+          toolCallId: 't1',
+        );
+        // Same/duplicate call also arrives as a chunk before cancel lands.
+        controller.add(updateChunk(time, id: 't2'));
+
+        final result = await future.timeout(const Duration(seconds: 5));
+        expect(result, isNull);
+        expect(transport.sendCount, 1);
+      },
+    );
+  });
+
+  group('ProactiveCareDecisionTools', () {
+    final now = DateTime(2026, 8, 3, 12);
+
+    test('13: parseUpdateTimeArgs keeps the old JSON-decision semantics', () {
+      // Valid local future time.
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(const <String, dynamic>{
+          'next_care_time': '2026-08-04T09:30:00',
+        }, now: now),
+        DateTime(2026, 8, 4, 9, 30),
+      );
+      // Past rejected.
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(const <String, dynamic>{
+          'next_care_time': '2026-08-02T09:30:00',
+        }, now: now),
+        isNull,
+      );
+      // Exactly now rejected (strictly after).
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(const <String, dynamic>{
+          'next_care_time': '2026-08-03T12:00:00',
+        }, now: now),
+        isNull,
+      );
+      // UTC converted to local, TZ-independent.
+      final utcResult = ProactiveCareDecisionTools.parseUpdateTimeArgs(
+        const <String, dynamic>{'next_care_time': '2026-08-04T01:30:00Z'},
+        now: now,
+      );
+      expect(utcResult, isNotNull);
+      expect(utcResult!.isUtc, isFalse);
+      expect(utcResult.toUtc(), DateTime.utc(2026, 8, 4, 1, 30));
+      // Non-string rejected.
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(const <String, dynamic>{
+          'next_care_time': 12345,
+        }, now: now),
+        isNull,
+      );
+      // Missing rejected.
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(
+          const <String, dynamic>{},
+          now: now,
+        ),
+        isNull,
+      );
+      // Empty string rejected.
+      expect(
+        ProactiveCareDecisionTools.parseUpdateTimeArgs(const <String, dynamic>{
+          'next_care_time': '   ',
+        }, now: now),
+        isNull,
+      );
+    });
+
+    test('14: definitions() are OpenAI-shaped function tools', () {
+      final defs = ProactiveCareDecisionTools.definitions();
+      expect(defs, hasLength(2));
+      for (final def in defs) {
+        expect(def['type'], 'function');
+      }
+      final update = Map<String, dynamic>.from(defs[0]['function'] as Map);
+      expect(update['name'], ProactiveCareDecisionTools.updateTime);
+      final params = Map<String, dynamic>.from(update['parameters'] as Map);
+      expect(params['required'], ['next_care_time']);
+      final keep = Map<String, dynamic>.from(defs[1]['function'] as Map);
+      expect(keep['name'], ProactiveCareDecisionTools.keepTime);
+    });
+  });
+}

--- a/test/core/services/proactive_care_decision_test.dart
+++ b/test/core/services/proactive_care_decision_test.dart
@@ -496,6 +496,31 @@ void main() {
       await pumpEventQueue();
       expect(transport.subscriptionCancelled[0], isTrue);
     });
+
+    test(
+      '22: validation uses a fresh clock, not the request-level now',
+      () async {
+        final controller = transport.enqueue();
+
+        // Timing margin: the proposed time is t0+150ms, future relative to
+        // the request-level clock captured inside decide() (~t0), but the
+        // chunk is only delivered after a real 300ms delay, so the fresh
+        // validation clock is already >= t0+300ms and the time is past.
+        // Direction is deterministic on any machine speed: the delay must
+        // elapse before the chunk arrives, and 300ms > 150ms. Reverting to
+        // the stale request-level clock would accept the time and fail here.
+        final t0 = DateTime.now();
+        final future = decide();
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+        controller.add(updateChunk(t0.add(const Duration(milliseconds: 150))));
+
+        final result = await future.timeout(const Duration(seconds: 5));
+
+        expect(result, isNull);
+        // Invalid/past args are final: no retry.
+        expect(transport.sendCount, 1);
+      },
+    );
   });
 
   group('ProactiveCareService', () {

--- a/test/core/services/proactive_care_decision_test.dart
+++ b/test/core/services/proactive_care_decision_test.dart
@@ -98,7 +98,10 @@ void main() {
     await transport.closeAll();
   });
 
-  Future<DateTime?> decide({List<Map<String, dynamic>>? history}) {
+  Future<DateTime?> decide({
+    List<Map<String, dynamic>>? history,
+    Duration decisionTimeout = const Duration(seconds: 45),
+  }) {
     return ProactiveCareMessageFlow.decideNextCareTime(
       config: ProviderConfig.defaultsFor('TestProvider'),
       modelId: 'test-model',
@@ -112,6 +115,7 @@ void main() {
           ],
       decisionPrompt: 'test',
       sendMessageStream: transport.send,
+      decisionTimeout: decisionTimeout,
     );
   }
 
@@ -308,8 +312,14 @@ void main() {
 
       final retryLast = transport.capturedMessages[1].last;
       expect(retryLast['role'], 'user');
-      expect(retryLast['content'] as String, contains('update_care_time'));
-      expect(retryLast['content'] as String, contains('keep_care_time'));
+      expect(
+        retryLast['content'] as String,
+        contains(ProactiveCareDecisionTools.updateTime),
+      );
+      expect(
+        retryLast['content'] as String,
+        contains(ProactiveCareDecisionTools.keepTime),
+      );
       expect(
         transport.capturedRequestIds[1],
         '${transport.capturedRequestIds[0]}-retry',
@@ -442,6 +452,70 @@ void main() {
         expect(transport.sendCount, 1);
       },
     );
+
+    test(
+      '18: first attempt timeout retries and second attempt decides',
+      () async {
+        transport.enqueue();
+        final second = transport.enqueue();
+        final time = futureTime();
+
+        final future = decide(
+          decisionTimeout: const Duration(milliseconds: 20),
+        );
+        // First stream never emits; the chunk is buffered for attempt 2.
+        second.add(updateChunk(time));
+
+        final result = await future.timeout(const Duration(seconds: 5));
+        expect(result, time);
+        expect(transport.sendCount, 2);
+      },
+    );
+
+    test('19: both attempts timing out returns null after two sends', () async {
+      transport.enqueue();
+      transport.enqueue();
+
+      final result = await decide(
+        decisionTimeout: const Duration(milliseconds: 20),
+      ).timeout(const Duration(seconds: 5));
+
+      expect(result, isNull);
+      expect(transport.sendCount, 2);
+    });
+
+    test('20: timeout cancels the hung attempt subscription', () async {
+      transport.enqueue();
+      transport.enqueue();
+
+      final result = await decide(
+        decisionTimeout: const Duration(milliseconds: 20),
+      ).timeout(const Duration(seconds: 5));
+      expect(result, isNull);
+
+      await pumpEventQueue();
+      expect(transport.subscriptionCancelled[0], isTrue);
+    });
+  });
+
+  group('ProactiveCareService', () {
+    test('21: empty decision prompt omits the system message', () {
+      final messages = ProactiveCareService.buildDecisionApiMessages(
+        decisionPrompt: '',
+        currentNextCareTime: null,
+        now: DateTime(2026, 8, 3, 12),
+        history: const <Map<String, dynamic>>[
+          {'role': 'user', 'content': 'hi'},
+        ],
+      );
+
+      expect(messages.where((m) => m['role'] == 'system'), isEmpty);
+      expect(messages.first['role'], 'user');
+      expect(
+        messages.first['content'] as String,
+        startsWith(ProactiveCareService.chatHistoryPrefix),
+      );
+    });
   });
 
   group('ProactiveCareDecisionTools', () {


### PR DESCRIPTION
## What

Replace the "Ta的来信" (proactive care) **decision flow**'s JSON-output-and-parse contract with native background tool calls, mirroring the group-chat Director pattern (`director_runner.dart`):

- New tools `update_care_time` (ISO-8601 `next_care_time` arg) / `keep_care_time` — first valid call wins, stream cancelled, neutral `{'ok': true}` result.
- One Director-style retry with a tool-only directive when the model replies free text; 45 s bound per attempt.
- **Deleted** `builtinDecisionJsonRules`, `parseDecision`, `_extractJsonObject` — no JSON parsing code or JSON prompt text remains (`rg` zero hits).

## Why

Strict-JSON replies are fragile (prose wrapping, malformed JSON). Native tool calls are the pattern already proven in this repo by the group-chat Director.

Known pitfall respected: `tool_choice` stays provider-default `'auto'` everywhere — never `'required'`, which fails intermittently on DeepSeek-style hosts. No `lib/core/services/api/**` changes.

## Behavior contract (unchanged)

- Validation semantics preserved: ISO-8601 parse, UTC→local, strictly future times; past/invalid → no update.
- Any failure → `decideNextCareTime` returns `null` → current schedule kept; non-fatal for both callers (foreground `_maybeUpdateProactiveCareFor` and dead-app alarm isolate).
- Care-letter flow, Assistant fields, DB schema, backup, l10n: untouched. No ARB changes (JSON rules were LLM-only constants).

## Verification

- `dart format` — clean on all changed files.
- `flutter analyze` — zero issues in repo code (pre-existing issues inside `dependencies/` path deps unchanged).
- `flutter test test/core/services/proactive_care_decision_test.dart` — **+17 passed** (happy path, past/malformed/missing args, keep tool, free-text retry, error exhaustion, unknown tool name, double delivery, neutral results, lenient name matching, empty history, arg-validation unit cases).
- `flutter test test/features/group_chat/` — +14 passed (Director regression sanity).

Not run: on-device Android alarm-isolate verification (needs physical device); the decision path is platform-agnostic Dart and host-tested, feature remains Android-gated.

## Delivery notes

- User-customized decision prompts that still mention JSON output are per-assistant data (not migrated); worst case the model doesn't call a tool → retry → `null` → current schedule kept (same failure mode as an unparseable JSON reply today).
- `now` is captured once at request build and reused for validation (consistent with the time footer shown to the model).
- The 45 s timeout branch and real-provider tool loops are deliberately not unit-tested (no extra seam added — mechanics identical to the production-proven Director).

Closes #152
