### PR TITLE
fix(ios): 沙箱 MethodChannel 回调统一切回主线程（shell 命令偶发无响应/崩溃）

### DIFF
--- a/ios/Runner/iSHSandbox/CuplivoLinuxSandboxPlugin.swift
+++ b/ios/Runner/iSHSandbox/CuplivoLinuxSandboxPlugin.swift
@@ -69,12 +69,17 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
       return
     }
     queue.async {
+      // FlutterResult must be called on the platform (main) thread; this
+      // queue is a background serial queue, so marshal the completion.
+      let complete: (Any?) -> Void = { value in
+        DispatchQueue.main.async { result(value) }
+      }
       do {
         try CuplivoSandboxRootfsInstaller.install(to: URL(fileURLWithPath: rootfsPath))
-        result(nil)
+        complete(nil)
       } catch {
         NSLog("CuplivoLinuxSandboxPlugin: installBase failed: \(error)")
-        result(
+        complete(
           FlutterError(
             code: "extract_failed", message: error.localizedDescription, details: nil))
       }
@@ -106,9 +111,16 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
     queue.async { [weak self] in
       guard let self else { return }
 
+      // FlutterResult must be called on the platform (main) thread; this
+      // queue and the executor callback are background threads, so marshal
+      // every completion through the main queue.
+      let complete: (Any?) -> Void = { value in
+        DispatchQueue.main.async { result(value) }
+      }
+
       let metaDb = URL(fileURLWithPath: rootfsPath).appendingPathComponent("meta.db")
       guard FileManager.default.fileExists(atPath: metaDb.path) else {
-        result(
+        complete(
           FlutterError(
             code: "rootfs_missing",
             message: "rootfs not installed at \(rootfsPath)",
@@ -120,7 +132,7 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
       if !kernel.isBooted {
         let err = kernel.boot(withRootPath: rootfsPath)
         if err < 0 {
-          result(
+          complete(
             FlutterError(
               code: "boot_failed",
               message: "iSH kernel boot failed: \(err)",
@@ -128,7 +140,7 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
           return
         }
       } else if kernel.bootRootPath != rootfsPath {
-        result(
+        complete(
           FlutterError(
             code: "boot_path_mismatch",
             message: "kernel already booted with a different rootfs; restart the app",
@@ -141,7 +153,7 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
       if self.mountedWorkspaceHostPath != workspacePath {
         let mountErr = kernel.bindMountPath("/workspace", toHostPath: workspacePath)
         if mountErr < 0 {
-          result(
+          complete(
             FlutterError(
               code: "mount_failed",
               message: "failed to mount workspace into guest: \(mountErr)",
@@ -169,7 +181,7 @@ final class CuplivoLinuxSandboxPlugin: NSObject {
         cwd: guestCwd,
         timeout: timeoutMs / 1000.0
       ) { execResult in
-        result(execResult)
+        complete(execResult)
       }
     }
   }


### PR DESCRIPTION
## 修复内容

`ios/Runner/iSHSandbox/CuplivoLinuxSandboxPlugin.swift` 的 `installBase` / `exec` 在**后台串行队列**里直接调用 `FlutterResult`（`exec` 更是在 `CuplivoISHExecutor` 的回调线程里回调），未切回主线程。Flutter 要求 `FlutterResult` 在 **platform thread（主线程）** 调用。

本 PR 为两处各引入 `complete` 闭包，统一 `DispatchQueue.main.async` 转发，覆盖所有完成路径：

- `installBase`：解压成功 / 失败；
- `exec`：`meta.db` 缺失、boot 失败、boot 路径不匹配、workspace 挂载失败、命令执行完成回调。

## 影响

- 修复前：沙箱 shell 命令偶发无响应/结果丢失/断言崩溃（debug 构建），超时与正常完成回调竞态；
- 修复后：所有 Flutter 回调回到主线程，与 Android 侧 `Handler(mainLooper)` 行为对齐。

## 验证

- 仅调整回调线程，不改变 channel 协议与语义；
- 每个完成路径恰好响应一次。

Fixes #381