### PR TITLE
fix: survive and log unhandled root-isolate errors instead of silent crash

### DIFF
--- a/lib/core/services/logging/flutter_logger.dart
+++ b/lib/core/services/logging/flutter_logger.dart
@@ -58,12 +58,20 @@ class FlutterLogger {
     _originalPlatformOnError = ui.PlatformDispatcher.instance.onError;
     ui.PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
       try {
-        log('$error\n$stack', tag: 'Uncaught');
+        // force: uncaught root-isolate errors are written to the log file even
+        // when the log toggle is off, so release crashes remain diagnosable.
+        log('$error\n$stack', tag: 'Uncaught', force: true);
+      } catch (_) {}
+      try {
+        debugPrint('[Uncaught] $error\n$stack');
       } catch (_) {}
 
       final original = _originalPlatformOnError;
       if (original != null) return original(error, stack);
-      return false;
+      // Returning true keeps the isolate alive. With the default `false` the
+      // engine terminates the process on the first unhandled root-isolate
+      // error, which surfaces as a silent window close in release builds.
+      return true;
     };
   }
 
@@ -127,8 +135,8 @@ class FlutterLogger {
     return _sink!;
   }
 
-  static void log(String message, {String? tag}) {
-    if (!_enabled) return;
+  static void log(String message, {String? tag, bool force = false}) {
+    if (!_enabled && !force) return;
     final now = DateTime.now();
     final prefix = '[${_formatTs(now)}]${tag == null ? '' : ' [$tag]'} ';
     final normalized = message.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
@@ -140,7 +148,7 @@ class FlutterLogger {
     final text = buffer.toString();
 
     _writeQueue = _writeQueue.then((_) async {
-      if (!_enabled) return;
+      if (!_enabled && !force) return;
       try {
         final sink = await _ensureSink();
         sink.write(text);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -91,7 +91,7 @@ http.Client _oauthHttpClient(SettingsProvider sp) {
 }
 
 Future<void> main() async {
-  await runZoned(
+  await runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
 
@@ -122,7 +122,19 @@ Future<void> main() async {
       // logging.Logger.root.onRecord.listen((rec) { ... });
       // Cache current Documents directory to fix sandboxed absolute paths on iOS
       await SandboxPathResolver.init();
-      await SkillManager.initRoot();
+      // Skills root is feature-level: a resolution failure (e.g. path_provider
+      // channel unavailable) must not block app startup. Degrade to "skills
+      // unavailable this session" instead of dying before runApp.
+      try {
+        await SkillManager.initRoot();
+      } catch (e, st) {
+        debugPrint('[main] SkillManager.initRoot failed: $e\n$st');
+        FlutterLogger.log(
+          'SkillManager.initRoot failed: $e\n$st',
+          tag: 'Startup',
+          force: true,
+        );
+      }
       await CodexDeviceCodeController.instance.init();
       await GrokDeviceCodeController.instance.init();
       // Enable edge-to-edge to allow content under system bars (Android)
@@ -133,6 +145,13 @@ Future<void> main() async {
       }
       // Start app (Flutter log capture is toggleable and off by default)
       runApp(const MyApp());
+    },
+    // Unhandled root-isolate errors must not kill the process silently: log
+    // them (console + Flutter log file, forced regardless of the log toggle)
+    // and keep the app alive.
+    (Object error, StackTrace stack) {
+      debugPrint('[main] uncaught error: $error\n$stack');
+      FlutterLogger.log('$error\n$stack', tag: 'Uncaught', force: true);
     },
     zoneSpecification: ZoneSpecification(
       print: (self, parent, zone, line) {

--- a/test/core/services/logging/flutter_logger_test.dart
+++ b/test/core/services/logging/flutter_logger_test.dart
@@ -1,0 +1,29 @@
+import 'dart:ui' as ui;
+
+import 'package:Cuplivo/core/services/logging/flutter_logger.dart';
+import 'package:flutter/foundation.dart' show FlutterError;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'installGlobalHandlers installs a non-null uncaught handler that returns '
+    'true when no original handler exists',
+    () {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      final originalPlatformOnError = ui.PlatformDispatcher.instance.onError;
+      final originalFlutterOnError = FlutterError.onError;
+      try {
+        FlutterLogger.installGlobalHandlers();
+        final handler = ui.PlatformDispatcher.instance.onError;
+        expect(handler, isNotNull);
+        // The dart:ui contract: returning true keeps the isolate alive.
+        // Returning false lets the engine terminate the process on the first
+        // unhandled root-isolate error (silent window close in release).
+        expect(handler!(StateError('boom'), StackTrace.current), isTrue);
+      } finally {
+        ui.PlatformDispatcher.instance.onError = originalPlatformOnError;
+        FlutterError.onError = originalFlutterOnError;
+      }
+    },
+  );
+}


### PR DESCRIPTION
Fixes #211.

- main: runZoned -> runZonedGuarded with an onError that logs and keeps
  the app alive; SkillManager.initRoot failure degrades to skills
  unavailable instead of blocking startup
- FlutterLogger: PlatformDispatcher.onError now returns true so the
  engine no longer terminates the process on the first unhandled
  error; log() gains a force flag so uncaught errors are written to
  the log file even when the log toggle is off
- test: lock in the keep-alive contract of the installed handler
