### PR TITLE
fix(chat): handle parallel Google tool call responses

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -1666,41 +1666,46 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       convo.add({'role': 'user', 'parts': responseParts});
     } else {
-      // Gemini 2.x: existing per-call reconstruction
+      // Gemini 2.x: replay all parallel calls in one model turn. The previous
+      // per-call model/user alternation made later calls look sequential.
+      final modelParts = <Map<String, dynamic>>[];
+      final responseParts = <Map<String, dynamic>>[];
       for (final c in calls) {
         final name = (c['name'] ?? '').toString();
         final args =
             (c['args'] as Map<String, dynamic>? ?? const <String, dynamic>{});
+        final apiId = c['apiId'] as String?;
         final resText = (c['result'] ?? '').toString();
         final thoughtSigKey = c['thoughtSigKey'] as String?;
         final thoughtSigVal = c['thoughtSigVal'];
-
         final part = <String, dynamic>{
-          'functionCall': {'name': name, 'args': args},
+          'functionCall': {
+            if (apiId != null) 'id': apiId,
+            'name': name,
+            'args': args,
+          },
         };
         if (thoughtSigKey != null && thoughtSigVal != null) {
           part[thoughtSigKey] = thoughtSigVal;
         }
+        modelParts.add(part);
 
-        convo.add({
-          'role': 'model',
-          'parts': [part],
-        });
         Map<String, dynamic> responseObj;
         try {
           responseObj = (jsonDecode(resText) as Map).cast<String, dynamic>();
         } catch (_) {
           responseObj = {'result': resText};
         }
-        convo.add({
-          'role': 'user',
-          'parts': [
-            {
-              'functionResponse': {'name': name, 'response': responseObj},
-            },
-          ],
+        responseParts.add({
+          'functionResponse': {
+            'name': name,
+            'response': responseObj,
+            if (apiId != null) 'id': apiId,
+          },
         });
       }
+      convo.add({'role': 'model', 'parts': modelParts});
+      convo.add({'role': 'user', 'parts': responseParts});
     }
     // Continue while(true) for next round
   }

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -353,6 +353,16 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     // Extract system messages into systemInstruction (Google Gemini API best practice)
     String systemPrompt = '';
     final contents = <Map<String, dynamic>>[];
+    final pendingFunctionResponses = <Map<String, dynamic>>[];
+    void flushPendingFunctionResponses() {
+      if (pendingFunctionResponses.isEmpty) return;
+      contents.add({
+        'role': 'user',
+        'parts': List<Map<String, dynamic>>.from(pendingFunctionResponses),
+      });
+      pendingFunctionResponses.clear();
+    }
+
     for (int i = 0; i < messages.length; i++) {
       final msg = messages[i];
       final roleRaw = (msg['role'] ?? 'user').toString();
@@ -363,14 +373,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         }
         continue;
       }
-      final role = roleRaw == 'assistant' ? 'model' : 'user';
       if (roleRaw == 'tool') {
-        contents.add({
-          'role': 'user',
-          'parts': [_googleFunctionResponsePartFromToolMessage(msg)],
-        });
+        pendingFunctionResponses.add(
+          _googleFunctionResponsePartFromToolMessage(msg),
+        );
         continue;
       }
+      flushPendingFunctionResponses();
+      final role = roleRaw == 'assistant' ? 'model' : 'user';
       if (roleRaw == 'assistant' && msg['tool_calls'] is List) {
         final parts = <Map<String, dynamic>>[];
         final raw = _extractGeminiThoughtMeta(
@@ -494,6 +504,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       contents.add({'role': role, 'parts': parts});
     }
+    flushPendingFunctionResponses();
 
     // Map OpenAI-style tools to Gemini functionDeclarations (MCP)
     List<Map<String, dynamic>>? geminiTools;
@@ -794,6 +805,16 @@ Stream<ChatStreamChunk> _sendGoogleStream(
   // Extract system messages into systemInstruction (Google Gemini API best practice)
   String systemPrompt = '';
   final contents = <Map<String, dynamic>>[];
+  final pendingFunctionResponses = <Map<String, dynamic>>[];
+  void flushPendingFunctionResponses() {
+    if (pendingFunctionResponses.isEmpty) return;
+    contents.add({
+      'role': 'user',
+      'parts': List<Map<String, dynamic>>.from(pendingFunctionResponses),
+    });
+    pendingFunctionResponses.clear();
+  }
+
   for (int i = 0; i < messages.length; i++) {
     final msg = messages[i];
     final roleRaw = (msg['role'] ?? 'user').toString();
@@ -804,14 +825,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       continue;
     }
-    final role = roleRaw == 'assistant' ? 'model' : 'user';
     if (roleRaw == 'tool') {
-      contents.add({
-        'role': 'user',
-        'parts': [_googleFunctionResponsePartFromToolMessage(msg)],
-      });
+      pendingFunctionResponses.add(
+        _googleFunctionResponsePartFromToolMessage(msg),
+      );
       continue;
     }
+    flushPendingFunctionResponses();
+    final role = roleRaw == 'assistant' ? 'model' : 'user';
     if (roleRaw == 'assistant' && msg['tool_calls'] is List) {
       final parts = <Map<String, dynamic>>[];
       final raw = (msg['content'] ?? '').toString();
@@ -938,6 +959,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     }
     contents.add({'role': role, 'parts': parts});
   }
+  flushPendingFunctionResponses();
 
   final wantsImageOutput = effective.output.contains(Modality.image);
   bool expectImage = wantsImageOutput;

--- a/test/parallel_tool_call_protocol_test.dart
+++ b/test/parallel_tool_call_protocol_test.dart
@@ -1,0 +1,419 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _googleConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GoogleParallelToolTest',
+    enabled: true,
+    name: 'GoogleParallelToolTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+ProviderConfig _claudeConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'ClaudeParallelToolTest',
+    enabled: true,
+    name: 'ClaudeParallelToolTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.claude,
+  );
+}
+
+Map<String, dynamic> _googleStreamChunk(
+  List<Map<String, dynamic>> parts, {
+  String? finishReason,
+}) {
+  return {
+    'candidates': [
+      {
+        'content': {'parts': parts},
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+  };
+}
+
+Map<String, dynamic> _googleFunctionCall(
+  String name,
+  Map<String, dynamic> args, {
+  String? id,
+}) {
+  return {
+    'functionCall': {if (id != null) 'id': id, 'name': name, 'args': args},
+  };
+}
+
+Future<void> _writeSseResponse(
+  HttpResponse response,
+  Iterable<Map<String, dynamic>> chunks,
+) async {
+  response.statusCode = HttpStatus.ok;
+  response.headers.contentType = ContentType('text', 'event-stream');
+  response.headers.set('Transfer-Encoding', 'chunked');
+  for (final chunk in chunks) {
+    response.write('data: ${jsonEncode(chunk)}\n\n');
+  }
+  response.write('data: [DONE]\n\n');
+  await response.close();
+}
+
+Future<Map<String, dynamic>> _jsonRequestBody(HttpRequest request) async {
+  return (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+      .cast<String, dynamic>();
+}
+
+void main() {
+  group('parallel tool call protocol', () {
+    test(
+      'groups parallel historical Google tool results into one user turn',
+      () async {
+        late Map<String, dynamic> requestBody;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+
+        server.listen((request) async {
+          requestBody = await _jsonRequestBody(request);
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType.json;
+          request.response.write(
+            jsonEncode({
+              'candidates': [
+                {
+                  'content': {
+                    'parts': [
+                      {'text': 'done'},
+                    ],
+                  },
+                  'finishReason': 'STOP',
+                },
+              ],
+            }),
+          );
+          await request.response.close();
+        });
+
+        await ChatApiService.sendMessageStream(
+          config: _googleConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-2.5-pro',
+          messages: const [
+            {'role': 'user', 'content': '查两个信息'},
+            {
+              'role': 'assistant',
+              'content': '\n\n',
+              'tool_calls': [
+                {
+                  'id': 'call_1',
+                  'type': 'function',
+                  'function': {
+                    'name': 'lookup_city',
+                    'arguments': '{"city":"Hangzhou"}',
+                  },
+                },
+                {
+                  'id': 'call_2',
+                  'type': 'function',
+                  'function': {
+                    'name': 'lookup_time',
+                    'arguments': '{"city":"Hangzhou"}',
+                  },
+                },
+              ],
+            },
+            {
+              'role': 'tool',
+              'tool_call_id': 'call_1',
+              'name': 'lookup_city',
+              'content': '{"temperature":20}',
+            },
+            {
+              'role': 'tool',
+              'tool_call_id': 'call_2',
+              'name': 'lookup_time',
+              'content': '{"time":"15:00"}',
+            },
+            {'role': 'user', 'content': '继续总结'},
+          ],
+          stream: false,
+        ).toList();
+
+        final contents = (requestBody['contents'] as List).cast<Map>();
+        expect(contents.map((content) => content['role']).toList(), [
+          'user',
+          'model',
+          'user',
+          'user',
+        ]);
+        final responseParts = (contents[2]['parts'] as List).cast<Map>();
+        expect(
+          responseParts
+              .map((part) => part['functionResponse']['name'])
+              .toList(),
+          ['lookup_city', 'lookup_time'],
+        );
+      },
+    );
+
+    test(
+      'returns parallel Google streaming calls in one follow-up turn',
+      () async {
+        final requestBodies = <Map<String, dynamic>>[];
+        var requestCount = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+
+        server.listen((request) async {
+          requestCount++;
+          requestBodies.add(await _jsonRequestBody(request));
+          if (requestCount == 1) {
+            await _writeSseResponse(request.response, [
+              _googleStreamChunk([
+                _googleFunctionCall('lookup_city', {
+                  'city': 'Hangzhou',
+                }, id: 'api_city_call'),
+                _googleFunctionCall('lookup_time', {
+                  'city': 'Hangzhou',
+                }, id: 'api_time_call'),
+              ], finishReason: 'STOP'),
+            ]);
+            return;
+          }
+          await _writeSseResponse(request.response, [
+            _googleStreamChunk([
+              {'text': 'done'},
+            ], finishReason: 'STOP'),
+          ]);
+        });
+
+        final seenToolCallIds = <String?>[];
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _googleConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'gemini-2.5-pro',
+          messages: const [
+            {'role': 'user', 'content': '查两个信息'},
+          ],
+          tools: const [
+            {
+              'type': 'function',
+              'function': {
+                'name': 'lookup_city',
+                'parameters': {'type': 'object'},
+              },
+            },
+            {
+              'type': 'function',
+              'function': {
+                'name': 'lookup_time',
+                'parameters': {'type': 'object'},
+              },
+            },
+          ],
+          onToolCall: (name, args, {toolCallId}) async {
+            seenToolCallIds.add(toolCallId);
+            return name == 'lookup_city'
+                ? 'not-json-tool-result'
+                : jsonEncode({'tool': name});
+          },
+        ).toList();
+
+        expect(chunks.last.isDone, isTrue);
+        expect(requestBodies, hasLength(2));
+        final followUpContents = (requestBodies[1]['contents'] as List)
+            .cast<Map>();
+        expect(followUpContents.map((content) => content['role']).toList(), [
+          'user',
+          'model',
+          'user',
+        ]);
+        expect(
+          (followUpContents[1]['parts'] as List)
+              .where((part) => (part as Map).containsKey('functionCall'))
+              .length,
+          2,
+        );
+        expect(seenToolCallIds, ['api_city_call', 'api_time_call']);
+        expect(
+          (followUpContents[1]['parts'] as List)
+              .map((part) => (part as Map)['functionCall']['id'])
+              .toList(),
+          ['api_city_call', 'api_time_call'],
+        );
+        expect(
+          (followUpContents[2]['parts'] as List)
+              .map((part) => (part as Map)['functionResponse']['name'])
+              .toList(),
+          ['lookup_city', 'lookup_time'],
+        );
+        expect(
+          (followUpContents[2]['parts'] as List)
+              .map((part) => (part as Map)['functionResponse']['id'])
+              .toList(),
+          ['api_city_call', 'api_time_call'],
+        );
+        expect(
+          (followUpContents[2]['parts'] as List)
+              .first['functionResponse']['response'],
+          {'result': 'not-json-tool-result'},
+        );
+      },
+    );
+
+    test(
+      'returns all parallel Anthropic streaming tool results together',
+      () async {
+        final requestBodies = <Map<String, dynamic>>[];
+        var requestCount = 0;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+
+        server.listen((request) async {
+          requestCount++;
+          requestBodies.add(await _jsonRequestBody(request));
+          if (requestCount == 1) {
+            await _writeSseResponse(request.response, [
+              {
+                'type': 'message_start',
+                'message': {'id': 'msg_1'},
+              },
+              {
+                'type': 'content_block_start',
+                'index': 0,
+                'content_block': {
+                  'type': 'tool_use',
+                  'id': 'toolu_1',
+                  'name': 'lookup_city',
+                  'input': {},
+                },
+              },
+              {
+                'type': 'content_block_delta',
+                'index': 0,
+                'delta': {
+                  'type': 'input_json_delta',
+                  'partial_json': '{"city":"Hangzhou"}',
+                },
+              },
+              {
+                'type': 'content_block_stop',
+                'index': 0,
+                'content_block': {'id': 'toolu_1'},
+              },
+              {
+                'type': 'content_block_start',
+                'index': 1,
+                'content_block': {
+                  'type': 'tool_use',
+                  'id': 'toolu_2',
+                  'name': 'lookup_time',
+                  'input': {},
+                },
+              },
+              {
+                'type': 'content_block_delta',
+                'index': 1,
+                'delta': {
+                  'type': 'input_json_delta',
+                  'partial_json': '{"city":"Hangzhou"}',
+                },
+              },
+              {
+                'type': 'content_block_stop',
+                'index': 1,
+                'content_block': {'id': 'toolu_2'},
+              },
+              {
+                'type': 'message_delta',
+                'delta': {'stop_reason': 'tool_use'},
+              },
+              {'type': 'message_stop'},
+            ]);
+            return;
+          }
+          await _writeSseResponse(request.response, [
+            {
+              'type': 'message_start',
+              'message': {'id': 'msg_2'},
+            },
+            {
+              'type': 'content_block_start',
+              'index': 0,
+              'content_block': {'type': 'text', 'text': ''},
+            },
+            {
+              'type': 'content_block_delta',
+              'index': 0,
+              'delta': {'type': 'text_delta', 'text': 'done'},
+            },
+            {'type': 'content_block_stop', 'index': 0},
+            {
+              'type': 'message_delta',
+              'delta': {'stop_reason': 'end_turn'},
+            },
+            {'type': 'message_stop'},
+          ]);
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _claudeConfig(
+            'http://${server.address.address}:${server.port}',
+          ),
+          modelId: 'claude-sonnet-4-6',
+          messages: const [
+            {'role': 'user', 'content': '查两个信息'},
+          ],
+          tools: const [
+            {
+              'type': 'function',
+              'function': {
+                'name': 'lookup_city',
+                'parameters': {'type': 'object'},
+              },
+            },
+            {
+              'type': 'function',
+              'function': {
+                'name': 'lookup_time',
+                'parameters': {'type': 'object'},
+              },
+            },
+          ],
+          onToolCall: (name, args, {toolCallId}) async =>
+              jsonEncode({'tool': name}),
+        ).toList();
+
+        expect(chunks.last.isDone, isTrue);
+        final followUpMessages = (requestBodies[1]['messages'] as List)
+            .cast<Map>();
+        expect(followUpMessages.map((message) => message['role']).toList(), [
+          'user',
+          'assistant',
+          'user',
+        ]);
+        expect(
+          (followUpMessages[1]['content'] as List)
+              .where((block) => (block as Map)['type'] == 'tool_use')
+              .length,
+          2,
+        );
+        expect(
+          (followUpMessages[2]['content'] as List)
+              .map((block) => (block as Map)['tool_use_id'])
+              .toList(),
+          ['toolu_1', 'toolu_2'],
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #176.

- Group consecutive Google tool results into one user turn.
- Replay Gemini 2.x parallel function calls as one model turn followed by one user turn containing all function responses.
- Preserve provider call IDs and malformed tool-result handling.
- Keep Gemini 3 replay behavior unchanged from the upstream implementation.
- Add Google and Anthropic parallel-tool protocol regression tests.

## Commit structure

1. 1c1eb614 fix(gemini): group historical tool responses
2. 2ba8def6 fix(gemini): keep parallel tool calls in one turn
3. 9ff089bd test(chat): cover parallel tool call protocol

## Upstream commits used

The related Kelivo commits were used as the implementation baseline:

- 096624b: fix(gemini): preserve function call ids
  https://github.com/Chevey339/kelivo/commit/096624bafefd4994838ff54497a13264cc890e4a
- cbac3dc: fix(chat): preserve provider reasoning signatures
  https://github.com/Chevey339/kelivo/commit/cbac3dc34170791fe97a7f9b776ad711713272de

Cuplivo master already contains equivalent adaptations as 40c7f2e2 and 505ab3d9. Therefore the original upstream commits are not duplicated in this PR history: cherry-picking them again would create empty or duplicate commits. The three commits above contain only the Cuplivo-specific delta that remains missing from upstream.

## Verification

- flutter test test/parallel_tool_call_protocol_test.dart
- flutter test test/claude_thinking_compat_test.dart
- flutter test test/gemini_part_id_payload_test.dart
- flutter test test/gemini_thought_signature_repro_test.dart
- flutter analyze lib/core/services/api/providers/google_common.dart test/parallel_tool_call_protocol_test.dart
- dart format and git diff --check

Full flutter analyze remains affected by the existing dependencies/mcp_client/test setup missing package:test/test.dart.