### PR TITLE
fix(chat): tool detail sheet no longer reads stale card context during streaming

### DIFF
--- a/lib/core/services/haptics.dart
+++ b/lib/core/services/haptics.dart
@@ -63,11 +63,13 @@ class Haptics {
 
   // Fire-and-forget wrapper to avoid exceptions on unsupported platforms.
   static void _safe(Future<void> Function() action) {
-    if (kIsWeb) return; // Skip on web targets
+    if (kIsWeb) return;
     try {
       // Don't await; haptic should not block UI.
       // ignore: discarded_futures
-      action();
+      action().catchError((Object _) {
+        // Swallow any MissingPluginException or platform channel errors.
+      });
     } catch (_) {
       // Swallow any MissingPluginException or platform channel errors.
     }

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -275,6 +275,14 @@ String _prettyToolJson(String raw) {
   }
 }
 
+String _prettyArgumentsJson(Map<String, dynamic> args) {
+  try {
+    return const JsonEncoder.withIndent('  ').convert(args);
+  } catch (_) {
+    return args.toString();
+  }
+}
+
 Widget _buildToolImageFromPath(
   BuildContext context,
   String path, {
@@ -341,7 +349,7 @@ void _showToolFullImage(BuildContext context, String path) {
 void _showToolDetail(BuildContext context, ToolUIPart part) {
   final cs = Theme.of(context).colorScheme;
   final l10n = AppLocalizations.of(context)!;
-  final argsPretty = const JsonEncoder.withIndent('  ').convert(part.arguments);
+  final argsPretty = _prettyArgumentsJson(part.arguments);
   final (cleanText, images) = _parseMcpImagePaths(part.content);
   final resultText = cleanText.isNotEmpty
       ? _prettyToolJson(cleanText)
@@ -367,11 +375,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
             borderRadius: BorderRadius.circular(16),
           ),
           child: ConstrainedBox(
-            constraints: const BoxConstraints(
-              minWidth: 360,
-              maxWidth: 560,
-              maxHeight: 560,
-            ),
+            constraints: const BoxConstraints(maxWidth: 560, maxHeight: 560),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(16),
               child: Material(
@@ -392,7 +396,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                           Expanded(
                             child: Text(
                               _toolTitleFor(
-                                context,
+                                ctx,
                                 part.toolName,
                                 part.arguments,
                                 isResult: !part.loading,
@@ -440,7 +444,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                                 padding: const EdgeInsets.all(10),
                                 decoration: BoxDecoration(
                                   color:
-                                      Theme.of(context).brightness ==
+                                      Theme.of(ctx).brightness ==
                                           Brightness.dark
                                       ? Colors.white10
                                       : const Color(0xFFF7F7F9),
@@ -470,7 +474,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                                 padding: const EdgeInsets.all(10),
                                 decoration: BoxDecoration(
                                   color:
-                                      Theme.of(context).brightness ==
+                                      Theme.of(ctx).brightness ==
                                           Brightness.dark
                                       ? Colors.white10
                                       : const Color(0xFFF7F7F9),
@@ -502,11 +506,11 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                                   children: images.map((path) {
                                     return GestureDetector(
                                       onTap: () =>
-                                          _showToolFullImage(context, path),
+                                          _showToolFullImage(ctx, path),
                                       child: ClipRRect(
                                         borderRadius: BorderRadius.circular(8),
                                         child: _buildToolImageFromPath(
-                                          context,
+                                          ctx,
                                           path,
                                           height: 280,
                                         ),
@@ -560,7 +564,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                       Expanded(
                         child: Text(
                           _toolTitleFor(
-                            context,
+                            ctx,
                             part.toolName,
                             part.arguments,
                             isResult: !part.loading,
@@ -586,7 +590,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                     width: double.infinity,
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.dark
+                      color: Theme.of(ctx).brightness == Brightness.dark
                           ? Colors.white10
                           : const Color(0xFFF7F7F9),
                       borderRadius: BorderRadius.circular(10),
@@ -612,7 +616,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                     width: double.infinity,
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.dark
+                      color: Theme.of(ctx).brightness == Brightness.dark
                           ? Colors.white10
                           : const Color(0xFFF7F7F9),
                       borderRadius: BorderRadius.circular(10),
@@ -644,11 +648,11 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                         itemBuilder: (ctx, i) {
                           final path = images[i];
                           return GestureDetector(
-                            onTap: () => _showToolFullImage(context, path),
+                            onTap: () => _showToolFullImage(ctx, path),
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(8),
                               child: _buildToolImageFromPath(
-                                context,
+                                ctx,
                                 path,
                                 height: 220,
                               ),
@@ -4740,9 +4744,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
   void _showDetail(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
-    final argsPretty = const JsonEncoder.withIndent(
-      '  ',
-    ).convert(widget.part.arguments);
+    final argsPretty = _prettyArgumentsJson(widget.part.arguments);
     final (cleanText, images) = _parseMcpImagePaths(widget.part.content);
     final resultText = cleanText.isNotEmpty
         ? _prettyJson(cleanText)
@@ -4768,11 +4770,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
               borderRadius: BorderRadius.circular(16),
             ),
             child: ConstrainedBox(
-              constraints: const BoxConstraints(
-                minWidth: 360,
-                maxWidth: 560,
-                maxHeight: 560,
-              ),
+              constraints: const BoxConstraints(maxWidth: 560, maxHeight: 560),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(16),
                 child: Material(
@@ -4797,7 +4795,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                             Expanded(
                               child: Text(
                                 _titleFor(
-                                  context,
+                                  ctx,
                                   widget.part.toolName,
                                   widget.part.arguments,
                                   isResult: !widget.part.loading,
@@ -4846,7 +4844,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                   padding: const EdgeInsets.all(10),
                                   decoration: BoxDecoration(
                                     color:
-                                        Theme.of(context).brightness ==
+                                        Theme.of(ctx).brightness ==
                                             Brightness.dark
                                         ? Colors.white10
                                         : const Color(0xFFF7F7F9),
@@ -4876,7 +4874,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                   padding: const EdgeInsets.all(10),
                                   decoration: BoxDecoration(
                                     color:
-                                        Theme.of(context).brightness ==
+                                        Theme.of(ctx).brightness ==
                                             Brightness.dark
                                         ? Colors.white10
                                         : const Color(0xFFF7F7F9),
@@ -4910,8 +4908,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                     runSpacing: 8,
                                     children: images.map((path) {
                                       return GestureDetector(
-                                        onTap: () =>
-                                            _showFullImage(context, path),
+                                        onTap: () => _showFullImage(ctx, path),
                                         child: ClipRRect(
                                           borderRadius: BorderRadius.circular(
                                             8,
@@ -4971,7 +4968,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                         Expanded(
                           child: Text(
                             _titleFor(
-                              context,
+                              ctx,
                               widget.part.toolName,
                               widget.part.arguments,
                               isResult: !widget.part.loading,
@@ -4997,7 +4994,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Theme.of(context).brightness == Brightness.dark
+                        color: Theme.of(ctx).brightness == Brightness.dark
                             ? Colors.white10
                             : const Color(0xFFF7F7F9),
                         borderRadius: BorderRadius.circular(10),
@@ -5023,7 +5020,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Theme.of(context).brightness == Brightness.dark
+                        color: Theme.of(ctx).brightness == Brightness.dark
                             ? Colors.white10
                             : const Color(0xFFF7F7F9),
                         borderRadius: BorderRadius.circular(10),
@@ -5052,7 +5049,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                         runSpacing: 8,
                         children: images.map((path) {
                           return GestureDetector(
-                            onTap: () => _showFullImage(context, path),
+                            onTap: () => _showFullImage(ctx, path),
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(8),
                               child: _buildImageFromPath(path, height: 240),

--- a/test/features/chat/widgets/chat_message_widget_tool_detail_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_tool_detail_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/tts_provider.dart';
+import 'package:Cuplivo/core/services/haptics.dart';
+import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_tactile.dart';
+
+SettingsProvider _createSettings() {
+  SharedPreferences.setMockInitialValues(const <String, Object>{});
+  return SettingsProvider();
+}
+
+Widget _buildHarness({
+  required SettingsProvider settings,
+  required Widget child,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+      ChangeNotifierProvider(create: (_) => TtsProvider()),
+      ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+      ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+const ToolUIPart _loadingCalculatePart = ToolUIPart(
+  id: 'calc-1',
+  toolName: 'calculate',
+  arguments: {'expression': '12212/2'},
+  loading: true,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('tool detail sheet stale-context race', () {
+    testWidgets(
+      'sheet stays healthy when the tool card is unmounted mid-animation',
+      (tester) async {
+        Haptics.setEnabled(false);
+        final settings = _createSettings();
+
+        Widget buildCard(Key key, List<ToolUIPart> parts) => _buildHarness(
+          settings: settings,
+          child: ChatMessageWidget(
+            key: key,
+            message: ChatMessage(
+              role: 'assistant',
+              content: '',
+              conversationId: 'conv-calc',
+            ),
+            showModelIcon: false,
+            toolParts: parts,
+          ),
+        );
+
+        await tester.pumpWidget(
+          buildCard(const ValueKey('card'), const [_loadingCalculatePart]),
+        );
+        await tester.pump();
+
+        final title = find.text('计算器');
+        expect(title, findsOneWidget);
+        await tester.tap(
+          find.ancestor(of: title, matching: find.byType(IosCardPress)).first,
+        );
+        await tester.pump();
+
+        await tester.pumpWidget(
+          buildCard(const ValueKey('card-replaced'), const <ToolUIPart>[]),
+        );
+        await tester.pump();
+
+        await tester.pump(const Duration(milliseconds: 120));
+        await tester.pump(const Duration(milliseconds: 120));
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(tester.takeException(), isNull);
+        expect(find.byType(BottomSheet), findsOneWidget);
+      },
+    );
+  });
+
+  group('Haptics', () {
+    testWidgets('soft haptic swallows async platform channel errors', (
+      tester,
+    ) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          throw PlatformException(code: 'boom');
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+      Haptics.setEnabled(true);
+      Haptics.soft();
+      await tester.pump();
+      expect(tester.takeException(), isNull);
+    });
+  });
+}


### PR DESCRIPTION
- Use the sheet/dialog's own context inside builders instead of the tool
  card context, which can be deactivated mid-stream and crash the app
  (white screen) when generation continues while the detail is open.
- Guard JsonEncoder on tool arguments with a safe fallback.
- Drop the desktop dialog minWidth constraint that breaks narrow windows.
- Harden Haptics._safe to swallow async platform channel errors.
- Add regression tests for the unmount race and haptic error path.
