### PR TITLE
feat(draft): persist chat input across restarts (chat_draft_v1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,10 +48,13 @@
 ## Input Draft Persistence
 
 - **InputDraftPersistence**: `lib/features/home/services/input_draft_persistence.dart`. Owns debounced (800ms) writes + lifecycle immediate save of chat input draft via `SharedPreferences`.
-- **Scope**: Single global draft (`chat_draft_v1` key). Not per-conversation — the input is shared across conversations.
+- **Scope**: Single global draft (`chat_draft_v1` key). Not per-conversation — the input is shared across conversations. Applies to the normal chat input bar ONLY: a `ChatInputMode.groupChat` bar neither saves nor restores (group chat is a distinct surface; its composer stays draft-free).
 - **Persistence**: JSON blob with `{text, images[], documents[{path,fileName,mime}]}`.
 - **Restore**: On cold start only, in `_ChatInputBarState._restoreDraft()`. Sets `TextEditingController.text` + media lists.
-- **Clear**: On send success or when input is fully empty. Debounce skips empty content.
+- **Synchronous preload (no restore race)**: The draft is preloaded in `main()` (right after the existing `SharedPreferences.getInstance()` await, same pattern as `SkillManager.initRoot`), so `_restoreDraft()` at input-bar mount is fully synchronous — the event loop cannot deliver user input before the first frame, so "user typed before the draft restored" is impossible. Deliberately NO overwrite-confirm dialog exists (a lazy async read would create the race; preload eliminates it). Restore fires ONCE per process — a desktop window recreate is NOT a cold start and never re-restores.
+- **Local-only (backup/sync excluded)**: `chat_draft_v1` is registered in `SharedPreferencesAsync._localOnlyKeys` (`data_sync.dart`) — the draft never leaves the device via settings backup/restore or LAN sync. A backup restored on another device never resurrects a stale draft, and sync peers never overwrite each other's drafts.
+- **Clear**: IMMEDIATE (not debounced) on `ChatInputSubmissionResult.sent` AND `.queued` — the content has moved to the conversation or the queue, and a debounced clear would resurrect the draft if the process dies within 800ms of sending. `rejected` does NOT clear (the bar keeps its content, the debounce keeps writing). Also cleared when the input becomes fully empty (whitespace-only text counts as empty) — the debounced writer removes the key rather than storing empty content. **Best-effort guarantee**: the underlying SharedPreferences writes are async fire-and-forget (platform channel + native disk write), so a kill inside the write window can still leave a stale key — the "no resurrection" property minimizes the window, it is not absolute.
+- **Edit-mode & queued-cancel interplay**: the draft mirrors the bar content at all times. Entering user-message edit mode replaces the bar content, so the persisted draft becomes the message content being edited (a kill mid-edit restores that content as input next start; exiting edit always clears). Cancelling a queued send restores the content into the bar, which re-drafts it. Both are consequences of the "always in sync" contract, not special cases.
 
 ## App Update Notice (新版本提示)
 

--- a/lib/core/models/chat_input_data.dart
+++ b/lib/core/models/chat_input_data.dart
@@ -1,3 +1,8 @@
+/// SharedPreferences key of the persisted chat input draft. Single global
+/// draft — the input is shared across conversations. Local-only: excluded
+/// from backups/LAN sync (see `SharedPreferencesAsync._localOnlyKeys`).
+const String chatInputDraftPrefsKey = 'chat_draft_v1';
+
 class DocumentAttachment {
   final String path; // absolute file path
   final String fileName;

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -13,6 +13,7 @@ import 'package:xml/xml.dart';
 
 import '../../models/assistant.dart';
 import '../../models/backup.dart';
+import '../../models/chat_input_data.dart';
 import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
 import '../../models/group_chat.dart';
@@ -2348,6 +2349,9 @@ class SharedPreferencesAsync {
     'desktop_hotkeys_enabled_v1',
     'codex_oauth_v1',
     'grok_oauth_v1',
+    // Chat input draft is transient per-device UI state — restoring a backup
+    // on another device must never resurrect a stale unsent draft.
+    chatInputDraftPrefsKey,
   };
 
   static Future<SharedPreferencesAsync> get instance async {

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -854,6 +854,7 @@ class HomePageController extends ChangeNotifier {
       selection: TextSelection.collapsed(offset: text.length),
       composing: TextRange.empty,
     );
+    _mediaController.syncDraft();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_context.mounted) return;
       _inputFocus.requestFocus();
@@ -2040,6 +2041,7 @@ class HomePageController extends ChangeNotifier {
     final prompt = _resolveSynthesizePrompt(l10n, task.defaultPromptKey);
     _inputController.text = prompt;
     _inputController.selection = TextSelection.collapsed(offset: prompt.length);
+    _mediaController.syncDraft();
 
     notifyListeners();
   }
@@ -2364,6 +2366,7 @@ class HomePageController extends ChangeNotifier {
       ),
       composing: TextRange.empty,
     );
+    _mediaController.syncDraft();
     notifyListeners();
   }
 
@@ -2382,6 +2385,7 @@ class HomePageController extends ChangeNotifier {
       selection: TextSelection.collapsed(offset: insertPos + quoted.length),
       composing: TextRange.empty,
     );
+    _mediaController.syncDraft();
     _inputFocus.requestFocus();
     notifyListeners();
   }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -750,6 +750,7 @@ class _HomePageState extends State<HomePage>
       selection: TextSelection.collapsed(offset: start + trimmed.length),
       composing: TextRange.empty,
     );
+    _mediaController.syncDraft();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _controller.forceScrollToBottomSoon(animate: false);

--- a/lib/features/home/services/input_draft_persistence.dart
+++ b/lib/features/home/services/input_draft_persistence.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/models/chat_input_data.dart';
+
+/// Persists the chat input bar's unsent content (`text` + media) across app
+/// restarts, under the single global key `chat_draft_v1`.
+///
+/// Owns the 800ms debounced writes and the lifecycle immediate flush. The
+/// draft is preloaded synchronously at startup (see [ensureInitialized],
+/// called from `main()` right after the SharedPreferences handle is ready),
+/// so restore at input-bar mount is race-free: the event loop cannot deliver
+/// user input before the first frame.
+class InputDraftPersistence with WidgetsBindingObserver {
+  /// Public so tests can construct isolated instances with a mock prefs
+  /// handle. The process-wide instance is created by [ensureInitialized].
+  ///
+  /// A null [prefs] yields a degraded no-op instance: the draft feature is
+  /// unavailable this session (startup SharedPreferences failure), every
+  /// method is a no-op and restore returns null — never a crash.
+  InputDraftPersistence(this._prefs) {
+    WidgetsBinding.instance.addObserver(this);
+    _preloadedDraft = _readFromPrefs();
+  }
+
+  static const String key = chatInputDraftPrefsKey;
+  static const Duration debounceDuration = Duration(milliseconds: 800);
+
+  static InputDraftPersistence? _instance;
+
+  /// The process-wide instance, installed by [ensureInitialized] in `main()`.
+  static InputDraftPersistence get instance {
+    final i = _instance;
+    if (i == null) {
+      throw StateError(
+        'InputDraftPersistence.ensureInitialized() must be called before '
+        'accessing instance',
+      );
+    }
+    return i;
+  }
+
+  /// Loads the persisted draft (if any) and installs the process-wide
+  /// instance. Must complete before `runApp` for the no-race restore
+  /// guarantee. On SharedPreferences failure the app degrades to a no-op
+  /// instance instead of dying before `runApp`.
+  static Future<void> ensureInitialized() async {
+    try {
+      _instance ??= InputDraftPersistence(
+        await SharedPreferences.getInstance(),
+      );
+    } catch (e, st) {
+      debugPrint(
+        '[InputDraftPersistence] prefs unavailable, draft disabled: $e\n$st',
+      );
+      _instance ??= InputDraftPersistence(null);
+    }
+  }
+
+  final SharedPreferences? _prefs;
+  ChatInputData? _preloadedDraft;
+  ChatInputData? _pending;
+  Timer? _debounce;
+  bool _disposed = false;
+
+  /// Cold-start restore handle. Consumed once per process: a second call (or
+  /// a later input-bar remount, e.g. a desktop window recreate) returns null.
+  ChatInputData? takeDraftForRestore() {
+    if (_prefs == null) return null;
+    final draft = _preloadedDraft;
+    _preloadedDraft = null;
+    return draft;
+  }
+
+  /// Debounced save of the latest input-bar content. Empty content removes
+  /// the persisted key instead of storing an empty blob.
+  void save(ChatInputData input) {
+    if (_disposed || _prefs == null) return;
+    _pending = input;
+    _debounce?.cancel();
+    _debounce = Timer(debounceDuration, flushNow);
+  }
+
+  /// Immediate removal. Send success / queued-send and bar clears all go
+  /// through here so a process death right after sending cannot resurrect
+  /// the draft. Best-effort: the underlying prefs write is async
+  /// fire-and-forget, so a kill inside the platform-channel write window
+  /// can still leave the stale key behind.
+  void clearNow() {
+    if (_disposed || _prefs == null) return;
+    _debounce?.cancel();
+    _debounce = null;
+    _pending = null;
+    _preloadedDraft = null;
+    _prefs.remove(key);
+  }
+
+  /// Writes any pending debounced content immediately (lifecycle save).
+  /// Best-effort like all other writes: fire-and-forget async.
+  void flushNow() {
+    if (_disposed || _prefs == null) return;
+    _debounce?.cancel();
+    _debounce = null;
+    final content = _pending;
+    if (content == null) return;
+    _pending = null;
+    _write(content);
+  }
+
+  /// Files (image paths + document paths) referenced by the unsent draft —
+  /// the union of the pending in-memory content and the persisted snapshot.
+  /// Used by the storage deletion guardrail (warn-and-allow).
+  Set<String> draftReferencedFiles() {
+    if (_prefs == null) return const <String>{};
+    final files = <String>{};
+    final preloaded = _preloadedDraft;
+    if (preloaded != null) {
+      files.addAll(preloaded.imagePaths);
+      files.addAll(preloaded.documents.map((d) => d.path));
+    }
+    final pending = _pending;
+    if (pending != null) {
+      files.addAll(pending.imagePaths);
+      files.addAll(pending.documents.map((d) => d.path));
+    }
+    final persisted = _readFromPrefs();
+    if (persisted != null) {
+      files.addAll(persisted.imagePaths);
+      files.addAll(persisted.documents.map((d) => d.path));
+    }
+    return files;
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Any transition away from resumed (paused/inactive/hidden/detached)
+    // flushes a pending debounced write immediately.
+    if (state != AppLifecycleState.resumed) {
+      flushNow();
+    }
+  }
+
+  void disposeInternal() {
+    if (_disposed) return;
+    _disposed = true;
+    _debounce?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  void _write(ChatInputData input) {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    final empty =
+        input.text.trim().isEmpty &&
+        input.imagePaths.isEmpty &&
+        input.documents.isEmpty;
+    if (empty) {
+      prefs.remove(key);
+      return;
+    }
+    prefs.setString(key, _encode(input));
+  }
+
+  static String _encode(ChatInputData input) {
+    return jsonEncode({
+      'text': input.text,
+      'images': input.imagePaths,
+      'documents': [
+        for (final d in input.documents)
+          {'path': d.path, 'fileName': d.fileName, 'mime': d.mime},
+      ],
+    });
+  }
+
+  ChatInputData? _readFromPrefs() {
+    final prefs = _prefs;
+    if (prefs == null) return null;
+    final raw = prefs.getString(key);
+    if (raw == null || raw.isEmpty) return null;
+    final parsed = _decode(raw);
+    if (parsed == null) {
+      debugPrint('[InputDraftPersistence] corrupt draft removed: $key');
+      prefs.remove(key);
+    }
+    return parsed;
+  }
+
+  static ChatInputData? _decode(String raw) {
+    try {
+      final map = jsonDecode(raw);
+      if (map is! Map<String, dynamic>) return null;
+      final text = map['text'];
+      final images = map['images'];
+      final documents = map['documents'];
+      final parsedDocs = documents is List
+          ? documents
+                .whereType<Map<String, dynamic>>()
+                .map(
+                  (d) => DocumentAttachment(
+                    path: (d['path'] as String?) ?? '',
+                    fileName: (d['fileName'] as String?) ?? '',
+                    mime: (d['mime'] as String?) ?? '',
+                  ),
+                )
+                .where((d) => d.path.isNotEmpty)
+                .toList()
+          : const <DocumentAttachment>[];
+      return ChatInputData(
+        text: text is String ? text : '',
+        imagePaths: images is List
+            ? images.whereType<String>().toList()
+            : const <String>[],
+        documents: parsedDocs,
+      );
+    } catch (e) {
+      debugPrint('[InputDraftPersistence] draft decode failed: $e');
+      return null;
+    }
+  }
+}

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -22,6 +22,7 @@ import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/search/search_service.dart';
 import '../../../core/services/api/builtin_tools.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../services/input_draft_persistence.dart';
 import '../../../core/utils/multimodal_input_utils.dart';
 import '../../model/utils/ocr_model_capability.dart';
 import '../../../utils/brand_assets.dart';
@@ -55,6 +56,11 @@ class ChatInputBarController {
   ChatInputData snapshotInput(String text) =>
       _state?._snapshotInput(text) ?? ChatInputData(text: text.trim());
   void clearDraft() => _state?._clearDraft();
+
+  /// Re-syncs the persisted draft with programmatic text changes made
+  /// outside the bar (suggestion insert, quick phrase, quote, synthesize
+  /// prompt). Text set via the controller does not fire `onChanged`.
+  void syncDraft() => _state?._scheduleDraftSave();
 }
 
 class ChatInputBar extends StatefulWidget {
@@ -176,6 +182,7 @@ class ChatInputBar extends StatefulWidget {
 class _ChatInputBarState extends State<ChatInputBar>
     with WidgetsBindingObserver {
   late TextEditingController _controller;
+  late InputDraftPersistence _draftPersistence;
   bool _isExpanded = false; // Track expand/collapse state for input field
   final List<String> _images = <String>[]; // local file paths
   final Map<String, int> _imageSizes = <String, int>{}; // path -> bytes
@@ -319,7 +326,57 @@ class _ChatInputBarState extends State<ChatInputBar>
   bool get _hasDraftMedia => _images.isNotEmpty || _docs.isNotEmpty;
 
   // Instance method for onChanged to avoid recreating the callback on every build
-  void _onTextChanged(String _) => setState(() {});
+  void _onTextChanged(String _) {
+    setState(() {});
+    _scheduleDraftSave();
+  }
+
+  /// Restores the cold-start draft into the input bar. Runs synchronously in
+  /// [initState], before any user input can be delivered. Fires once per
+  /// process — `takeDraftForRestore()` consumes the preloaded draft.
+  void _restoreDraft() {
+    if (widget.mode == ChatInputMode.groupChat) return;
+    final draft = _draftPersistence.takeDraftForRestore();
+    if (draft == null) return;
+    final images = <String>[];
+    for (final path in draft.imagePaths) {
+      if (path.startsWith('data:') || File(path).existsSync()) {
+        images.add(path);
+      }
+    }
+    final documents = <DocumentAttachment>[];
+    for (final doc in draft.documents) {
+      if (File(doc.path).existsSync()) documents.add(doc);
+    }
+    if (draft.text.trim().isEmpty && images.isEmpty && documents.isEmpty) {
+      // Everything was filtered out (whitespace-only text, media files
+      // deleted on disk) — drop the stale draft instead of leaving it to
+      // nag the storage guardrail forever.
+      _clearPersistedDraft();
+      return;
+    }
+    _controller.text = draft.text;
+    _images.addAll(images);
+    for (final p in images) {
+      _imageSizes[p] = _fileSize(p);
+    }
+    _docs.addAll(documents);
+    // Re-persist the filtered content so storage stays in sync with the bar.
+    _scheduleDraftSave();
+  }
+
+  /// Feeds the current bar content into the debounced draft writer. No-op for
+  /// group-chat bars (group composer stays draft-free).
+  void _scheduleDraftSave() {
+    if (widget.mode == ChatInputMode.groupChat) return;
+    _draftPersistence.save(
+      ChatInputData(
+        text: _controller.text,
+        imagePaths: List<String>.of(_images),
+        documents: List<DocumentAttachment>.of(_docs),
+      ),
+    );
+  }
 
   void _addImages(List<String> paths) {
     if (paths.isEmpty) return;
@@ -333,6 +390,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         _imageSizes[p] = _fileSize(p);
       }
     });
+    _scheduleDraftSave();
   }
 
   int _fileSize(String path) {
@@ -356,15 +414,18 @@ class _ChatInputBarState extends State<ChatInputBar>
 
   void _clearImages() {
     setState(() => _resetMedia(images: true));
+    _scheduleDraftSave();
   }
 
   void _addFiles(List<DocumentAttachment> docs) {
     if (docs.isEmpty) return;
     setState(() => _docs.addAll(docs));
+    _scheduleDraftSave();
   }
 
   void _clearFiles() {
     setState(() => _resetMedia(docs: true));
+    _scheduleDraftSave();
   }
 
   void _restoreInput(ChatInputData input) {
@@ -380,6 +441,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         ..clear()
         ..addAll(input.documents);
     });
+    _scheduleDraftSave();
   }
 
   ChatInputData _snapshotInput(String text) {
@@ -396,6 +458,14 @@ class _ChatInputBarState extends State<ChatInputBar>
       _controller.clear();
       _resetMedia(images: true, docs: true);
     });
+    _clearPersistedDraft();
+  }
+
+  /// Immediate draft removal, gated so a group-chat bar never touches the
+  /// normal-chat draft.
+  void _clearPersistedDraft() {
+    if (widget.mode == ChatInputMode.groupChat) return;
+    _draftPersistence.clearNow();
   }
 
   void _removeImageAt(int index) {
@@ -404,10 +474,12 @@ class _ChatInputBarState extends State<ChatInputBar>
       _images.removeAt(index);
       _imageSizes.remove(path);
     });
+    _scheduleDraftSave();
   }
 
   void _removeDocumentAt(int index) {
     setState(() => _docs.removeAt(index));
+    _scheduleDraftSave();
   }
 
   Future<void> _openCompressionDialog(int idx) async {
@@ -480,6 +552,7 @@ class _ChatInputBarState extends State<ChatInputBar>
     _imageSizes[newPath] = size;
     _imageSizes.remove(oldPath);
     imageCache.evict(FileImage(File(oldPath)));
+    _scheduleDraftSave();
     return size;
   }
 
@@ -640,6 +713,8 @@ class _ChatInputBarState extends State<ChatInputBar>
     _controller = widget.controller ?? TextEditingController();
     widget.mediaController?._bind(this);
     WidgetsBinding.instance.addObserver(this);
+    _draftPersistence = context.read<InputDraftPersistence>();
+    _restoreDraft();
   }
 
   @override
@@ -681,6 +756,9 @@ class _ChatInputBarState extends State<ChatInputBar>
     if (widget.controller == null) {
       _controller.dispose();
     }
+    // Flush any pending debounced write so the draft survives the bar being
+    // torn down.
+    _draftPersistence.flushNow();
     super.dispose();
   }
 
@@ -728,6 +806,11 @@ class _ChatInputBarState extends State<ChatInputBar>
           _controller.clear();
           _resetMedia(images: true, docs: true);
         });
+        // The content has moved into the conversation or the queue — clear
+        // the draft immediately so a process death right after sending
+        // cannot resurrect it (best-effort: the underlying prefs write is
+        // itself async fire-and-forget).
+        _clearPersistedDraft();
         // Keep focus on desktop so user can continue typing
         try {
           if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
@@ -760,6 +843,7 @@ class _ChatInputBarState extends State<ChatInputBar>
       );
     }
     setState(() {});
+    _scheduleDraftSave();
     _ensureCaretVisible();
   }
 
@@ -815,6 +899,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                     text: newText,
                     selection: TextSelection.collapsed(offset: start),
                   );
+                  _scheduleDraftSave();
                 } catch (_) {}
                 state.hideToolbar();
               },
@@ -1158,6 +1243,7 @@ class _ChatInputBarState extends State<ChatInputBar>
                 );
               }
               setState(() {});
+              _scheduleDraftSave();
               return;
             }
           } catch (_) {}
@@ -1213,6 +1299,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         );
       }
       setState(() {});
+      _scheduleDraftSave();
     } catch (_) {}
   }
 

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -26,6 +26,7 @@ import '../../../utils/platform_utils.dart';
 import '../../../utils/app_directories.dart';
 import '../../../utils/path_canon.dart';
 import '../../chat/pages/image_viewer_page.dart';
+import '../../home/services/input_draft_persistence.dart';
 import 'log_viewer_page.dart';
 import 'mount_files_page.dart';
 import 'trash_detail_page.dart';
@@ -1651,9 +1652,19 @@ class _UploadManagerState extends State<_UploadManager> {
         ? _selected.where((p) => _refCountFor(p) > 0).length
         : 0;
     final hasRefs = refCount > 0;
-    final content = hasRefs
+    final draftFiles = context
+        .read<InputDraftPersistence>()
+        .draftReferencedFiles();
+    final draftHitCount = _selected.where(draftFiles.contains).length;
+    var content = hasRefs
         ? '${l10n.storageSpaceDeleteUploadsConfirmMessage(count)}\n\n${l10n.storageSpaceDeleteRefWarning(refCount)}'
         : l10n.storageSpaceDeleteSimpleConfirm(count);
+    // Deletion guardrail: warn (but do not block) when the selected files
+    // are still referenced by the unsent input draft.
+    if (draftHitCount > 0) {
+      content =
+          '$content\n\n${l10n.storageSpaceDeleteDraftWarning(draftHitCount)}';
+    }
     final ok = await showDialog<bool>(
       context: context,
       builder: (ctx) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -228,6 +228,11 @@
   "storageSpaceComputeRefs": "Compute refs",
   "storageSpaceLocateTitle": "Referenced by",
   "storageSpaceDeleteRefWarning": "{count} files are referenced by messages — deleting will break their display",
+  "storageSpaceDeleteDraftWarning": "{count} files are still referenced by your unsaved draft",
+  "@storageSpaceDeleteDraftWarning": {
+    "description": "Storage delete guardrail: selected files are still referenced by the unsent input draft",
+    "placeholders": {"count": {"type": "int"}}
+  },
   "@storageSpaceDeleteRefWarning": {
     "placeholders": {
       "count": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -910,6 +910,12 @@ abstract class AppLocalizations {
   /// **'{count} files are referenced by messages — deleting will break their display'**
   String storageSpaceDeleteRefWarning(int count);
 
+  /// Storage delete guardrail: selected files are still referenced by the unsent input draft
+  ///
+  /// In en, this message translates to:
+  /// **'{count} files are still referenced by your unsaved draft'**
+  String storageSpaceDeleteDraftWarning(int count);
+
   /// No description provided for @storageSpaceAiGenerated.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -494,6 +494,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String storageSpaceDeleteDraftWarning(int count) {
+    return '$count files are still referenced by your unsaved draft';
+  }
+
+  @override
   String get storageSpaceAiGenerated => 'AI generated';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -481,6 +481,11 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String storageSpaceDeleteDraftWarning(int count) {
+    return '其中 $count 个文件仍被未发送的草稿引用';
+  }
+
+  @override
   String get storageSpaceAiGenerated => 'AI 生成';
 
   @override
@@ -7565,6 +7570,11 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   }
 
   @override
+  String storageSpaceDeleteDraftWarning(int count) {
+    return '其中 $count 个文件仍被未发送的草稿引用';
+  }
+
+  @override
   String get storageSpaceAiGenerated => 'AI 生成';
 
   @override
@@ -14645,6 +14655,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String storageSpaceDeleteRefWarning(int count) {
     return '其中 $count 個檔案被訊息引用——刪除後將無法顯示';
+  }
+
+  @override
+  String storageSpaceDeleteDraftWarning(int count) {
+    return '其中 $count 個檔案仍被未發送的草稿引用';
   }
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -134,6 +134,7 @@
   "storageSpaceComputeRefs": "计算引用",
   "storageSpaceLocateTitle": "引用此文件的消息",
   "storageSpaceDeleteRefWarning": "其中 {count} 个文件被消息引用——删除后将无法显示",
+  "storageSpaceDeleteDraftWarning": "其中 {count} 个文件仍被未发送的草稿引用",
   "storageSpaceAiGenerated": "AI 生成",
   "storageSpaceMarkdownRefLimitation": "注：不统计 Markdown 格式引用的本地图片。images/ 下的 AI 生成图片显示为「AI 生成」——请勿误删。",
   "settingsPageAboutSection": "关于",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -134,6 +134,7 @@
   "storageSpaceComputeRefs": "计算引用",
   "storageSpaceLocateTitle": "引用此文件的消息",
   "storageSpaceDeleteRefWarning": "其中 {count} 个文件被消息引用——删除后将无法显示",
+  "storageSpaceDeleteDraftWarning": "其中 {count} 个文件仍被未发送的草稿引用",
   "storageSpaceAiGenerated": "AI 生成",
   "storageSpaceMarkdownRefLimitation": "注：不统计 Markdown 格式引用的本地图片。images/ 下的 AI 生成图片显示为「AI 生成」——请勿误删。",
   "settingsPageAboutSection": "关于",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -134,6 +134,7 @@
   "storageSpaceComputeRefs": "計算引用",
   "storageSpaceLocateTitle": "引用此檔案的消息",
   "storageSpaceDeleteRefWarning": "其中 {count} 個檔案被訊息引用——刪除後將無法顯示",
+  "storageSpaceDeleteDraftWarning": "其中 {count} 個檔案仍被未發送的草稿引用",
   "storageSpaceAiGenerated": "AI 生成",
   "storageSpaceMarkdownRefLimitation": "註：不統計 Markdown 格式引用的本地圖片。images/ 下的 AI 生成圖片顯示為「AI 生成」——請勿誤刪。",
   "settingsPageAboutSection": "關於",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,6 +44,7 @@ import 'core/services/headless_generation_service.dart';
 import 'core/services/network/dio_http_client.dart';
 import 'core/services/logging/flutter_logger.dart';
 import 'features/home/services/ask_user_interaction_service.dart';
+import 'features/home/services/input_draft_persistence.dart';
 import 'features/home/services/tool_approval_service.dart';
 import 'utils/sandbox_path_resolver.dart';
 import 'features/skills/skill_manager.dart';
@@ -105,6 +106,10 @@ Future<void> main() async {
         final enabled = prefs.getBool('flutter_log_enabled_v1') ?? false;
         await FlutterLogger.setEnabled(enabled);
       } catch (_) {}
+      // Preload the chat input draft synchronously (before runApp) so restore
+      // at input-bar mount is race-free: the user cannot type before the
+      // draft is already in the controller.
+      await InputDraftPersistence.ensureInitialized();
       // Trim Flutter global image cache to reduce memory pressure from large images
       try {
         PaintingBinding.instance.imageCache.maximumSize = 200;
@@ -199,6 +204,9 @@ class MyApp extends StatelessWidget {
           value: GrokDeviceCodeController.instance,
         ),
         ChangeNotifierProvider(create: (_) => ChatService()),
+        Provider<InputDraftPersistence>.value(
+          value: InputDraftPersistence.instance,
+        ),
         ChangeNotifierProvider(create: (_) => McpToolService()),
         ChangeNotifierProvider(create: (_) => FilesystemMountsProvider()),
         ChangeNotifierProvider(

--- a/test/features/home/services/input_draft_persistence_test.dart
+++ b/test/features/home/services/input_draft_persistence_test.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/models/chat_input_data.dart';
+import 'package:Cuplivo/features/home/services/input_draft_persistence.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferences prefs;
+  InputDraftPersistence? service;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() {
+    service?.disposeInternal();
+    service = null;
+  });
+
+  InputDraftPersistence buildService() {
+    service = InputDraftPersistence(prefs);
+    return service!;
+  }
+
+  String encodeDraft({
+    String text = '',
+    List<String> images = const [],
+    List<Map<String, String>> documents = const [],
+  }) {
+    return jsonEncode({
+      'text': text,
+      'images': images,
+      'documents': [
+        for (final d in documents)
+          {'path': d['path'], 'fileName': d['fileName'], 'mime': d['mime']},
+      ],
+    });
+  }
+
+  group('save / flush / clear', () {
+    test(
+      'save is debounced: nothing persisted before the debounce window',
+      () async {
+        final service = buildService();
+        service.save(ChatInputData(text: 'hello', imagePaths: ['/tmp/a.png']));
+        expect(prefs.getString(InputDraftPersistence.key), isNull);
+        await Future<void>.delayed(
+          InputDraftPersistence.debounceDuration +
+              const Duration(milliseconds: 100),
+        );
+        final raw = prefs.getString(InputDraftPersistence.key);
+        expect(raw, isNotNull);
+        final decoded = jsonDecode(raw!) as Map<String, dynamic>;
+        expect(decoded['text'], 'hello');
+        expect(decoded['images'], ['/tmp/a.png']);
+      },
+    );
+
+    test('empty content removes the persisted key instead of storing an '
+        'empty blob', () async {
+      prefs.setString(InputDraftPersistence.key, encodeDraft(text: 'old'));
+      final service = buildService();
+      service.save(ChatInputData(text: '   ', imagePaths: ['/tmp/gone.png']));
+      service.clearNow();
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+
+      service.save(
+        ChatInputData(
+          text: 'x',
+          imagePaths: ['/tmp/a.png'],
+          documents: [
+            DocumentAttachment(
+              path: '/tmp/d.pdf',
+              fileName: 'd.pdf',
+              mime: 'application/pdf',
+            ),
+          ],
+        ),
+      );
+      await Future<void>.delayed(
+        InputDraftPersistence.debounceDuration +
+            const Duration(milliseconds: 100),
+      );
+      final decoded =
+          jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+              as Map<String, dynamic>;
+      expect(decoded['documents'], [
+        {'path': '/tmp/d.pdf', 'fileName': 'd.pdf', 'mime': 'application/pdf'},
+      ]);
+      // Whitespace-only text must clear again.
+      service.save(ChatInputData(text: '   '));
+      await Future<void>.delayed(
+        InputDraftPersistence.debounceDuration +
+            const Duration(milliseconds: 100),
+      );
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+    });
+
+    test('flushNow writes pending content immediately', () async {
+      final service = buildService();
+      service.save(ChatInputData(text: 'urgent'));
+      service.flushNow();
+      expect(
+        (jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+            as Map<String, dynamic>)['text'],
+        'urgent',
+      );
+    });
+
+    test('clearNow cancels a pending debounce and removes the key', () async {
+      final service = buildService();
+      service.save(ChatInputData(text: 'doomed'));
+      service.clearNow();
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+      await Future<void>.delayed(
+        InputDraftPersistence.debounceDuration +
+            const Duration(milliseconds: 100),
+      );
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+    });
+
+    test('app lifecycle flush writes pending content immediately', () async {
+      final service = buildService();
+      service.save(ChatInputData(text: 'lifecycle'));
+      binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      expect(
+        (jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+            as Map<String, dynamic>)['text'],
+        'lifecycle',
+      );
+    });
+  });
+
+  group('preload / restore', () {
+    test('degraded instance (null prefs) no-ops without crashing', () {
+      final service = InputDraftPersistence(null);
+      expect(service.takeDraftForRestore(), isNull);
+      service.save(ChatInputData(text: 'x'));
+      service.flushNow();
+      service.clearNow();
+      expect(service.draftReferencedFiles(), isEmpty);
+    });
+
+    test(
+      'takeDraftForRestore returns the preloaded draft exactly once',
+      () async {
+        prefs.setString(
+          InputDraftPersistence.key,
+          encodeDraft(
+            text: 'draft text',
+            images: ['/tmp/a.png'],
+            documents: [
+              {
+                'path': '/tmp/d.pdf',
+                'fileName': 'd.pdf',
+                'mime': 'application/pdf',
+              },
+            ],
+          ),
+        );
+        final service = buildService();
+        final first = service.takeDraftForRestore();
+        expect(first?.text, 'draft text');
+        expect(first?.imagePaths, ['/tmp/a.png']);
+        expect(first?.documents.single.path, '/tmp/d.pdf');
+        expect(service.takeDraftForRestore(), isNull);
+      },
+    );
+
+    test('no persisted draft: takeDraftForRestore returns null', () async {
+      final service = buildService();
+      expect(service.takeDraftForRestore(), isNull);
+    });
+
+    test('corrupt draft is removed and never restored', () async {
+      prefs.setString(InputDraftPersistence.key, '{not json!!');
+      final service = buildService();
+      expect(service.takeDraftForRestore(), isNull);
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+    });
+
+    test('draft with wrong JSON shapes is decoded defensively', () async {
+      prefs.setString(InputDraftPersistence.key, '{"text": 42}');
+      final service = buildService();
+      final draft = service.takeDraftForRestore();
+      expect(draft?.text, '');
+      expect(draft?.imagePaths, isEmpty);
+    });
+  });
+
+  group('draftReferencedFiles', () {
+    test('unions pending and persisted file references', () async {
+      prefs.setString(
+        InputDraftPersistence.key,
+        encodeDraft(images: ['/persisted/a.png']),
+      );
+      final service = buildService();
+      // Pending content (not yet flushed).
+      service.save(
+        ChatInputData(
+          text: 'x',
+          imagePaths: ['/pending/b.png'],
+          documents: [
+            DocumentAttachment(
+              path: '/pending/c.pdf',
+              fileName: 'c.pdf',
+              mime: 'application/pdf',
+            ),
+          ],
+        ),
+      );
+      expect(service.draftReferencedFiles(), {
+        '/persisted/a.png',
+        '/pending/b.png',
+        '/pending/c.pdf',
+      });
+    });
+  });
+}

--- a/test/features/home/widgets/chat_input_bar_draft_test.dart
+++ b/test/features/home/widgets/chat_input_bar_draft_test.dart
@@ -1,0 +1,437 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/models/chat_input_data.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/features/group_chat/models/chat_input_mode.dart';
+import 'package:Cuplivo/features/home/services/input_draft_persistence.dart';
+import 'package:Cuplivo/features/home/widgets/chat_input_bar.dart';
+import 'package:Cuplivo/icons/lucide_adapter.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  InputDraftPersistence? draftPersistence;
+  late Directory tempDir;
+  int fileCounter = 0;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    tempDir = Directory.systemTemp.createTempSync('chat_input_draft_test');
+    fileCounter = 0;
+  });
+
+  tearDown(() {
+    draftPersistence?.disposeInternal();
+    draftPersistence = null;
+    tempDir.deleteSync(recursive: true);
+  });
+
+  /// Seeds the persisted draft, then constructs the service so its preload
+  /// picks it up (mirrors the real cold-start order: prefs written last
+  /// session, service preloaded this session).
+  InputDraftPersistence seedAndBuild({
+    String text = '',
+    List<String> images = const [],
+    List<Map<String, String>> documents = const [],
+  }) {
+    final raw = jsonEncode({
+      'text': text,
+      'images': images,
+      'documents': [
+        for (final d in documents)
+          {'path': d['path'], 'fileName': d['fileName'], 'mime': d['mime']},
+      ],
+    });
+    prefs.setString(InputDraftPersistence.key, raw);
+    draftPersistence = InputDraftPersistence(prefs);
+    return draftPersistence!;
+  }
+
+  InputDraftPersistence buildService() {
+    draftPersistence = InputDraftPersistence(prefs);
+    return draftPersistence!;
+  }
+
+  File makeImageFile() {
+    final file = File('${tempDir.path}/draft_img_${fileCounter++}.png');
+    file.writeAsBytesSync(
+      base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+      ),
+    );
+    return file;
+  }
+
+  File makeDocFile() {
+    final file = File('${tempDir.path}/draft_doc_${fileCounter++}.pdf');
+    file.writeAsBytesSync([0x25, 0x50, 0x44, 0x46]);
+    return file;
+  }
+
+  Widget buildHarness({
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    Future<ChatInputSubmissionResult> Function(ChatInputData input)? onSend,
+    ChatInputBarController? mediaController,
+    ChatInputMode mode = ChatInputMode.normal,
+  }) {
+    return MultiProvider(
+      providers: [
+        Provider<InputDraftPersistence>.value(
+          value: draftPersistence ?? buildService(),
+        ),
+        ChangeNotifierProvider.value(value: SettingsProvider()),
+        ChangeNotifierProvider.value(value: AssistantProvider()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ChatInputBar(
+            controller: controller,
+            focusNode: focusNode,
+            mediaController: mediaController,
+            onSend: onSend ?? (_) async => ChatInputSubmissionResult.rejected,
+            mode: mode,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('cold-start restore', () {
+    testWidgets('restores text and existing media from the draft', (
+      tester,
+    ) async {
+      final image = makeImageFile();
+      final doc = makeDocFile();
+      seedAndBuild(
+        text: 'unfinished message',
+        images: [image.path],
+        documents: [
+          {
+            'path': doc.path,
+            'fileName': doc.path.split(Platform.pathSeparator).last,
+            'mime': 'application/pdf',
+          },
+        ],
+      );
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+      final mediaController = ChatInputBarController();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          mediaController: mediaController,
+        ),
+      );
+
+      expect(controller.text, 'unfinished message');
+      final restored = mediaController.snapshotInput(controller.text);
+      expect(restored.imagePaths, [image.path]);
+      expect(restored.documents.single.path, doc.path);
+
+      // Flush the post-restore re-save so no timer outlives the test.
+      await tester.pump(const Duration(milliseconds: 900));
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets(
+      'filters out deleted files but keeps data-URL images on restore',
+      (tester) async {
+        final image = makeImageFile();
+        seedAndBuild(
+          text: 'media draft',
+          images: [
+            image.path,
+            '/definitely/missing.png',
+            'data:image/png;base64,abc',
+          ],
+        );
+        final controller = TextEditingController();
+        final focusNode = FocusNode();
+        final mediaController = ChatInputBarController();
+
+        await tester.pumpWidget(
+          buildHarness(
+            controller: controller,
+            focusNode: focusNode,
+            mediaController: mediaController,
+          ),
+        );
+
+        final restored = mediaController.snapshotInput(controller.text);
+        expect(restored.imagePaths, [image.path, 'data:image/png;base64,abc']);
+
+        await tester.pump(const Duration(milliseconds: 900));
+        controller.dispose();
+        focusNode.dispose();
+      },
+    );
+
+    testWidgets('restores only once per process (draft consumed)', (
+      tester,
+    ) async {
+      seedAndBuild(text: 'once only');
+      final firstController = TextEditingController();
+      final secondController = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(controller: firstController, focusNode: focusNode),
+      );
+      expect(firstController.text, 'once only');
+
+      // A later bar mount (e.g. desktop window recreate) must not re-restore.
+      await tester.pumpWidget(
+        buildHarness(controller: secondController, focusNode: focusNode),
+      );
+      expect(secondController.text, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 900));
+      firstController.dispose();
+      secondController.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('group-chat bar neither restores nor touches the draft', (
+      tester,
+    ) async {
+      seedAndBuild(text: 'normal chat draft');
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          mode: ChatInputMode.groupChat,
+        ),
+      );
+      expect(controller.text, isEmpty);
+      // The draft must remain unconsumed for the normal bar.
+      expect(
+        draftPersistence!.takeDraftForRestore()?.text,
+        'normal chat draft',
+      );
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('draft with whitespace-only text and deleted media is cleared '
+        'on restore', (tester) async {
+      seedAndBuild(text: '   ', images: ['/definitely/missing.png']);
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(controller: controller, focusNode: focusNode),
+      );
+
+      expect(controller.text, isEmpty);
+      // The un-restorable stale draft must not linger for the guardrail.
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+  });
+
+  group('debounced save', () {
+    testWidgets('typing persists after the debounce window', (tester) async {
+      buildService();
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(controller: controller, focusNode: focusNode),
+      );
+
+      await tester.enterText(find.byType(TextField), 'draft me');
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+
+      await tester.pump(const Duration(milliseconds: 900));
+      final decoded =
+          jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+              as Map<String, dynamic>;
+      expect(decoded['text'], 'draft me');
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('media added through the controller is persisted', (
+      tester,
+    ) async {
+      final image = makeImageFile();
+      buildService();
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+      final mediaController = ChatInputBarController();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          mediaController: mediaController,
+        ),
+      );
+      mediaController.addImages([image.path]);
+      await tester.pump(const Duration(milliseconds: 900));
+
+      final decoded =
+          jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+              as Map<String, dynamic>;
+      expect(decoded['images'], [image.path]);
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('Shift+Enter newline insert persists to the draft', (
+      tester,
+    ) async {
+      buildService();
+      // The Enter-key handler only activates on tablet/desktop widths.
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(controller: controller, focusNode: focusNode),
+      );
+
+      await tester.enterText(find.byType(TextField), 'line one');
+      // Programmatic insert paths never fire onChanged — the draft must be
+      // saved explicitly.
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump(const Duration(milliseconds: 900));
+
+      expect(controller.text, 'line one\n');
+      final decoded =
+          jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+              as Map<String, dynamic>;
+      expect(decoded['text'], 'line one\n');
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+  });
+
+  group('clear semantics', () {
+    testWidgets('sent clears the persisted draft immediately', (tester) async {
+      seedAndBuild(text: 'about to send');
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          onSend: (_) async => ChatInputSubmissionResult.sent,
+        ),
+      );
+      expect(controller.text, 'about to send');
+
+      await tester.tap(find.byIcon(Lucide.ArrowUp));
+      await tester.pumpAndSettle();
+
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+      expect(controller.text, isEmpty);
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('queued clears the persisted draft immediately', (
+      tester,
+    ) async {
+      seedAndBuild(text: 'queued content');
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          onSend: (_) async => ChatInputSubmissionResult.queued,
+        ),
+      );
+      await tester.tap(find.byIcon(Lucide.ArrowUp));
+      await tester.pumpAndSettle();
+
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('rejected keeps the draft and the input', (tester) async {
+      seedAndBuild(text: 'stays put');
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          onSend: (_) async => ChatInputSubmissionResult.rejected,
+        ),
+      );
+      await tester.tap(find.byIcon(Lucide.ArrowUp));
+      await tester.pumpAndSettle();
+
+      expect(controller.text, 'stays put');
+      final decoded =
+          jsonDecode(prefs.getString(InputDraftPersistence.key)!)
+              as Map<String, dynamic>;
+      expect(decoded['text'], 'stays put');
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    testWidgets('clearDraft removes the persisted draft', (tester) async {
+      seedAndBuild(text: 'wiped');
+      final controller = TextEditingController();
+      final focusNode = FocusNode();
+      final mediaController = ChatInputBarController();
+
+      await tester.pumpWidget(
+        buildHarness(
+          controller: controller,
+          focusNode: focusNode,
+          mediaController: mediaController,
+        ),
+      );
+      expect(controller.text, 'wiped');
+
+      mediaController.clearDraft();
+      await tester.pump();
+
+      expect(controller.text, isEmpty);
+      expect(prefs.getString(InputDraftPersistence.key), isNull);
+
+      controller.dispose();
+      focusNode.dispose();
+    });
+  });
+}

--- a/test/features/home/widgets/chat_input_bar_queue_test.dart
+++ b/test/features/home/widgets/chat_input_bar_queue_test.dart
@@ -1,6 +1,7 @@
 import 'package:Cuplivo/core/models/chat_input_data.dart';
 import 'package:Cuplivo/core/providers/assistant_provider.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/features/home/services/input_draft_persistence.dart';
 import 'package:Cuplivo/features/home/widgets/chat_input_bar.dart';
 import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
@@ -10,8 +11,17 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  setUp(() {
+  late InputDraftPersistence draftPersistence;
+
+  setUp(() async {
     SharedPreferences.setMockInitialValues({});
+    draftPersistence = InputDraftPersistence(
+      await SharedPreferences.getInstance(),
+    );
+  });
+
+  tearDown(() {
+    draftPersistence.disposeInternal();
   });
 
   Widget buildHarness({
@@ -35,6 +45,7 @@ void main() {
   }) {
     return MultiProvider(
       providers: [
+        Provider<InputDraftPersistence>.value(value: draftPersistence),
         ChangeNotifierProvider.value(
           value: settingsProvider ?? SettingsProvider(),
         ),

--- a/test/shared_preferences_async_backup_filter_test.dart
+++ b/test/shared_preferences_async_backup_filter_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:Cuplivo/core/models/chat_input_data.dart';
 import 'package:Cuplivo/core/services/backup/data_sync.dart' as backup_sync;
 
 void main() {
@@ -115,6 +116,38 @@ void main() {
 
       final rawPrefs = await SharedPreferences.getInstance();
       expect(rawPrefs.getString('codex_oauth_v1'), '{"accessToken":"old"}');
+    });
+
+    test('snapshot excludes the chat input draft key', () async {
+      SharedPreferences.setMockInitialValues({
+        chatInputDraftPrefsKey: '{"text":"unsent"}',
+        'display_auto_scroll_enabled_v1': true,
+      });
+
+      final prefs = await backup_sync.SharedPreferencesAsync.instance;
+      final snapshot = await prefs.snapshot();
+
+      expect(snapshot.containsKey(chatInputDraftPrefsKey), isFalse);
+      expect(snapshot['display_auto_scroll_enabled_v1'], isTrue);
+    });
+
+    test('restore ignores the chat input draft key', () async {
+      SharedPreferences.setMockInitialValues({
+        chatInputDraftPrefsKey: '{"text":"local draft"}',
+      });
+
+      final prefs = await backup_sync.SharedPreferencesAsync.instance;
+      await prefs.restore({
+        chatInputDraftPrefsKey: '{"text":"remote stale draft"}',
+        'display_auto_scroll_enabled_v1': true,
+      });
+
+      final rawPrefs = await SharedPreferences.getInstance();
+      expect(
+        rawPrefs.getString(chatInputDraftPrefsKey),
+        '{"text":"local draft"}',
+      );
+      expect(rawPrefs.getBool('display_auto_scroll_enabled_v1'), isTrue);
     });
   });
 }


### PR DESCRIPTION
- InputDraftPersistence service: 800ms debounced writes + lifecycle flush,
  preloaded in main() before runApp so cold-start restore is synchronous
  and race-free (once per process, no overwrite dialog)
- Input bar wiring: restore on mount, save on text/media changes, immediate
  clear on sent/queued, keep on rejected; group-chat bar excluded
- chat_draft_v1 registered in SharedPreferencesAsync._localOnlyKeys so the
  draft never leaves the device via backup or LAN sync
- Storage delete guardrail: warn (not block) when selected files are still
  referenced by the unsent draft; new storageSpaceDeleteDraftWarning key
- Sync draft on programmatic text inserts (suggestion/quick phrase/quote/
  synthesize prompt/process text/newline/paste/cut)
- Degraded no-op instance when SharedPreferences fails at startup
- CONTEXT.md: document synchronous preload, scope, clear semantics
