### PR TITLE
perf(ios): 沙箱命令注入 GOMAXPROCS/GODEBUG 降低 Go 负载在模拟器下的开销

### DIFF
--- a/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
+++ b/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
@@ -241,6 +241,13 @@ static dispatch_queue_t _readerQueue;
     ENVP_APPEND("PYTHONDONTWRITEBYTECODE=1");
     // V8 cannot JIT under emulation; node honours NODE_OPTIONS.
     ENVP_APPEND("NODE_OPTIONS=--jitless --max-old-space-size=512");
+    // Go tuning (ported from OpenMinis): cap the scheduler to one core-pair
+    // so it does not spin extra threads under the interpreter, and disable
+    // async preemption which is expensive under emulation.
+    ENVP_APPEND("GOMAXPROCS=2");
+    ENVP_APPEND("GODEBUG=asyncpreemptoff=1");
+    // OpenMinis also injects ENV=/etc/profile and node LD_PRELOAD=/lib/zero_free.so;
+    // both are intentionally omitted here pending rootfs confirmation (#361).
 
     // Device timezone for musl (POSIX TZ with fixed name; +/- abbreviations
     // confuse musl's parser — OpenMinis approach).


### PR DESCRIPTION
## Summary

修复 #361：iOS 沙箱 guest 环境未注入 Go 运行时调优变量，Go 类负载在 iSH 解释器下额外放大 CPU 开销。对照 OpenMinis `ISHShellExecutor.m` 补齐。

## Root Cause

`ios/Runner/iSHSandbox/CuplivoISHExecutor.m` 的 envp 已有 `NO_COLOR=1` / `PYTHONMALLOC=malloc` / `PYTHONDONTWRITEBYTECODE=1` / `NODE_OPTIONS=--jitless --max-old-space-size=512` 等，但缺少 OpenMinis 注入的 Go 调优项（此前 #361 评论中已核对，实际缺失项为 `GOMAXPROCS` / `GODEBUG` / `ENV` / `LD_PRELOAD`）。

## Changes

在 envp 中新增（来自 OpenMinis）：

```objc
ENVP_APPEND("GOMAXPROCS=2");                 // Go 调度器限制为核心对数量，避免在解释器下空转额外线程
ENVP_APPEND("GODEBUG=asyncpreemptoff=1");    // 关闭异步抢占——在模拟环境下的开销远大于收益
```

**有意不加**（已在代码注释说明）：

- `ENV=/etc/profile`：会改变非交互 shell 行为，需要 rootfs 确认后再评估；
- node `LD_PRELOAD=/lib/zero_free.so`：依赖 rootfs 内置该库，需确认后单独跟进。

## Impact

- Go 类负载（`go run` / Go 二进制）在沙箱内减少解释器下的调度空转与抢占开销；
- Python/Node/Shell 不受影响（这些变量对它们无副作用）。

## Verification

- 沙箱内 `go version` / 短 Go 程序，确认无报错；
- 对比注入前后 CPU 占用（Instruments / Energy Log）。

Closes #361