### PR TITLE
fix(backup): restore refresh completeness and restart contract

### DIFF
--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -465,6 +465,21 @@ class McpProvider extends ChangeNotifier {
   int get requestTimeoutSeconds => _requestTimeout.inSeconds;
 
   Future<void> _load() async {
+    await _reloadServersFromPrefs();
+
+    // Refresh @kelivo/subagent tool definitions when assistants change
+    assistantProvider?.addListener(_onAssistantsChanged);
+  }
+
+  /// Re-reads `mcp_servers_v1` / `mcp_request_timeout_ms_v1` from
+  /// SharedPreferences, rebuilds the in-memory server list (including built-in
+  /// servers), and auto-connects enabled servers.
+  ///
+  /// Used by the constructor and by [reloadFromPrefs] after a backup/import
+  /// restore rewrote the prefs, so the in-memory state never diverges from
+  /// disk. Listener registration (e.g. assistant changes) is NOT repeated
+  /// here — callers own it.
+  Future<void> _reloadServersFromPrefs() async {
     final prefs = await SharedPreferences.getInstance();
     final timeoutMs = prefs.getInt(_prefsTimeoutKey);
     if (timeoutMs != null && timeoutMs > 0) {
@@ -502,9 +517,27 @@ class McpProvider extends ChangeNotifier {
       // fire and forget
       unawaited(connect(s.id));
     }
+  }
 
-    // Refresh @kelivo/subagent tool definitions when assistants change
-    assistantProvider?.addListener(_onAssistantsChanged);
+  /// Reloads the server list and connections from SharedPreferences.
+  ///
+  /// After a backup/import restore rewrote `mcp_servers_v1`, the in-memory
+  /// list would otherwise keep the pre-restore servers while disk already
+  /// holds the restored ones. This disconnects every live client, rebuilds
+  /// the list from disk, and reconnects enabled servers.
+  Future<void> reloadFromPrefs() async {
+    for (final id in _clients.keys.toList()) {
+      try {
+        await disconnect(id);
+      } catch (e) {
+        debugPrint('[MCP/Reload] disconnect $id failed: $e');
+      }
+    }
+    _servers = <McpServerConfig>[];
+    _status.clear();
+    _errors.clear();
+    _reconnecting.clear();
+    await _reloadServersFromPrefs();
   }
 
   void _onAssistantsChanged() {
@@ -1721,6 +1754,12 @@ class McpProvider extends ChangeNotifier {
     try {
       // debugPrint('[MCP/Tools] listTools() ...');
       final tools = await client.listTools();
+      // The client may have been disconnected or replaced while listTools was
+      // in flight (e.g. restore reload rebuilt the server list). Never write
+      // a stale tool refresh back to disk — it would clobber the restored
+      // mcp_servers_v1 with the pre-restore list (assistant changes trigger
+      // this refresh, and restore reloads assistants).
+      if (!identical(_clients[id], client)) return;
       // debugPrint('[MCP/Tools] listTools() returned ${tools.length} tools');
       // Preserve enabled state from existing config
       final idx = _servers.indexWhere((e) => e.id == id);

--- a/lib/core/services/backup/restore_refresher.dart
+++ b/lib/core/services/backup/restore_refresher.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/assistant_provider.dart';
+import '../../providers/group_chat_provider.dart';
+import '../../providers/mcp_provider.dart';
+import '../chat/chat_service.dart';
+
+/// Re-reads every provider that mirrors persisted state after a restore /
+/// import rewrote SQLite or SharedPreferences, so the UI does not keep a
+/// cleared or pre-restore in-memory snapshot.
+///
+/// Single shared refresh list for all restore entry points (mobile backup
+/// page, desktop backup pane, LAN sync). Any new provider that persists state
+/// must subscribe here; adding reloads at individual call sites is what let
+/// the refresh list drift out of sync before.
+Future<void> refreshProvidersAfterRestore(BuildContext context) async {
+  final chatService = context.read<ChatService>();
+  final assistantProvider = context.read<AssistantProvider>();
+  final groupChatProvider = context.read<GroupChatProvider>();
+  final mcpProvider = context.read<McpProvider>();
+  try {
+    await chatService.reloadCachesFromDb();
+  } catch (e) {
+    debugPrint('refreshProvidersAfterRestore: ChatService: $e');
+  }
+  try {
+    // Reload MCP BEFORE assistants: reloading assistants fires
+    // McpProvider._onAssistantsChanged -> refreshTools('kelivo_subagent'),
+    // which persists the whole server list. If the old client were still
+    // live at that point it would write the pre-restore list over the
+    // restored mcp_servers_v1; reloading MCP first means any such refresh
+    // runs against the new client (or no client) and stays harmless.
+    await mcpProvider.reloadFromPrefs();
+  } catch (e) {
+    debugPrint('refreshProvidersAfterRestore: McpProvider: $e');
+  }
+  try {
+    await assistantProvider.reloadFromRepo();
+  } catch (e) {
+    debugPrint('refreshProvidersAfterRestore: AssistantProvider: $e');
+  }
+  try {
+    await groupChatProvider.load();
+  } catch (e) {
+    debugPrint('refreshProvidersAfterRestore: GroupChatProvider: $e');
+  }
+}

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -14,6 +14,7 @@ import '../../core/providers/settings_provider.dart';
 import '../../core/services/chat/chat_service.dart';
 import '../../core/services/backup/cherry_importer.dart';
 import '../../core/services/backup/chatbox_importer.dart';
+import '../../core/services/backup/restore_refresher.dart';
 import '../../utils/platform_utils.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../shared/widgets/snackbar.dart';
@@ -999,22 +1000,28 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                     if (!rootCtx.mounted) return;
                     await showDialog(
                       context: rootCtx,
-                      builder: (dctx) => AlertDialog(
-                        backgroundColor: cs.surface,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        title: Text(l10n.backupPageRestartRequired),
-                        content: Text(l10n.backupPageRestartContent),
-                        actions: [
-                          TextButton(
-                            onPressed: () async {
-                              Navigator.of(rootCtx).pop();
-                              PlatformUtils.restartApp();
-                            },
-                            child: Text(l10n.backupPageOK),
+                      barrierDismissible: false,
+                      builder: (dctx) => PopScope(
+                        // Import contract matches restore: restart is
+                        // required for the imported data to take effect.
+                        canPop: false,
+                        child: AlertDialog(
+                          backgroundColor: cs.surface,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
                           ),
-                        ],
+                          title: Text(l10n.backupPageRestartRequired),
+                          content: Text(l10n.backupPageRestartContent),
+                          actions: [
+                            TextButton(
+                              onPressed: () async {
+                                Navigator.of(rootCtx).pop();
+                                PlatformUtils.restartApp();
+                              },
+                              child: Text(l10n.backupPageOK),
+                            ),
+                          ],
+                        ),
                       ),
                     );
                   } catch (e) {
@@ -1467,6 +1474,8 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
       if (mounted) setState(() => _loading = false);
     }
     if (!rootCtx.mounted) return;
+    await refreshProvidersAfterRestore(rootCtx);
+    if (!rootCtx.mounted) return;
     await showRestartRequiredDialog(rootCtx);
   }
 
@@ -1495,6 +1504,8 @@ class _RemoteBackupsDialogState extends State<_RemoteBackupsDialog> {
     } finally {
       if (mounted) setState(() => _loading = false);
     }
+    if (!rootCtx.mounted) return;
+    await refreshProvidersAfterRestore(rootCtx);
     if (!rootCtx.mounted) return;
     await showRestartRequiredDialog(rootCtx);
   }

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -12,15 +12,14 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../shared/animations/widgets.dart';
 import '../../../core/services/haptics.dart';
 import '../../../core/models/backup.dart';
-import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/backup_provider.dart';
 import '../../../core/providers/backup_reminder_provider.dart';
-import '../../../core/providers/group_chat_provider.dart';
 import '../../../core/providers/s3_backup_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/trash_restore_coordinator.dart';
 import '../../../core/services/backup/data_sync.dart';
+import '../../../core/services/backup/restore_refresher.dart';
 import '../../../core/services/native_file_save.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/dialogs/incremental_backup_dialog.dart';
@@ -1279,25 +1278,31 @@ class _BackupPageState extends State<BackupPage> {
                   if (!context.mounted) return;
                   await showDialog(
                     context: context,
-                    builder: (dctx) => AlertDialog(
-                      title: Text(l10n.backupPageRestartRequired),
-                      content: Text(
-                        '${l10n.backupPageImportFromChatbox}:\n'
-                        ' • Providers: ${res.providers}\n'
-                        ' • Assistants: ${res.assistants}\n'
-                        ' • Conversations: ${res.conversations}\n'
-                        ' • Messages: ${res.messages}\n\n'
-                        '${l10n.backupPageRestartContent}',
-                      ),
-                      actions: [
-                        TextButton(
-                          onPressed: () async {
-                            Navigator.of(dctx).pop();
-                            PlatformUtils.restartApp();
-                          },
-                          child: Text(l10n.backupPageOK),
+                    barrierDismissible: false,
+                    builder: (dctx) => PopScope(
+                      // Import contract matches restore: restart is required
+                      // for the imported data to take effect.
+                      canPop: false,
+                      child: AlertDialog(
+                        title: Text(l10n.backupPageRestartRequired),
+                        content: Text(
+                          '${l10n.backupPageImportFromChatbox}:\n'
+                          ' • Providers: ${res.providers}\n'
+                          ' • Assistants: ${res.assistants}\n'
+                          ' • Conversations: ${res.conversations}\n'
+                          ' • Messages: ${res.messages}\n\n'
+                          '${l10n.backupPageRestartContent}',
                         ),
-                      ],
+                        actions: [
+                          TextButton(
+                            onPressed: () async {
+                              Navigator.of(dctx).pop();
+                              PlatformUtils.restartApp();
+                            },
+                            child: Text(l10n.backupPageOK),
+                          ),
+                        ],
+                      ),
                     ),
                   );
                 } catch (e) {
@@ -1371,25 +1376,10 @@ class _BackupPageState extends State<BackupPage> {
 
   /// After wipe/restore, providers must re-read SQLite; otherwise UI keeps a
   /// cleared or pre-restore in-memory snapshot (P0 empty chats/assistants).
+  /// Delegates to the shared refresh list so every restore entry point
+  /// (mobile page, desktop pane, LAN sync) stays in sync.
   Future<void> _refreshProvidersAfterRestore(BuildContext context) async {
-    final chatService = context.read<ChatService>();
-    final assistantProvider = context.read<AssistantProvider>();
-    final groupChatProvider = context.read<GroupChatProvider>();
-    try {
-      await chatService.reloadCachesFromDb();
-    } catch (e) {
-      debugPrint('backup refresh ChatService: $e');
-    }
-    try {
-      await assistantProvider.reloadFromRepo();
-    } catch (e) {
-      debugPrint('backup refresh AssistantProvider: $e');
-    }
-    try {
-      await groupChatProvider.load();
-    } catch (e) {
-      debugPrint('backup refresh GroupChatProvider: $e');
-    }
+    await refreshProvidersAfterRestore(context);
   }
 
   Future<void> _doImportLocal(BuildContext context, BackupProvider vm) async {

--- a/lib/shared/dialogs/restart_required_dialog.dart
+++ b/lib/shared/dialogs/restart_required_dialog.dart
@@ -9,20 +9,26 @@ Future<void> showRestartRequiredDialog(BuildContext context) async {
   await showDialog(
     context: context,
     barrierDismissible: false,
-    builder: (dctx) => AlertDialog(
-      backgroundColor: cs.surface,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      title: Text(l10n.backupPageRestartRequired),
-      content: Text(l10n.backupPageRestartContent),
-      actions: [
-        TextButton(
-          onPressed: () {
-            Navigator.of(dctx).pop();
-            PlatformUtils.restartApp();
-          },
-          child: Text(l10n.backupPageOK),
-        ),
-      ],
+    builder: (dctx) => PopScope(
+      // The restore contract is "restart to take effect": the system back
+      // button / Esc must not dismiss this dialog, or the user would keep a
+      // half-refreshed in-memory state that only a restart can repair.
+      canPop: false,
+      child: AlertDialog(
+        backgroundColor: cs.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: Text(l10n.backupPageRestartRequired),
+        content: Text(l10n.backupPageRestartContent),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(dctx).pop();
+              PlatformUtils.restartApp();
+            },
+            child: Text(l10n.backupPageOK),
+          ),
+        ],
+      ),
     ),
   );
 }

--- a/lib/shared/widgets/lan_sync_section.dart
+++ b/lib/shared/widgets/lan_sync_section.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../../core/models/backup.dart';
 import '../../core/services/backup/data_sync.dart';
+import '../../core/services/backup/restore_refresher.dart';
 import '../../core/services/chat/chat_service.dart';
 import '../../core/services/sync/lan_sync_client.dart';
 import '../../core/services/sync/lan_sync_models.dart';
@@ -80,6 +81,10 @@ class _LanSyncSectionState extends State<LanSyncSection> {
       const WebDavConfig(includeChats: true, includeFiles: true),
       mode: RestoreMode.merge,
     );
+    if (!mounted) return;
+    // Keep the in-memory providers consistent with the merged disk state
+    // while the restart prompt is up (and defensively if it is dismissed).
+    await refreshProvidersAfterRestore(context);
     if (!mounted) return;
     await showRestartRequiredDialog(context);
   }

--- a/test/core/providers/mcp_provider_reload_test.dart
+++ b/test/core/providers/mcp_provider_reload_test.dart
@@ -1,0 +1,125 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/providers/mcp_provider.dart';
+
+McpServerConfig _server(String id, String name) => McpServerConfig(
+  id: id,
+  name: name,
+  enabled: false,
+  transport: McpTransportType.http,
+  url: 'http://127.0.0.1:1/$id',
+);
+
+Future<Set<String>> _persistedServerIds() async {
+  final prefs = await SharedPreferences.getInstance();
+  final raw = prefs.getString('mcp_servers_v1');
+  if (raw == null || raw.isEmpty) return <String>{};
+  final list = jsonDecode(raw) as List;
+  return list
+      .map((e) => ((e as Map)['id'] ?? '').toString())
+      .where((id) => id.isNotEmpty)
+      .toSet();
+}
+
+void main() {
+  test(
+    'reloadFromPrefs rebuilds the server list and timeout from SharedPreferences',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'mcp_servers_v1': jsonEncode([_server('srv-a', 'Server A').toJson()]),
+        'mcp_request_timeout_ms_v1': 15000,
+      });
+
+      final provider = McpProvider(
+        contextProvider: () => throw UnimplementedError(),
+      );
+      await pumpEventQueue();
+
+      expect(provider.servers.map((s) => s.id), contains('srv-a'));
+      expect(provider.requestTimeoutSeconds, 15);
+
+      // Simulate a restore that rewrote the prefs (e.g. overwrite restore of
+      // mcp_servers_v1). The in-memory list must follow disk, not keep the
+      // pre-restore servers.
+      SharedPreferences.setMockInitialValues({
+        'mcp_servers_v1': jsonEncode([_server('srv-b', 'Server B').toJson()]),
+        'mcp_request_timeout_ms_v1': 42000,
+      });
+      await provider.reloadFromPrefs();
+
+      final ids = provider.servers.map((s) => s.id).toList();
+      expect(ids, contains('srv-b'));
+      expect(ids, isNot(contains('srv-a')));
+      expect(provider.requestTimeoutSeconds, 42);
+
+      // Stop the built-in servers' auto-connect (heartbeat timers) so the
+      // test ends without pending timers.
+      for (final s in provider.servers) {
+        await provider.disconnect(s.id);
+      }
+    },
+  );
+
+  test(
+    'refreshTools after disconnect never writes stale servers back to prefs',
+    () async {
+      // Start with the pre-restore list.
+      SharedPreferences.setMockInitialValues({
+        'mcp_servers_v1': jsonEncode([_server('srv-a', 'Server A').toJson()]),
+      });
+      final provider = McpProvider(
+        contextProvider: () => throw UnimplementedError(),
+      );
+      await pumpEventQueue();
+      expect(provider.servers.map((s) => s.id), contains('srv-a'));
+
+      // Restore rewrote prefs to the new list; the old client is disconnected
+      // before the in-memory state is rebuilt. A tool refresh fired from the
+      // old client (assistant-change listener) must not persist the old list.
+      SharedPreferences.setMockInitialValues({
+        'mcp_servers_v1': jsonEncode([_server('srv-b', 'Server B').toJson()]),
+      });
+      await provider.disconnect('kelivo_subagent');
+      await provider.refreshTools('kelivo_subagent');
+
+      expect(await _persistedServerIds(), contains('srv-b'));
+      expect(await _persistedServerIds(), isNot(contains('srv-a')));
+
+      for (final s in provider.servers) {
+        await provider.disconnect(s.id);
+      }
+    },
+  );
+
+  test('refreshTools after reload keeps the restored list in prefs', () async {
+    SharedPreferences.setMockInitialValues({
+      'mcp_servers_v1': jsonEncode([_server('srv-a', 'Server A').toJson()]),
+    });
+    final provider = McpProvider(
+      contextProvider: () => throw UnimplementedError(),
+    );
+    await pumpEventQueue();
+
+    // Restore rewrote prefs; reload rebuilds memory + connections.
+    SharedPreferences.setMockInitialValues({
+      'mcp_servers_v1': jsonEncode([_server('srv-b', 'Server B').toJson()]),
+    });
+    await provider.reloadFromPrefs();
+    await pumpEventQueue();
+
+    // A refresh triggered after the reload runs against the new client (or
+    // none) and must not resurrect the pre-restore servers on disk.
+    await provider.refreshTools('kelivo_subagent');
+    await pumpEventQueue();
+
+    expect(await _persistedServerIds(), contains('srv-b'));
+    expect(await _persistedServerIds(), isNot(contains('srv-a')));
+
+    for (final s in provider.servers) {
+      await provider.disconnect(s.id);
+    }
+  });
+}

--- a/test/shared/dialogs/restart_required_dialog_test.dart
+++ b/test/shared/dialogs/restart_required_dialog_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/dialogs/restart_required_dialog.dart';
+
+Widget _buildHarness() {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Builder(
+      builder: (context) => Center(
+        child: ElevatedButton(
+          onPressed: () => showRestartRequiredDialog(context),
+          child: const Text('open'),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('restart dialog cannot be dismissed by the system back button', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_buildHarness());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('OK'), findsOneWidget);
+
+    // Simulate the Android back button / desktop Esc: the dialog must stay
+    // open because the restore contract is "restart to take effect".
+    final handled = await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(handled, isTrue);
+    expect(find.text('OK'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Restore left providers half-refreshed: the restart dialog could be
dismissed via system back, MCP servers stayed stale in memory until
restart, the desktop backup pane refreshed nothing, and an assistant
reload during restore could clobber the restored mcp_servers_v1.

- Block system back/Esc on all post-restore restart dialogs
  (shared dialog + Chatbox/Cherry import dialogs)
- Add McpProvider.reloadFromPrefs() and a shared
  refreshProvidersAfterRestore() used by mobile backup page, desktop
  backup pane and LAN sync
- Guard refreshTools against persisting stale tool refreshes from a
  client that was disconnected/replaced (restore reload), and reload
  MCP before assistants so the assistant-change listener cannot write
  the pre-restore server list back to disk
- Tests: restart dialog cannot be dismissed by back; reload/refresh
  never resurrects pre-restore MCP servers

Fixes #185.
