### PR TITLE
feat(markdown): add math formula export (copy LaTeX / copy PNG / download PNG)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,6 +61,17 @@
 - **Markdown image SVG**: `imageBuilder` detects `.svg` extension in URL and `data:image/svg+xml;base64,...` pattern, routes to `SvgPicture.network()` or `SvgPicture.string()` respectively.
 - **Known limitation**: URLs without `.svg` extension (e.g. shields.io badges like `https://img.shields.io/badge/release-1.0.0-blue`) are not detected as SVG. The user must ensure LLM output includes `.svg` suffix, or append it manually. Deliberate trade-off: avoids an extra failing HTTP request for every extensionless URL.
 
+## Math Formula Export (公式导出)
+
+- **Trigger**: Display math only (`$$…$$` / `\[…\]`). Inline math (`$…$` / `\(…\)`) has no export gesture (deferred — WidgetSpan capture + baseline hit-testing is disproportionate for v1). Mobile = long-press, desktop = right-click on the formula.
+- **Menu (3 items, dual-shell)**: desktop `showDesktopContextMenuAt` / mobile bottom sheet with `IosCardPress` rows — 复制 LaTeX · 复制 PNG · 下载 PNG.
+- **复制 LaTeX**: copies the RAW `body` between delimiters (no delimiters, no `_normalizeMathTex` rewriting) — fidelity over WYSIWYG: the clipboard gets what the model emitted, not the `\tag`-approximated render input (see ADR-0023).
+- **PNG capture**: reuses the shared `_captureRepaintBoundaryPng` helper (extracted from the markdown table block): `RepaintBoundary.toImage(pixelRatio: 3.0)` → `rawStraightRgba` → `image_lib.encodePng` (8-bit, avoids iOS Impeller wide-gamut). The `Math.tex` output is wrapped in its own `RepaintBoundary` + a `cs.surface` background container (theme-matched — a transparent capture leaves dark glyphs invisible on dark viewers).
+- **复制 PNG**: `SystemClipboard`/super_clipboard `DataWriterItem(Formats.png)` with `ClipboardImages.setImagePath` desktop fallback (same as the table block).
+- **下载 PNG**: `FilePicker.saveFile` desktop / bytes mobile, filename stem `markdownMathDefaultFileNameStem`.
+- **Event capture order**: the formula's `GestureDetector` (`onLongPressStart` mobile / `onSecondaryTapDown` desktop) is the deepest hit target, so it wins the gesture arena over the assistant `SelectionArea` and the user bubble `GestureDetector`; a `RawGestureDetector` pointer-claim fallback is reserved if `SelectionArea` co-fires on secondary tap (pinned by widget test).
+- **Menu availability**: the gesture + boundary wrap whatever `_renderMath` returned, so 复制 LaTeX also works on parse-fallback `Text` and during streaming (no `ExportCaptureScope` gating — math has no WebView, unlike Mermaid/HtmlPreviewBlock).
+
 ## Input Draft Persistence
 
 - **InputDraftPersistence**: `lib/features/home/services/input_draft_persistence.dart`. Owns debounced (800ms) writes + lifecycle immediate save of chat input draft via `SharedPreferences`.

--- a/docs/adr/0030-math-formula-export.md
+++ b/docs/adr/0030-math-formula-export.md
@@ -1,0 +1,35 @@
+# ADR-0030: Math formula export is display-only, copies raw TeX, and reuses the table PNG capture pipeline
+
+Long-press (mobile) / right-click (desktop) on a rendered display formula opens a 3-item menu — copy LaTeX, copy PNG, download PNG — instead of the surrounding message's context menu.
+
+## Context
+
+`MarkdownWithCodeHighlight` renders display math (`$$…$$` / `\[…\]`) via `LatexBlockScrollableMd`, which normalizes the TeX (`_normalizeMathTex`) before handing it to `Math.tex` (flutter_math_fork). The rendered formula lives *inside* the assistant message's `SelectionArea` (which owns its own context menu) and inside the user bubble's `GestureDetector`. There was previously no way to copy a formula's source or image.
+
+## Decisions
+
+1. **Display math only.** Inline math (`$…$`, `\(…\)`) gets no gesture in v1. Inline math is a `WidgetSpan` inside rich text: baseline-anchored, horizontally scrollable, and a per-span `RepaintBoundary` capture is unreliable (glyph bleed) while span hit-testing collides with the parent text's selection/gesture handling. Display math is a standalone block widget — near-zero-risk to wrap in a gesture + boundary. Inline can be added later without touching the vendored `gpt_markdown` dependency.
+
+2. **复制 LaTeX copies the raw body, not the normalized render input.** `_normalizeMathTex` rewrites `\tag{X}` → `\qquad\text{(X)}` and strips `\notag` (ADR-0023) so the *rendering* doesn't throw. Copying that string would hand the user an approximated/corrupted TeX. The clipboard gets the trimmed content between the delimiters, with no delimiters — what pastes cleanly into Overleaf/KaTeX. Fidelity over WYSIWYG.
+
+3. **PNG capture reuses the table block's pipeline.** The markdown table block already had the correct primitive: `RepaintBoundary.toImage(pixelRatio: 3.0)` → `rawStraightRgba` readback → `image_lib.encodePng` (8-bit — `ImageByteFormat.png` embeds wide-gamut bytes on iOS Impeller that downstream consumers misinterpret). This is extracted into a shared `_captureRepaintBoundaryPng` / `_copyPngToClipboard` / `_savePngFile` so table and math use one implementation. Copy-PNG uses super_clipboard `SystemClipboard` with a `ClipboardImages.setImagePath` desktop fallback; download-PNG uses `FilePicker.saveFile` (desktop) / bytes (mobile).
+
+4. **Theme-matched background.** `Math.tex` paints glyphs on a transparent canvas; a transparent capture leaves dark glyphs invisible on a dark viewer. The formula is wrapped in a `cs.surface` container so the PNG matches what the user sees.
+
+5. **Leaf-wins gesture, with a capture-order caveat.** The formula's `GestureDetector` (`onLongPressStart` mobile / `onSecondaryTapDown` desktop) is the deepest hit target, so it enters the gesture arena before the `SelectionArea`'s and the bubble's recognizers and wins. `onSecondaryTapDown` can fire eagerly on pointer-down, so an ancestor `SelectionArea` right-click handler may co-fire in some Flutter versions; the fallback is a `RawGestureDetector`/`Listener` that resolves `GestureDisposition.accepted` before the `SelectionArea` sees it. This is pinned by a widget test (formula menu opens; the SelectionArea toolbar does not).
+
+6. **Menu always available.** The gesture + boundary wrap whatever `_renderMath` returned, so 复制 LaTeX works on parse-fallback `Text` and during streaming. No `ExportCaptureScope` gating — math has no WebView, so offscreen export captures it normally.
+
+## Considered Options
+
+1. **Reuse the table capture pipeline (chosen).** One shared implementation, no new plugin, no duplicated ~50 lines.
+2. **New dedicated capture utility / plugin.** Rejected — the table block already proved the path; a new abstraction is YAGNI.
+3. **Include inline math in v1.** Rejected — disproportionate capture + gesture-correctness cost for the value; cleanly deferrable.
+4. **Copy normalized TeX.** Rejected — corrupts `\tag`/`\notag` formulas (ADR-0023 approximation would leak into user output).
+
+## Consequences
+
+- A visible `cs.surface` box now sits behind each display formula in chat (nearly invisible — it matches the chat surface). Acceptable; consistent with the table/Mermaid/SVG/HTML preview-block visual language.
+- Wide formulas still export in full: the `RepaintBoundary` is inside the horizontal `SingleChildScrollView`, and `toImage` captures the whole layer, not the visible slice.
+- The shared helper change is behavior-preserving for the table block (the table methods now delegate to it).
+- Future: if inline math export is added, it lands in `markdown_with_highlight.dart` only; the vendored `gpt_markdown` stays untouched.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -695,6 +695,10 @@
   "markdownTableCopyMarkdownLabel": "Copy as Markdown",
   "markdownTableCopyTsvLabel": "Copy as TSV (Excel)",
   "markdownTableCopyPngLabel": "Copy as PNG image",
+  "markdownMathCopyLatexLabel": "Copy LaTeX",
+  "markdownMathCopyPngLabel": "Copy as PNG",
+  "markdownMathDownloadPngLabel": "Download PNG",
+  "markdownMathDefaultFileNameStem": "math",
   "codeBlockCollapsedLines": "… {n} lines folded",
   "@codeBlockCollapsedLines": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3227,6 +3227,30 @@ abstract class AppLocalizations {
   /// **'Copy as PNG image'**
   String get markdownTableCopyPngLabel;
 
+  /// No description provided for @markdownMathCopyLatexLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy LaTeX'**
+  String get markdownMathCopyLatexLabel;
+
+  /// No description provided for @markdownMathCopyPngLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy as PNG'**
+  String get markdownMathCopyPngLabel;
+
+  /// No description provided for @markdownMathDownloadPngLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Download PNG'**
+  String get markdownMathDownloadPngLabel;
+
+  /// No description provided for @markdownMathDefaultFileNameStem.
+  ///
+  /// In en, this message translates to:
+  /// **'math'**
+  String get markdownMathDefaultFileNameStem;
+
   /// No description provided for @codeBlockCollapsedLines.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1742,6 +1742,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markdownTableCopyPngLabel => 'Copy as PNG image';
 
   @override
+  String get markdownMathCopyLatexLabel => 'Copy LaTeX';
+
+  @override
+  String get markdownMathCopyPngLabel => 'Copy as PNG';
+
+  @override
+  String get markdownMathDownloadPngLabel => 'Download PNG';
+
+  @override
+  String get markdownMathDefaultFileNameStem => 'math';
+
+  @override
   String codeBlockCollapsedLines(int n) {
     return '… $n lines folded';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1679,6 +1679,18 @@ class AppLocalizationsZh extends AppLocalizations {
   String get markdownTableCopyPngLabel => '复制为 PNG 图片';
 
   @override
+  String get markdownMathCopyLatexLabel => '复制 LaTeX';
+
+  @override
+  String get markdownMathCopyPngLabel => '复制为 PNG';
+
+  @override
+  String get markdownMathDownloadPngLabel => '下载 PNG';
+
+  @override
+  String get markdownMathDefaultFileNameStem => '公式';
+
+  @override
   String codeBlockCollapsedLines(int n) {
     return '… 已折叠 $n 行';
   }
@@ -9313,6 +9325,18 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get markdownTableCopyPngLabel => '复制为 PNG 图片';
 
   @override
+  String get markdownMathCopyLatexLabel => '复制 LaTeX';
+
+  @override
+  String get markdownMathCopyPngLabel => '复制为 PNG';
+
+  @override
+  String get markdownMathDownloadPngLabel => '下载 PNG';
+
+  @override
+  String get markdownMathDefaultFileNameStem => '公式';
+
+  @override
   String codeBlockCollapsedLines(int n) {
     return '… 已折叠 $n 行';
   }
@@ -16944,6 +16968,18 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get markdownTableCopyPngLabel => '複製為 PNG 圖片';
+
+  @override
+  String get markdownMathCopyLatexLabel => '複製 LaTeX';
+
+  @override
+  String get markdownMathCopyPngLabel => '複製為 PNG';
+
+  @override
+  String get markdownMathDownloadPngLabel => '下載 PNG';
+
+  @override
+  String get markdownMathDefaultFileNameStem => '公式';
 
   @override
   String codeBlockCollapsedLines(int n) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -474,6 +474,10 @@
   "markdownTableCopyMarkdownLabel": "复制为 Markdown",
   "markdownTableCopyTsvLabel": "复制为 TSV（Excel）",
   "markdownTableCopyPngLabel": "复制为 PNG 图片",
+  "markdownMathCopyLatexLabel": "复制 LaTeX",
+  "markdownMathCopyPngLabel": "复制为 PNG",
+  "markdownMathDownloadPngLabel": "下载 PNG",
+  "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已折叠 {n} 行",
   "@codeBlockCollapsedLines": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -478,6 +478,10 @@
   "markdownTableCopyMarkdownLabel": "复制为 Markdown",
   "markdownTableCopyTsvLabel": "复制为 TSV（Excel）",
   "markdownTableCopyPngLabel": "复制为 PNG 图片",
+  "markdownMathCopyLatexLabel": "复制 LaTeX",
+  "markdownMathCopyPngLabel": "复制为 PNG",
+  "markdownMathDownloadPngLabel": "下载 PNG",
+  "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已折叠 {n} 行",
   "@codeBlockCollapsedLines": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -464,6 +464,10 @@
   "markdownTableCopyMarkdownLabel": "複製為 Markdown",
   "markdownTableCopyTsvLabel": "複製為 TSV（Excel）",
   "markdownTableCopyPngLabel": "複製為 PNG 圖片",
+  "markdownMathCopyLatexLabel": "複製 LaTeX",
+  "markdownMathCopyPngLabel": "複製為 PNG",
+  "markdownMathDownloadPngLabel": "下載 PNG",
+  "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已摺疊 {n} 行",
   "@codeBlockCollapsedLines": {
     "placeholders": {

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -20,6 +20,7 @@ import 'package:image_gallery_saver_plus/image_gallery_saver_plus.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 import '../../utils/sandbox_path_resolver.dart';
 import '../../utils/clipboard_images.dart';
+import '../../core/services/haptics.dart';
 import '../../features/chat/pages/image_viewer_page.dart';
 import 'snackbar.dart';
 import 'ios_tactile.dart';
@@ -2756,6 +2757,108 @@ String markdownTableRowsToMarkdownForTesting(List<List<String>> rows) =>
 @visibleForTesting
 TargetPlatform? markdownTableTargetPlatformOverride;
 
+@visibleForTesting
+TargetPlatform? markdownMathTargetPlatformOverride;
+
+bool _markdownMathTargetPlatformIsDesktop() {
+  final override = markdownMathTargetPlatformOverride;
+  if (override != null) {
+    return override == TargetPlatform.macOS ||
+        override == TargetPlatform.windows ||
+        override == TargetPlatform.linux;
+  }
+  return Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+}
+
+/// Captures the PNG bytes of the [RepaintBoundary] identified by [boundaryKey].
+///
+/// Shared by the markdown table block and the math formula block. Reads back
+/// 8-bit straight-alpha RGBA and re-encodes with `image` instead of using
+/// `ImageByteFormat.png` directly: on wide-gamut backends (iOS Impeller) the
+/// latter embeds 10/16-bit bytes that downstream consumers misinterpret as sRGB.
+Future<Uint8List?> _captureRepaintBoundaryPng(GlobalKey boundaryKey) async {
+  await WidgetsBinding.instance.endOfFrame;
+  final boundary =
+      boundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+  if (boundary == null) return null;
+  final image = await boundary.toImage(pixelRatio: 3.0);
+  final data = await image.toByteData(
+    format: ui.ImageByteFormat.rawStraightRgba,
+  );
+  if (data == null) return null;
+  return image_lib.encodePng(
+    image_lib.Image.fromBytes(
+      width: image.width,
+      height: image.height,
+      bytes: data.buffer,
+      numChannels: 4,
+    ),
+  );
+}
+
+Future<File> _writePngTempFile(Uint8List bytes, String stem) async {
+  final dir = Directory.systemTemp;
+  final file = File(
+    p.join(dir.path, '$stem-${DateTime.now().millisecondsSinceEpoch}.png'),
+  );
+  await file.writeAsBytes(bytes, flush: true);
+  return file;
+}
+
+Future<String?> _savePngFile({
+  required String dialogTitle,
+  required String filename,
+  required Uint8List bytes,
+}) async {
+  if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    final savePath = await FilePicker.platform.saveFile(
+      dialogTitle: dialogTitle,
+      fileName: filename,
+      type: FileType.custom,
+      allowedExtensions: const ['png'],
+    );
+    if (savePath == null) return null;
+    await File(savePath).parent.create(recursive: true);
+    await File(savePath).writeAsBytes(bytes, flush: true);
+    return savePath;
+  }
+
+  return FilePicker.platform.saveFile(
+    dialogTitle: dialogTitle,
+    fileName: filename,
+    type: FileType.custom,
+    allowedExtensions: const ['png'],
+    bytes: bytes,
+  );
+}
+
+Future<bool> _copyPngToClipboard(Uint8List bytes, String suggestedName) async {
+  try {
+    final clipboard = SystemClipboard.instance;
+    if (clipboard != null) {
+      final item = DataWriterItem(suggestedName: suggestedName);
+      item.add(Formats.png(bytes));
+      await clipboard.write([item]);
+      return true;
+    }
+  } catch (e) {
+    debugPrint('PNG clipboard write via super_clipboard failed: $e');
+  }
+
+  try {
+    final file = await _writePngTempFile(
+      bytes,
+      suggestedName.endsWith('.png')
+          ? suggestedName.substring(0, suggestedName.length - 4)
+          : suggestedName,
+    );
+    return await ClipboardImages.setImagePath(file.path);
+  } catch (e) {
+    debugPrint('PNG clipboard write via ClipboardImages fallback failed: $e');
+    return false;
+  }
+}
+
 class _MarkdownTableBlock extends StatelessWidget {
   _MarkdownTableBlock({
     required this.rows,
@@ -3204,88 +3307,18 @@ class _MarkdownTableBlock extends StatelessWidget {
     }
   }
 
-  Future<Uint8List?> _captureTablePngBytes() async {
-    await WidgetsBinding.instance.endOfFrame;
-    final boundary =
-        _tableBoundaryKey.currentContext?.findRenderObject()
-            as RenderRepaintBoundary?;
-    if (boundary == null) return null;
-    final image = await boundary.toImage(pixelRatio: 3.0);
-    final data = await image.toByteData(
-      format: ui.ImageByteFormat.rawStraightRgba,
-    );
-    if (data == null) return null;
-    // 8-bit straight-alpha readback: ImageByteFormat.png on wide-gamut
-    // backends (iOS Impeller) embeds 10/16-bit wide-gamut bytes that
-    // downstream consumers misinterpret as sRGB. Encode to a plain
-    // 8-bit PNG here instead.
-    return image_lib.encodePng(
-      image_lib.Image.fromBytes(
-        width: image.width,
-        height: image.height,
-        bytes: data.buffer,
-        numChannels: 4,
-      ),
-    );
-  }
-
-  Future<File> _writeTableImageTempFile(Uint8List bytes) async {
-    final dir = Directory.systemTemp;
-    final file = File(
-      p.join(
-        dir.path,
-        'cuplivo-table-${DateTime.now().millisecondsSinceEpoch}.png',
-      ),
-    );
-    await file.writeAsBytes(bytes, flush: true);
-    return file;
-  }
+  Future<Uint8List?> _captureTablePngBytes() =>
+      _captureRepaintBoundaryPng(_tableBoundaryKey);
 
   Future<String?> _savePngBytes({
     required String dialogTitle,
     required String filename,
     required Uint8List bytes,
-  }) async {
-    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-      final savePath = await FilePicker.platform.saveFile(
-        dialogTitle: dialogTitle,
-        fileName: filename,
-        type: FileType.custom,
-        allowedExtensions: const ['png'],
-      );
-      if (savePath == null) return null;
-      await File(savePath).parent.create(recursive: true);
-      await File(savePath).writeAsBytes(bytes, flush: true);
-      return savePath;
-    }
+  }) =>
+      _savePngFile(dialogTitle: dialogTitle, filename: filename, bytes: bytes);
 
-    return FilePicker.platform.saveFile(
-      dialogTitle: dialogTitle,
-      fileName: filename,
-      type: FileType.custom,
-      allowedExtensions: const ['png'],
-      bytes: bytes,
-    );
-  }
-
-  Future<bool> _writePngToClipboard(Uint8List bytes) async {
-    try {
-      final clipboard = SystemClipboard.instance;
-      if (clipboard != null) {
-        final item = DataWriterItem(suggestedName: 'cuplivo-table.png');
-        item.add(Formats.png(bytes));
-        await clipboard.write([item]);
-        return true;
-      }
-    } catch (_) {}
-
-    try {
-      final file = await _writeTableImageTempFile(bytes);
-      return await ClipboardImages.setImagePath(file.path);
-    } catch (_) {
-      return false;
-    }
-  }
+  Future<bool> _writePngToClipboard(Uint8List bytes) =>
+      _copyPngToClipboard(bytes, 'cuplivo-table.png');
 }
 
 class _MarkdownTableCell extends StatelessWidget {
@@ -4503,7 +4536,7 @@ class LatexBlockScrollableMd extends BlockMd {
     final body = ((m.group(1) ?? m.group(2) ?? '')).trim();
     if (body.isEmpty) return const SizedBox.shrink();
 
-    final math = _renderMath(body, style: config.style, displayMode: true);
+    final math = _LatexMathBlock(body: body, style: config.style);
     // Wrap in horizontal scroll to avoid overflow and center within available width
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -4522,6 +4555,230 @@ class LatexBlockScrollableMd extends BlockMd {
         },
       ),
     );
+  }
+}
+
+/// Display math block with an export gesture (long-press on mobile,
+/// right-click on desktop) and a capture boundary for PNG export.
+class _LatexMathBlock extends StatefulWidget {
+  const _LatexMathBlock({required this.body, required this.style});
+
+  final String body;
+  final TextStyle? style;
+
+  @override
+  State<_LatexMathBlock> createState() => _LatexMathBlockState();
+}
+
+class _LatexMathBlockState extends State<_LatexMathBlock> {
+  final GlobalKey _boundaryKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final isDesktop = _markdownMathTargetPlatformIsDesktop();
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onLongPressStart: isDesktop ? null : (_) => _showMobileMenu(),
+      onSecondaryTapDown: isDesktop
+          ? (details) => _showDesktopMenu(details.globalPosition)
+          : null,
+      child: RepaintBoundary(
+        key: _boundaryKey,
+        child: Container(
+          // Matches the chat surface (cs.surface) so the box is invisible in
+          // the message; the color exists only so the captured PNG has a
+          // non-transparent, theme-matched background. Symmetric padding gives
+          // the PNG a small margin without shifting the formula's center.
+          color: cs.surface,
+          padding: const EdgeInsets.all(4),
+          child: _renderMath(
+            widget.body,
+            style: widget.style,
+            displayMode: true,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showDesktopMenu(Offset globalPosition) {
+    final l10n = AppLocalizations.of(context)!;
+    showDesktopContextMenuAt(
+      context,
+      globalPosition: globalPosition,
+      items: [
+        DesktopContextMenuItem(
+          icon: Lucide.Copy,
+          label: l10n.markdownMathCopyLatexLabel,
+          onTap: _copyLatex,
+        ),
+        DesktopContextMenuItem(
+          icon: Lucide.Image,
+          label: l10n.markdownMathCopyPngLabel,
+          onTap: _copyPng,
+        ),
+        DesktopContextMenuItem(
+          icon: Lucide.Download,
+          label: l10n.markdownMathDownloadPngLabel,
+          onTap: _downloadPng,
+        ),
+      ],
+    );
+  }
+
+  void _showMobileMenu() {
+    final cs = Theme.of(context).colorScheme;
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: cs.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (ctx) {
+        final l10n = AppLocalizations.of(ctx)!;
+        return SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 6, 12, 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _menuItem(
+                  ctx,
+                  Lucide.Copy,
+                  l10n.markdownMathCopyLatexLabel,
+                  _copyLatex,
+                ),
+                _menuItem(
+                  ctx,
+                  Lucide.Image,
+                  l10n.markdownMathCopyPngLabel,
+                  _copyPng,
+                ),
+                _menuItem(
+                  ctx,
+                  Lucide.Download,
+                  l10n.markdownMathDownloadPngLabel,
+                  _downloadPng,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _menuItem(
+    BuildContext ctx,
+    IconData icon,
+    String label,
+    VoidCallback onTap,
+  ) {
+    final cs = Theme.of(ctx).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: SizedBox(
+        height: 48,
+        child: IosCardPress(
+          borderRadius: BorderRadius.circular(14),
+          baseColor: cs.surface,
+          duration: const Duration(milliseconds: 260),
+          onTap: () {
+            try {
+              Haptics.light();
+            } catch (_) {}
+            Navigator.of(ctx).maybePop();
+            onTap();
+          },
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Icon(icon, size: 20, color: cs.onSurface),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: AppFontWeights.medium,
+                    color: cs.onSurface,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _copyLatex() async {
+    final l10n = AppLocalizations.of(context)!;
+    await Clipboard.setData(ClipboardData(text: widget.body));
+    if (!mounted) return;
+    showAppSnackBar(
+      context,
+      message: l10n.chatMessageWidgetCopiedToClipboard,
+      type: NotificationType.success,
+    );
+  }
+
+  Future<void> _copyPng() async {
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final bytes = await _captureRepaintBoundaryPng(_boundaryKey);
+      if (bytes == null) throw 'render error';
+      final ok = await _copyPngToClipboard(bytes, 'cuplivo-math.png');
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: ok
+            ? l10n.chatMessageWidgetCopiedToClipboard
+            : l10n.messageExportSheetExportFailed('clipboard'),
+        type: ok ? NotificationType.success : NotificationType.error,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.messageExportSheetExportFailed('$e'),
+        type: NotificationType.error,
+      );
+    }
+  }
+
+  Future<void> _downloadPng() async {
+    final l10n = AppLocalizations.of(context)!;
+    final timestamp = DateTime.now().toLocal().toIso8601String().replaceAll(
+      RegExp(r'[:.]'),
+      '-',
+    );
+    final filename = '${l10n.markdownMathDefaultFileNameStem}_$timestamp.png';
+    try {
+      final bytes = await _captureRepaintBoundaryPng(_boundaryKey);
+      if (bytes == null) throw 'render error';
+      final savePath = await _savePngFile(
+        dialogTitle: l10n.backupPageExportToFile,
+        filename: filename,
+        bytes: bytes,
+      );
+      if (savePath == null) return;
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.messageExportSheetExportedAs(p.basename(savePath)),
+        type: NotificationType.success,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.messageExportSheetExportFailed('$e'),
+        type: NotificationType.error,
+      );
+    }
   }
 }
 

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -11,6 +11,7 @@ import 'package:Cuplivo/l10n/app_localizations.dart';
 import 'package:Cuplivo/theme/palettes.dart';
 import 'package:Cuplivo/theme/theme_factory.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -3677,6 +3678,136 @@ void main() {
       );
       expect(plainText, isNot(contains('<details>')));
       expect(plainText, isNot(contains('<a href=')));
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight opens math export menu on long press',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      await tester.pumpWidget(_markdownHarness(r'\[E = mc^2\]', width: 360));
+      await tester.pump();
+
+      await tester.longPress(
+        find.byType(Math),
+        warnIfMissed: false, // Math's RenderLine is paint-only; the gesture
+        // lands on the enclosing export GestureDetector.
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy LaTeX'), findsOneWidget);
+      expect(find.text('Copy as PNG'), findsOneWidget);
+      expect(find.text('Download PNG'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight copies raw LaTeX without tag normalization',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      String? clipboardText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              final data = Map<String, dynamic>.from(call.arguments as Map);
+              clipboardText = data['text'] as String?;
+            }
+            return null;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      await tester.pumpWidget(
+        _markdownHarness(r'\[E = mc^2 \tag{1}\]', width: 360),
+      );
+      await tester.pump();
+
+      await tester.longPress(
+        find.byType(Math),
+        warnIfMissed: false, // Math's RenderLine is paint-only; the gesture
+        // lands on the enclosing export GestureDetector.
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy LaTeX'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(clipboardText, r'E = mc^2 \tag{1}');
+      expect(clipboardText, isNot(contains(r'\qquad')));
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight opens math menu on desktop right click',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      await tester.pumpWidget(_markdownHarness(r'\[E = mc^2\]', width: 360));
+      await tester.pump();
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(Math)),
+        kind: PointerDeviceKind.mouse,
+        buttons: kSecondaryButton,
+      );
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy LaTeX'), findsOneWidget);
+      expect(find.text('Copy as PNG'), findsOneWidget);
+      expect(find.text('Download PNG'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight math menu wins over enclosing SelectionArea',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      SharedPreferences.setMockInitialValues({});
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => SettingsProvider(),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SelectionArea(
+                contextMenuBuilder: (context, selectableRegionState) {
+                  return const Text('SELECTION_TOOLBAR_MARKER');
+                },
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: SizedBox(
+                    width: 360,
+                    child: MarkdownWithCodeHighlight(text: r'\[E = mc^2\]'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(
+        find.byType(Math),
+        warnIfMissed: false, // Math's RenderLine is paint-only; the gesture
+        // lands on the enclosing export GestureDetector.
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Copy LaTeX'), findsOneWidget);
+      expect(find.text('SELECTION_TOOLBAR_MARKER'), findsNothing);
     },
   );
 }


### PR DESCRIPTION
Fixes #271.



Long-press (mobile) / right-click (desktop) on a display formula opens a 3-item menu: copy raw LaTeX source, copy the rendered formula as PNG, or download it as PNG.

* Reuses the table block's PNG capture pipeline, extracted into shared helpers (RepaintBoundary.toImage -> rawStraightRgba -> 8-bit PNG encode -> super\_clipboard/ClipboardImages or FilePicker).
* The formula block wraps Math.tex in a RepaintBoundary with a theme-matched (cs.surface) background and a leaf GestureDetector that wins the arena over the enclosing SelectionArea.
* Copy LaTeX copies the trimmed raw body (no normalization, no delimiters).
* Display math only; inline math deferred (see ADR-0030).

