### PR TITLE
fix(desktop): replace Material Slider with SfSliderTile to fix Windows crashes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,12 @@ dart analyze --fatal-infos lib test
 - When touching a path dependency under `dependencies/`, update that dependency's own source in the same change; do not patch only the root repo surface.
 - Trap: "I fixed it in one place" is not "done". Before marking a task complete, run `rg` for the changed identifier / pattern across the whole repo and confirm every parallel surface was updated or explicitly excluded. State any intentional exclusions in the delivery notes.
 
+### 3.21 Sliders: Never Material `Slider` on Desktop / Windows
+
+- Hard constraint: Material `Slider` (always creates an `OverlayPortal`) is forbidden on Windows paths -- it corrupts the Windows accessibility tree and crashes the app (incident from #119; Flutter https://github.com/flutter/flutter/issues/190357).
+- New sliders in `lib/desktop/**` must use the shared `SfSliderTile` (`lib/shared/widgets/sf_slider_tile.dart`, wraps Syncfusion `SfSlider`, zero `OverlayPortal`) or a custom-drawn slider without `OverlayPortal` (e.g. `HueSlider`).
+- Before adding a slider widget, `rg` its source for `OverlayPortal`.
+
 ## 4. Recommended Execution Order
 
 1. `git status --short` -- confirm workspace baseline. Don't panic if `windows/flutter/generated_plugin_registrant.{cc,h}`, `linux/flutter/generated_plugin_registrant.{cc,h}`, or `macos/Flutter/GeneratedPluginRegistrant.swift` show up as whole-file diffs: Flutter tool regeneration can flip their line endings (LF/CRLF -- this repo has no `.gitattributes`), so the diff is auto-generate churn, not a real change. Restore with `git checkout -- <file>` and continue; never commit the churn.

--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -25,6 +25,7 @@ import 'widgets/desktop_select_dropdown.dart';
 import '../shared/widgets/ios_labeled_switch_row.dart';
 import '../shared/widgets/ios_switch.dart';
 import '../shared/widgets/ios_checkbox.dart';
+import '../shared/widgets/sf_slider_tile.dart';
 import '../shared/widgets/custom_key_value_editor.dart';
 // Desktop assistants panel dependencies
 import '../features/assistant/pages/assistant_settings_edit_page.dart'

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -3469,12 +3469,14 @@ class _OneClickCompressLongEdgeRow extends StatelessWidget {
             children: [
               SizedBox(
                 width: 160,
-                child: Slider(
+                child: SfSliderTile(
                   value: val.toDouble(),
                   min: 768,
                   max: 4096,
                   divisions: 13,
                   label: '${val}px',
+                  semanticLabel: l10n.oneClickCompressMaxLongEdgeTitle,
+                  semanticFormatterCallback: (value) => '${value.round()}px',
                   onChanged: (v) => context
                       .read<SettingsProvider>()
                       .setOneClickCompressMaxLongEdge(v.round()),
@@ -3520,12 +3522,14 @@ class _OneClickCompressQualityRow extends StatelessWidget {
             children: [
               SizedBox(
                 width: 160,
-                child: Slider(
+                child: SfSliderTile(
                   value: val.toDouble(),
                   min: 50,
                   max: 95,
                   divisions: 9,
                   label: '$val%',
+                  semanticLabel: l10n.oneClickCompressQualityTitle,
+                  semanticFormatterCallback: (value) => '${value.round()}%',
                   onChanged: (v) => context
                       .read<SettingsProvider>()
                       .setOneClickCompressQuality(v.round()),

--- a/lib/desktop/setting/tts_services_pane.dart
+++ b/lib/desktop/setting/tts_services_pane.dart
@@ -10,6 +10,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../../utils/brand_assets.dart';
 import '../../features/settings/pages/tts_settings_page.dart';
 import '../../theme/app_font_weights.dart';
+import '../../shared/widgets/sf_slider_tile.dart';
 
 /// Desktop: TTS (语音服务) right-side pane
 /// Adapts mobile TTS page to desktop with hoverable list card style
@@ -683,10 +684,14 @@ class _SystemTtsCardState extends State<_SystemTtsCard> {
                       color: cs.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
-                  Slider(
+                  SfSliderTile(
                     value: rate,
                     min: 0.1,
                     max: 1.0,
+                    label: rate.toStringAsFixed(2),
+                    semanticLabel: l10n.ttsServicesPageSpeechRateLabel,
+                    semanticFormatterCallback: (value) =>
+                        value.toStringAsFixed(2),
                     onChanged: (v) {
                       rate = v;
                       if (ctx.mounted) (ctx as Element).markNeedsBuild();
@@ -701,10 +706,14 @@ class _SystemTtsCardState extends State<_SystemTtsCard> {
                       color: cs.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
-                  Slider(
+                  SfSliderTile(
                     value: pitch,
                     min: 0.5,
                     max: 2.0,
+                    label: pitch.toStringAsFixed(2),
+                    semanticLabel: l10n.ttsServicesPagePitchLabel,
+                    semanticFormatterCallback: (value) =>
+                        value.toStringAsFixed(2),
                     onChanged: (v) {
                       pitch = v;
                       if (ctx.mounted) (ctx as Element).markNeedsBuild();

--- a/lib/shared/widgets/sf_slider_tile.dart
+++ b/lib/shared/widgets/sf_slider_tile.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:syncfusion_flutter_core/theme.dart';
+import 'package:syncfusion_flutter_sliders/sliders.dart';
+
+import '../../theme/app_font_weights.dart';
+
+/// Shared slider built on Syncfusion [SfSlider].
+///
+/// Syncfusion's slider draws its track, thumb and tooltip entirely inside its
+/// own widget tree (it never creates an [OverlayPortal]), so it is safe on
+/// Windows where Material [Slider]'s OverlayPortal can serialize orphan
+/// semantics nodes and corrupt the accessibility tree
+/// (https://github.com/flutter/flutter/issues/190357).
+///
+/// Visual style follows the assistant settings sliders
+/// ([SfSliderTheme] + waterdrop tooltip), while keyboard access and the
+/// screen-reader value/increase/decrease actions are provided by [SfSlider]
+/// itself.
+class SfSliderTile extends StatelessWidget {
+  const SfSliderTile({
+    super.key,
+    required this.value,
+    required this.min,
+    required this.max,
+    this.divisions,
+    required this.label,
+    required this.onChanged,
+    this.onChangeEnd,
+    this.semanticLabel,
+    this.semanticFormatterCallback,
+    this.showTicks = false,
+    this.showLabels = false,
+    this.interval,
+  }) : assert(min < max),
+       assert(divisions == null || divisions > 0);
+
+  /// The current value, clamped to [min]..[max] before rendering.
+  final double value;
+
+  final double min;
+
+  final double max;
+
+  /// Number of equal steps the range is divided into, mirroring Material's
+  /// `divisions` semantics: `step = (max - min) / divisions`.
+  ///
+  /// When null the slider moves continuously.
+  final int? divisions;
+
+  /// Text shown in the waterdrop tooltip while interacting.
+  final String label;
+
+  final ValueChanged<double> onChanged;
+
+  final ValueChanged<double>? onChangeEnd;
+
+  /// Screen-reader label for the slider node.
+  final String? semanticLabel;
+
+  /// Formats the screen-reader value (e.g. `1024px`, `80%`).
+  final String Function(double value)? semanticFormatterCallback;
+
+  final bool showTicks;
+
+  final bool showLabels;
+
+  /// Label/ticks interval, computed like the assistant settings slider when
+  /// null.
+  final double? interval;
+
+  double? get _stepSize => divisions == null ? null : (max - min) / divisions!;
+
+  double _toDouble(dynamic v) => v is num ? v.toDouble() : (v as double);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    final active = cs.primary;
+    final inactive = cs.onSurface.withValues(alpha: isDark ? 0.25 : 0.20);
+    final clamped = value.clamp(min, max).toDouble();
+    final total = (max - min).abs();
+    final step = _stepSize;
+
+    // Compute a readable major interval and minor tick count, matching the
+    // assistant settings slider.
+    double resolvedInterval;
+    if (interval != null) {
+      resolvedInterval = interval!;
+    } else if (total <= 0) {
+      resolvedInterval = 1;
+    } else if ((divisions ?? 0) <= 20) {
+      resolvedInterval = total / 4; // up to 5 major ticks inc endpoints
+    } else if ((divisions ?? 0) <= 50) {
+      resolvedInterval = total / 5;
+    } else {
+      resolvedInterval = total / 8;
+    }
+    if (resolvedInterval <= 0) resolvedInterval = 1;
+    int minor = 0;
+    if (step != null && step > 0) {
+      minor = ((resolvedInterval / step) - 1).round();
+      if (minor < 0) minor = 0;
+      if (minor > 8) minor = 8;
+    }
+
+    final slider = SfSliderTheme(
+      data: SfSliderThemeData(
+        activeTrackHeight: 8,
+        inactiveTrackHeight: 8,
+        overlayRadius: 14,
+        activeTrackColor: active,
+        inactiveTrackColor: inactive,
+        // Waterdrop tooltip uses theme primary background with onPrimary text
+        tooltipBackgroundColor: cs.primary,
+        tooltipTextStyle: TextStyle(
+          color: cs.onPrimary,
+          fontWeight: AppFontWeights.semibold,
+        ),
+        thumbStrokeColor: Colors.transparent,
+        thumbStrokeWidth: 0,
+        activeTickColor: cs.onSurface.withValues(alpha: isDark ? 0.45 : 0.35),
+        inactiveTickColor: cs.onSurface.withValues(alpha: isDark ? 0.30 : 0.25),
+        activeMinorTickColor: cs.onSurface.withValues(
+          alpha: isDark ? 0.34 : 0.28,
+        ),
+        inactiveMinorTickColor: cs.onSurface.withValues(
+          alpha: isDark ? 0.24 : 0.20,
+        ),
+      ),
+      child: SfSlider(
+        value: clamped,
+        min: min,
+        max: max,
+        stepSize: step,
+        enableTooltip: true,
+        // Show the paddle tooltip only while interacting
+        shouldAlwaysShowTooltip: false,
+        showTicks: showTicks,
+        showLabels: showLabels,
+        interval: resolvedInterval,
+        minorTicksPerInterval: minor,
+        activeColor: active,
+        inactiveColor: inactive,
+        tooltipTextFormatterCallback: (actual, text) => label,
+        tooltipShape: const SfPaddleTooltipShape(),
+        labelFormatterCallback: (actual, formattedText) {
+          // Prefer integers for wide ranges, keep 2 decimals for 0..1
+          if (total <= 2.0) return actual.toStringAsFixed(2);
+          if (actual == actual.roundToDouble()) {
+            return actual.toStringAsFixed(0);
+          }
+          return actual.toStringAsFixed(1);
+        },
+        semanticFormatterCallback: semanticFormatterCallback == null
+            ? null
+            : (v) => semanticFormatterCallback!(_toDouble(v)),
+        thumbIcon: Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: cs.primary,
+            shape: BoxShape.circle,
+            boxShadow: isDark
+                ? const []
+                : [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.08),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+          ),
+        ),
+        onChanged: (v) => onChanged(_toDouble(v)),
+        onChangeEnd: onChangeEnd == null
+            ? null
+            : (v) => onChangeEnd!(_toDouble(v)),
+      ),
+    );
+    final accessibilityLabel = semanticLabel;
+    // SfSlider exposes its value and increase/decrease actions on its own
+    // semantic node but no label, so attach the label on a wrapping node.
+    return accessibilityLabel == null
+        ? slider
+        : Semantics(label: accessibilityLabel, child: slider);
+  }
+}

--- a/test/shared/widgets/sf_slider_tile_test.dart
+++ b/test/shared/widgets/sf_slider_tile_test.dart
@@ -1,0 +1,174 @@
+import 'package:Cuplivo/shared/widgets/sf_slider_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:syncfusion_flutter_sliders/sliders.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(child: SizedBox(width: 300, child: child)),
+      ),
+    );
+  }
+
+  testWidgets('renders SfSlider with min/max/value and stepped size', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        SfSliderTile(
+          value: 1536,
+          min: 768,
+          max: 4096,
+          divisions: 13,
+          label: '1536px',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    final slider = tester.widget<SfSlider>(find.byType(SfSlider));
+    expect(slider.min, 768);
+    expect(slider.max, 4096);
+    expect(slider.value, 1536);
+    // step = (4096 - 768) / 13 = 256
+    expect(slider.stepSize, 256);
+    expect(slider.enableTooltip, isTrue);
+    expect(slider.shouldAlwaysShowTooltip, isFalse);
+  });
+
+  testWidgets('continuous slider has no step size', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        SfSliderTile(
+          value: 0.5,
+          min: 0.1,
+          max: 1.0,
+          label: '0.50',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    final slider = tester.widget<SfSlider>(find.byType(SfSlider));
+    expect(slider.stepSize, isNull);
+  });
+
+  testWidgets('clamps out-of-range value before rendering', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        SfSliderTile(
+          value: 9999,
+          min: 50,
+          max: 95,
+          divisions: 9,
+          label: '9999%',
+          onChanged: (_) {},
+        ),
+      ),
+    );
+
+    final slider = tester.widget<SfSlider>(find.byType(SfSlider));
+    expect(slider.value, 95);
+  });
+
+  testWidgets('dragging fires onChanged with a step-aligned value', (
+    tester,
+  ) async {
+    final values = <double>[];
+    await tester.pumpWidget(
+      wrap(
+        SfSliderTile(
+          value: 50,
+          min: 0,
+          max: 100,
+          divisions: 4,
+          label: '50',
+          onChanged: values.add,
+        ),
+      ),
+    );
+
+    await tester.drag(find.byType(SfSlider), const Offset(100, 0));
+    await tester.pumpAndSettle();
+    // Drain the slider's tooltip show/hide timers before the test ends.
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(values, isNotEmpty);
+    final allowed = <double>{0, 25, 50, 75, 100};
+    for (final v in values) {
+      expect(allowed.contains(v), isTrue, reason: 'off-step value $v');
+    }
+  });
+
+  testWidgets('dragging a continuous slider fires onChanged and onChangeEnd', (
+    tester,
+  ) async {
+    final changed = <double>[];
+    final ended = <double>[];
+    await tester.pumpWidget(
+      wrap(
+        SfSliderTile(
+          value: 0.1,
+          min: 0.1,
+          max: 1.0,
+          label: '0.10',
+          onChanged: changed.add,
+          onChangeEnd: ended.add,
+        ),
+      ),
+    );
+
+    await tester.drag(find.byType(SfSlider), const Offset(100, 0));
+    await tester.pumpAndSettle();
+    // Drain the slider's tooltip show/hide timers before the test ends.
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(changed, isNotEmpty);
+    expect(ended, isNotEmpty);
+    expect(changed.last, inInclusiveRange(0.1, 1.0));
+    expect(ended.last, changed.last);
+  });
+
+  testWidgets(
+    'exposes a labeled semantics node with value and adjust actions',
+    (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        wrap(
+          SfSliderTile(
+            value: 80,
+            min: 50,
+            max: 95,
+            divisions: 9,
+            label: '80%',
+            semanticLabel: 'quality',
+            semanticFormatterCallback: (value) => '${value.round()}%',
+            onChanged: (_) {},
+          ),
+        ),
+      );
+
+      // The label lives on the wrapping node, the value and adjust actions on
+      // SfSlider's own semantics node; both are visible to assistive
+      // technologies.
+      final nodes = tester.semantics.simulatedAccessibilityTraversal();
+      expect(nodes, contains(isSemantics(label: 'quality')));
+      expect(
+        nodes,
+        contains(
+          isSemantics(
+            value: '80%',
+            increasedValue: '85%',
+            decreasedValue: '75%',
+            hasIncreaseAction: true,
+            hasDecreaseAction: true,
+          ),
+        ),
+      );
+
+      handle.dispose();
+    },
+  );
+}


### PR DESCRIPTION
## 问题

Fixes #153, Fixes #211.

v2.2.0 起 Windows 端闪退（#119 引入）：关闭弹窗、窗口最大化、从群聊返回都会先无响应再崩溃（3× `0xC0000005`、1× `0xC000041D`），崩溃前持续出现 `Failed to update ui::AXTree`。

## 根因

#119 在桌面显示设置新增的两个 Material `Slider` 是崩溃根源。Flutter 3.44 的 Material `Slider` 始终创建 `OverlayPortal`，在 Windows 辅助功能开启时会序列化孤儿语义节点、损坏 `ui::AXTree`；之后任何触发语义树重建的操作（关弹窗/最大化/路由返回）都会让 AccessibilityBridge 原生崩溃。与 [flutter/flutter#190357](https://github.com/flutter/flutter/issues/190357) 症状一致。空白会话仍崩溃、报告含"跳过桌面回焦"日志后仍崩溃，排除了图片压缩执行逻辑和 #206 的 TextInput 竞态。

## 修复

- 新增共享组件 `lib/shared/widgets/sf_slider_tile.dart`：复用 Syncfusion `SfSlider`（源码零 `OverlayPortal`），视觉与助手设置滑杆一致，保留键盘增减、语义 value/increase/decrease 动作、离散步长与设置持久化
- 替换 4 处桌面 Material `Slider`：显示设置长边/质量滑杆、TTS 语速/音调滑杆
- 新增 widget 测试 6 个用例：范围/步长、连续模式、越界 clamp、离散步长拖动吸附、onChangeEnd、语义节点
- `AGENTS.md` 新增 3.21：桌面/Windows 路径禁止 Material `Slider`（含 `OverlayPortal` 检查）

## 验证

- `dart analyze --fatal-infos lib test`：零问题
- 全量 `flutter test`：1721 个用例全部通过
- Windows release 构建未在本机执行（环境限制），需在 Windows 上回归：开关弹窗、最大化/还原、群聊返回，以及滑杆调节后重启确认持久化