### PR TITLE
fix(storage): 补回缺失的「其他」分类，使总占用=分类之和、比例条正确

### DIFF
--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -150,6 +150,13 @@ abstract final class StorageUsageService {
       'other_logs': _MutableStats(),
     };
 
+    // Everything outside the known top-level directories lands in "other".
+    // Group it by top-level directory so users can actually see where the
+    // bytes went (workspaces, linux-sandbox, skills, fonts, root-level
+    // stray files, …). Key = top-level dir name; 'root_files' = loose files
+    // directly under appData.
+    final otherSubs = <String, _MutableStats>{};
+
     int totalBytes = 0;
     int totalFiles = 0;
 
@@ -198,6 +205,7 @@ abstract final class StorageUsageService {
             chatSubs[chatSubId]!.add(bytes);
           } else {
             byCat[StorageUsageCategoryKey.other]!.add(bytes);
+            (otherSubs['root_files'] ??= _MutableStats()).add(bytes);
           }
           continue;
         }
@@ -242,6 +250,7 @@ abstract final class StorageUsageService {
             break;
           default:
             byCat[StorageUsageCategoryKey.other]!.add(bytes);
+            (otherSubs[parts.first] ??= _MutableStats()).add(bytes);
             break;
         }
       }
@@ -406,6 +415,27 @@ abstract final class StorageUsageService {
               stats: logsSubs['other_logs']!.toStats(),
               path: logsDir.path,
             ),
+        ],
+      ),
+      // Everything not under upload/avatars/images/cache/logs. Previously the
+      // bytes were counted into totalBytes but the category was never added
+      // to this list, so total != sum(parts) and the usage bar was drawn
+      // against a fraction of the real total. Now surfaced with per-directory
+      // subcategories so users can see (and later manage) workspaces,
+      // linux-sandbox, skills, fonts and stray root files.
+      StorageUsageCategory(
+        key: StorageUsageCategoryKey.other,
+        stats: byCat[StorageUsageCategoryKey.other]!.toStats(),
+        subcategories: [
+          for (final e in otherSubs.entries)
+            if (e.value.bytes > 0 || e.value.fileCount > 0)
+              StorageUsageSubcategory(
+                id: e.key,
+                stats: e.value.toStats(),
+                path: e.key == 'root_files'
+                    ? root.path
+                    : p.join(root.path, e.key),
+              ),
         ],
       ),
       // Deleted records — informational entry (actual bytes loaded by the


### PR DESCRIPTION
## Summary

修复 #378：存储空间页「总占用」与「分类相加」永远对不上（用户实测：总占用 1.06 GB，分类相加仅 43.71 MB），比例条渲染失真，「其他」大块占用完全不可见。

## Root Cause

`lib/core/services/storage/storage_usage_service.dart` `computeReport()`：

- 统计循环把 `upload/avatars/images/cache/logs` 之外的所有文件计入 `byCat[other]`（并进入 `totalBytes`）；
- 但构建返回的 `categories` 列表**从未加入 `StorageUsageCategory(key: other)`**——`_categoryOrder` 常量里有它，列表构建时漏掉了。

后果（与用户截图逐一对应）：

1. `totalBytes`（1.06 GB）包含 workspaces / 沙箱 rootfs / skills / fonts 等 ~1 GB，分类列表却只有 43.71 MB → **总占用 ≠ 细项之和**；
2. `_UsageBar` / `_UsageLegend` 基于 `categories`（无 other）渲染 → 33 MB 缓存被画成 ~75% 的"大头"，与顶部 1.06 GB 完全失真；
3. 那 ~1 GB 占用对用户完全不可见、无任何管理入口 → "缓存特别高却清不掉"的直接体感来源（Android proot rootfs + 工作区通常最大）。

## Changes

- `computeReport()` 将 `other` 分类加回 `categories`，并按**顶层目录分组**填充子分类：`workspaces` / `linux-sandbox` / `skills` / `fonts` / `root_files`（appData 根目录散落文件）等，每个子项带大小、文件数、路径；
- 统计循环中 `parts.length == 1` 的非 sqlite 根文件、以及 default 分支，分别计入 `root_files` 与对应顶层目录子分类；
- `other` 分类大小/文件数直接来自 `byCat[other]`，与 `totalBytes` 口径一致。

## Impact

- 总量 = 细项之和（修复前 1.06 GB vs 43.71 MB → 修复后一致）；
- 比例条按真实总量渲染（other 作为灰色段正确占比，缓存不再"虚胖"）；
- 用户能看到"其他"里到底是什么（workspaces / 沙箱 / 技能 / 字体），为后续按子项提供管理入口打底（清理入口属于 #378 后续，本 PR 先做可见性）。

## Verification

- `computeReport()` 单测思路：构造 appData 下 workspaces/、skills/、根文件，断言 `totalBytes == sum(categories.stats.bytes)`、other 子分类出现且路径正确；
- 真机/模拟器：设置 → 存储空间，确认总占用与分类之和一致、比例条正确、其他分类可展开查看子项。

Closes #378