### PR TITLE
feat(mini-map): message-level search with shared logic, desktop search field, debounce and highlighting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -615,6 +615,18 @@
 
 - "显示公式" / "display formula" was used in issue #218 to mean block-level math as opposed to inline — resolved: the domain term is **Display math** (block-level TeX forms `$$...$$` and `\[...\]`); "inline math" is the flow-level counterpart.
 
+## Mini Map Search (迷你地图搜索)
+
+- **Model**: filter-navigation (过滤导航) — 搜索是地图的定位工具，不是结果列表。输入关键词 → 消息级命中行（单消息一行，hit-centered 片段 + 高亮），点击跳转原消息；清空 → 恢复 Q/A 对鸟瞰图。
+- **Match source**: raw content（原始文本）— 与显示剥离逻辑解耦；`<think>/<thought>/<reasoning>`、`[image:]/[file:]` 内的文字可被命中。已知边缘：命中词恰好是标记/标签名本身（如搜 `think` 匹配 `<think>`）时，压平后的 snippet 不含该词 → 命中行无高亮（匹配源与显示源分裂的固有结果，接受）。
+- **Snippet source**: raw text with tag-flattening — 从原始文本以命中为中心截取，标签字符删除、内部文字保留；markdown 语法符号不动。窗口截断产生的残留裸标签/裸 `[image:`/`[file:` 前缀会再清洗一遍。
+- **Token semantics**: whitespace 分词 AND（与全局搜索 `_tokensOf` 一致）。
+- **Highlight**: 与全局搜索同色（暗 0xFFB8860B@55% / 亮 0xFFFFD700@55%），"黄色=命中"为 app 级心智模型。
+- **Entry divergence**: 手机图标切换式（屏幕窄）+ autofocus；桌面常驻搜索框 + 打开即 autofocus + Esc 两级退（先清空、再关闭）。共享的是逻辑（`lib/shared/widgets/mini_map/`），不是入口 UI。
+- **Debounce**: 150-200ms 各壳私有 Timer（dispose 取消）；shared 保持无状态纯函数。
+- **Performance note**: 单对话内消息级过滤；跨对话的 200 条限制属于全局搜索（issue #243 的另一半，未在本任务处理）。
+- **Selection mode**: 命中行点击 = 切换勾选（`onToggleSelection`），与跳转互斥。
+
 ## Token Accounting (Token 统计)
 
 - **Tool-call round (工具调用轮次)**: One independent API request within a single assistant turn. A multi-round turn = model calls tools → tool results appended → follow-up request, repeated. Each round is separately billed, and its `usage` snapshot resets per request (except Gemini-style within-stream cumulative `usageMetadata`).

--- a/lib/desktop/mini_map_popover.dart
+++ b/lib/desktop/mini_map_popover.dart
@@ -2,8 +2,13 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../core/models/chat_message.dart';
+import '../icons/lucide_adapter.dart';
+import '../l10n/app_localizations.dart';
+import '../shared/widgets/mini_map/mini_map_shared.dart';
+import '../theme/app_font_weights.dart';
 
 Future<String?> showDesktopMiniMapPopover(
   BuildContext context, {
@@ -183,6 +188,7 @@ class _MiniMapPopoverState extends State<_MiniMapPopover>
                           selecting: widget.selecting,
                           selectedMessageIds: widget.selectedMessageIds,
                           selectionListenable: widget.selectionListenable,
+                          onClose: _close,
                           onTapMessage: (id) {
                             if (_closing) return;
                             if (widget.selecting) {
@@ -248,12 +254,14 @@ class _MiniMapList extends StatefulWidget {
   const _MiniMapList({
     required this.messages,
     required this.onTapMessage,
+    required this.onClose,
     required this.selecting,
     this.selectedMessageIds,
     this.selectionListenable,
   });
   final List<ChatMessage> messages;
   final ValueChanged<String> onTapMessage;
+  final VoidCallback onClose;
   final bool selecting;
   final Set<String>? selectedMessageIds;
   final Listenable? selectionListenable;
@@ -263,159 +271,413 @@ class _MiniMapList extends StatefulWidget {
 }
 
 class _MiniMapListState extends State<_MiniMapList> {
-  late List<_QaPair> _pairs;
+  late List<MiniMapQaPair> _pairs;
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocusNode = FocusNode();
+  final ScrollController _resultsScrollController = ScrollController();
+
+  String _query = '';
+  List<String> _tokens = const [];
+  List<ChatMessage> _searchResults = const [];
+  Timer? _searchDebounce;
 
   @override
   void initState() {
     super.initState();
-    _pairs = _buildPairs(widget.messages);
+    _pairs = buildMiniMapPairs(widget.messages);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _searchFocusNode.requestFocus();
+    });
   }
 
   @override
   void didUpdateWidget(covariant _MiniMapList oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.messages, widget.messages)) {
-      _pairs = _buildPairs(widget.messages);
+      _pairs = buildMiniMapPairs(widget.messages);
     }
-  }
-
-  String _oneLine(String s) {
-    var t = s
-        .replaceAll(
-          RegExp(
-            r'<(?:think|thought)>[\s\S]*?<\/(?:think|thought)>',
-            caseSensitive: false,
-          ),
-          '',
-        )
-        .replaceAll(RegExp(r"\[image:[^\]]+\]"), "")
-        .replaceAll(RegExp(r"\[file:[^\]]+\]"), "")
-        .replaceAll('\n', ' ')
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
-    return t;
-  }
-
-  List<_QaPair> _buildPairs(List<ChatMessage> items) {
-    final pairs = <_QaPair>[];
-    ChatMessage? pendingUser;
-    for (final m in items) {
-      if (m.role == 'user') {
-        if (pendingUser != null) {
-          pairs.add(_QaPair(user: pendingUser, assistant: null));
-        }
-        pendingUser = m;
-      } else if (m.role == 'assistant') {
-        if (pendingUser != null) {
-          pairs.add(_QaPair(user: pendingUser, assistant: m));
-          pendingUser = null;
-        } else {
-          pairs.add(_QaPair(user: null, assistant: m));
-        }
-      }
-    }
-    if (pendingUser != null) {
-      pairs.add(_QaPair(user: pendingUser, assistant: null));
-    }
-    return pairs;
   }
 
   @override
-  Widget build(BuildContext context) {
-    Widget buildList(List<_QaPair> pairs) {
-      return Padding(
-        padding: const EdgeInsets.only(bottom: 2),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 420),
-          child: ListView.builder(
-            padding: const EdgeInsets.fromLTRB(12, 10, 12, 2),
-            primary: false,
-            shrinkWrap: true,
-            itemCount: pairs.length,
-            itemBuilder: (context, index) {
-              final p = pairs[index];
-              final userSelected =
-                  widget.selecting &&
-                  widget.selectedMessageIds != null &&
-                  p.user != null &&
-                  widget.selectedMessageIds!.contains(p.user!.id);
-              final assistantSelected =
-                  widget.selecting &&
-                  widget.selectedMessageIds != null &&
-                  p.assistant != null &&
-                  widget.selectedMessageIds!.contains(p.assistant!.id);
+  void dispose() {
+    _searchDebounce?.cancel();
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    _resultsScrollController.dispose();
+    super.dispose();
+  }
 
-              return Padding(
-                padding: const EdgeInsets.only(bottom: 6),
-                child: _MiniMapRow(
-                  user: p.user,
-                  assistant: p.assistant,
-                  userSelected: userSelected,
-                  assistantSelected: assistantSelected,
-                  toOneLine: _oneLine,
-                  onTapMessage: widget.onTapMessage,
-                ),
-              );
-            },
+  void _onSearchChanged(String value) {
+    setState(() => _query = value);
+    _searchDebounce?.cancel();
+    if (value.trim().isNotEmpty && _tokens.isEmpty) {
+      // First keystroke: apply immediately so the search view shows real
+      // results right away (no debounce-window collapse). Subsequent
+      // keystrokes are debounced and keep the previous result set visible.
+      _applySearch();
+      return;
+    }
+    _searchDebounce = Timer(const Duration(milliseconds: 180), _applySearch);
+  }
+
+  void _applySearch() {
+    final tokens = miniMapSearchTokens(_query);
+    final results = tokens.isEmpty
+        ? const <ChatMessage>[]
+        : filterMiniMapMessages(widget.messages, tokens);
+    if (!mounted) return;
+    setState(() {
+      _tokens = tokens;
+      _searchResults = results;
+    });
+    final sc = _resultsScrollController;
+    if (sc.hasClients) {
+      sc.jumpTo(0);
+    }
+  }
+
+  void _clearSearch() {
+    _searchDebounce?.cancel();
+    setState(() {
+      _query = '';
+      _tokens = const [];
+      _searchResults = const [];
+      _searchController.clear();
+    });
+    _searchFocusNode.requestFocus();
+  }
+
+  KeyEventResult _onSearchKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.escape) {
+      if (_query.isNotEmpty) {
+        _clearSearch();
+      } else {
+        widget.onClose();
+      }
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  Widget _buildSearchField(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final borderColor = cs.outlineVariant.withValues(alpha: isDark ? 0.5 : 0.8);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
+      child: SizedBox(
+        height: 36,
+        child: Focus(
+          onKeyEvent: _onSearchKeyEvent,
+          child: TextField(
+            controller: _searchController,
+            focusNode: _searchFocusNode,
+            onChanged: _onSearchChanged,
+            textInputAction: TextInputAction.search,
+            textAlignVertical: TextAlignVertical.center,
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: MaterialLocalizations.of(context).searchFieldLabel,
+              prefixIcon: Icon(Lucide.Search, size: 18, color: cs.onSurface),
+              suffixIcon: _query.isEmpty
+                  ? null
+                  : IconButton(
+                      padding: EdgeInsets.zero,
+                      icon: Icon(
+                        Lucide.X,
+                        size: 16,
+                        color: cs.onSurface.withValues(alpha: 0.7),
+                      ),
+                      onPressed: _clearSearch,
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonLabel,
+                    ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 8,
+              ),
+              filled: true,
+              fillColor: cs.surfaceContainerHighest.withValues(
+                alpha: isDark ? 0.35 : 0.6,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: borderColor),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: borderColor),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: cs.primary),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchResultsList(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textBase = isDark ? Colors.white : Colors.black;
+    final highlightColor = isDark
+        ? const Color(0xFFB8860B).withValues(alpha: 0.55)
+        : const Color(0xFFFFD700).withValues(alpha: 0.55);
+
+    if (_tokens.isEmpty) {
+      // Debounce window: query entered but no result set computed yet.
+      // Keep the previous state's space without flashing a false empty state.
+      return const SizedBox.shrink();
+    }
+
+    if (_searchResults.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24),
+        child: Center(
+          child: Text(
+            l10n.miniMapSearchNoResults,
+            style: TextStyle(
+              fontSize: 13,
+              color: textBase.withValues(alpha: 0.45),
+            ),
           ),
         ),
       );
     }
 
-    if (widget.selecting && widget.selectionListenable != null) {
-      return AnimatedBuilder(
-        animation: widget.selectionListenable!,
-        builder: (context, child) => buildList(_pairs),
-      );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(4, 0, 4, 6),
+          child: Text(
+            l10n.miniMapSearchResultCount(_searchResults.length),
+            style: TextStyle(
+              fontSize: 12,
+              color: textBase.withValues(alpha: 0.5),
+              fontWeight: AppFontWeights.medium,
+            ),
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            controller: _resultsScrollController,
+            padding: const EdgeInsets.fromLTRB(12, 0, 12, 2),
+            primary: false,
+            shrinkWrap: true,
+            itemCount: _searchResults.length,
+            itemBuilder: (context, index) {
+              final message = _searchResults[index];
+              return _MiniMapSearchRow(
+                message: message,
+                tokens: _tokens,
+                highlightColor: highlightColor,
+                selecting: widget.selecting,
+                selectedMessageIds: widget.selectedMessageIds,
+                onTap: () => widget.onTapMessage(message.id),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPairsList(List<MiniMapQaPair> pairs) {
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 2),
+      primary: false,
+      shrinkWrap: true,
+      itemCount: pairs.length,
+      itemBuilder: (context, index) {
+        final p = pairs[index];
+        final userSelected =
+            widget.selecting &&
+            widget.selectedMessageIds != null &&
+            p.user != null &&
+            widget.selectedMessageIds!.contains(p.user!.id);
+        final assistantSelected =
+            widget.selecting &&
+            widget.selectedMessageIds != null &&
+            p.assistant != null &&
+            widget.selectedMessageIds!.contains(p.assistant!.id);
+
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: _MiniMapRow(
+            user: p.user,
+            assistant: p.assistant,
+            userSelected: userSelected,
+            assistantSelected: assistantSelected,
+            onTapMessage: widget.onTapMessage,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Search view is active while a query is present — even during the
+    // debounce window, where the previous result set stays visible — or once
+    // a result set has been computed.
+    final hasActiveSearch = _query.trim().isNotEmpty || _tokens.isNotEmpty;
+    Widget buildList() {
+      if (hasActiveSearch) {
+        return _buildSearchResultsList(context);
+      }
+      return _buildPairsList(_pairs);
     }
 
+    final Widget list = widget.selecting && widget.selectionListenable != null
+        ? AnimatedBuilder(
+            animation: widget.selectionListenable!,
+            builder: (context, child) => buildList(),
+          )
+        : buildList();
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 420),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildSearchField(context),
+          Flexible(child: list),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniMapSearchRow extends StatefulWidget {
+  final ChatMessage message;
+  final List<String> tokens;
+  final Color highlightColor;
+  final bool selecting;
+  final Set<String>? selectedMessageIds;
+  final VoidCallback onTap;
+
+  const _MiniMapSearchRow({
+    required this.message,
+    required this.tokens,
+    required this.highlightColor,
+    required this.selecting,
+    required this.selectedMessageIds,
+    required this.onTap,
+  });
+
+  @override
+  State<_MiniMapSearchRow> createState() => _MiniMapSearchRowState();
+}
+
+class _MiniMapSearchRowState extends State<_MiniMapSearchRow> {
+  bool _hover = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final isUser = widget.message.role == 'user';
+    final snippet = miniMapHitSnippet(widget.message.content, widget.tokens);
+
+    final selected =
+        widget.selecting &&
+        widget.selectedMessageIds != null &&
+        widget.selectedMessageIds!.contains(widget.message.id);
+    final bg = isUser
+        ? (isDark
+              ? cs.primary.withValues(alpha: 0.15)
+              : cs.primary.withValues(alpha: 0.08))
+        : cs.onSurface.withValues(alpha: isDark ? 0.05 : 0.03);
+    final hoverBg = isUser
+        ? (isDark
+              ? cs.primary.withValues(alpha: 0.22)
+              : cs.primary.withValues(alpha: 0.14))
+        : cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.06);
+    final selectedBg = isUser
+        ? (isDark
+              ? cs.primary.withValues(alpha: 0.26)
+              : cs.primary.withValues(alpha: 0.14))
+        : (isDark
+              ? cs.primary.withValues(alpha: 0.18)
+              : cs.primary.withValues(alpha: 0.10));
+    final border = cs.primary.withValues(alpha: isDark ? 0.38 : 0.28);
+
+    final baseStyle = TextStyle(
+      fontSize: 15,
+      height: 1.4,
+      color: cs.onSurface,
+      decoration: TextDecoration.none,
+    );
+    final highlightStyle = baseStyle.copyWith(
+      backgroundColor: widget.highlightColor,
+    );
+
     return Padding(
-      padding: const EdgeInsets.only(bottom: 2),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxHeight: 420),
-        child: ListView.builder(
-          padding: const EdgeInsets.fromLTRB(12, 10, 12, 2),
-          primary: false,
-          shrinkWrap: true,
-          itemCount: _pairs.length,
-          itemBuilder: (context, index) {
-            final p = _pairs[index];
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 6),
-              child: _MiniMapRow(
-                user: p.user,
-                assistant: p.assistant,
-                userSelected: false,
-                assistantSelected: false,
-                toOneLine: _oneLine,
-                onTapMessage: widget.onTapMessage,
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Align(
+        alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.sizeOf(context).width * 0.75,
+          ),
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onEnter: (_) => setState(() => _hover = true),
+            onExit: (_) => setState(() => _hover = false),
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: widget.onTap,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 120),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: selected ? selectedBg : (_hover ? hoverBg : bg),
+                  borderRadius: BorderRadius.circular(16),
+                  border: selected ? Border.all(color: border, width: 1) : null,
+                ),
+                child: RichText(
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  text: TextSpan(
+                    children: buildMiniMapHighlightSpans(
+                      snippet.isEmpty
+                          ? miniMapOneLine(widget.message.content)
+                          : snippet,
+                      widget.tokens,
+                      baseStyle,
+                      highlightStyle,
+                    ),
+                  ),
+                ),
               ),
-            );
-          },
+            ),
+          ),
         ),
       ),
     );
   }
 }
 
-class _QaPair {
-  final ChatMessage? user;
-  final ChatMessage? assistant;
-  _QaPair({required this.user, required this.assistant});
-}
-
 class _MiniMapRow extends StatefulWidget {
   const _MiniMapRow({
     required this.user,
     required this.assistant,
-    required this.toOneLine,
     required this.onTapMessage,
     required this.userSelected,
     required this.assistantSelected,
   });
   final ChatMessage? user;
   final ChatMessage? assistant;
-  final String Function(String) toOneLine;
   final ValueChanged<String> onTapMessage;
   final bool userSelected;
   final bool assistantSelected;
@@ -480,7 +742,7 @@ class _MiniMapRowState extends State<_MiniMapRow> {
                       : null,
                 ),
                 child: Text(
-                  userText.isNotEmpty ? widget.toOneLine(userText) : ' ',
+                  userText.isNotEmpty ? miniMapOneLine(userText) : ' ',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(
@@ -529,7 +791,7 @@ class _MiniMapRowState extends State<_MiniMapRow> {
                       : null,
                 ),
                 child: Text(
-                  asstText.isNotEmpty ? widget.toOneLine(asstText) : ' ',
+                  asstText.isNotEmpty ? miniMapOneLine(asstText) : ' ',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: const TextStyle(

--- a/lib/features/home/widgets/mini_map_sheet.dart
+++ b/lib/features/home/widgets/mini_map_sheet.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/mini_map/mini_map_shared.dart';
 import '../../../theme/app_font_weights.dart';
 
 Future<String?> showMiniMapSheet(
@@ -58,28 +60,34 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
     with TickerProviderStateMixin {
   late final TextEditingController _searchController;
   late final FocusNode _searchFocusNode;
-  late List<_QaPair> _pairs;
+  late List<MiniMapQaPair> _pairs;
   String _query = '';
   bool _isSearching = false;
+
+  List<String> _tokens = const [];
+  List<ChatMessage> _searchResults = const [];
+  Timer? _searchDebounce;
+  ScrollController? _sheetController;
 
   @override
   void initState() {
     super.initState();
     _searchController = TextEditingController();
     _searchFocusNode = FocusNode();
-    _pairs = _buildPairs(widget.messages);
+    _pairs = buildMiniMapPairs(widget.messages);
   }
 
   @override
   void didUpdateWidget(covariant _MiniMapSheet oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.messages, widget.messages)) {
-      _pairs = _buildPairs(widget.messages);
+      _pairs = buildMiniMapPairs(widget.messages);
     }
   }
 
   @override
   void dispose() {
+    _searchDebounce?.cancel();
     _searchController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
@@ -97,8 +105,11 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
   }
 
   void _clearOrCloseSearch({bool close = false}) {
+    _searchDebounce?.cancel();
     setState(() {
       _query = '';
+      _tokens = const [];
+      _searchResults = const [];
       _searchController.clear();
       _isSearching = close ? false : _isSearching;
     });
@@ -108,6 +119,41 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
       _searchFocusNode.requestFocus();
     }
   }
+
+  void _onSearchChanged(String value) {
+    setState(() => _query = value);
+    _searchDebounce?.cancel();
+    if (value.trim().isNotEmpty && _tokens.isEmpty) {
+      // First keystroke: apply immediately so the search view shows real
+      // results right away (no debounce-window collapse). Subsequent
+      // keystrokes are debounced and keep the previous result set visible.
+      _applySearch();
+      return;
+    }
+    _searchDebounce = Timer(const Duration(milliseconds: 180), _applySearch);
+  }
+
+  void _applySearch() {
+    final tokens = miniMapSearchTokens(_query);
+    final results = tokens.isEmpty
+        ? const <ChatMessage>[]
+        : filterMiniMapMessages(widget.messages, tokens);
+    if (!mounted) return;
+    setState(() {
+      _tokens = tokens;
+      _searchResults = results;
+    });
+    final sc = _sheetController;
+    if (sc != null && sc.hasClients) {
+      sc.jumpTo(0);
+    }
+  }
+
+  /// True while the search view should replace the Q/A pair map: a query is
+  /// present (even during the debounce window, where the previous result set
+  /// stays visible) or a result set has been computed.
+  bool get _searchActive =>
+      _isSearching && (_query.trim().isNotEmpty || _tokens.isNotEmpty);
 
   @override
   Widget build(BuildContext context) {
@@ -122,14 +168,17 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
         minChildSize: 0.35,
         maxChildSize: 0.9,
         builder: (ctx, controller) {
-          final pairs = _filteredPairs(_pairs);
+          _sheetController = controller;
           Widget buildList() {
+            if (_searchActive) {
+              return _buildSearchResultsList(context, controller);
+            }
             return ListView.builder(
               controller: controller,
-              itemCount: pairs.length,
+              itemCount: _pairs.length,
               itemBuilder: (context, index) {
                 return _MiniMapRow(
-                  pair: pairs[index],
+                  pair: _pairs[index],
                   selecting: widget.selecting,
                   selectedMessageIds: widget.selectedMessageIds,
                   onToggleSelection: widget.onToggleSelection,
@@ -171,29 +220,30 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
                       ),
                     ),
                     const SizedBox(width: 4),
-                    SizedBox(
-                      height: 36,
-                      width: 36,
-                      child: IconButton(
-                        padding: EdgeInsets.zero,
-                        icon: Icon(
-                          Lucide.ChevronsDown,
-                          size: 18,
-                          color: cs.onSurface,
+                    if (!_searchActive)
+                      SizedBox(
+                        height: 36,
+                        width: 36,
+                        child: IconButton(
+                          padding: EdgeInsets.zero,
+                          icon: Icon(
+                            Lucide.ChevronsDown,
+                            size: 18,
+                            color: cs.onSurface,
+                          ),
+                          tooltip: AppLocalizations.of(
+                            context,
+                          )!.miniMapScrollToBottomTooltip,
+                          onPressed: () {
+                            if (controller.hasClients &&
+                                controller.position.maxScrollExtent > 0) {
+                              controller.jumpTo(
+                                controller.position.maxScrollExtent,
+                              );
+                            }
+                          },
                         ),
-                        tooltip: AppLocalizations.of(
-                          context,
-                        )!.miniMapScrollToBottomTooltip,
-                        onPressed: () {
-                          if (controller.hasClients &&
-                              controller.position.maxScrollExtent > 0) {
-                            controller.jumpTo(
-                              controller.position.maxScrollExtent,
-                            );
-                          }
-                        },
                       ),
-                    ),
                     _buildSearchToggle(context, searchWidth),
                   ],
                 ),
@@ -212,6 +262,76 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
           );
         },
       ),
+    );
+  }
+
+  Widget _buildSearchResultsList(
+    BuildContext context,
+    ScrollController controller,
+  ) {
+    final l10n = AppLocalizations.of(context)!;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textBase = isDark ? Colors.white : Colors.black;
+    final highlightColor = isDark
+        ? const Color(0xFFB8860B).withValues(alpha: 0.55)
+        : const Color(0xFFFFD700).withValues(alpha: 0.55);
+
+    if (_tokens.isEmpty) {
+      // Debounce window: query entered but no result set computed yet.
+      // Keep the previous state's space without flashing a false empty state.
+      return const SizedBox.shrink();
+    }
+
+    if (_searchResults.isEmpty) {
+      return Center(
+        child: Text(
+          l10n.miniMapSearchNoResults,
+          style: TextStyle(
+            fontSize: 13,
+            color: textBase.withValues(alpha: 0.45),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(4, 0, 4, 6),
+          child: Text(
+            l10n.miniMapSearchResultCount(_searchResults.length),
+            style: TextStyle(
+              fontSize: 12,
+              color: textBase.withValues(alpha: 0.5),
+              fontWeight: AppFontWeights.medium,
+            ),
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            controller: controller,
+            itemCount: _searchResults.length,
+            itemBuilder: (context, index) {
+              final message = _searchResults[index];
+              return _MiniMapSearchRow(
+                message: message,
+                tokens: _tokens,
+                highlightColor: highlightColor,
+                selecting: widget.selecting,
+                selectedMessageIds: widget.selectedMessageIds,
+                onTap: () {
+                  if (widget.selecting) {
+                    widget.onToggleSelection?.call(message.id);
+                  } else {
+                    Navigator.of(context).pop(message.id);
+                  }
+                },
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 
@@ -247,7 +367,7 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
                         child: TextField(
                           controller: _searchController,
                           focusNode: _searchFocusNode,
-                          onChanged: (value) => setState(() => _query = value),
+                          onChanged: _onSearchChanged,
                           textInputAction: TextInputAction.search,
                           textAlignVertical: TextAlignVertical.center,
                           decoration: InputDecoration(
@@ -313,52 +433,109 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
       ),
     );
   }
-
-  List<_QaPair> _buildPairs(List<ChatMessage> items) {
-    final pairs = <_QaPair>[];
-    ChatMessage? pendingUser;
-    for (final m in items) {
-      if (m.role == 'user') {
-        // Push previous if it had no assistant
-        if (pendingUser != null) {
-          pairs.add(_QaPair(user: pendingUser, assistant: null));
-        }
-        pendingUser = m;
-      } else if (m.role == 'assistant') {
-        if (pendingUser != null) {
-          pairs.add(_QaPair(user: pendingUser, assistant: m));
-          pendingUser = null;
-        } else {
-          // Assistant without user: show as orphan on the right
-          pairs.add(_QaPair(user: null, assistant: m));
-        }
-      }
-    }
-    if (pendingUser != null) {
-      pairs.add(_QaPair(user: pendingUser, assistant: null));
-    }
-    return pairs;
-  }
-
-  List<_QaPair> _filteredPairs(List<_QaPair> base) {
-    final needle = _query.trim().toLowerCase();
-    if (needle.isEmpty) return base;
-    return base.where((pair) {
-      final user = pair.user?.content.toLowerCase() ?? '';
-      final asst = pair.assistant?.content.toLowerCase() ?? '';
-      return user.contains(needle) || asst.contains(needle);
-    }).toList();
-  }
 }
 
-class _QaPair {
-  final ChatMessage? user;
-  final ChatMessage? assistant;
-  _QaPair({required this.user, required this.assistant});
+class _MiniMapSearchRow extends StatelessWidget {
+  final ChatMessage message;
+  final List<String> tokens;
+  final Color highlightColor;
+  final bool selecting;
+  final Set<String>? selectedMessageIds;
+  final VoidCallback onTap;
+
+  const _MiniMapSearchRow({
+    required this.message,
+    required this.tokens,
+    required this.highlightColor,
+    required this.selecting,
+    required this.selectedMessageIds,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final isUser = message.role == 'user';
+    final snippet = miniMapHitSnippet(message.content, tokens);
+
+    final selected =
+        selecting &&
+        selectedMessageIds != null &&
+        selectedMessageIds!.contains(message.id);
+    final bg = isUser
+        ? (isDark
+              ? cs.primary.withValues(alpha: 0.15)
+              : cs.primary.withValues(alpha: 0.08))
+        : cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04);
+    final selectedBg = isUser
+        ? (isDark
+              ? cs.primary.withValues(alpha: 0.26)
+              : cs.primary.withValues(alpha: 0.14))
+        : (isDark
+              ? cs.primary.withValues(alpha: 0.18)
+              : cs.primary.withValues(alpha: 0.10));
+    final border = isUser
+        ? cs.primary.withValues(alpha: isDark ? 0.45 : 0.35)
+        : cs.primary.withValues(alpha: isDark ? 0.38 : 0.28);
+
+    final baseStyle = TextStyle(
+      fontSize: 15.5,
+      height: 1.4,
+      color: cs.onSurface,
+    );
+    final highlightStyle = baseStyle.copyWith(backgroundColor: highlightColor);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Align(
+        alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth:
+                MediaQuery.sizeOf(context).width * 0.75 -
+                32, // subtract side paddings approx in sheet
+          ),
+          child: Material(
+            color: Colors.transparent,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onTap,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: selected ? selectedBg : bg,
+                  borderRadius: BorderRadius.circular(16),
+                  border: selected ? Border.all(color: border, width: 1) : null,
+                ),
+                child: RichText(
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  text: TextSpan(
+                    children: buildMiniMapHighlightSpans(
+                      snippet.isEmpty
+                          ? miniMapOneLine(message.content)
+                          : snippet,
+                      tokens,
+                      baseStyle,
+                      highlightStyle,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _MiniMapRow extends StatelessWidget {
-  final _QaPair pair;
+  final MiniMapQaPair pair;
   final bool selecting;
   final Set<String>? selectedMessageIds;
   final ValueChanged<String>? onToggleSelection;
@@ -369,25 +546,6 @@ class _MiniMapRow extends StatelessWidget {
     this.selectedMessageIds,
     this.onToggleSelection,
   });
-
-  String _oneLine(String s) {
-    // Strip inline embed markers used in user messages to avoid noise
-    var t = s
-        // remove vendor inline reasoning blocks if present
-        .replaceAll(
-          RegExp(
-            r'<(?:think|thought)>[\s\S]*?<\/(?:think|thought)>',
-            caseSensitive: false,
-          ),
-          '',
-        )
-        .replaceAll(RegExp(r"\[image:[^\]]+\]"), "")
-        .replaceAll(RegExp(r"\[file:[^\]]+\]"), "")
-        .replaceAll('\n', ' ')
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
-    return t;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -454,7 +612,9 @@ class _MiniMapRow extends StatelessWidget {
                                 : null,
                           ),
                           child: Text(
-                            userText.isNotEmpty ? _oneLine(userText) : ' ',
+                            userText.isNotEmpty
+                                ? miniMapOneLine(userText)
+                                : ' ',
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(
@@ -481,7 +641,9 @@ class _MiniMapRow extends StatelessWidget {
                             borderRadius: BorderRadius.circular(16),
                           ),
                           child: Text(
-                            userText.isNotEmpty ? _oneLine(userText) : ' ',
+                            userText.isNotEmpty
+                                ? miniMapOneLine(userText)
+                                : ' ',
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(
@@ -529,7 +691,9 @@ class _MiniMapRow extends StatelessWidget {
                                 : null,
                           ),
                           child: Text(
-                            asstText.isNotEmpty ? _oneLine(asstText) : ' ',
+                            asstText.isNotEmpty
+                                ? miniMapOneLine(asstText)
+                                : ' ',
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(fontSize: 15.7, height: 1.5),
@@ -553,7 +717,9 @@ class _MiniMapRow extends StatelessWidget {
                             borderRadius: BorderRadius.circular(16),
                           ),
                           child: Text(
-                            asstText.isNotEmpty ? _oneLine(asstText) : ' ',
+                            asstText.isNotEmpty
+                                ? miniMapOneLine(asstText)
+                                : ' ',
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(fontSize: 15.7, height: 1.5),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1864,6 +1864,15 @@
   "miniMapTitle": "Minimap",
   "miniMapTooltip": "Minimap",
   "miniMapScrollToBottomTooltip": "Scroll to bottom",
+  "miniMapSearchResultCount": "{count, plural, one{{count} match} other{{count} matches}}",
+  "@miniMapSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "miniMapSearchNoResults": "No matching messages",
   "searchServicesPageApiKeyRequiredStatus": "API Key Required",
   "searchServicesPageUrlRequiredStatus": "URL Required",
   "searchServicesAddDialogTitle": "Add Search Service",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -8126,6 +8126,18 @@ abstract class AppLocalizations {
   /// **'Scroll to bottom'**
   String get miniMapScrollToBottomTooltip;
 
+  /// No description provided for @miniMapSearchResultCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{{count} match} other{{count} matches}}'**
+  String miniMapSearchResultCount(int count);
+
+  /// No description provided for @miniMapSearchNoResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No matching messages'**
+  String get miniMapSearchNoResults;
+
   /// No description provided for @searchServicesPageApiKeyRequiredStatus.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4438,6 +4438,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get miniMapScrollToBottomTooltip => 'Scroll to bottom';
 
   @override
+  String miniMapSearchResultCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count matches',
+      one: '$count match',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get miniMapSearchNoResults => 'No matching messages';
+
+  @override
   String get searchServicesPageApiKeyRequiredStatus => 'API Key Required';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4271,6 +4271,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get miniMapScrollToBottomTooltip => '滚动到底部';
 
   @override
+  String miniMapSearchResultCount(int count) {
+    return '命中 $count 条';
+  }
+
+  @override
+  String get miniMapSearchNoResults => '无匹配结果';
+
+  @override
   String get searchServicesPageApiKeyRequiredStatus => '需要 API Key';
 
   @override
@@ -11587,6 +11595,14 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get miniMapScrollToBottomTooltip => '滚动到底部';
 
   @override
+  String miniMapSearchResultCount(int count) {
+    return '命中 $count 条';
+  }
+
+  @override
+  String get miniMapSearchNoResults => '无匹配结果';
+
+  @override
   String get searchServicesPageApiKeyRequiredStatus => '需要 API Key';
 
   @override
@@ -18898,6 +18914,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get miniMapScrollToBottomTooltip => '捲動到底部';
+
+  @override
+  String miniMapSearchResultCount(int count) {
+    return '命中 $count 條';
+  }
+
+  @override
+  String get miniMapSearchNoResults => '無匹配結果';
 
   @override
   String get searchServicesPageApiKeyRequiredStatus => '需要 API Key';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1446,6 +1446,15 @@
   "miniMapTitle": "迷你地图",
   "miniMapTooltip": "迷你地图",
   "miniMapScrollToBottomTooltip": "滚动到底部",
+  "miniMapSearchResultCount": "命中 {count} 条",
+  "@miniMapSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "miniMapSearchNoResults": "无匹配结果",
   "searchServicesPageApiKeyRequiredStatus": "需要 API Key",
   "searchServicesPageUrlRequiredStatus": "需要 URL",
   "searchServicesAddDialogTitle": "添加搜索服务",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1848,6 +1848,15 @@
   "miniMapTitle": "迷你地图",
   "miniMapTooltip": "迷你地图",
   "miniMapScrollToBottomTooltip": "滚动到底部",
+  "miniMapSearchResultCount": "命中 {count} 条",
+  "@miniMapSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "miniMapSearchNoResults": "无匹配结果",
   "displaySettingsPageEnableDollarLatexTitle": "启用 $...$ 渲染",
   "displaySettingsPageEnableDollarLatexSubtitle": "将 $...$ 之间的内容按行内数学公式渲染",
   "displaySettingsPageEnableMathTitle": "启用数学公式渲染",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1815,6 +1815,15 @@
   "miniMapTitle": "迷你地圖",
   "miniMapTooltip": "迷你地圖",
   "miniMapScrollToBottomTooltip": "捲動到底部",
+  "miniMapSearchResultCount": "命中 {count} 條",
+  "@miniMapSearchResultCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "miniMapSearchNoResults": "無匹配結果",
   "displaySettingsPageEnableDollarLatexTitle": "啟用 $...$ 渲染",
   "displaySettingsPageEnableDollarLatexSubtitle": "將 $...$ 之間的內容以行內數學公式渲染",
   "displaySettingsPageEnableMathTitle": "啟用數學公式渲染",

--- a/lib/shared/widgets/mini_map/mini_map_shared.dart
+++ b/lib/shared/widgets/mini_map/mini_map_shared.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/painting.dart';
+
+import '../../../core/models/chat_message.dart';
+
+/// Q/A pairing of one user message with the assistant reply that follows it.
+class MiniMapQaPair {
+  const MiniMapQaPair({this.user, this.assistant});
+
+  final ChatMessage? user;
+  final ChatMessage? assistant;
+}
+
+/// Groups messages into user/assistant Q/A pairs for the mini map bird's-eye
+/// view. An assistant message without a preceding user message becomes an
+/// orphan on the assistant side; a trailing user message without an assistant
+/// reply stays as a user-only pair.
+List<MiniMapQaPair> buildMiniMapPairs(List<ChatMessage> messages) {
+  final pairs = <MiniMapQaPair>[];
+  ChatMessage? pendingUser;
+  for (final m in messages) {
+    if (m.role == 'user') {
+      if (pendingUser != null) {
+        pairs.add(MiniMapQaPair(user: pendingUser, assistant: null));
+      }
+      pendingUser = m;
+    } else if (m.role == 'assistant') {
+      if (pendingUser != null) {
+        pairs.add(MiniMapQaPair(user: pendingUser, assistant: m));
+        pendingUser = null;
+      } else {
+        pairs.add(MiniMapQaPair(user: null, assistant: m));
+      }
+    }
+  }
+  if (pendingUser != null) {
+    pairs.add(MiniMapQaPair(user: pendingUser, assistant: null));
+  }
+  return pairs;
+}
+
+/// Flattens message content to a single line for mini map display bubbles.
+/// Strips vendor inline reasoning/thought blocks, `[image:]` / `[file:]`
+/// markers, collapses newlines and repeated whitespace. Unlike
+/// [miniMapHitSnippet], stripped regions are removed entirely — this is the
+/// DISPLAY text, while search matches against the raw content.
+String miniMapOneLine(String s) {
+  var t = s
+      .replaceAll(
+        RegExp(
+          r'<(?:think|thought)>[\s\S]*?<\/(?:think|thought)>',
+          caseSensitive: false,
+        ),
+        '',
+      )
+      .replaceAll(
+        RegExp(r'<reasoning>[\s\S]*?<\/reasoning>', caseSensitive: false),
+        '',
+      )
+      .replaceAll(RegExp(r"\[image:[^\]]+\]"), "")
+      .replaceAll(RegExp(r"\[file:[^\]]+\]"), "")
+      .replaceAll('\n', ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  return t;
+}
+
+/// Splits a search query into whitespace-separated lowercase tokens,
+/// mirroring the global search tokenizer.
+List<String> miniMapSearchTokens(String query) {
+  return query
+      .toLowerCase()
+      .split(RegExp(r'\s+'))
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .toList();
+}
+
+/// Message-level search: every token must hit the RAW content of the message
+/// (AND semantics). Only user/assistant messages participate, consistent with
+/// the Q/A pair view. Order follows the original message order.
+List<ChatMessage> filterMiniMapMessages(
+  List<ChatMessage> messages,
+  List<String> tokens,
+) {
+  if (tokens.isEmpty) return const <ChatMessage>[];
+  final out = <ChatMessage>[];
+  for (final m in messages) {
+    if (m.role != 'user' && m.role != 'assistant') continue;
+    final lower = m.content.toLowerCase();
+    var allHit = true;
+    for (final t in tokens) {
+      if (!lower.contains(t)) {
+        allHit = false;
+        break;
+      }
+    }
+    if (allHit) out.add(m);
+  }
+  return out;
+}
+
+final RegExp _vendorBlockRe = RegExp(
+  r'<(?:think|thought|reasoning)>[\s\S]*?<\/(?:think|thought|reasoning)>',
+  caseSensitive: false,
+);
+
+/// `[image:...]` / `[file:...]` inline markers.
+final RegExp _markerRe = RegExp(r'\[(?:image|file):[^\]]*\]');
+
+/// Keeps the inner text of a matched block but removes the tag markup.
+String _flattenBlock(Match m) {
+  return m[0]!.replaceAll(RegExp(r'<\/?[^>]+>'), ' ');
+}
+
+/// Keeps the marker's inner text but removes `[image:` / `]` markup.
+String _flattenMarker(Match m) {
+  final raw = m[0]!;
+  final colon = raw.indexOf(':');
+  if (colon < 0) return ' ';
+  return raw.substring(colon + 1, raw.length - 1);
+}
+
+/// Hit-centered snippet extracted from the RAW content with tag-flattening:
+/// `<think>/<thought>/<reasoning>` and `[image:]`/`[file:]` markers keep their
+/// inner text but lose their markup, so a hit inside a stripped region stays
+/// visible and explainable. Markdown syntax symbols are left untouched.
+String miniMapHitSnippet(
+  String content,
+  List<String> tokens, {
+  int maxChars = 140,
+}) {
+  if (content.isEmpty || tokens.isEmpty) return '';
+
+  final lower = content.toLowerCase();
+  var hit = -1;
+  for (final t in tokens) {
+    final idx = lower.indexOf(t);
+    if (idx >= 0 && (hit < 0 || idx < hit)) hit = idx;
+  }
+
+  var start = 0;
+  var end = content.length;
+  var hasBefore = false;
+  var hasAfter = false;
+  if (content.length > maxChars) {
+    if (hit >= 0) {
+      final anchor = (maxChars * 0.45).round();
+      start = (hit - anchor).clamp(0, content.length - maxChars);
+    }
+    end = (start + maxChars).clamp(0, content.length);
+    hasBefore = start > 0;
+    hasAfter = end < content.length;
+  }
+
+  var frag = content.substring(start, end);
+  frag = frag.replaceAllMapped(_vendorBlockRe, _flattenBlock);
+  frag = frag.replaceAllMapped(_markerRe, _flattenMarker);
+  // A window cut mid-block leaves a stray open/close tag that never matched
+  // _vendorBlockRe; scrub bare vendor tags so snippets never show raw markup.
+  frag = frag.replaceAll(
+    RegExp(r'<\/?(?:think|thought|reasoning)>', caseSensitive: false),
+    ' ',
+  );
+  // Likewise, a cut mid-marker leaves an unterminated `[image:`/`[file:`
+  // prefix; drop the prefix (its inner text survives the window).
+  frag = frag.replaceAll(RegExp(r'\[(?:image|file):'), ' ');
+  frag = frag.replaceAll('\n', ' ').replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (hasBefore) frag = '... $frag';
+  if (hasAfter) frag = '$frag ...';
+  return frag;
+}
+
+/// Splits [text] into a span sequence where token occurrences receive the
+/// [highlight] style and everything else the [base] style. Same algorithm as
+/// the global search result highlighting.
+List<TextSpan> buildMiniMapHighlightSpans(
+  String text,
+  List<String> tokens,
+  TextStyle base,
+  TextStyle highlight,
+) {
+  if (tokens.isEmpty || text.isEmpty) {
+    return [TextSpan(text: text, style: base)];
+  }
+  final spans = <TextSpan>[];
+  final lower = text.toLowerCase();
+  int pos = 0;
+  while (pos < text.length) {
+    int earliest = -1;
+    int earliestLen = 0;
+    for (final t in tokens) {
+      final idx = lower.indexOf(t, pos);
+      if (idx >= 0 && (earliest < 0 || idx < earliest)) {
+        earliest = idx;
+        earliestLen = t.length;
+      }
+    }
+    if (earliest < 0) {
+      spans.add(TextSpan(text: text.substring(pos), style: base));
+      break;
+    }
+    if (earliest > pos) {
+      spans.add(TextSpan(text: text.substring(pos, earliest), style: base));
+    }
+    spans.add(
+      TextSpan(
+        text: text.substring(earliest, earliest + earliestLen),
+        style: highlight,
+      ),
+    );
+    pos = earliest + earliestLen;
+  }
+  return spans;
+}

--- a/test/shared/widgets/mini_map/mini_map_shared_test.dart
+++ b/test/shared/widgets/mini_map/mini_map_shared_test.dart
@@ -1,0 +1,258 @@
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/shared/widgets/mini_map/mini_map_shared.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ChatMessage _msg(String role, String content, {String? id}) {
+  return ChatMessage(
+    id: id ?? 'msg-$role-${content.hashCode}',
+    role: role,
+    content: content,
+    conversationId: 'conv',
+  );
+}
+
+void main() {
+  group('buildMiniMapPairs', () {
+    test('pairs user with following assistant', () {
+      final pairs = buildMiniMapPairs([
+        _msg('user', 'q1'),
+        _msg('assistant', 'a1'),
+        _msg('user', 'q2'),
+        _msg('assistant', 'a2'),
+      ]);
+      expect(pairs, hasLength(2));
+      expect(pairs[0].user!.content, 'q1');
+      expect(pairs[0].assistant!.content, 'a1');
+      expect(pairs[1].user!.content, 'q2');
+      expect(pairs[1].assistant!.content, 'a2');
+    });
+
+    test('orphan assistant without user', () {
+      final pairs = buildMiniMapPairs([
+        _msg('assistant', 'lonely'),
+        _msg('user', 'q'),
+      ]);
+      expect(pairs, hasLength(2));
+      expect(pairs[0].user, isNull);
+      expect(pairs[0].assistant!.content, 'lonely');
+      expect(pairs[1].user!.content, 'q');
+      expect(pairs[1].assistant, isNull);
+    });
+
+    test('trailing user without assistant', () {
+      final pairs = buildMiniMapPairs([
+        _msg('user', 'q'),
+        _msg('assistant', 'a'),
+        _msg('user', 'trailing'),
+      ]);
+      expect(pairs, hasLength(2));
+      expect(pairs[1].user!.content, 'trailing');
+      expect(pairs[1].assistant, isNull);
+    });
+
+    test('non user/assistant roles are ignored', () {
+      final pairs = buildMiniMapPairs([
+        _msg('system', 'sys'),
+        _msg('user', 'q'),
+        _msg('tool', 'tool-result'),
+        _msg('assistant', 'a'),
+      ]);
+      expect(pairs, hasLength(1));
+      expect(pairs[0].user!.content, 'q');
+      expect(pairs[0].assistant!.content, 'a');
+    });
+
+    test('empty input', () {
+      expect(buildMiniMapPairs(const []), isEmpty);
+    });
+  });
+
+  group('miniMapOneLine', () {
+    test('strips think/thought/reasoning blocks entirely', () {
+      expect(
+        miniMapOneLine('hi <think>inner</think> <reasoning>r</reasoning> x'),
+        'hi x',
+      );
+      expect(miniMapOneLine('<thought>t</thought>only'), 'only');
+    });
+
+    test('strips image and file markers', () {
+      expect(
+        miniMapOneLine('see [image:foo.png] and [file:a.txt] done'),
+        'see and done',
+      );
+    });
+
+    test('collapses newlines and whitespace', () {
+      expect(miniMapOneLine('a\n  b\t c'), 'a b c');
+    });
+  });
+
+  group('miniMapSearchTokens', () {
+    test('splits on whitespace and lowercases', () {
+      expect(miniMapSearchTokens('Hello  World'), ['hello', 'world']);
+    });
+
+    test('drops empty tokens', () {
+      expect(miniMapSearchTokens('   '), isEmpty);
+      expect(miniMapSearchTokens(''), isEmpty);
+    });
+  });
+
+  group('filterMiniMapMessages', () {
+    test('AND semantics: every token must hit', () {
+      final msgs = [
+        _msg('user', 'foo bar'),
+        _msg('assistant', 'foo only'),
+        _msg('user', 'bar only'),
+        _msg('user', 'foo bar baz'),
+      ];
+      final result = filterMiniMapMessages(
+        msgs,
+        miniMapSearchTokens('foo bar'),
+      );
+      expect(result.map((m) => m.content), ['foo bar', 'foo bar baz']);
+    });
+
+    test('single token matches', () {
+      final msgs = [_msg('user', 'alpha'), _msg('assistant', 'beta')];
+      final result = filterMiniMapMessages(msgs, ['beta']);
+      expect(result.map((m) => m.content), ['beta']);
+    });
+
+    test('empty tokens returns empty list', () {
+      expect(filterMiniMapMessages([_msg('user', 'x')], const []), isEmpty);
+    });
+
+    test('matches inside raw content including stripped regions', () {
+      final msgs = [
+        _msg('user', 'before <think>secret</think> after'),
+        _msg('assistant', '[image:photo.png] plain'),
+      ];
+      expect(filterMiniMapMessages(msgs, ['secret']).map((m) => m.content), [
+        'before <think>secret</think> after',
+      ]);
+      expect(filterMiniMapMessages(msgs, ['photo']).map((m) => m.content), [
+        '[image:photo.png] plain',
+      ]);
+    });
+
+    test('excludes tool/system messages', () {
+      final msgs = [_msg('tool', 'foo'), _msg('system', 'foo')];
+      expect(filterMiniMapMessages(msgs, ['foo']), isEmpty);
+    });
+  });
+
+  group('miniMapHitSnippet', () {
+    test('centers on the hit', () {
+      final content = List.filled(30, 'word').join(' ');
+      final snippet = miniMapHitSnippet(content, ['word'], maxChars: 80);
+      expect(snippet, contains('word'));
+      expect(snippet.length, lessThanOrEqualTo(86)); // 80 + ellipsis
+    });
+
+    test('flattens tags but keeps inner text', () {
+      final snippet = miniMapHitSnippet(
+        'before <think>secret needle</think> after',
+        ['needle'],
+      );
+      expect(snippet, contains('needle'));
+      expect(snippet, isNot(contains('<think>')));
+      expect(snippet, isNot(contains('</think>')));
+    });
+
+    test('flattens image marker keeping inner text', () {
+      final snippet = miniMapHitSnippet('see [image:photo.png] here', [
+        'photo',
+      ]);
+      expect(snippet, contains('photo'));
+      expect(snippet, isNot(contains('[image:')));
+    });
+
+    test('window cut mid-block leaves no stray vendor tags', () {
+      // The window (hit-centered, maxChars 100) contains the full `<think>`
+      // opening tag and the needle, but its end lands before `</think>` —
+      // a lone opening tag that must be scrubbed.
+      final content =
+          '${List.filled(20, 'pad').join(' ')} <think>needle '
+          '${List.filled(60, 'x').join('')} </think> '
+          '${List.filled(20, 'tail').join(' ')}';
+      final snippet = miniMapHitSnippet(content, ['needle'], maxChars: 100);
+      expect(snippet, isNot(contains('<think>')));
+      expect(snippet, isNot(contains('</think>')));
+      expect(snippet, contains('needle'));
+      expect(snippet, startsWith('... '));
+      expect(snippet, endsWith(' ...'));
+    });
+
+    test('window cut mid-marker leaves no raw marker prefix', () {
+      // The needle sits before the marker, so the window starts with
+      // `[image:` but cuts inside its inner text — the unterminated prefix
+      // must be scrubbed (inner text survives).
+      final content =
+          '${List.filled(10, 'pad').join(' ')} needle '
+          '${List.filled(10, 'mid').join(' ')} [image:'
+          '${List.filled(30, 'x').join('')}]';
+      final snippet = miniMapHitSnippet(content, ['needle'], maxChars: 100);
+      expect(snippet, isNot(contains('[image:')));
+      expect(snippet, contains('needle'));
+      expect(snippet, contains('xxx'));
+    });
+
+    test('unterminated marker prefix is scrubbed', () {
+      final snippet = miniMapHitSnippet('see [image:photo.png here', ['photo']);
+      expect(snippet, isNot(contains('[image:')));
+      expect(snippet, contains('photo'));
+    });
+
+    test('short content is returned whole', () {
+      expect(miniMapHitSnippet('a needle b', ['needle']), 'a needle b');
+    });
+
+    test('empty input', () {
+      expect(miniMapHitSnippet('', ['x']), '');
+      expect(miniMapHitSnippet('x', const []), '');
+    });
+  });
+
+  group('buildMiniMapHighlightSpans', () {
+    test('highlights matching token case-insensitively', () {
+      final spans = buildMiniMapHighlightSpans(
+        'Hello world hello',
+        ['hello'],
+        const TextStyle(),
+        const TextStyle(backgroundColor: Color(0xFFFF0000)),
+      );
+      expect(spans, hasLength(3));
+      expect(spans[0].text, 'Hello');
+      expect(spans[0].style?.backgroundColor, const Color(0xFFFF0000));
+      expect(spans[1].text, ' world ');
+      expect(spans[1].style?.backgroundColor, isNull);
+      expect(spans[2].text, 'hello');
+      expect(spans[2].style?.backgroundColor, const Color(0xFFFF0000));
+    });
+
+    test('no tokens yields single plain span', () {
+      final spans = buildMiniMapHighlightSpans(
+        'plain',
+        const [],
+        const TextStyle(),
+        const TextStyle(),
+      );
+      expect(spans, hasLength(1));
+      expect(spans[0].text, 'plain');
+    });
+
+    test('empty text yields single empty span', () {
+      final spans = buildMiniMapHighlightSpans(
+        '',
+        ['x'],
+        const TextStyle(),
+        const TextStyle(),
+      );
+      expect(spans, hasLength(1));
+      expect(spans[0].text, '');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #243.

Rewrite mini map search from pair-level substring filtering to message-level
filter-navigation (issue #243): token AND matching against raw content,
hit-centered tag-flattened snippets, global-search-consistent highlighting.

- lib/shared/widgets/mini_map/: shared pure logic (pairing, one-line,
  tokens, filter, snippet, highlight spans) consumed by both shells
- Mobile sheet: search toggle keeps Q/A map until a query is entered;
  debounce 180ms with immediate first-keystroke apply; result count and
  no-match empty state; scroll reset per query
- Desktop popover: new persistent search field with autofocus and Esc
  two-level clear/close; same message-level result rows with hover
- l10n: miniMapSearchResultCount (ICU plural), miniMapSearchNoResults in
  all 4 ARB files
- CONTEXT.md: Mini Map Search glossary section
