### PR TITLE
fix: avoid Win11 desktop focus race after group chat back

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -2532,15 +2532,19 @@ class HomePageController extends ChangeNotifier {
 
   void onDidPopNext() {
     if (isDesktopPlatform) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _inputFocus.requestFocus();
-      });
-    } else {
-      WidgetsBinding.instance.addPostFrameCallback((_) => dismissKeyboard());
+      debugPrint(
+        '[HomePageController] didPopNext: skip desktop input refocus '
+        'to avoid TextInput transition race',
+      );
+      return;
     }
+
+    debugPrint('[HomePageController] didPopNext: dismiss mobile keyboard');
+    WidgetsBinding.instance.addPostFrameCallback((_) => dismissKeyboard());
   }
 
   void onDidPushNext() {
+    debugPrint('[HomePageController] didPushNext: dismiss keyboard');
     dismissKeyboard();
   }
 


### PR DESCRIPTION
## Summary
- Stop desktop HomePage from refocusing the chat input after a child route is popped.
- Preserve mobile keyboard dismissal behavior.
- Add didPushNext/didPopNext diagnostics for Win11 reproduction.

## Root cause
Returning from 我的群聊 triggers HomePage.didPopNext(). The desktop callback previously requested focus on the underlying chat TextField on the next frame, which can race with Windows Flutter TextInput teardown/reconnect during route transition.

## Verification
- flutter analyze on affected files: passed
- dart format: passed
- git diff --check: passed
- Full flutter analyze remains blocked by the existing vendored dependencies/mcp_client/test files missing package:test.
- Win11 runtime verification is still required.