### PR TITLE
fix(tts): 支持 MiniMax 自动情感，移除 emotion 参数 calm 兜底

### DIFF
--- a/lib/core/services/tts/network_tts.dart
+++ b/lib/core/services/tts/network_tts.dart
@@ -91,7 +91,7 @@ abstract class TtsServiceOptions {
               .toString(),
           model: (json['model'] ?? 'speech-2.6-turbo').toString(),
           voiceId: (json['voiceId'] ?? 'female-shaonv').toString(),
-          emotion: (json['emotion'] ?? 'calm').toString(),
+          emotion: (json['emotion'] ?? '').toString(),
           speed: _toDouble(json['speed'], 1.0),
         );
       case 'qwen':
@@ -591,7 +591,7 @@ class NetworkTtsService {
       'stream_options': {'exclude_aggregated_audio': true},
       'voice_setting': {
         'voice_id': opt.voiceId,
-        'emotion': opt.emotion,
+        if (opt.emotion.isNotEmpty) 'emotion': opt.emotion,
         'speed': opt.speed,
       },
     });

--- a/lib/desktop/setting/tts_services_pane.dart
+++ b/lib/desktop/setting/tts_services_pane.dart
@@ -1127,7 +1127,7 @@ Future<TtsServiceOptions?> _showNetworkDialog(
         : '',
   );
   final emotionCtl = TextEditingController(
-    text: (initial is MiniMaxTtsOptions) ? initial.emotion : 'calm',
+    text: (initial is MiniMaxTtsOptions) ? initial.emotion : '',
   );
   final speedCtl = TextEditingController(
     text: (initial is MiniMaxTtsOptions) ? initial.speed.toString() : '1.0',
@@ -1298,7 +1298,7 @@ Future<TtsServiceOptions?> _showNetworkDialog(
                               _InputRow(
                                 label: l10n.ttsServicesFieldEmotionLabel,
                                 controller: emotionCtl,
-                                hint: 'calm',
+                                hint: l10n.ttsServicesEmotionAutoHint,
                               ),
                               const SizedBox(height: 6),
                               _InputRow(
@@ -1393,9 +1393,7 @@ Future<TtsServiceOptions?> _showNetworkDialog(
                                   baseUrl: base,
                                   model: model,
                                   voiceId: voice,
-                                  emotion: emotionCtl.text.trim().isEmpty
-                                      ? 'calm'
-                                      : emotionCtl.text.trim(),
+                                  emotion: emotionCtl.text.trim(),
                                   speed: spd,
                                 );
                               } else if (kind == NetworkTtsKind.qwen) {

--- a/lib/features/settings/pages/tts_services_page.dart
+++ b/lib/features/settings/pages/tts_services_page.dart
@@ -816,7 +816,7 @@ class _NetworkTtsEditorPageState extends State<_NetworkTtsEditorPage> {
     _modelCtl = TextEditingController(text: _modelOf(initial));
     _voiceCtl = TextEditingController(text: _voiceOf(initial));
     _emotionCtl = TextEditingController(
-      text: (initial is MiniMaxTtsOptions) ? initial.emotion : 'calm',
+      text: (initial is MiniMaxTtsOptions) ? initial.emotion : '',
     );
     _speedCtl = TextEditingController(
       text: (initial is MiniMaxTtsOptions) ? initial.speed.toString() : '1.0',
@@ -945,7 +945,7 @@ class _NetworkTtsEditorPageState extends State<_NetworkTtsEditorPage> {
                           _TtsEditorTextField(
                             label: l10n.ttsServicesFieldEmotionLabel,
                             controller: _emotionCtl,
-                            hint: 'calm',
+                            hint: l10n.ttsServicesEmotionAutoHint,
                           ),
                           _TtsEditorTextField(
                             label: l10n.ttsServicesFieldSpeedLabel,
@@ -1049,9 +1049,7 @@ class _NetworkTtsEditorPageState extends State<_NetworkTtsEditorPage> {
           baseUrl: base,
           model: model,
           voiceId: voice,
-          emotion: _emotionCtl.text.trim().isEmpty
-              ? 'calm'
-              : _emotionCtl.text.trim(),
+          emotion: _emotionCtl.text.trim(),
           speed: double.tryParse(_speedCtl.text.trim()) ?? 1.0,
         );
       case NetworkTtsKind.qwen:

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2155,6 +2155,7 @@
   "ttsServicesFieldVoiceLabel": "Voice",
   "ttsServicesFieldVoiceIdLabel": "Voice ID",
   "ttsServicesFieldEmotionLabel": "Emotion",
+  "ttsServicesEmotionAutoHint": "Leave empty for auto emotion",
   "ttsServicesFieldSpeedLabel": "Speed",
   "ttsServicesFieldLanguageTypeLabel": "Language type",
   "ttsServicesFieldLanguageLabel": "Language",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -9416,6 +9416,12 @@ abstract class AppLocalizations {
   /// **'Emotion'**
   String get ttsServicesFieldEmotionLabel;
 
+  /// No description provided for @ttsServicesEmotionAutoHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Leave empty for auto emotion'**
+  String get ttsServicesEmotionAutoHint;
+
   /// No description provided for @ttsServicesFieldSpeedLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5166,6 +5166,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get ttsServicesFieldEmotionLabel => 'Emotion';
 
   @override
+  String get ttsServicesEmotionAutoHint => 'Leave empty for auto emotion';
+
+  @override
   String get ttsServicesFieldSpeedLabel => 'Speed';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4942,6 +4942,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get ttsServicesFieldEmotionLabel => '情感';
 
   @override
+  String get ttsServicesEmotionAutoHint => '留空即自动';
+
+  @override
   String get ttsServicesFieldSpeedLabel => '语速';
 
   @override
@@ -12266,6 +12269,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get ttsServicesFieldEmotionLabel => '情感';
 
   @override
+  String get ttsServicesEmotionAutoHint => '留空即自动';
+
+  @override
   String get ttsServicesFieldSpeedLabel => '语速';
 
   @override
@@ -19585,6 +19591,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get ttsServicesFieldEmotionLabel => '情感';
+
+  @override
+  String get ttsServicesEmotionAutoHint => '留空即自動';
 
   @override
   String get ttsServicesFieldSpeedLabel => '語速';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1695,6 +1695,7 @@
   "ttsServicesFieldVoiceLabel": "音色",
   "ttsServicesFieldVoiceIdLabel": "音色 ID",
   "ttsServicesFieldEmotionLabel": "情感",
+  "ttsServicesEmotionAutoHint": "留空即自动",
   "ttsServicesFieldSpeedLabel": "语速",
   "ttsServicesFieldLanguageTypeLabel": "语言类型",
   "ttsServicesFieldLanguageLabel": "语言",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1706,6 +1706,7 @@
   "ttsServicesFieldVoiceLabel": "音色",
   "ttsServicesFieldVoiceIdLabel": "音色 ID",
   "ttsServicesFieldEmotionLabel": "情感",
+  "ttsServicesEmotionAutoHint": "留空即自动",
   "ttsServicesFieldSpeedLabel": "语速",
   "ttsServicesFieldLanguageTypeLabel": "语言类型",
   "ttsServicesFieldLanguageLabel": "语言",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1673,6 +1673,7 @@
   "ttsServicesFieldVoiceLabel": "音色",
   "ttsServicesFieldVoiceIdLabel": "音色 ID",
   "ttsServicesFieldEmotionLabel": "情感",
+  "ttsServicesEmotionAutoHint": "留空即自動",
   "ttsServicesFieldSpeedLabel": "語速",
   "ttsServicesFieldLanguageTypeLabel": "語言類型",
   "ttsServicesFieldLanguageLabel": "語言",

--- a/test/core/services/tts/network_tts_test.dart
+++ b/test/core/services/tts/network_tts_test.dart
@@ -45,6 +45,7 @@ void main() {
 
       expect(minimax, isA<MiniMaxTtsOptions>());
       expect((minimax as MiniMaxTtsOptions).model, 'speech-2.6-turbo');
+      expect(minimax.emotion, '');
     });
   });
 
@@ -352,6 +353,62 @@ void main() {
           ),
           throwsA(isA<Exception>()),
         );
+      },
+    );
+    test(
+      'omits MiniMax voice_setting.emotion when empty, sends it when set',
+      () async {
+        late Map<String, dynamic> bodyEmpty;
+        late Map<String, dynamic> bodyEmotion;
+        final server = await _bindServer((request) async {
+          final body =
+              jsonDecode(await utf8.decoder.bind(request).join())
+                  as Map<String, dynamic>;
+          final voiceSetting = body['voice_setting'] as Map;
+          if (!voiceSetting.containsKey('emotion')) {
+            bodyEmpty = body;
+          } else {
+            bodyEmotion = body;
+          }
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.write(
+            'data: ${jsonEncode({
+              'data': {'audio': '01ff'},
+            })}\n\n',
+          );
+          await request.response.close();
+        });
+
+        addTearDown(() async => server.close(force: true));
+
+        MiniMaxTtsOptions options(String emotion) => MiniMaxTtsOptions(
+          enabled: true,
+          name: 'MiniMax',
+          apiKey: 'mm-key',
+          baseUrl: _baseUrl(server),
+          model: 'speech-2.8-hd',
+          voiceId: 'female-shaonv',
+          emotion: emotion,
+          speed: 1.0,
+        );
+
+        await NetworkTtsService.synthesize(options: options(''), text: 'hello');
+        await NetworkTtsService.synthesize(
+          options: options('happy'),
+          text: 'hello',
+        );
+
+        expect(bodyEmpty, isNotNull);
+        expect(bodyEmotion, isNotNull);
+        expect(
+          (bodyEmpty['voice_setting'] as Map).containsKey('emotion'),
+          isFalse,
+        );
+        expect((bodyEmotion['voice_setting'] as Map)['emotion'], 'happy');
       },
     );
   });


### PR DESCRIPTION
## 背景

MiniMax T2A v2 的 `voice_setting.emotion` 为**可选参数**：省略该字段时模型自动匹配情感（speech-2.8 系列官方推荐模式），而 `"auto"` **不是合法枚举值**，直接传 `auto` 会被接口拒绝。

原实现将 `calm` 作为默认值硬编码在整条链路上，导致 `emotion` 字段永远无法省略：

- 设置界面情感输入框提示 `calm`，提交时空值被强制替换为 `calm`
- `MiniMaxTtsOptions.fromJson` 反序列化缺省 `emotion` 也默认 `calm`
- `_miniMaxSpeech` 构造请求体时总是携带 `voice_setting.emotion`

结果：用户手动填 `auto` → 接口 400 拒绝；想留空省略 → 被兜底成 `calm`。speech-2.8 自动情感能力被锁死。

## 修改

1. **`lib/core/services/tts/network_tts.dart`**
   - `fromJson` 缺省 `emotion` 由 `'calm'` 改为 `''`（空串）
   - `_miniMaxSpeech` 仅当 `emotion` 非空时才写入 `voice_setting.emotion`，为空则省略，触发自动情感
2. **设置页（移动端 + 桌面端并行表面）**
   - `lib/features/settings/pages/tts_services_page.dart`
   - `lib/desktop/setting/tts_services_pane.dart`
   - 初始值 `'calm'` → `''`；提交时空值不再兜底替换为 `'calm'`
   - 输入框 hint 改为 l10n 文案（新增 `ttsServicesEmotionAutoHint`，4 个 ARB 已同步）
3. **测试** `test/core/services/tts/network_tts_test.dart`
   - fromJson 缺省 emotion 断言为 `''`
   - 新增用例：空 emotion 时请求体 `voice_setting` **省略** emotion 字段；非空时正常携带

## 兼容性

- 存量配置中已显式存储的 `emotion: 'calm'` 保持不变，仅新建/缺省服务走自动情感，无数据迁移风险
- `toJson` / `fromJson` round-trip 一致

## 验证

- `dart format` ✅
- `dart analyze --fatal-infos lib test` 0 issues ✅
- 全量 `flutter test` 1774 通过 ✅
- `desiredFileName.txt` 无新增未翻译项 ✅

## 手动测试计划

- 快乐路径：MiniMax 服务情感留空 → 朗读请求体不含 `emotion`，自动匹配情感；填 `happy` → 请求体含 `emotion: happy`
- 边界：编辑存量（曾存 `calm`）的服务，字段回显 `calm`；留空保存后切换为自动模式
- 未做真机/桌面构建验证（Linux 环境无对应目标配置），风险集中在 UI 层，逻辑层已被测试覆盖