### PR TITLE
fix(ios): BGTask identifier 与 Info.plist 对齐（后台生成任务从未被调度）

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,8 +4,8 @@ import BackgroundTasks
 import UserNotifications
 import ActivityKit
 
-private let backgroundRefreshIdentifier = "psyche.cuplivo.background-generation.refresh"
-private let backgroundProcessingIdentifier = "psyche.cuplivo.background-generation.processing"
+private let backgroundRefreshIdentifier = "com.cup11.cuplivo.background-generation.refresh"
+private let backgroundProcessingIdentifier = "com.cup11.cuplivo.background-generation.processing"
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {


### PR DESCRIPTION
## 修复内容

`ios/Runner/AppDelegate.swift` 中 BGTask 的 identifier 与 `Info.plist` 的 `BGTaskSchedulerPermittedIdentifiers` 声明不一致：

| 位置 | 值 |
|---|---|
| AppDelegate 原值 | `psyche.cuplivo.background-generation.refresh` / `processing` |
| Info.plist 声明 | `com.cup11.cuplivo.background-generation.refresh` / `processing` |

**`BGTaskScheduler.register(forTaskWithIdentifier:)` 的 identifier 必须与 Info.plist 的 permitted list 完全匹配**，否则系统不会为该任务启动 App（注册被拒/静默不调度）。本 PR 将 AppDelegate 两个常量统一为 Info.plist 的值（`com.cup11.cuplivo.*`）。

## 影响

- 修复前：iOS「后台生成 + 系统刷新」的 BGTask 通道从未被系统调度过（#372 所述"空任务周期唤醒"实际连唤醒都不会发生，属于更深一层的失效）；
- 修复后：BGTask 可以正常注册与调度；handler 本身仍是占位实现（无实际续跑逻辑），该部分由 #372 继续跟踪。

## 验证

- 仅改两个字符串常量，无行为变更风险；
- identifier 与 Info.plist 声明逐字对齐。

Fixes #372