### PR TITLE
fix(android): 移除 legacy native 打包，proot 沙箱不再依赖解压目录

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -52,14 +52,6 @@ android {
             }
         }
     }
-
-    // proot must be a real on-disk executable for ProcessBuilder (not only
-    // memory-mapped for System.loadLibrary). Legacy packaging extracts jniLibs.
-    packaging {
-        jniLibs {
-            useLegacyPackaging = true
-        }
-    }
 }
 
 kotlin {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Photo access for picking images -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -18,9 +17,7 @@
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true"
-        android:icon="@mipmap/ic_launcher"
-        android:extractNativeLibs="true"
-        tools:replace="android:extractNativeLibs">
+        android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/kotlin/com/cup11/cuplivo/LinuxSandboxPlugin.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/LinuxSandboxPlugin.kt
@@ -35,7 +35,14 @@ class LinuxSandboxPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
 
   override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
     when (call.method) {
-      "isSupported" -> result.success(hasProot())
+      "isSupported" -> {
+        Thread {
+          val supported = hasProot()
+          android.os.Handler(android.os.Looper.getMainLooper()).post {
+            result.success(supported)
+          }
+        }.start()
+      }
       "getAbi" -> result.success(primaryAbi())
       "extractRootfs" -> {
         val workspace = call.argument<String>("workspacePath")
@@ -140,8 +147,7 @@ class LinuxSandboxPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     if (!ok) {
       Log.w(
         TAG,
-        "proot runtime missing: exec=${exec?.absolutePath} loader=${loader?.absolutePath} " +
-          "nativeLibraryDir=${appContext.applicationInfo.nativeLibraryDir}",
+        "proot runtime missing: exec=${exec?.absolutePath} loader=${loader?.absolutePath}",
       )
     }
     return ok
@@ -241,9 +247,7 @@ private class GuestCommandRunner(private val appContext: Context) {
     timeoutMs: Long,
   ): Map<String, Any?> {
     val exec = NativeLibResolver.resolve(appContext, EXEC_LIB)
-      ?: throw IllegalStateException(
-        "proot missing (nativeLibraryDir=${appContext.applicationInfo.nativeLibraryDir})",
-      )
+      ?: throw IllegalStateException("proot missing (filesDir cache and APK copy both failed)")
     val loader = NativeLibResolver.resolve(appContext, LOADER_LIB)
       ?: throw IllegalStateException("proot loader missing")
     val linux = File(workspacePath, ".sandbox/linux")
@@ -273,15 +277,12 @@ private class GuestCommandRunner(private val appContext: Context) {
   }
 }
 
-/** Vendored proot native library resolution (installed lib dir → cached copy → APK). */
+/** Vendored proot native library resolution (cached copy → APK). */
 private object NativeLibResolver {
   fun resolve(appContext: Context, libFileName: String): File? {
     val candidates = mutableListOf<File>()
 
-    // 1) Extracted nativeLibraryDir (extractNativeLibs=true / legacy packaging)
-    candidates += File(appContext.applicationInfo.nativeLibraryDir, libFileName)
-
-    // 2) Previously copied fallback
+    // 1) Previously copied fallback (survives restarts and app updates)
     candidates += File(appContext.filesDir, "proot/$libFileName")
 
     for (f in candidates) {
@@ -291,7 +292,7 @@ private object NativeLibResolver {
       }
     }
 
-    // 3) Copy out of APK / split APKs into app filesDir
+    // 2) Copy out of APK / split APKs into app filesDir
     val copied = copyFromApk(appContext, libFileName)
     if (copied != null) {
       makeExecutable(copied)
@@ -343,6 +344,10 @@ private object NativeLibResolver {
         Log.w("LinuxSandbox", "copyFromApk($apk, $libFileName): ${e.message}")
       }
     }
+    Log.w(
+      "LinuxSandbox",
+      "copyFromApk: no $libFileName entry found (abi=$abi, entries=$entryNames, apks=$apkPaths)",
+    )
     return null
   }
 


### PR DESCRIPTION
## 背景

为启用安卓端 Linux 沙箱（proot），此前开启了 `useLegacyPackaging = true` 与 `android:extractNativeLibs="true"`（.so 压缩进 APK、安装时解压到 nativeLibraryDir）。本 PR 移除该打包方式，native 库恢复 AGP 默认行为：不压缩、4KB 对齐、随 APK 原地 mmap 加载，安装时不再解压。

## 变更内容

- **build.gradle.kts**：删除 `packaging { jniLibs { useLegacyPackaging = true } }`
- **AndroidManifest.xml**：删除 `android:extractNativeLibs="true"` 及 `tools:replace`（无其他来源声明该属性，合并无冲突）
- **LinuxSandboxPlugin.kt**：
  - proot 运行时解析不再依赖 `nativeLibraryDir`（去掉 legacy 打包后该目录必然为空，原路径本就无效），改为：`filesDir/proot/` 缓存 → 从 APK / split APK 的 `lib/<abi>/` zip entry 拷贝
  - 错误消息同步更新（filesDir 缓存与 APK 拷贝均失败）
  - 加固 1：`isSupported` 的解析移到后台线程（首次调用可能从 APK 拷贝约 0.5MB，此前阻塞平台线程）
  - 加固 2：`copyFromApk` 在找不到 zip entry 时输出日志（ABI、期望 entry、APK 路径），打包回归可诊断

## 理论验证（为何沙箱不会因此不可用）

1. 无论 entry 是 store 还是 deflate，`ZipFile.getInputStream` 都能读出原始 ELF 字节，proot 库仍在 APK 的 `lib/<abi>/` 下
2. 安卓 W^X/execmem 限制针对 `dlopen`/`mmap(PROT_EXEC)` 应用可写文件，不限制 `execve`（Termux/UserLAnd 同机制）；proot loader 经 `PROOT_LOADER` 被 execve，从不 dlopen
3. 被删除的 `nativeLibraryDir` 路径在移除 legacy 打包后必然返回 null，删除是行为一致而非回归
4. Flutter 引擎（`libapp.so`/`libflutter.so`）恢复标准默认配置（不压缩+对齐+mmap），3.44 gradle 插件经标准 jniLibs 合并（`FlutterPlugin.kt:340`）
5. 升级路径安全：`filesDir` 缓存跨重启、跨应用升级保留
6. 失败优雅降级：`hasRuntime()=false` → `SandboxStatus.runtimeMissing` → 沙箱入口显示警告，app 本身不受影响

## 残余风险 / 待验证

- 拷贝+exec 路径此前仅是 fallback，很可能从未在真机执行过，现为唯一路径：需真机验证首次 `isSupported` → rootfs 安装 → staged apt（recover→update→install）→ `exec`
- CI 的 `build-stable-44.yml` 使用 `flutter build apk --release --split-per-abi`，本 PR 在构建产物中的 zip entry 布局与 manifest 合并结果需以 CI 构建确认

## 测试

- 本地：未构建（按要求不在本地构建）
- 待跑：`pr-check.yml`（flutter test）+ `build-stable-44.yml`（workflow_dispatch，arm64 APK）