### PR TITLE
fix: guard shell tool from crash when native runtime is missing

### DIFF
--- a/lib/core/services/workspace/workspace_tools_service.dart
+++ b/lib/core/services/workspace/workspace_tools_service.dart
@@ -94,10 +94,38 @@ class WorkspaceToolsService {
     },
   };
 
+  /// Whether shell should be exposed to the model.
+  ///
+  /// Previously this returned true on any mobile platform even when the
+  /// native runtime was missing, causing the model to invoke shell and
+  /// trigger a native crash. Now we cache a synchronous flag that is set
+  /// after the first successful [LinuxSandboxService.hasRuntime] probe.
   static bool _shellAvailable(LinuxSandboxService? sandbox) {
     if (sandbox == null) return false;
     if (!Platform.isAndroid && !Platform.isIOS) return false;
-    return true;
+    // Only expose shell when we have confirmed the runtime exists.
+    // The flag is set by [probeShellAvailability] at app startup.
+    return _shellRuntimeConfirmed;
+  }
+
+  /// Cached result of the async runtime check. Defaults to false (safe)
+  /// until explicitly confirmed.
+  static bool _shellRuntimeConfirmed = false;
+
+  /// Call once at app startup (e.g. in main or provider init) to probe
+  /// whether the native sandbox runtime is available. Until this completes,
+  /// shell tools will not be exposed to models — preventing native crashes
+  /// on builds that lack the proot/iSH binary.
+  static Future<void> probeShellAvailability([
+    LinuxSandboxService? sandbox,
+  ]) async {
+    if (!Platform.isAndroid && !Platform.isIOS) return;
+    final svc = sandbox ?? LinuxSandboxService.instance;
+    try {
+      _shellRuntimeConfirmed = await svc.hasRuntime();
+    } catch (_) {
+      _shellRuntimeConfirmed = false;
+    }
   }
 
   static Workspace? _boundWorkspace(

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -377,7 +377,9 @@ class ToolHandlerService {
           sandbox: LinuxSandboxService.instance,
         ),
       );
-    } on ProviderNotFoundException catch (e) {
+    } catch (e) {
+      // Catch all exceptions (not just ProviderNotFoundException) to prevent
+      // crashes when workspace/sandbox initialization fails on first launch.
       debugPrint('workspace tools defs skipped: $e');
     }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,7 @@ import 'dart:io'
 import 'core/services/android_background.dart';
 import 'core/services/notification_service.dart';
 import 'core/services/proactive_care_alarm_service.dart';
+import 'core/services/workspace/workspace_tools_service.dart';
 import 'core/services/proactive_care_message_flow.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
@@ -148,6 +149,12 @@ Future<void> main() async {
       // Android: start AlarmManager service for proactive care exact alarms
       if (!kIsWeb && Platform.isAndroid) {
         await ProactiveCareAlarmService.initialize();
+      }
+      // Probe sandbox runtime availability BEFORE runApp so shell tools
+      // are only exposed when the native binary is confirmed present.
+      // This prevents native crashes on builds without proot/iSH.
+      if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+        await WorkspaceToolsService.probeShellAvailability();
       }
       // Start app (Flutter log capture is toggleable and off by default)
       runApp(const MyApp());


### PR DESCRIPTION
## Summary

Fixes app crash (force close) when workspace tools are invoked on Android builds where the proot native binary is not ready or not installed.

## Root Cause

`_shellAvailable()` in `WorkspaceToolsService` unconditionally returned `true` on any mobile platform without verifying the native sandbox runtime exists. When the model invoked the shell tool, it hit an unregistered MethodChannel → native crash.

## Changes

- `workspace_tools_service.dart`: Replace blind platform check with a cached runtime probe (`_shellRuntimeConfirmed`). Shell tools are only exposed after `probeShellAvailability()` confirms the binary is present.
- `main.dart`: Call `probeShellAvailability()` before `runApp()` on mobile.
- `tool_handler_service.dart`: Broaden `buildToolDefinitions` workspace try-catch from `ProviderNotFoundException` to catch-all, preventing unrelated init errors from crashing the chat flow.

## Testing

- Without sandbox installed: shell tool no longer appears in model tool list → no crash.
- With sandbox installed: shell tool works as before.

Closes #311 (partial)
