### PR TITLE
feat: change default behavior (provider, assistant params, logging)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -544,3 +544,21 @@
 ### Flagged Ambiguities
 
 - "显示公式" / "display formula" was used in issue #218 to mean block-level math as opposed to inline — resolved: the domain term is **Display math** (block-level TeX forms `$$...$$` and `\[...\]`); "inline math" is the flow-level counterpart.
+
+## Default Behavior (Out-of-the-Box Defaults)
+
+- **DeepSeek default**: DeepSeek is the first base provider (position 1) and enabled in the built-in provider list, and the global default chat model is seeded to `DeepSeek` / `deepseek-v4-flash` **once** — on the first load where no model was ever persisted (fresh installs and legacy installs that never chose a model). A sentinel (`default_model_seeded_v1`) is armed whenever a selection is persisted or the seed runs, so explicit user actions (`resetCurrentModel`, provider/model disable or delete) are never undone by a later launch. Persisted `providersOrder` / `currentModel` win on existing installs. The default assistant is NOT bound to DeepSeek explicitly (`chatModelProvider` stays null) — it resolves through the global default model, keeping a single source of truth.
+- **Temperature default off (默认关闭温度)**: New assistants (default assistant, sample assistant, `addAssistant()`) are created with temperature disabled (`null` → the parameter is omitted from the API payload, letting the provider sample by its own default). Toggling temperature on mid-session starts from 0.6. "关闭" means omit, never "temperature: 0".
+- **Context message limit default off**: New assistants default to `limitContextMessages: false` — full conversation history is sent without trimming. Deliberate consequence: nothing auto-guards token overrun (compression and clear-context are manual actions), so very long chats can hit provider context limits. Persisted assistants keep their stored value (`fromJson` fallback `true` untouched).
+- **Request logging default on (llm)**: The llm request-log category defaults to ON (new and missing-key installs); mcp/tts/search/flutter categories stay OFF (user opt-in). Log total is capped at 50 MB by default (oldest-first eviction, enforced at startup). Defaults apply to any install missing the key — including existing installs that never touched the toggles.
+- **Credential masking in logs (日志脱敏)**: Credential-bearing request headers (`authorization`, `proxy-authorization`, `x-api-key`, `x-goog-api-key`, `api-key`, case-insensitive) are masked in log output: the first 7 characters of the value are kept, then ` [N more]` where N = remaining length (e.g. `Authorization: Bearer [45 more]`). Bodies are logged unmasked — the troubleshooting value of the logs is preserved while credentials at rest are not.
+
+### Example Dialogue
+
+> **Dev:** "I enabled logging and my DeepSeek API key shows up in the log file!"
+> **Domain expert:** "It can't — credential-bearing headers are masked to `Bearer [45 more]` before they're written. The request bodies stay fully logged, so the request/response flow is still debuggable end-to-end. The 50 MB cap keeps the on-by-default logging from growing unbounded."
+
+### Flagged Ambiguities
+
+- "默认启动 DeepSeek" (issue #196) — resolved: default **selection**, not zero-config working. The base URL is seeded but the API key still comes from the user.
+- "关闭温度" — resolved: omit the sampling parameter, not send `temperature: 0`.

--- a/docs/adr/0021-request-logging-default-on-credential-masking.md
+++ b/docs/adr/0021-request-logging-default-on-credential-masking.md
@@ -1,0 +1,14 @@
+# Request Logging Default-On with Credential Masking
+
+Default-on LLM request logging with a 50 MB cap and credential masking was chosen over opt-in logging: the log category `llm` defaults to ON for missing-key installs (new and existing alike), the log total is capped at 50 MB with oldest-first eviction, and credential-bearing headers (`authorization`, `proxy-authorization`, `x-api-key`, `x-goog-api-key`, `api-key`) are masked in log output to the first 7 characters plus the remaining length (`Bearer [45 more]`) so the logs stay fully debuggable without credentials at rest. Issue #196.
+
+## Considered Options
+
+- **All categories on**: rejected — tts/search/flutter logs are noise for support; kept user-opt-in.
+- **Log headers unmasked**: rejected — with logging on by default, API keys would land in plaintext `logs/*.txt` on every install; masking costs nothing diagnostically (bodies keep full fidelity).
+- **Redaction via full suppression**: rejected — `***` would hide whether the scheme/header shape is correct, which matters when debugging provider-specific auth issues.
+
+## Consequences
+
+- Defaults apply to any install missing the key, including existing installs that never touched the toggles — logging becomes active and the 50 MB cap (previously unlimited) starts being enforced at startup cleanup.
+- Bodies remain unmasked by design; the accepted residual exposure is conversation content at rest, not credentials.

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -109,7 +109,7 @@ Do **not** store sensitive information, including:
     this.temperature,
     this.topP,
     this.contextMessageSize = 64,
-    this.limitContextMessages = true,
+    this.limitContextMessages = false,
     this.streamOutput = true,
     this.thinkingBudget,
     this.maxTokens,

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -255,7 +255,6 @@ class AssistantProvider extends ChangeNotifier {
     name: l10n.assistantProviderDefaultAssistantName,
     systemPrompt: '',
     thinkingBudget: null,
-    temperature: 0.6,
     topP: null,
   );
 
@@ -279,7 +278,6 @@ class AssistantProvider extends ChangeNotifier {
           '{device_info}',
           '{system_version}',
         ),
-        temperature: 0.6,
         topP: null,
       ),
     );
@@ -500,7 +498,6 @@ class AssistantProvider extends ChangeNotifier {
           (context != null
               ? AppLocalizations.of(context)!.assistantProviderNewAssistantName
               : 'New Assistant')),
-      temperature: 0.6,
       topP: null,
     );
     _assistants.add(a);

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -57,13 +57,13 @@ class SettingsProvider extends ChangeNotifier {
       'provider_ungrouped_position_v1'; // display index among groups
   static const String providerUngroupedGroupKey = '__ungrouped__';
   static const List<String> _builtInProviderKeysInOrder = [
+    'DeepSeek',
     'OpenAI',
     'SiliconFlow',
     'Gemini',
     'OpenRouter',
     'KelivoIN',
     'Tensdaq',
-    'DeepSeek',
     'AIhubmix',
     'Aliyun',
     'Zhipu AI',
@@ -89,6 +89,7 @@ class SettingsProvider extends ChangeNotifier {
   };
   static const String _pinnedModelsKey = 'pinned_models_v1';
   static const String _selectedModelKey = 'selected_model_v1';
+  static const String _defaultModelSeededKey = 'default_model_seeded_v1';
   static const String _titleModelKey = 'title_model_v1';
   static const String _titlePromptKey = 'title_prompt_v1';
   static const String _ocrModelKey = 'ocr_model_v1';
@@ -851,6 +852,20 @@ class SettingsProvider extends ChangeNotifier {
         _currentModelProvider = parts[0];
         _currentModelId = parts.sublist(1).join('::');
       }
+      // A persisted selection means the user has owned this choice at least
+      // once; arm the sentinel so a later reset is never re-seeded.
+      await prefs.setBool(_defaultModelSeededKey, true);
+    } else {
+      // One-time default: DeepSeek as the global default chat model.
+      // Seeded only on the first load where no model was ever persisted
+      // (guarded by a sentinel so explicit resets/deletes are never undone
+      // on later launches).
+      if (!(prefs.getBool(_defaultModelSeededKey) ?? false)) {
+        _currentModelProvider = 'DeepSeek';
+        _currentModelId = 'deepseek-v4-flash';
+        await prefs.setBool(_defaultModelSeededKey, true);
+        await prefs.setString(_selectedModelKey, 'DeepSeek::deepseek-v4-flash');
+      }
     }
     // load title model
     final titleSel = prefs.getString(_titleModelKey);
@@ -1035,7 +1050,7 @@ class SettingsProvider extends ChangeNotifier {
     _keepAssistantListExpandedOnSidebarClose =
         prefs.getBool(_displayKeepAssistantListExpandedOnSidebarCloseKey) ??
         false;
-    _requestLogEnabled = prefs.getBool(_requestLogEnabledKey) ?? false;
+    _requestLogEnabled = prefs.getBool(_requestLogEnabledKey) ?? true;
     await RequestLogger.setEnabled(_requestLogEnabled);
     _mcpLogEnabled = prefs.getBool(_mcpLogEnabledKey) ?? false;
     await RequestLogger.setCategoryEnabled(
@@ -1057,7 +1072,7 @@ class SettingsProvider extends ChangeNotifier {
     _logSaveOutput = prefs.getBool(_logSaveOutputKey) ?? true;
     RequestLogger.saveOutput = _logSaveOutput;
     _logAutoDeleteDays = prefs.getInt(_logAutoDeleteDaysKey) ?? 0;
-    _logMaxSizeMB = prefs.getInt(_logMaxSizeMBKey) ?? 0;
+    _logMaxSizeMB = prefs.getInt(_logMaxSizeMBKey) ?? 50;
     _trashCapMb = prefs.getInt(_trashCapMbKey) ?? 10;
     _appLaunchCount = prefs.getInt(_appLaunchCountKey) ?? 0;
     // Run log cleanup based on current settings
@@ -5206,6 +5221,7 @@ class ProviderConfig {
   static ProviderConfig defaultsFor(String key, {String? displayName}) {
     bool defaultEnabled(String k) {
       final s = k.toLowerCase();
+      if (s.contains('deepseek')) return true;
       if (s.contains('tensdaq')) return true;
       if (s.contains('openai')) return true;
       if (s.contains('gemini') || s.contains('google')) return true;

--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -176,7 +176,8 @@ class DioHttpClient extends http.BaseClient {
       RequestLogger.logLine('[REQ $reqId] $method $uri');
       if (reqHeaders.isNotEmpty) {
         RequestLogger.logLine(
-          '[REQ $reqId] headers=${RequestLogger.encodeObject(reqHeaders)}',
+          '[REQ $reqId] headers='
+          '${RequestLogger.encodeObject(RequestLogger.redactHeaders(reqHeaders))}',
         );
       }
       if (bodyBytes.isNotEmpty) {
@@ -216,7 +217,8 @@ class DioHttpClient extends http.BaseClient {
         RequestLogger.logLine('[RES $reqId] status=$statusCode');
         if (headers.isNotEmpty) {
           RequestLogger.logLine(
-            '[RES $reqId] headers=${RequestLogger.encodeObject(headers)}',
+            '[RES $reqId] headers='
+            '${RequestLogger.encodeObject(RequestLogger.redactHeaders(headers))}',
           );
         }
       }

--- a/lib/core/services/network/logging_http_client.dart
+++ b/lib/core/services/network/logging_http_client.dart
@@ -70,7 +70,7 @@ class LoggingHttpClient extends http.BaseClient {
       if (request.headers.isNotEmpty) {
         RequestLogger.logLine(
           '[$tag REQ $reqId] headers='
-          '${RequestLogger.encodeObject(request.headers)}',
+          '${RequestLogger.encodeObject(RequestLogger.redactHeaders(request.headers))}',
           category: categoryName,
         );
       }
@@ -122,7 +122,8 @@ class LoggingHttpClient extends http.BaseClient {
     );
     if (response.headers.isNotEmpty) {
       RequestLogger.logLine(
-        '[$tag RES $reqId] headers=${RequestLogger.encodeObject(response.headers)}',
+        '[$tag RES $reqId] headers='
+        '${RequestLogger.encodeObject(RequestLogger.redactHeaders(response.headers))}',
         category: categoryName,
       );
     }

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -14,6 +14,32 @@ class RequestLogger {
   static const String catTts = 'tts';
   static const String catSearch = 'search';
 
+  /// Header names whose values are masked in log output (case-insensitive).
+  /// Credentials stay out of the plaintext log files: only the first 7
+  /// characters plus the remaining length are written (e.g. `Bearer [45 more]`).
+  static const Set<String> _credentialHeaderNames = <String>{
+    'authorization',
+    'proxy-authorization',
+    'x-api-key',
+    'x-goog-api-key',
+    'api-key',
+  };
+
+  /// Returns [headers] with credential-bearing values masked for logging.
+  static Map<String, String> redactHeaders(Map<String, String> headers) {
+    if (headers.isEmpty) return headers;
+    return headers.map((name, value) {
+      if (value.isNotEmpty &&
+          _credentialHeaderNames.contains(name.toLowerCase())) {
+        final masked = value.length <= 7
+            ? value
+            : '${value.substring(0, 7).trimRight()} [${value.length - 7} more]';
+        return MapEntry(name, masked);
+      }
+      return MapEntry(name, value);
+    });
+  }
+
   static bool _suspended = false;
   static final Map<String, bool> _categoryEnabled = {
     catLlm: false,

--- a/lib/features/provider/pages/providers_page.dart
+++ b/lib/features/provider/pages/providers_page.dart
@@ -463,6 +463,7 @@ class _ProvidersPageState extends State<ProvidersPage> {
   }
 
   List<_Provider> _providers({required AppLocalizations l10n}) => [
+    _p('DeepSeek', 'DeepSeek', enabled: true, models: 0),
     _p('OpenAI', 'OpenAI', enabled: true, models: 0),
     _p(
       l10n.providersPageSiliconFlowName,
@@ -474,7 +475,6 @@ class _ProvidersPageState extends State<ProvidersPage> {
     _p('OpenRouter', 'OpenRouter', enabled: true, models: 0),
     _p('KelivoIN', 'KelivoIN', enabled: true, models: 0),
     _p('Tensdaq', 'Tensdaq', enabled: false, models: 0),
-    _p('DeepSeek', 'DeepSeek', enabled: false, models: 0),
     _p('AIhubmix', 'AIhubmix', enabled: false, models: 0),
     _p(l10n.providersPageAliyunName, 'Aliyun', enabled: false, models: 0),
     _p(l10n.providersPageZhipuName, 'Zhipu AI', enabled: false, models: 0),

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -12,6 +12,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_switch.dart';
+import '../../../shared/widgets/ios_labeled_switch_row.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../shared/widgets/expansion_setting_tile.dart';
 import '../../../utils/app_directories.dart';
@@ -1904,7 +1905,7 @@ class _LogSettingsSheet extends StatelessWidget {
     );
 
     return SafeArea(
-      child: Padding(
+      child: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -1928,6 +1929,49 @@ class _LogSettingsSheet extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 16),
+
+            // Category toggles (request/llm, mcp, tts, search, flutter)
+            IosLabeledSwitchRow(
+              title: l10n.requestLogSettingTitle,
+              value: settings.requestLogEnabled,
+              onChanged: (v) {
+                settings.setRequestLogEnabled(v);
+                onChanged();
+              },
+            ),
+            IosLabeledSwitchRow(
+              title: l10n.logSettingsMcpEnabled,
+              value: settings.mcpLogEnabled,
+              onChanged: (v) {
+                settings.setMcpLogEnabled(v);
+                onChanged();
+              },
+            ),
+            IosLabeledSwitchRow(
+              title: l10n.logSettingsTtsEnabled,
+              value: settings.ttsLogEnabled,
+              onChanged: (v) {
+                settings.setTtsLogEnabled(v);
+                onChanged();
+              },
+            ),
+            IosLabeledSwitchRow(
+              title: l10n.logSettingsSearchEnabled,
+              value: settings.searchLogEnabled,
+              onChanged: (v) {
+                settings.setSearchLogEnabled(v);
+                onChanged();
+              },
+            ),
+            IosLabeledSwitchRow(
+              title: l10n.flutterLogSettingTitle,
+              value: settings.flutterLogEnabled,
+              onChanged: (v) {
+                settings.setFlutterLogEnabled(v);
+                onChanged();
+              },
+            ),
+            const SizedBox(height: 12),
 
             // Save output toggle
             Container(

--- a/test/core/services/network/request_logger_redact_test.dart
+++ b/test/core/services/network/request_logger_redact_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/services/network/request_logger.dart';
+
+void main() {
+  group('RequestLogger.redactHeaders', () {
+    test(
+      'masks credential-bearing headers keeping first 7 chars + rest length',
+      () {
+        final redacted = RequestLogger.redactHeaders(<String, String>{
+          'Authorization': 'Bearer sk-abcdefghijklmnopqrstuvwxyz',
+        });
+
+        expect(redacted['Authorization'], 'Bearer [29 more]');
+      },
+    );
+
+    test('leaves non-credential headers untouched', () {
+      final redacted = RequestLogger.redactHeaders(<String, String>{
+        'Content-Type': 'application/json',
+        'User-Agent': 'Kelivo',
+      });
+
+      expect(redacted['Content-Type'], 'application/json');
+      expect(redacted['User-Agent'], 'Kelivo');
+    });
+
+    test('matches credential header names case-insensitively', () {
+      final redacted = RequestLogger.redactHeaders(<String, String>{
+        'X-Api-Key': 'secret123456789',
+        'PROXY-Authorization': 'Basic dXNlcjpwYXNz',
+      });
+
+      expect(redacted['X-Api-Key'], 'secret1 [8 more]');
+      expect(redacted['PROXY-Authorization'], 'Basic d [11 more]');
+    });
+
+    test('keeps short values as-is', () {
+      final redacted = RequestLogger.redactHeaders(<String, String>{
+        'api-key': 'abc1234',
+      });
+
+      expect(redacted['api-key'], 'abc1234');
+    });
+
+    test('returns empty map unchanged', () {
+      expect(RequestLogger.redactHeaders(<String, String>{}), isEmpty);
+    });
+  });
+}

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -605,7 +605,12 @@ void main() {
 
       service.applyContextLimit(
         apiMessages,
-        Assistant(id: 'assistant-1', name: 'test', contextMessageSize: 3),
+        Assistant(
+          id: 'assistant-1',
+          name: 'test',
+          contextMessageSize: 3,
+          limitContextMessages: true,
+        ),
       );
 
       expect(
@@ -652,7 +657,12 @@ void main() {
 
       service.applyContextLimit(
         apiMessages,
-        Assistant(id: 'assistant-1', name: 'test', contextMessageSize: 4),
+        Assistant(
+          id: 'assistant-1',
+          name: 'test',
+          contextMessageSize: 4,
+          limitContextMessages: true,
+        ),
       );
 
       expect(

--- a/test/settings_provider_default_model_seed_test.dart
+++ b/test/settings_provider_default_model_seed_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+Future<void> _waitForSettingsLoad() async {
+  for (var i = 0; i < 25; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsProvider default model seed', () {
+    test('seeds DeepSeek once on a fresh install', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+
+      expect(settings.currentModelProvider, 'DeepSeek');
+      expect(settings.currentModelId, 'deepseek-v4-flash');
+    });
+
+    test('does not re-seed after the user resets the model', () async {
+      SharedPreferences.setMockInitialValues({});
+      final first = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      expect(first.currentModelProvider, 'DeepSeek');
+
+      await first.resetCurrentModel();
+      expect(first.currentModelProvider, isNull);
+
+      // Simulate a restart: a fresh provider instance re-reads prefs.
+      final second = SettingsProvider();
+      await _waitForSettingsLoad();
+
+      expect(second.currentModelProvider, isNull);
+      expect(second.currentModelId, isNull);
+    });
+
+    test('keeps a persisted model selection untouched', () async {
+      SharedPreferences.setMockInitialValues({
+        'selected_model_v1': 'OpenAI::gpt-4o',
+      });
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+
+      expect(settings.currentModelProvider, 'OpenAI');
+      expect(settings.currentModelId, 'gpt-4o');
+    });
+
+    test(
+      'does not re-seed an install that already had a model and reset it',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'selected_model_v1': 'OpenAI::gpt-4o',
+        });
+        final first = SettingsProvider();
+
+        await _waitForSettingsLoad();
+        expect(first.currentModelProvider, 'OpenAI');
+
+        await first.resetCurrentModel();
+
+        final second = SettingsProvider();
+        await _waitForSettingsLoad();
+
+        expect(second.currentModelProvider, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #196.

- DeepSeek as first base provider (position 1) and enabled by default
- Seed global default chat model to DeepSeek/deepseek-v4-flash once (sentinel-guarded)
- New assistants default to temperature off (null) and unlimited context messages
- LLM request logging default-on with 50MB cap; credential headers masked
- Log viewer settings sheet gains the category toggles
