### PR TITLE
fix(android): pick in-app update APK by device ABI (#230)

### DIFF
--- a/lib/core/providers/update_provider.dart
+++ b/lib/core/providers/update_provider.dart
@@ -1,9 +1,45 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
+
+// Longest-first so `x86_64` is not partially matched as `x86`.
+// Also used as static fallback order when device ABIs are unknown/unmatched.
+const List<String> kAndroidApkArchTags = [
+  'arm64-v8a',
+  'armeabi-v7a',
+  'x86_64',
+  'x86',
+];
+
+String? parseAndroidApkArch(String assetName) {
+  final lower = assetName.toLowerCase();
+  for (final arch in kAndroidApkArchTags) {
+    if (lower.contains(arch)) return arch;
+  }
+  return null;
+}
+
+String? selectAndroidDownloadUrl({
+  required Map<String, String> apkByArch,
+  String? unarchUrl,
+  List<String> supportedAbis = const [],
+}) {
+  for (final abi in supportedAbis) {
+    final url = apkByArch[abi];
+    if (url != null && url.isNotEmpty) return url;
+  }
+  for (final arch in kAndroidApkArchTags) {
+    final url = apkByArch[arch];
+    if (url != null && url.isNotEmpty) return url;
+  }
+  if (unarchUrl != null && unarchUrl.isNotEmpty) return unarchUrl;
+  if (apkByArch.isNotEmpty) return apkByArch.values.first;
+  return null;
+}
 
 class UpdateInfo {
   final String app;
@@ -74,7 +110,10 @@ class UpdateInfo {
   }
 
   /// Parses a GitHub Releases API response into [UpdateInfo].
-  factory UpdateInfo.fromGithubRelease(Map<String, dynamic> json) {
+  factory UpdateInfo.fromGithubRelease(
+    Map<String, dynamic> json, {
+    List<String> androidAbis = const [],
+  }) {
     final tag = (json['tag_name'] ?? '').toString();
     // Strip leading 'v' prefix if present (e.g. "v1.2.3" -> "1.2.3")
     final version = tag.startsWith('v') ? tag.substring(1) : tag;
@@ -89,6 +128,8 @@ class UpdateInfo {
 
     // Map release assets to platform download keys
     final downloads = <String, String>{};
+    final apkByArch = <String, String>{};
+    String? unarchApkUrl;
     final assets = (json['assets'] as List?) ?? const [];
     for (final asset in assets) {
       if (asset is! Map) continue;
@@ -96,7 +137,12 @@ class UpdateInfo {
       final url = (asset['browser_download_url'] ?? '').toString();
       if (url.isEmpty) continue;
       if (name.endsWith('.apk')) {
-        downloads['android'] = url;
+        final arch = parseAndroidApkArch(name);
+        if (arch != null) {
+          apkByArch[arch] = url;
+        } else {
+          unarchApkUrl = url;
+        }
       } else if (name.endsWith('.ipa')) {
         downloads['ios'] = url;
       } else if (name.endsWith('.dmg') || name.endsWith('.pkg')) {
@@ -108,6 +154,15 @@ class UpdateInfo {
           name.endsWith('.rpm')) {
         downloads['linux'] = url;
       }
+    }
+
+    final androidUrl = selectAndroidDownloadUrl(
+      apkByArch: apkByArch,
+      unarchUrl: unarchApkUrl,
+      supportedAbis: androidAbis,
+    );
+    if (androidUrl != null) {
+      downloads['android'] = androidUrl;
     }
 
     return UpdateInfo(
@@ -156,7 +211,8 @@ class UpdateProvider extends ChangeNotifier {
       }
       final data =
           jsonDecode(utf8.decode(resp.bodyBytes)) as Map<String, dynamic>;
-      final info = UpdateInfo.fromGithubRelease(data);
+      final androidAbis = await _androidSupportedAbis();
+      final info = UpdateInfo.fromGithubRelease(data, androidAbis: androidAbis);
 
       final pkg = await PackageInfo.fromPlatform();
       final currentVer = pkg.version; // e.g., 1.0.0
@@ -172,6 +228,17 @@ class UpdateProvider extends ChangeNotifier {
     } finally {
       _checking = false;
       notifyListeners();
+    }
+  }
+
+  Future<List<String>> _androidSupportedAbis() async {
+    if (!Platform.isAndroid) return const [];
+    try {
+      final info = await DeviceInfoPlugin().androidInfo;
+      return List<String>.from(info.supportedAbis);
+    } catch (e) {
+      debugPrint('UpdateProvider: failed to read Android ABIs: $e');
+      return const [];
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   flutter_slidable: ^3.0.1
   url_launcher: ^6.3.2
   package_info_plus: ^8.3.1
+  device_info_plus: ^11.5.0
   gpt_markdown: #^1.1.7
     path: ./dependencies/gpt_markdown
   uuid: ^4.5.0

--- a/test/core/providers/update_provider_android_apk_test.dart
+++ b/test/core/providers/update_provider_android_apk_test.dart
@@ -1,0 +1,162 @@
+import 'package:Cuplivo/core/providers/update_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Mirrors v2.6.2 GitHub release asset order (arm64 → v7a → x86_64 last).
+Map<String, dynamic> _releaseWithSplitApks() {
+  return {
+    'tag_name': 'v2.6.2',
+    'published_at': '2026-08-01T00:00:00Z',
+    'body': 'notes',
+    'assets': [
+      {
+        'name': 'Cuplivo_android_2.6.2+28_arm64-v8a.apk',
+        'browser_download_url':
+            'https://example.com/Cuplivo_android_2.6.2+28_arm64-v8a.apk',
+      },
+      {
+        'name': 'Cuplivo_android_2.6.2+28_armeabi-v7a.apk',
+        'browser_download_url':
+            'https://example.com/Cuplivo_android_2.6.2+28_armeabi-v7a.apk',
+      },
+      {
+        'name': 'Cuplivo_android_2.6.2+28_x86_64.apk',
+        'browser_download_url':
+            'https://example.com/Cuplivo_android_2.6.2+28_x86_64.apk',
+      },
+      {
+        'name': 'Cuplivo_windows_2.6.2+28.exe',
+        'browser_download_url': 'https://example.com/windows.exe',
+      },
+    ],
+  };
+}
+
+void main() {
+  group('parseAndroidApkArch', () {
+    test('extracts known ABI tags from asset names', () {
+      expect(
+        parseAndroidApkArch('Cuplivo_android_2.6.2+28_arm64-v8a.apk'),
+        'arm64-v8a',
+      );
+      expect(
+        parseAndroidApkArch('Cuplivo_android_2.6.2+28_armeabi-v7a.apk'),
+        'armeabi-v7a',
+      );
+      expect(
+        parseAndroidApkArch('Cuplivo_android_2.6.2+28_x86_64.apk'),
+        'x86_64',
+      );
+      expect(parseAndroidApkArch('app-x86-release.apk'), 'x86');
+    });
+
+    test('returns null when no arch tag is present', () {
+      expect(parseAndroidApkArch('Cuplivo_android_2.6.2.apk'), isNull);
+    });
+  });
+
+  group('selectAndroidDownloadUrl', () {
+    const byArch = {
+      'arm64-v8a': 'https://example.com/arm64.apk',
+      'armeabi-v7a': 'https://example.com/v7a.apk',
+      'x86_64': 'https://example.com/x86_64.apk',
+    };
+
+    test('prefers device supportedAbis order', () {
+      expect(
+        selectAndroidDownloadUrl(
+          apkByArch: byArch,
+          supportedAbis: const ['arm64-v8a', 'armeabi-v7a', 'x86_64'],
+        ),
+        'https://example.com/arm64.apk',
+      );
+      expect(
+        selectAndroidDownloadUrl(
+          apkByArch: byArch,
+          supportedAbis: const ['armeabi-v7a'],
+        ),
+        'https://example.com/v7a.apk',
+      );
+      expect(
+        selectAndroidDownloadUrl(
+          apkByArch: byArch,
+          supportedAbis: const ['x86_64'],
+        ),
+        'https://example.com/x86_64.apk',
+      );
+    });
+
+    test('falls back to arm64 when abis empty (not last-wins x86_64)', () {
+      expect(
+        selectAndroidDownloadUrl(apkByArch: byArch),
+        'https://example.com/arm64.apk',
+      );
+    });
+
+    test('uses unarch url when no arch-tagged apks match', () {
+      expect(
+        selectAndroidDownloadUrl(
+          apkByArch: const {},
+          unarchUrl: 'https://example.com/universal.apk',
+        ),
+        'https://example.com/universal.apk',
+      );
+    });
+  });
+
+  group('UpdateInfo.fromGithubRelease android apk selection', () {
+    test('default abis picks arm64 even when x86_64 is last asset', () {
+      final info = UpdateInfo.fromGithubRelease(_releaseWithSplitApks());
+      expect(
+        info.downloads['android'],
+        'https://example.com/Cuplivo_android_2.6.2+28_arm64-v8a.apk',
+      );
+      expect(info.downloads['windows'], 'https://example.com/windows.exe');
+      expect(info.version, '2.6.2');
+    });
+
+    test('matches arm64 device abis', () {
+      final info = UpdateInfo.fromGithubRelease(
+        _releaseWithSplitApks(),
+        androidAbis: const ['arm64-v8a', 'armeabi-v7a', 'x86_64'],
+      );
+      expect(info.downloads['android'], contains('arm64-v8a'));
+    });
+
+    test('matches armeabi-v7a-only device', () {
+      final info = UpdateInfo.fromGithubRelease(
+        _releaseWithSplitApks(),
+        androidAbis: const ['armeabi-v7a'],
+      );
+      expect(info.downloads['android'], contains('armeabi-v7a'));
+    });
+
+    test('matches x86_64 emulator', () {
+      final info = UpdateInfo.fromGithubRelease(
+        _releaseWithSplitApks(),
+        androidAbis: const ['x86_64'],
+      );
+      expect(info.downloads['android'], contains('x86_64'));
+    });
+
+    test('unarch apk is selected when no arch tags present', () {
+      final info = UpdateInfo.fromGithubRelease({
+        'tag_name': 'v1.0.0',
+        'assets': [
+          {
+            'name': 'Cuplivo_android_1.0.0.apk',
+            'browser_download_url': 'https://example.com/universal.apk',
+          },
+        ],
+      });
+      expect(info.downloads['android'], 'https://example.com/universal.apk');
+    });
+
+    test('empty assets leaves android download unset', () {
+      final info = UpdateInfo.fromGithubRelease({
+        'tag_name': 'v1.0.0',
+        'assets': <Map<String, dynamic>>[],
+      });
+      expect(info.downloads.containsKey('android'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fix in-app update always downloading the x86_64 APK on Android (#230)
- `fromGithubRelease` now groups split-per-abi APKs by arch tag and selects via device `supportedAbis` (`device_info_plus`), with static fallback `arm64-v8a → armeabi-v7a → x86_64 → x86`
- Add unit coverage for arch parse / selection / multi-APK release fixture

## Test plan
- [x] `dart analyze --fatal-infos` on changed files
- [x] `flutter test test/core/providers/update_provider_android_apk_test.dart` (passed earlier in session; later rerun hit env compiler flake)
- [ ] Manual: arm64 phone → download URL/filename contains `arm64-v8a`
- [ ] Manual (optional): x86_64 emulator → `x86_64` APK
- [ ] Manual: non-Android desktop update link unchanged

Closes #230