### PR TITLE
fix: support DeepSeek Responses reasoning metadata

### DIFF
--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -98,6 +98,21 @@ void _applyCompatibleResponsesReasoning(
   int? thinkingBudget,
 }) {
   if (config.useResponseApi != true) return;
+
+  final host = Uri.tryParse(config.baseUrl)?.host.toLowerCase() ?? '';
+  final isDeepSeek =
+      host.contains('deepseek') ||
+      config.id.toLowerCase().contains('deepseek') ||
+      upstreamModelId.toLowerCase().contains('deepseek');
+  if (isDeepSeek) {
+    if (!isReasoning) {
+      body.remove('reasoning');
+    } else if (_isOff(thinkingBudget)) {
+      body['reasoning'] = {'effort': 'none'};
+    }
+    return;
+  }
+
   if (!BuiltInToolsHelper.isDashScopeProvider(config)) return;
 
   body.remove('reasoning');
@@ -479,17 +494,46 @@ int _readOpenAIUsageInt(dynamic value) {
 TokenUsage? _mergeOpenAICompatibleUsage(TokenUsage? current, dynamic rawUsage) {
   if (rawUsage is! Map) return current;
 
-  final details = rawUsage['prompt_tokens_details'];
+  final details =
+      rawUsage['prompt_tokens_details'] ?? rawUsage['input_tokens_details'];
   final cachedTokens = details is Map
       ? _readOpenAIUsageInt(details['cached_tokens'])
       : 0;
   return (current ?? const TokenUsage()).merge(
     TokenUsage(
-      promptTokens: _readOpenAIUsageInt(rawUsage['prompt_tokens']),
-      completionTokens: _readOpenAIUsageInt(rawUsage['completion_tokens']),
+      promptTokens: _readOpenAIUsageInt(
+        rawUsage['prompt_tokens'] ?? rawUsage['input_tokens'],
+      ),
+      completionTokens: _readOpenAIUsageInt(
+        rawUsage['completion_tokens'] ?? rawUsage['output_tokens'],
+      ),
       cachedTokens: cachedTokens,
     ),
   );
+}
+
+String _responsesReasoningText(dynamic rawOutput) {
+  if (rawOutput is! List) return '';
+
+  final buffer = StringBuffer();
+  for (final item in rawOutput) {
+    if (item is! Map || item['type'] != 'reasoning') continue;
+    final content = item['content'];
+    if (content is String) {
+      buffer.write(content);
+      continue;
+    }
+    if (content is! List) continue;
+    for (final part in content) {
+      if (part is String) {
+        buffer.write(part);
+      } else if (part is Map &&
+          (part['type'] == 'reasoning_text' || part['type'] == 'text')) {
+        buffer.write((part['text'] ?? part['content'] ?? '').toString());
+      }
+    }
+  }
+  return buffer.toString();
 }
 
 String _stripDataUrlPrefix(String dataUrl) {
@@ -1739,6 +1783,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       // Responses API non-stream
       if (config.useResponseApi == true) {
         String outText = '';
+        final rawOutput = obj['output'] ?? obj['response']?['output'];
+        final reasoningText = _responsesReasoningText(rawOutput);
         try {
           outText = (obj['output_text'] ?? '').toString();
         } catch (_) {}
@@ -1749,7 +1795,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
         }
         if (outText.isEmpty) {
           try {
-            final out = obj['output'] as List?;
+            final out = rawOutput as List?;
             if (out != null) {
               final buf = StringBuffer();
               for (final it in out) {
@@ -1784,28 +1830,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             }
           } catch (_) {}
         }
-        TokenUsage? usage;
-        try {
-          final u = (obj['usage'] ?? obj['response']?['usage']) as Map?;
-          if (u != null) {
-            final prompt =
-                (u['prompt_tokens'] ?? u['input_tokens'] ?? 0) as int? ?? 0;
-            final completion =
-                (u['completion_tokens'] ?? u['output_tokens'] ?? 0) as int? ??
-                0;
-            final cached =
-                (u['prompt_tokens_details']?['cached_tokens'] ?? 0) as int? ??
-                0;
-            usage = TokenUsage(
-              promptTokens: prompt,
-              completionTokens: completion,
-              cachedTokens: cached,
-              totalTokens: prompt + completion,
-            );
-          }
-        } catch (_) {}
+        final usage = _mergeOpenAICompatibleUsage(
+          null,
+          obj['usage'] ?? obj['response']?['usage'],
+        );
         yield ChatStreamChunk(
           content: outText,
+          reasoning: reasoningText.isEmpty ? null : reasoningText,
           isDone: true,
           totalTokens: usage?.totalTokens ?? 0,
           usage: usage,
@@ -2750,15 +2781,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               }
             }
           } else if (type == 'response.incomplete') {
-            final u = json['response']?['usage'];
-            if (u != null) {
-              final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
-              final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
-              usage = (usage ?? const TokenUsage()).merge(
-                TokenUsage(promptTokens: inTok, completionTokens: outTok),
-              );
-              totalTokens = usage.totalTokens;
-            }
+            usage = _mergeOpenAICompatibleUsage(
+              usage,
+              json['response']?['usage'],
+            );
+            totalTokens = usage?.totalTokens ?? totalTokens;
             try {
               final details = json['response']?['incomplete_details'];
               if (details is Map) {
@@ -2766,15 +2793,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               }
             } catch (_) {}
           } else if (type == 'response.completed') {
-            final u = json['response']?['usage'];
-            if (u != null) {
-              final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
-              final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
-              usage = (usage ?? const TokenUsage()).merge(
-                TokenUsage(promptTokens: inTok, completionTokens: outTok),
-              );
-              totalTokens = usage.totalTokens;
-            }
+            usage = _mergeOpenAICompatibleUsage(
+              usage,
+              json['response']?['usage'],
+            );
+            totalTokens = usage?.totalTokens ?? totalTokens;
             // Extract web search citations from final output (Responses API)
             try {
               final output = json['response']?['output'];
@@ -3165,19 +3188,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                       } else if (o is Map &&
                           (o['type'] ?? '') == 'response.completed') {
                         // usage
-                        final u2 = o['response']?['usage'];
-                        if (u2 != null) {
-                          final inTok = (u2['input_tokens'] ?? 0) as int? ?? 0;
-                          final outTok =
-                              (u2['output_tokens'] ?? 0) as int? ?? 0;
-                          usage = (usage ?? const TokenUsage()).merge(
-                            TokenUsage(
-                              promptTokens: inTok,
-                              completionTokens: outTok,
-                            ),
-                          );
-                          totalTokens = usage.totalTokens;
-                        }
+                        usage = _mergeOpenAICompatibleUsage(
+                          usage,
+                          o['response']?['usage'],
+                        );
+                        totalTokens = usage?.totalTokens ?? totalTokens;
                         // capture output items
                         final out2 = o['response']?['output'];
                         if (out2 is List) {
@@ -3351,15 +3366,8 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             if (output != null) {
               content = (output['content'] ?? '').toString();
               approxCompletionChars += content.length;
-              final u = json['usage'];
-              if (u != null) {
-                final inTok = (u['input_tokens'] ?? 0) as int? ?? 0;
-                final outTok = (u['output_tokens'] ?? 0) as int? ?? 0;
-                usage = (usage ?? const TokenUsage()).merge(
-                  TokenUsage(promptTokens: inTok, completionTokens: outTok),
-                );
-                totalTokens = usage.totalTokens;
-              }
+              usage = _mergeOpenAICompatibleUsage(usage, json['usage']);
+              totalTokens = usage?.totalTokens ?? totalTokens;
             }
           }
         } else {

--- a/test/openai_deepseek_compat_test.dart
+++ b/test/openai_deepseek_compat_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/api/chat_api_service.dart';
 
-ProviderConfig _deepSeekConfig(String baseUrl) {
+ProviderConfig _deepSeekConfig(String baseUrl, {bool useResponseApi = false}) {
   return ProviderConfig(
     id: 'DeepSeekCompatTest',
     enabled: true,
@@ -14,6 +14,7 @@ ProviderConfig _deepSeekConfig(String baseUrl) {
     apiKey: 'test-key',
     baseUrl: baseUrl,
     providerType: ProviderKind.openai,
+    useResponseApi: useResponseApi,
   );
 }
 
@@ -24,6 +25,218 @@ Future<Map<String, dynamic>> _readJsonBody(HttpRequest request) async {
 
 void main() {
   group('DeepSeek OpenAI compatibility', () {
+    test('Responses non-stream returns reasoning and cached tokens', () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody = await _readJsonBody(request);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'id': 'resp-deepseek',
+            'object': 'response',
+            'status': 'completed',
+            'output_text': '9.8 is greater.',
+            'output': [
+              {
+                'id': 'reasoning-deepseek',
+                'type': 'reasoning',
+                'content': [
+                  {
+                    'type': 'reasoning_text',
+                    'text': 'Compare the decimal values.',
+                  },
+                ],
+              },
+              {
+                'id': 'message-deepseek',
+                'type': 'message',
+                'role': 'assistant',
+                'status': 'completed',
+                'content': [
+                  {'type': 'output_text', 'text': '9.8 is greater.'},
+                ],
+              },
+            ],
+            'usage': {
+              'input_tokens': 100,
+              'input_tokens_details': {'cached_tokens': 64},
+              'output_tokens': 30,
+              'output_tokens_details': {'reasoning_tokens': 20},
+              'total_tokens': 130,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _deepSeekConfig(baseUrl, useResponseApi: true),
+        modelId: 'deepseek-v4-flash',
+        messages: const [
+          {'role': 'user', 'content': '9.11 and 9.8, which is greater?'},
+        ],
+        thinkingBudget: 2000,
+        stream: false,
+      ).toList();
+
+      expect(requestBody['stream'], isFalse);
+      expect(chunks, hasLength(1));
+      expect(chunks.single.content, '9.8 is greater.');
+      expect(chunks.single.reasoning, 'Compare the decimal values.');
+      expect(chunks.single.usage?.promptTokens, 100);
+      expect(chunks.single.usage?.completionTokens, 30);
+      expect(chunks.single.usage?.cachedTokens, 64);
+      expect(chunks.single.usage?.totalTokens, 130);
+    });
+
+    test('Responses stream reports cached tokens without DONE event', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await _readJsonBody(request);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'type': 'response.completed',
+            'response': {
+              'output': const [],
+              'usage': {
+                'input_tokens': 80,
+                'input_tokens_details': {'cached_tokens': 48},
+                'output_tokens': 12,
+                'output_tokens_details': {'reasoning_tokens': 8},
+                'total_tokens': 92,
+              },
+            },
+          })}\n\n',
+        );
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _deepSeekConfig(baseUrl, useResponseApi: true),
+        modelId: 'deepseek-v4-flash',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(chunks.last.usage?.promptTokens, 80);
+      expect(chunks.last.usage?.completionTokens, 12);
+      expect(chunks.last.usage?.cachedTokens, 48);
+      expect(chunks.last.usage?.totalTokens, 92);
+    });
+
+    test('Responses incomplete stream reports cached tokens', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await _readJsonBody(request);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'type': 'response.incomplete',
+            'response': {
+              'usage': {
+                'input_tokens': 60,
+                'input_tokens_details': {'cached_tokens': 36},
+                'output_tokens': 9,
+                'output_tokens_details': {'reasoning_tokens': 6},
+                'total_tokens': 69,
+              },
+              'incomplete_details': {'reason': 'max_tokens'},
+            },
+          })}\n\n',
+        );
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _deepSeekConfig(baseUrl, useResponseApi: true),
+        modelId: 'deepseek-v4-flash',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(chunks.last.usage?.promptTokens, 60);
+      expect(chunks.last.usage?.completionTokens, 9);
+      expect(chunks.last.usage?.cachedTokens, 36);
+      expect(chunks.last.usage?.totalTokens, 69);
+    });
+
+    test('Responses off reasoning sends effort none', () async {
+      late Map<String, dynamic> requestBody;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBody = await _readJsonBody(request);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'id': 'resp-deepseek',
+            'object': 'response',
+            'status': 'completed',
+            'output_text': 'ok',
+            'output': const [],
+            'usage': {
+              'input_tokens': 1,
+              'input_tokens_details': {'cached_tokens': 0},
+              'output_tokens': 1,
+              'output_tokens_details': {'reasoning_tokens': 0},
+              'total_tokens': 2,
+            },
+          }),
+        );
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _deepSeekConfig(baseUrl, useResponseApi: true),
+        modelId: 'deepseek-v4-flash',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 0,
+        stream: false,
+      ).toList();
+
+      expect(chunks.last.isDone, isTrue);
+      expect(requestBody['reasoning'], {'effort': 'none'});
+    });
+
     test(
       'xhigh reasoning keeps thinking enabled and passes xhigh effort',
       () async {


### PR DESCRIPTION
## Summary

Port upstream [Kelivo 41482ab0](https://github.com/Chevey339/kelivo/commit/41482ab0) (\ix: support DeepSeek Responses reasoning metadata\) to Cuplivo, fixing DeepSeek V4 Flash official Responses API: deep thinking was dropped and context cache hit stats were lost.

## Changes

- **\_applyCompatibleResponsesReasoning\**: DeepSeek branch — removes \easoning\ when thinking is off, sends \easoning: {effort: 'none'}\ when thinkingBudget is off (OpenAI-style body for DeepSeek Responses API).
- **\_mergeOpenAICompatibleUsage\**: accepts DeepSeek usage naming (\input_tokens\ / \output_tokens\ / \input_tokens_details.cached_tokens\) alongside the OpenAI naming.
- **\_responsesReasoningText\** (new): extracts \	ype: reasoning\ items from the Responses \output\ array; non-stream responses now yield \ChatStreamChunk.reasoning\.
- **Streaming usage**: all Responses SSE usage branches (incl. \esponse.incomplete\, which is Cuplivo-only — upstream doesn't have this branch) route through the shared merge so cached-token stats work in every path.

## Tests

4 new tests in \	est/openai_deepseek_compat_test.dart\ (3 ported verbatim + 1 covering \esponse.incomplete\ cached tokens). All 6 tests in the file pass.

## Verification

- \dart format\ — clean
- \dart analyze --fatal-infos lib test\ — no issues
- \lutter test test/openai_deepseek_compat_test.dart\ — 6/6 pass

Closes #302