### PR TITLE
feat(api): sync reasoning content replay policy from upstream Kelivo

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -715,3 +715,12 @@
   - `KelivoImageSettingsMapper` and the "Kelivo backup" interop terms — they describe the upstream project, which legitimately exists
 - **Cuplivo identity surfaces (已更名面)**: All user-visible brand strings and outbound identity use Cuplivo — notifications, about page, share text, HTTP User-Agent, OpenRouter title/referer, MCP client name, downloaded/temp file prefixes (`cuplivo-table-*`, `cuplivo-mermaid-*`, `cuplivo_tts_*`).
 - **Residue sweep (issue #274, ADR-0029)**: The v3.0 sweep fixes tier-A (user-visible/externally-visible) residue only; tier-B/C/D (protocol, persistence, legacy compat, external infra) keep the Kelivo name by design. "夺舍" is complete on every surface users and third parties see; it is deliberately incomplete on identity-bearing internals.
+
+## Reasoning Content Replay (思维链回放)
+
+- **Reasoning content**: unsigned plain-text thinking (`reasoning_content`), distinct from signed **reasoning details** (Anthropic/OpenRouter `reasoning_details`) and native **thinking blocks** (Anthropic).
+- **Replay policy**: per-provider decision on whether to echo reasoning content back into conversation history:
+  - **preserve-all**: always echo — Kimi K3 family (`kimi-k3`, incl. the bare `k3` official alias) plus `kimi-k2.7-code`.
+  - **tool-turns-only**: echo only across turns that involve a tool call — DeepSeek, MiMo, Zhipu, Kimi thinking models (k2.5/k2.6/k2.7).
+  - **strip**: never echo — everyone else (Claude additionally requires signed reasoning details; its unsigned echo is dropped).
+- **Coupling**: the message builder always attaches reasoning content to assistant history; the provider layer then applies the replay policy (builder supplies the data, provider strips it). Rationale: providers reject or waste tokens on reasoning echoed outside tool turns. Synced from upstream Kelivo v1.2.1 (issue #343).

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -123,7 +123,7 @@ bool _isKimiK25Model(String upstreamModelId) {
 bool _isKimiK3Model(String upstreamModelId) {
   final trimmed = upstreamModelId.trim();
   return RegExp(
-        r'(^|[/_:@])kimi-k3(?:$|[-.])',
+        r'(^|[/_:@])kimi-k3(?:$|[-.:])',
         caseSensitive: false,
       ).hasMatch(trimmed) ||
       RegExp(
@@ -131,6 +131,14 @@ bool _isKimiK3Model(String upstreamModelId) {
         caseSensitive: false,
       ).hasMatch(trimmed);
 }
+
+bool _isKimiPreservedThinkingModel(String upstreamModelId) {
+  final normalized = upstreamModelId.trim().toLowerCase();
+  return _isKimiK3Model(normalized) ||
+      RegExp(r'(^|[/_:@])kimi-k2\.7-code(?:$|[-.:])').hasMatch(normalized);
+}
+
+enum _ReasoningContentReplayPolicy { none, toolTurns, all }
 
 bool _isRemoteHttpUrl(String source) {
   final normalized = source.trim().toLowerCase();
@@ -788,6 +796,7 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
   required bool canImageInput,
   required bool allowRemoteImages,
   bool sendToolResultImages = false,
+  required _ReasoningContentReplayPolicy reasoningContentReplayPolicy,
   bool stripUnsignedReasoningContent = false,
 }) async {
   int lastUserIndex = -1;
@@ -795,6 +804,22 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
     if ((messages[i]['role'] ?? '').toString() == 'user') {
       lastUserIndex = i;
       break;
+    }
+  }
+
+  final toolTurnIds = <int>{};
+  final messageTurnIds = <int>[];
+  var currentTurnId = -1;
+  for (final message in messages) {
+    final messageRole = (message['role'] ?? 'user').toString();
+    if (messageRole == 'user') currentTurnId++;
+    messageTurnIds.add(currentTurnId);
+    final messageToolCalls = message['tool_calls'];
+    if (messageRole == 'tool' ||
+        (messageRole == 'assistant' &&
+            messageToolCalls is List &&
+            messageToolCalls.isNotEmpty)) {
+      toolTurnIds.add(currentTurnId);
     }
   }
 
@@ -810,10 +835,19 @@ Future<List<Map<String, dynamic>>> _buildOpenAIChatCompletionMessages(
     final outMsg = Map<String, dynamic>.from(m);
     outMsg.remove(multimodalInternalMediaPathsKey);
     outMsg['role'] = role;
-    if (stripUnsignedReasoningContent && role == 'assistant') {
+    if (role == 'assistant') {
       final details = outMsg['reasoning_details'];
-      final hasSignedDetails = details is List && details.isNotEmpty;
-      if (!hasSignedDetails) {
+      final hasSignedClaudeReasoning =
+          stripUnsignedReasoningContent &&
+          details is List &&
+          details.isNotEmpty;
+      final keepReasoningContent =
+          hasSignedClaudeReasoning ||
+          reasoningContentReplayPolicy == _ReasoningContentReplayPolicy.all ||
+          (reasoningContentReplayPolicy ==
+                  _ReasoningContentReplayPolicy.toolTurns &&
+              toolTurnIds.contains(messageTurnIds[i]));
+      if (!keepReasoningContent) {
         outMsg.remove('reasoning_content');
         outMsg.remove('reasoning');
       }
@@ -1096,6 +1130,17 @@ class _OpenAIProviderInfo {
 
   bool get needsReasoningEcho =>
       isDeepSeek || isMimo || isZhipu || isKimiThinkingModel;
+
+  _ReasoningContentReplayPolicy get reasoningContentReplayPolicy {
+    if (_isKimiPreservedThinkingModel(upstreamModelId)) {
+      return _ReasoningContentReplayPolicy.all;
+    }
+    if (needsReasoningEcho) {
+      return _ReasoningContentReplayPolicy.toolTurns;
+    }
+    return _ReasoningContentReplayPolicy.none;
+  }
+
   String get completionTokensKey =>
       (isAzureOpenAI || isMimo) ? 'max_completion_tokens' : 'max_tokens';
 }
@@ -1634,6 +1679,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         canImageInput: canImageInput,
         allowRemoteImages: allowRemoteImages,
         sendToolResultImages: sendToolResultImages,
+        reasoningContentReplayPolicy: info.reasoningContentReplayPolicy,
         stripUnsignedReasoningContent: isClaudeUpstream,
       );
       body = {
@@ -1990,6 +2036,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   canImageInput: canImageInput,
                   allowRemoteImages: allowRemoteImages,
                   sendToolResultImages: sendToolResultImages,
+                  reasoningContentReplayPolicy:
+                      info.reasoningContentReplayPolicy,
                   stripUnsignedReasoningContent: isClaudeUpstream,
                 );
           reqBody.remove('stream');
@@ -2241,6 +2289,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       canImageInput: canImageInput,
                       allowRemoteImages: allowRemoteImages,
                       sendToolResultImages: sendToolResultImages,
+                      reasoningContentReplayPolicy:
+                          info.reasoningContentReplayPolicy,
                       stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
@@ -3797,6 +3847,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       canImageInput: canImageInput,
                       allowRemoteImages: allowRemoteImages,
                       sendToolResultImages: sendToolResultImages,
+                      reasoningContentReplayPolicy:
+                          info.reasoningContentReplayPolicy,
                       stripUnsignedReasoningContent: isClaudeUpstream,
                     ),
                     'stream': true,
@@ -4335,6 +4387,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                           canImageInput: canImageInput,
                           allowRemoteImages: allowRemoteImages,
                           sendToolResultImages: sendToolResultImages,
+                          reasoningContentReplayPolicy:
+                              info.reasoningContentReplayPolicy,
                           stripUnsignedReasoningContent: isClaudeUpstream,
                         ),
                         'stream': true,

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -142,9 +142,10 @@ class MessageBuilderService {
     final out = <Map<String, dynamic>>[];
 
     for (final m in source) {
-      String? toolContinuationReasoningContent;
+      String? assistantReasoningContent;
       dynamic reasoningDetails;
       if (m.role == 'assistant') {
+        assistantReasoningContent = _reasoningContentForToolContinuation(m);
         reasoningDetails = _reasoningDetailsForApi(m);
       }
       if (includeToolMessages && m.role == 'assistant') {
@@ -153,8 +154,6 @@ class MessageBuilderService {
           // Tool-call history is only valid once every call has a result.
           final hasPendingToolEvent = events.any((e) => e['content'] == null);
           if (!hasPendingToolEvent) {
-            toolContinuationReasoningContent =
-                _reasoningContentForToolContinuation(m);
             final calls = <Map<String, dynamic>>[];
             final toolMessages = <Map<String, dynamic>>[];
 
@@ -202,9 +201,9 @@ class MessageBuilderService {
                 'content': '\n\n',
                 'tool_calls': calls,
               };
-              if (toolContinuationReasoningContent.isNotEmpty) {
+              if (assistantReasoningContent?.isNotEmpty == true) {
                 assistantToolMessage['reasoning_content'] =
-                    toolContinuationReasoningContent;
+                    assistantReasoningContent;
               }
               out.add(assistantToolMessage);
               out.addAll(toolMessages);
@@ -227,8 +226,8 @@ class MessageBuilderService {
         message[_isPresetKey] = m.isPreset;
         message[_timestampKey] = m.timestamp.toIso8601String();
       }
-      if (toolContinuationReasoningContent?.isNotEmpty == true) {
-        message['reasoning_content'] = toolContinuationReasoningContent;
+      if (assistantReasoningContent?.isNotEmpty == true) {
+        message['reasoning_content'] = assistantReasoningContent;
       }
       if (reasoningDetails != null) {
         message['reasoning_details'] = reasoningDetails;

--- a/test/openai_deepseek_compat_test.dart
+++ b/test/openai_deepseek_compat_test.dart
@@ -128,5 +128,122 @@ void main() {
       expect(requests.single['thinking'], {'type': 'disabled'});
       expect(requests.single.containsKey('reasoning_effort'), isFalse);
     });
+
+    test('ordinary history strips reasoning_content', () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody = await _readJsonBody(request);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'choices': [
+              {
+                'delta': {'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _deepSeekConfig(baseUrl),
+        modelId: 'deepseek-reasoner',
+        messages: const [
+          {'role': 'user', 'content': 'first question'},
+          {
+            'role': 'assistant',
+            'content': 'first answer',
+            'reasoning_content': 'private first-turn reasoning',
+          },
+          {'role': 'user', 'content': 'follow up'},
+        ],
+      ).toList();
+
+      final history = (requestBody['messages'] as List).cast<Map>();
+      expect(history[1].containsKey('reasoning_content'), isFalse);
+    });
+
+    test(
+      'tool-call turn preserves every assistant reasoning_content',
+      () async {
+        late Map<String, dynamic> requestBody;
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          requestBody = await _readJsonBody(request);
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+            charset: 'utf-8',
+          );
+          request.response.write(
+            'data: ${jsonEncode({
+              'choices': [
+                {
+                  'delta': {'content': 'ok'},
+                  'finish_reason': 'stop',
+                },
+              ],
+            })}\n\n',
+          );
+          request.response.write('data: [DONE]\n\n');
+          await request.response.close();
+        });
+
+        final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+        await ChatApiService.sendMessageStream(
+          config: _deepSeekConfig(baseUrl),
+          modelId: 'deepseek-reasoner',
+          messages: const [
+            {'role': 'user', 'content': 'check the weather'},
+            {
+              'role': 'assistant',
+              'content': '',
+              'reasoning_content': 'decide to call weather tool',
+              'tool_calls': [
+                {
+                  'id': 'call_weather',
+                  'type': 'function',
+                  'function': {'name': 'weather', 'arguments': '{}'},
+                },
+              ],
+            },
+            {
+              'role': 'tool',
+              'tool_call_id': 'call_weather',
+              'content': 'sunny',
+            },
+            {
+              'role': 'assistant',
+              'content': 'It is sunny.',
+              'reasoning_content': 'summarize the tool result',
+            },
+            {'role': 'user', 'content': 'thanks'},
+          ],
+        ).toList();
+
+        final history = (requestBody['messages'] as List).cast<Map>();
+        expect(history[1]['reasoning_content'], 'decide to call weather tool');
+        expect(history[3]['reasoning_content'], 'summarize the tool result');
+      },
+    );
   });
 }

--- a/test/openai_kimi_compat_test.dart
+++ b/test/openai_kimi_compat_test.dart
@@ -745,5 +745,74 @@ void main() {
       expect(body.containsKey('temperature'), isFalse);
       expect(body.containsKey('top_p'), isFalse);
     });
+
+    test(
+      'kimi-k3 and kimi-k2.7-code preserved-thinking variants keep history',
+      () async {
+        final requestBodies = <Map<String, dynamic>>[];
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          requestBodies.add(
+            (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+                .cast<String, dynamic>(),
+          );
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+            charset: 'utf-8',
+          );
+          request.response.write(
+            'data: ${jsonEncode({
+              'id': 'cmpl-preserved',
+              'object': 'chat.completion.chunk',
+              'created': 0,
+              'model': 'kimi',
+              'choices': [
+                {
+                  'index': 0,
+                  'delta': {'role': 'assistant', 'content': 'ok'},
+                  'finish_reason': 'stop',
+                },
+              ],
+            })}\n\n',
+          );
+          request.response.write('data: [DONE]\n\n');
+          await request.response.close();
+        });
+
+        final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+        for (final modelId in const [
+          'moonshotai/kimi-k3:nitro',
+          'moonshotai/kimi-k2.7-code:floor',
+        ]) {
+          final chunks = await ChatApiService.sendMessageStream(
+            config: _moonshotConfig(baseUrl),
+            modelId: modelId,
+            messages: const [
+              {'role': 'user', 'content': 'hello'},
+              {
+                'role': 'assistant',
+                'content': 'hi there',
+                'reasoning_content': 'preserved thinking text',
+              },
+              {'role': 'user', 'content': 'follow up'},
+            ],
+          ).toList();
+
+          expect(chunks.last.isDone, isTrue);
+        }
+
+        expect(requestBodies, hasLength(2));
+        for (final requestBody in requestBodies) {
+          final messages = (requestBody['messages'] as List).cast<Map>();
+          expect(messages[1]['reasoning_content'], 'preserved thinking text');
+        }
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #343



Port upstream's per-provider reasoning\_content replay policy (preserve-all /
tool-turns-only / strip) into the OpenAI-compatible builder. The message
builder now attaches reasoning content to every assistant history entry and
the provider layer strips it per vendor, instead of only stripping Claude's
unsigned echo. Adds kimi-k2.7-code and the bare k3 alias to the preserve-all
set, with tests for DeepSeek and Kimi compatibility.

