### PR TITLE
feat(provider): auto-select model in the test connection dialog

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -649,3 +649,14 @@
 
 - "默认启动 DeepSeek" (issue #196) — resolved: default **selection**, not zero-config working. The base URL is seeded but the API key still comes from the user.
 - "关闭温度" — resolved: omit the sampling parameter, not send `temperature: 0`.
+
+## Test Connection Model Auto-Selection (测试连接自动选模型)
+
+- **测试连接 (Test Connection)**: The dialog that verifies a provider's API credentials by sending a minimal request for a chosen model. Two parallel implementations must stay in sync: mobile `_ConnectionTestDialog` (`lib/features/provider/pages/provider_detail_page.dart`) and desktop `_showTestConnectionDialog` (`lib/desktop/setting/providers_pane.dart`).
+- **Auto-selection priority (自动选择优先级, issue #257)**: When the test connection dialog opens, the model field is pre-filled by this cascade — each rule applies only if the candidate is actually present in the provider's model list (`ProviderConfig.models`):
+  1. The chat's **effective** current model (`Assistant.chatModelProvider` if the current assistant has a binding, else `SettingsProvider.currentModel`), if it belongs to this provider. A separate "assistant-bound model" tier was deliberately absorbed into this rule — the binding IS the currently-used model, so a later global-model tier could prefill a stale model over the live one.
+  2. The most recently added model (`ProviderConfig.models` last element). Heuristic, not a contract: the list is append-ordered in most paths, but bulk fetch / select-all flows rebuild it from a set (API-response order), so the tail can deviate from user add-time order.
+  3. Single model → covered by the cascade (it is both the first valid candidate and the last element).
+  A global scan of ALL assistants was rejected (ambiguous when multiple assistants bind different models of the same provider).
+- **Zero-model case (暂无模型)**: 0 models → the dialog body shows a hint (title `providerDetailPageNoModelsTitle` + dialog-specific subtitle `providerDetailPageTestNoModelsHint` — the page-level `providerDetailPageNoModelsSubtitle` ("tap the buttons below") is NOT reused in the dialog, where no such buttons exist) with the test button disabled and only 取消 available; the empty model picker is never opened in this state. The model picker (`showModelSelector`) only enumerates `cfg.models`, so an empty list renders a blank sheet.
+- **No auto-run (只预填不自动测试)**: Auto-selection only pre-fills the model field; the user still clicks 测试. The existing "更改" button stays as-is (issue #257's "在下面再放选择模型的按钮" is satisfied by the existing change affordance — no layout redesign).

--- a/lib/core/providers/model_provider.dart
+++ b/lib/core/providers/model_provider.dart
@@ -13,6 +13,7 @@ import '../services/api/provider_request_headers.dart';
 import '../services/model_override_payload_parser.dart';
 import 'package:Cuplivo/secrets/fallback.dart';
 import '../services/api/google_service_account_auth.dart';
+import '../models/assistant.dart';
 import '../models/model_types.dart';
 
 class ModelRegistry {
@@ -450,6 +451,35 @@ class ProviderManager {
 
   static Future<List<ModelInfo>> listModels(ProviderConfig cfg) {
     return forConfig(cfg).listModels(cfg);
+  }
+
+  /// Resolves the model the test connection dialog should pre-fill
+  /// (issue #257). Cascade, each rule applies only if the candidate is
+  /// present in [cfg.models]:
+  /// 1. The chat's effective current model: the current assistant's binding
+  ///    when it has one, else the global selection.
+  /// 2. The most recently added model (last element of [cfg.models]).
+  /// The last element is a heuristic: the list is append-ordered in most
+  /// paths, but bulk fetch / select-all flows rebuild it from a set, so the
+  /// tail is not a guaranteed add-time order.
+  /// Returns null when the provider has no models.
+  static String? resolvePreferredTestModel({
+    required ProviderConfig cfg,
+    required Assistant? currentAssistant,
+    required String? currentModelProvider,
+    required String? currentModelId,
+  }) {
+    if (cfg.models.isEmpty) return null;
+    final String? effective;
+    if (currentAssistant?.chatModelProvider != null) {
+      effective = currentAssistant!.chatModelProvider == cfg.id
+          ? currentAssistant.chatModelId
+          : null;
+    } else {
+      effective = currentModelProvider == cfg.id ? currentModelId : null;
+    }
+    if (effective != null && cfg.models.contains(effective)) return effective;
+    return cfg.models.last;
   }
 
   static Future<void> testConnection(

--- a/lib/desktop/setting/providers_pane.dart
+++ b/lib/desktop/setting/providers_pane.dart
@@ -2817,8 +2817,8 @@ class _DesktopProviderDetailPaneState
                                               value: toolImagesNow == null
                                                   ? 'auto'
                                                   : (toolImagesNow
-                                                            ? 'on'
-                                                            : 'off'),
+                                                        ? 'on'
+                                                        : 'off'),
                                               options: [
                                                 DesktopSelectOption(
                                                   value: 'auto',
@@ -4605,7 +4605,18 @@ class _DesktopProviderDetailPaneState
 
   Future<void> _showTestConnectionDialog(BuildContext context) async {
     final cs = Theme.of(context).colorScheme;
-    String? selectedModelId;
+    final settings = context.read<SettingsProvider>();
+    final cfg = settings.getProviderConfig(
+      widget.providerKey,
+      defaultName: widget.displayName,
+    );
+    final hasModels = cfg.models.isNotEmpty;
+    String? selectedModelId = ProviderManager.resolvePreferredTestModel(
+      cfg: cfg,
+      currentAssistant: context.read<AssistantProvider>().currentAssistant,
+      currentModelProvider: settings.currentModelProvider,
+      currentModelId: settings.currentModelId,
+    );
     _TestState state = _TestState.idle;
     String errorMessage = '';
     bool useStream = false;
@@ -4706,63 +4717,95 @@ class _DesktopProviderDetailPaneState
                         ),
                       ),
                       const SizedBox(height: 14),
-                      GestureDetector(
-                        onTap: pickModel,
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 10,
-                          ),
-                          decoration: BoxDecoration(
-                            color: Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF7F7F9),
-                            borderRadius: BorderRadius.circular(12),
-                            border: Border.all(
-                              color: cs.outlineVariant.withValues(alpha: 0.12),
-                              width: 0.6,
-                            ),
-                          ),
-                          child: Row(
+                      if (!hasModels)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Column(
                             children: [
-                              if (selectedModelId != null)
-                                _BrandCircle(name: selectedModelId!, size: 22),
-                              if (selectedModelId != null)
-                                const SizedBox(width: 8),
-                              Expanded(
-                                child: Text(
-                                  selectedModelId ??
-                                      l10n.providerDetailPageSelectModelButton,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                    fontWeight: AppFontWeights.semibold,
-                                  ),
+                              Text(
+                                l10n.providerDetailPageNoModelsTitle,
+                                style: TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: AppFontWeights.emphasis,
+                                ),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                l10n.providerDetailPageTestNoModelsHint,
+                                textAlign: TextAlign.center,
+                                style: TextStyle(
+                                  fontSize: 13,
+                                  color: cs.onSurface.withValues(alpha: 0.6),
                                 ),
                               ),
                             ],
                           ),
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: Text(
-                              l10n.providerDetailPageUseStreamingLabel,
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: cs.onSurface.withValues(alpha: 0.9),
+                        )
+                      else
+                        GestureDetector(
+                          onTap: pickModel,
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 10,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Theme.of(ctx).brightness == Brightness.dark
+                                  ? Colors.white10
+                                  : const Color(0xFFF7F7F9),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: cs.outlineVariant.withValues(
+                                  alpha: 0.12,
+                                ),
+                                width: 0.6,
                               ),
                             ),
+                            child: Row(
+                              children: [
+                                if (selectedModelId != null)
+                                  _BrandCircle(
+                                    name: selectedModelId!,
+                                    size: 22,
+                                  ),
+                                if (selectedModelId != null)
+                                  const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    selectedModelId ??
+                                        l10n.providerDetailPageSelectModelButton,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      fontWeight: AppFontWeights.semibold,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
-                          IosSwitch(
-                            value: useStream,
-                            onChanged: (v) => setState(() => useStream = v),
-                          ),
-                        ],
-                      ),
+                        ),
+                      if (hasModels) ...[
+                        const SizedBox(height: 12),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                l10n.providerDetailPageUseStreamingLabel,
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: cs.onSurface.withValues(alpha: 0.9),
+                                ),
+                              ),
+                            ),
+                            IosSwitch(
+                              value: useStream,
+                              onChanged: (v) => setState(() => useStream = v),
+                            ),
+                          ],
+                        ),
+                      ],
                       const SizedBox(height: 14),
                       if (state == _TestState.loading)
                         Center(

--- a/lib/features/provider/pages/provider_detail_page.dart
+++ b/lib/features/provider/pages/provider_detail_page.dart
@@ -4322,6 +4322,24 @@ class _ConnectionTestDialogState extends State<_ConnectionTestDialog> {
   _TestState _state = _TestState.idle;
   String _errorMessage = '';
   bool _useStream = false;
+  bool _hasModels = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final settings = context.read<SettingsProvider>();
+    final cfg = settings.getProviderConfig(
+      widget.providerKey,
+      defaultName: widget.providerDisplayName,
+    );
+    _hasModels = cfg.models.isNotEmpty;
+    _selectedModelId = ProviderManager.resolvePreferredTestModel(
+      cfg: cfg,
+      currentAssistant: context.read<AssistantProvider>().currentAssistant,
+      currentModelProvider: settings.currentModelProvider,
+      currentModelId: settings.currentModelId,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -4417,7 +4435,28 @@ class _ConnectionTestDialogState extends State<_ConnectionTestDialog> {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        if (_selectedModelId == null)
+        if (!_hasModels)
+          Column(
+            children: [
+              Text(
+                l10n.providerDetailPageNoModelsTitle,
+                style: TextStyle(
+                  fontWeight: AppFontWeights.emphasis,
+                  fontSize: 15,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                l10n.providerDetailPageTestNoModelsHint,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: cs.onSurface.withValues(alpha: 0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          )
+        else if (_selectedModelId == null)
           TextButton(
             onPressed: _pickModel,
             child: Text(l10n.providerDetailPageSelectModelButton),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1734,6 +1734,7 @@
   "providerDetailPageProviderRemovedMessage": "Provider removed",
   "providerDetailPageNoModelsTitle": "No Models",
   "providerDetailPageNoModelsSubtitle": "Tap the buttons below to add models",
+  "providerDetailPageTestNoModelsHint": "Add a model first, then test the connection.",
   "providerDetailPageDeleteModelButton": "Delete",
   "providerDetailPageConfirmDeleteTitle": "Confirm Delete",
   "providerDetailPageConfirmDeleteContent": "This can be undone via Undo. Delete?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7430,6 +7430,12 @@ abstract class AppLocalizations {
   /// **'Tap the buttons below to add models'**
   String get providerDetailPageNoModelsSubtitle;
 
+  /// No description provided for @providerDetailPageTestNoModelsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a model first, then test the connection.'**
+  String get providerDetailPageTestNoModelsHint;
+
   /// No description provided for @providerDetailPageDeleteModelButton.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4079,6 +4079,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Tap the buttons below to add models';
 
   @override
+  String get providerDetailPageTestNoModelsHint =>
+      'Add a model first, then test the connection.';
+
+  @override
   String get providerDetailPageDeleteModelButton => 'Delete';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3917,6 +3917,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get providerDetailPageNoModelsSubtitle => '点击下方按钮添加模型';
 
   @override
+  String get providerDetailPageTestNoModelsHint => '请先添加模型，再进行连接测试';
+
+  @override
   String get providerDetailPageDeleteModelButton => '删除';
 
   @override
@@ -11233,6 +11236,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get providerDetailPageNoModelsSubtitle => '点击下方按钮添加模型';
 
   @override
+  String get providerDetailPageTestNoModelsHint => '请先添加模型，再进行连接测试';
+
+  @override
   String get providerDetailPageDeleteModelButton => '删除';
 
   @override
@@ -18545,6 +18551,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get providerDetailPageNoModelsSubtitle => '點擊下方按鈕新增模型';
+
+  @override
+  String get providerDetailPageTestNoModelsHint => '請先新增模型，再進行連線測試';
 
   @override
   String get providerDetailPageDeleteModelButton => '刪除';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1330,6 +1330,7 @@
   "providerDetailPageProviderRemovedMessage": "供应商已删除",
   "providerDetailPageNoModelsTitle": "暂无模型",
   "providerDetailPageNoModelsSubtitle": "点击下方按钮添加模型",
+  "providerDetailPageTestNoModelsHint": "请先添加模型，再进行连接测试",
   "providerDetailPageDeleteModelButton": "删除",
   "providerDetailPageConfirmDeleteTitle": "确认删除",
   "providerDetailPageConfirmDeleteContent": "删除后可通过撤销恢复。是否删除？",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1353,6 +1353,7 @@
   "providerDetailPageProviderRemovedMessage": "供应商已删除",
   "providerDetailPageNoModelsTitle": "暂无模型",
   "providerDetailPageNoModelsSubtitle": "点击下方按钮添加模型",
+  "providerDetailPageTestNoModelsHint": "请先添加模型，再进行连接测试",
   "providerDetailPageDeleteModelButton": "删除",
   "providerDetailPageConfirmDeleteTitle": "确认删除",
   "providerDetailPageConfirmDeleteContent": "删除后可通过撤销恢复。是否删除？",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1320,6 +1320,7 @@
   "providerDetailPageProviderRemovedMessage": "供應商已刪除",
   "providerDetailPageNoModelsTitle": "暫無模型",
   "providerDetailPageNoModelsSubtitle": "點擊下方按鈕新增模型",
+  "providerDetailPageTestNoModelsHint": "請先新增模型，再進行連線測試",
   "providerDetailPageDeleteModelButton": "刪除",
   "providerDetailPageConfirmDeleteTitle": "確認刪除",
   "providerDetailPageConfirmDeleteContent": "刪除後可透過撤銷還原。是否刪除？",

--- a/test/provider_test_connection_prefill_test.dart
+++ b/test/provider_test_connection_prefill_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/providers/model_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+ProviderConfig _cfg(List<String> models) => ProviderConfig(
+  id: 'MyProvider',
+  enabled: true,
+  name: 'MyProvider',
+  apiKey: 'sk-test',
+  baseUrl: 'https://example.com/v1',
+  providerType: ProviderKind.openai,
+  models: models,
+);
+
+void main() {
+  group('ProviderManager.resolvePreferredTestModel', () {
+    test('uses the global current model when it belongs to the provider', () {
+      final cfg = _cfg(['m1', 'm2', 'm3']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: null,
+        currentModelProvider: 'MyProvider',
+        currentModelId: 'm2',
+      );
+      expect(result, 'm2');
+    });
+
+    test('assistant binding wins over the global current model', () {
+      final cfg = _cfg(['m1', 'm2', 'm3']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: Assistant(
+          id: 'a1',
+          name: 'A',
+          chatModelProvider: 'MyProvider',
+          chatModelId: 'm3',
+        ),
+        currentModelProvider: 'MyProvider',
+        currentModelId: 'm2',
+      );
+      expect(result, 'm3');
+    });
+
+    test('skips a candidate that is not in the model list', () {
+      final cfg = _cfg(['m1', 'm2']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: null,
+        currentModelProvider: 'MyProvider',
+        currentModelId: 'deleted-model',
+      );
+      expect(result, 'm2');
+    });
+
+    test(
+      'falls through when the current model belongs to another provider',
+      () {
+        final cfg = _cfg(['m1', 'm2']);
+        final result = ProviderManager.resolvePreferredTestModel(
+          cfg: cfg,
+          currentAssistant: null,
+          currentModelProvider: 'OtherProvider',
+          currentModelId: 'x',
+        );
+        expect(result, 'm2');
+      },
+    );
+
+    test('assistant bound to another provider never falls back to the global '
+        'current model', () {
+      final cfg = _cfg(['m1', 'm2']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: Assistant(
+          id: 'a1',
+          name: 'A',
+          chatModelProvider: 'OtherProvider',
+          chatModelId: 'x',
+        ),
+        currentModelProvider: 'MyProvider',
+        currentModelId: 'm1',
+      );
+      expect(result, 'm2');
+    });
+
+    test('falls back to the most recently added model (last element)', () {
+      final cfg = _cfg(['m1', 'm2', 'm3']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: null,
+        currentModelProvider: null,
+        currentModelId: null,
+      );
+      expect(result, 'm3');
+    });
+
+    test('a single model is chosen without any current selection', () {
+      final cfg = _cfg(['only']);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: null,
+        currentModelProvider: null,
+        currentModelId: null,
+      );
+      expect(result, 'only');
+    });
+
+    test('returns null when the provider has no models', () {
+      final cfg = _cfg(const []);
+      final result = ProviderManager.resolvePreferredTestModel(
+        cfg: cfg,
+        currentAssistant: null,
+        currentModelProvider: 'MyProvider',
+        currentModelId: 'm1',
+      );
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #257

The test connection dialog now pre-fills a model instead of forcing the user to pick one manually, closing the empty-model dead end (a provider with zero models used to open a blank model picker).

What changed:

- New ProviderManager.resolvePreferredTestModel() pure resolver (no Flutter deps, unit-testable) with the cascade: 1) the chat's effective current model (current assistant binding, else the global selection) when it belongs to this provider and still exists in its model list; 2) the most recently added model (last element of cfg.models - documented heuristic: bulk fetch/select-all paths can rebuild the list in API-response order); 3) null for zero-model providers. A global scan of ALL assistants was deliberately rejected (ambiguous when multiple assistants bind different models of the same provider).

- Mobile _ConnectionTestDialog and desktop _showTestConnectionDialog both resolve once at dialog open and stay in sync (they are two parallel implementations). Zero-model providers show the existing 暂无模型 title plus a new dialog-specific hint (providerDetailPageTestNoModelsHint - the page-level 'tap the buttons below' subtitle is NOT reused because the dialog has no such buttons); the test button stays disabled and the empty picker is never opened.

- Layout kept as-is: the model row + 更改 button and the streaming toggle are untouched; auto-selection only pre-fills, it never auto-runs the test (per issue #257's wording).

- New l10n key added to all 4 ARB files in sync; flutter gen-l10n regenerated app_localizations*; desiredFileName.txt reports no untranslated messages.

- 8 new unit tests cover the full cascade: effective model hit, cross-provider fallthrough, deleted-model skip, assistant-binding priority over a stale global model, last-element fallback, single model, and zero models.

- CONTEXT.md documents the auto-selection rules and the two dialog implementations that must stay in sync.

Verification: dart analyze --fatal-infos lib test clean; full flutter test suite passed (1723 tests) before the l10n key was added, and a post-key full run was aborted mid-suite by the user, who then manually verified the change on the main machine (Windows desktop + mobile). Windows build not run in this worktree (cargokit/nuget environment issue); macOS/Linux desktop surfaces not covered here.
