### PR TITLE
fix(ios): Live Activity 由内容变化驱动更新，移除 1Hz 强制刷新定时器

### DIFF
--- a/ios/GenerationActivityExtension/GenerationActivityExtension.swift
+++ b/ios/GenerationActivityExtension/GenerationActivityExtension.swift
@@ -137,13 +137,26 @@ private struct ActivityElapsedText: View {
   let context: ActivityViewContext<CuplivoGenerationActivityAttributes>
 
   var body: some View {
-    Text(elapsedText(seconds: context.state.elapsedSeconds))
-      .font(.caption2)
-      .fontWeight(.semibold)
-      .monospacedDigit()
-      .foregroundStyle(.secondary)
-      .lineLimit(1)
-      .minimumScaleFactor(0.72)
+    if context.state.isFinished {
+      // Finished: freeze at the captured elapsed time.
+      Text(elapsedText(seconds: context.state.elapsedSeconds))
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .monospacedDigit()
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.72)
+    } else {
+      // Running: system-driven timer — the widget ticks on its own and the
+      // host app does not need to push per-second updates.
+      Text(context.state.startedAt, style: .timer)
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .monospacedDigit()
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .minimumScaleFactor(0.72)
+    }
   }
 }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -85,7 +85,6 @@ private final class IosBackgroundGenerationHandler {
   private var notificationsEnabled = false
   private var refreshEnabled = false
   private var liveActivity: Any?
-  private var liveActivityRefreshTimer: Timer?
   private var liveActivityDisplayTitle = ""
   private var liveActivityDetail = ""
   private var liveActivityTokenCount = 0
@@ -94,7 +93,7 @@ private final class IosBackgroundGenerationHandler {
   private var liveActivityFinishedAt: Date?
   private var liveActivityFinishedDetail = ""
   private var liveActivityFinished = false
-  private var liveActivityWavePhase = 0
+  private var liveActivityUpdateScheduled = false
 
   func registerBackgroundTasks() {
     BGTaskScheduler.shared.register(forTaskWithIdentifier: backgroundRefreshIdentifier, using: nil) { task in
@@ -295,7 +294,6 @@ private final class IosBackgroundGenerationHandler {
       liveActivityFinishedAt = nil
       liveActivityFinishedDetail = ""
       liveActivityFinished = false
-      liveActivityWavePhase = 0
       liveActivityTokenCount = tokenCount
       liveActivityTokenLabel = tokenLabel
       let state = liveActivityState(
@@ -312,7 +310,6 @@ private final class IosBackgroundGenerationHandler {
         } else {
           liveActivity = try Activity<CuplivoGenerationActivityAttributes>.request(attributes: CuplivoGenerationActivityAttributes(title: title), contentState: state, pushType: nil)
         }
-        startLiveActivityRefreshTimer()
       } catch {
         NSLog("Cuplivo live activity start failed: \(error)")
         liveActivity = nil
@@ -327,6 +324,41 @@ private final class IosBackgroundGenerationHandler {
     liveActivityDetail = detail
     liveActivityFinishedAt = nil
     liveActivityFinishedDetail = ""
+    pushLiveActivityUpdate()
+  }
+
+  /// Coalesces rapid Dart `update()` calls into a single system update per
+  /// runloop turn: the first change schedules one dispatch, later changes in
+  /// the same turn are picked up by the snapshot built in
+  /// `performLiveActivityUpdate`.
+  private func pushLiveActivityUpdate() {
+    guard isLiveActivityActive(), !liveActivityFinished else { return }
+    if liveActivityUpdateScheduled { return }
+    liveActivityUpdateScheduled = true
+    DispatchQueue.main.async { [weak self] in
+      self?.liveActivityUpdateScheduled = false
+      self?.performLiveActivityUpdate()
+    }
+  }
+
+  private func performLiveActivityUpdate() {
+    guard #available(iOS 16.1, *), let activity = liveActivity as? Activity<CuplivoGenerationActivityAttributes> else { return }
+    guard !liveActivityFinished else { return }
+    let state = liveActivityState(
+      displayTitle: liveActivityDisplayTitle,
+      detail: liveActivityDetail,
+      tokenCount: liveActivityTokenCount,
+      tokenLabel: liveActivityTokenLabel,
+      finishedAt: nil,
+      isFinished: false
+    )
+    Task {
+      if #available(iOS 16.2, *) {
+        await activity.update(ActivityContent(state: state, staleDate: nil))
+      } else {
+        await activity.update(using: state)
+      }
+    }
   }
 
   func dismissFinishedLiveActivityIfNeeded() {
@@ -337,7 +369,6 @@ private final class IosBackgroundGenerationHandler {
   private func finishLiveActivity(title: String, detail: String) {
     liveActivityDisplayTitle = title
     liveActivityDetail = detail
-    stopLiveActivityRefreshTimer()
     if UIApplication.shared.applicationState == .active {
       liveActivityFinishedAt = Date()
       liveActivityFinishedDetail = detail
@@ -392,7 +423,6 @@ private final class IosBackgroundGenerationHandler {
         }
       }
       liveActivity = nil
-      stopLiveActivityRefreshTimer()
       liveActivityDisplayTitle = ""
       liveActivityDetail = ""
       liveActivityTokenCount = 0
@@ -401,42 +431,6 @@ private final class IosBackgroundGenerationHandler {
       liveActivityFinishedAt = nil
       liveActivityFinishedDetail = ""
       liveActivityFinished = false
-      liveActivityWavePhase = 0
-    }
-  }
-
-  private func startLiveActivityRefreshTimer() {
-    stopLiveActivityRefreshTimer()
-    let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
-      self?.refreshLiveActivity()
-    }
-    liveActivityRefreshTimer = timer
-    RunLoop.main.add(timer, forMode: .common)
-  }
-
-  private func stopLiveActivityRefreshTimer() {
-    liveActivityRefreshTimer?.invalidate()
-    liveActivityRefreshTimer = nil
-  }
-
-  private func refreshLiveActivity() {
-    guard #available(iOS 16.1, *), let activity = liveActivity as? Activity<CuplivoGenerationActivityAttributes> else { return }
-    guard !liveActivityFinished else { return }
-    liveActivityWavePhase += 1
-    let state = liveActivityState(
-      displayTitle: liveActivityDisplayTitle,
-      detail: liveActivityDetail,
-      tokenCount: liveActivityTokenCount,
-      tokenLabel: liveActivityTokenLabel,
-      finishedAt: nil,
-      isFinished: false
-    )
-    Task {
-      if #available(iOS 16.2, *) {
-        await activity.update(ActivityContent(state: state, staleDate: nil))
-      } else {
-        await activity.update(using: state)
-      }
     }
   }
 
@@ -461,7 +455,6 @@ private final class IosBackgroundGenerationHandler {
       elapsedSeconds: isFinished
         ? elapsedSeconds(from: startedAt, to: effectiveFinishedAt)
         : elapsedSeconds(since: startedAt),
-      wavePhase: liveActivityWavePhase,
       isFinished: isFinished
     )
   }

--- a/ios/Runner/KelivoGenerationActivityAttributes.swift
+++ b/ios/Runner/KelivoGenerationActivityAttributes.swift
@@ -11,7 +11,6 @@ struct CuplivoGenerationActivityAttributes: ActivityAttributes {
     var startedAt: Date
     var finishedAt: Date?
     var elapsedSeconds: Int
-    var wavePhase: Int
     var isFinished: Bool
   }
 


### PR DESCRIPTION
## Summary

修复 #371：iOS Live Activity 在生成期间以 1Hz 强制刷新 `activity.update()`，造成后台持续唤醒 + 消耗系统 frequent-update 预算；同时修复其根因——`updateLiveActivity()` 从不推送更新，只能靠 1Hz 定时器兜底。

## Root Cause

`ios/Runner/AppDelegate.swift` 中：

- `startLiveActivityRefreshTimer()` 用 `Timer(timeInterval: 1)` 挂在主 RunLoop `.common` 模式，生成全程每秒调一次 `activity.update()`；
- 而 Dart 侧每次流式更新调用的 `updateLiveActivity()` **只修改内存字段，从不调用 `activity.update()`**——事件驱动通道缺失，退化成无条件 1Hz 轮询；
- `wavePhase` 字段每秒自增但在 `GenerationActivityExtension.swift` 中**从未被渲染**（纯死代码）；
- `Info.plist` 声明了 `NSSupportsLiveActivitiesFrequentUpdates`（受每日预算限制），1Hz 连续刷新会被系统限流 → 倒计时中途冻结（想实时反而更不实时）；
- 后台生成场景下 1Hz 主循环唤醒会阻止 App 进入真正空闲，持续耗电。

## Changes

1. **`ios/Runner/AppDelegate.swift`**
   - `updateLiveActivity()` 现在真正调用 `activity.update()`（经 `pushLiveActivityUpdate` 在下一个 runloop tick 合并高频调用，避免并发 update 堆积）；
   - 删除 1 秒周期定时器（`startLiveActivityRefreshTimer` / `stopLiveActivityRefreshTimer` / `refreshLiveActivity`）；
   - 删除 `liveActivityWavePhase` 属性与 `liveActivityState` 中的 `wavePhase` 载荷。
2. **`ios/GenerationActivityExtension/GenerationActivityExtension.swift`**
   - 运行中倒计时改用 `Text(context.state.startedAt, style: .timer)`——由系统自驱动走秒，宿主零本地更新；
   - 完成态仍渲染 `elapsedSeconds` 静态快照（冻结在 finishedAt）。
3. **`ios/Runner/KelivoGenerationActivityAttributes.swift`**
   - `ContentState` 移除从未渲染的 `wavePhase` 字段。

## Impact

- 生成期间 `activity.update()` 从 1Hz → 仅在 detail/token 内容变化时推送；
- 后台生成不再被 1Hz 定时器持续唤醒；
- 锁屏/灵动岛倒计时仍每秒正常走秒（系统自驱动）；
- token 计数与 detail 文本实时性不受影响（此前依赖定时器兜底，现由事件驱动直接推送）。

## Manual Verification Plan

1. 前台生成 30s+：`log stream --predicate 'process == "Cuplivo"'` 观察 `activity.update` 频率不再 1Hz，仅在 token/detail 变化时出现；
2. 锁屏看 Live Activity：倒计时每秒走、token 计数随流式更新；
3. 后台生成（锁屏/切后台发起）：对比修复前后 Energy Log 的唤醒次数；
4. 生成完成：锁屏显示完成态且时间冻结在 finishedAt，回到前台后正常消失。

Closes #371