### PR TITLE
feat: add iOS scheduled tasks

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C50000000000000000000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = C50000000000000000000010 /* Localizable.strings */; };
 		A10000000000000000000001 /* KelivoGenerationActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000010 /* KelivoGenerationActivityAttributes.swift */; };
 		A10000000000000000000002 /* KelivoGenerationActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000010 /* KelivoGenerationActivityAttributes.swift */; };
 		A10000000000000000000003 /* GenerationActivityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000011 /* GenerationActivityExtension.swift */; };
@@ -112,6 +113,9 @@
 		B15A000000000000000000B7 /* CuplivoLinuxSandboxPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuplivoLinuxSandboxPlugin.swift; sourceTree = "<group>"; };
 		B15A000000000000000000B8 /* CuplivoSandboxRootfsInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuplivoSandboxRootfsInstaller.swift; sourceTree = "<group>"; };
 		B15A000000000000000000B9 /* alpine-rootfs.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; name = "alpine-rootfs.zip"; path = "sandbox/resources/alpine-rootfs.zip"; sourceTree = SOURCE_ROOT; };
+		C50000000000000000000011 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C50000000000000000000012 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		C50000000000000000000013 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +202,7 @@
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
+				C50000000000000000000010 /* Localizable.strings */,
 				97C147021CF9000F007C117D /* Info.plist */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
@@ -378,6 +383,7 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+				C50000000000000000000001 /* Localizable.strings in Resources */,
 				B15A000000000000000000A6 /* alpine-rootfs.zip in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -565,6 +571,16 @@
 				54161FB12E6B1519001222B5 /* en */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		C50000000000000000000010 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C50000000000000000000011 /* en */,
+				C50000000000000000000012 /* zh-Hans */,
+				C50000000000000000000013 /* zh-Hant */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -569,19 +569,31 @@ private final class NativeFileSaveHandler: NSObject, UIDocumentPickerDelegate {
 // MARK: - iOS Shortcuts scheduled-task bridge
 
 @available(iOS 16.0, *)
-struct RunCuplivoScheduledTaskIntent: AppIntent {
-  static var title: LocalizedStringResource = "Run Cuplivo Scheduled Task"
+struct RunDueCuplivoScheduledTasksIntent: AppIntent {
+  static var title: LocalizedStringResource = "Run Due Cuplivo Scheduled Tasks"
   static var description = IntentDescription(
-    "Runs one Cuplivo scheduled task in the background using its Trigger ID."
+    "Runs every Cuplivo scheduled task that is due at the current local time."
   )
   static var openAppWhenRun: Bool { false }
 
-  @Parameter(title: "Trigger ID")
-  var triggerId: String
-
   func perform() async throws -> some IntentResult {
-    _ = await ScheduledTaskIntentBridge.shared.execute(triggerId: triggerId)
+    _ = await ScheduledTaskIntentBridge.shared.executeDueTasks()
     return .result()
+  }
+}
+
+@available(iOS 16.0, *)
+struct CuplivoScheduledTaskShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: RunDueCuplivoScheduledTasksIntent(),
+      phrases: [
+        "Run due tasks in \(.applicationName)",
+        "Run scheduled tasks in \(.applicationName)"
+      ],
+      shortTitle: "Run Due Scheduled Tasks",
+      systemImageName: "clock.badge.checkmark"
+    )
   }
 }
 
@@ -589,7 +601,8 @@ struct RunCuplivoScheduledTaskIntent: AppIntent {
 private final class ScheduledTaskIntentBridge {
   static let shared = ScheduledTaskIntentBridge()
 
-  private let pendingKey = "cuplivo.scheduled_tasks.pending_trigger_ids"
+  private let pendingDueSweepKey = "cuplivo.scheduled_tasks.pending_due_sweep"
+  private let legacyPendingTriggerIdsKey = "cuplivo.scheduled_tasks.pending_trigger_ids"
   private var channel: FlutterMethodChannel?
   private var dartReady = false
   private var backgroundTasks = [UUID: UIBackgroundTaskIdentifier]()
@@ -608,20 +621,17 @@ private final class ScheduledTaskIntentBridge {
       case "setReady":
         self.dartReady = true
         result(true)
-      case "consumePendingTriggers":
-        result(self.consumePendingTriggers())
+      case "consumePendingDueSweep":
+        result(self.consumePendingDueSweep())
       case "openShortcutSetup":
-        self.openShortcutSetup(arguments: call.arguments, result: result)
+        self.openShortcutSetup(result: result)
       default:
         result(FlutterMethodNotImplemented)
       }
     }
   }
 
-  func execute(triggerId: String) async -> Bool {
-    let id = triggerId.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !id.isEmpty else { return false }
-
+  func executeDueTasks() async -> Bool {
     // During a cold App Intent launch Flutter may still be booting. Wait a
     // small bounded amount of time for Dart to install its channel handler.
     for _ in 0..<24 {
@@ -630,7 +640,7 @@ private final class ScheduledTaskIntentBridge {
     }
 
     guard dartReady, let channel else {
-      enqueue(triggerId: id)
+      enqueueDueSweep()
       return false
     }
 
@@ -638,43 +648,54 @@ private final class ScheduledTaskIntentBridge {
     defer { endBackgroundTask(backgroundToken) }
 
     return await withCheckedContinuation { continuation in
-      channel.invokeMethod("executeTrigger", arguments: ["triggerId": id]) { response in
+      channel.invokeMethod("executeDueTasks", arguments: nil) { response in
         if response is FlutterError {
-          self.enqueue(triggerId: id)
+          self.enqueueDueSweep()
           continuation.resume(returning: false)
           return
         }
-        if let map = response as? [String: Any], map["handled"] as? Bool == true {
-          let title = (map["taskName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Cuplivo"
-          let body = (map["notificationBody"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-          self.showNotification(title: title.isEmpty ? "Cuplivo" : title, body: body)
-          continuation.resume(returning: map["success"] as? Bool ?? false)
-        } else {
-          // Unknown/disabled/completed/old Trigger IDs intentionally succeed
-          // silently so obsolete Personal Automations remain harmless.
-          continuation.resume(returning: true)
+
+        guard let rawResults = response as? [[String: Any]] else {
+          // No due tasks is a successful no-op. Dart returns an empty list in
+          // that case, which bridges as an NSArray and normally casts here.
+          if let array = response as? [Any], array.isEmpty {
+            continuation.resume(returning: true)
+          } else {
+            self.enqueueDueSweep()
+            continuation.resume(returning: false)
+          }
+          return
         }
+
+        var allSuccessful = true
+        for map in rawResults {
+          guard map["handled"] as? Bool == true else { continue }
+          let title = (map["taskName"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "Cuplivo"
+          let body = (map["notificationBody"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+          self.showNotification(
+            title: title.isEmpty ? "Cuplivo" : title,
+            body: body
+          )
+          if map["success"] as? Bool != true {
+            allSuccessful = false
+          }
+        }
+        continuation.resume(returning: allSuccessful)
       }
     }
   }
 
-  private func openShortcutSetup(arguments: Any?, result: @escaping FlutterResult) {
-    let args = arguments as? [String: Any] ?? [:]
-    let triggerId = (args["triggerId"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !triggerId.isEmpty else {
-      result(false)
-      return
-    }
-
+  private func openShortcutSetup(result: @escaping FlutterResult) {
     // Ask for notification permission while the app is foregrounded. A later
     // background App Intent cannot reliably present this permission sheet.
     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in
       DispatchQueue.main.async {
-        // Apple documents shortcuts://create-shortcut as the supported URL for
-        // entering the new-shortcut editor. Copy the exact Trigger ID so the
-        // user can paste it into the Cuplivo App Intent parameter.
-        UIPasteboard.general.string = triggerId
-        guard let url = URL(string: "shortcuts://create-shortcut") else {
+        // Cuplivo exposes a zero-setup App Shortcut named “Run Due Scheduled
+        // Tasks”. Opening Shortcuts (rather than the blank shortcut editor)
+        // lets the user create a Personal Automation and select that action.
+        guard let url = URL(string: "shortcuts://") else {
           result(false)
           return
         }
@@ -698,21 +719,24 @@ private final class ScheduledTaskIntentBridge {
     UNUserNotificationCenter.current().add(request)
   }
 
-  private func enqueue(triggerId: String) {
-    var pending = UserDefaults.standard.stringArray(forKey: pendingKey) ?? []
-    if !pending.contains(triggerId) { pending.append(triggerId) }
-    UserDefaults.standard.set(pending, forKey: pendingKey)
+  private func enqueueDueSweep() {
+    UserDefaults.standard.set(true, forKey: pendingDueSweepKey)
   }
 
-  private func consumePendingTriggers() -> [String] {
-    let pending = UserDefaults.standard.stringArray(forKey: pendingKey) ?? []
-    UserDefaults.standard.removeObject(forKey: pendingKey)
-    return pending
+  private func consumePendingDueSweep() -> Bool {
+    let pending = UserDefaults.standard.bool(forKey: pendingDueSweepKey)
+    UserDefaults.standard.removeObject(forKey: pendingDueSweepKey)
+
+    // Migrate any trigger-ID work queued by the previous development build to
+    // one due-task sweep. Old IDs are intentionally not interpreted anymore.
+    let legacy = UserDefaults.standard.stringArray(forKey: legacyPendingTriggerIdsKey) ?? []
+    UserDefaults.standard.removeObject(forKey: legacyPendingTriggerIdsKey)
+    return pending || !legacy.isEmpty
   }
 
   private func beginBackgroundTask() -> UUID? {
     let token = UUID()
-    let identifier = UIApplication.shared.beginBackgroundTask(withName: "CuplivoScheduledTaskIntent") { [weak self] in
+    let identifier = UIApplication.shared.beginBackgroundTask(withName: "CuplivoDueScheduledTasksIntent") { [weak self] in
       Task { @MainActor [weak self] in
         self?.endBackgroundTask(token)
       }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,6 +3,7 @@ import UIKit
 import BackgroundTasks
 import UserNotifications
 import ActivityKit
+import AppIntents
 
 private let backgroundRefreshIdentifier = "psyche.cuplivo.background-generation.refresh"
 private let backgroundProcessingIdentifier = "psyche.cuplivo.background-generation.processing"
@@ -58,6 +59,8 @@ private let backgroundProcessingIdentifier = "psyche.cuplivo.background-generati
       iosBackgroundChannel.setMethodCallHandler { [weak self] call, result in
         self?.backgroundGenerationHandler.handle(call: call, result: result)
       }
+
+      ScheduledTaskIntentBridge.shared.register(messenger: controller.binaryMessenger)
 
       // Exposes the real app tmp directory (NSTemporaryDirectory = <container>/tmp).
       // path_provider's getTemporaryDirectory() returns the Caches directory on
@@ -560,5 +563,167 @@ private final class NativeFileSaveHandler: NSObject, UIDocumentPickerDelegate {
       return topViewController(from: presented)
     }
     return controller
+  }
+}
+
+// MARK: - iOS Shortcuts scheduled-task bridge
+
+@available(iOS 16.0, *)
+struct RunCuplivoScheduledTaskIntent: AppIntent {
+  static var title: LocalizedStringResource = "Run Cuplivo Scheduled Task"
+  static var description = IntentDescription(
+    "Runs one Cuplivo scheduled task in the background using its Trigger ID."
+  )
+  static var openAppWhenRun: Bool { false }
+
+  @Parameter(title: "Trigger ID")
+  var triggerId: String
+
+  func perform() async throws -> some IntentResult {
+    _ = await ScheduledTaskIntentBridge.shared.execute(triggerId: triggerId)
+    return .result()
+  }
+}
+
+@MainActor
+private final class ScheduledTaskIntentBridge {
+  static let shared = ScheduledTaskIntentBridge()
+
+  private let pendingKey = "cuplivo.scheduled_tasks.pending_trigger_ids"
+  private var channel: FlutterMethodChannel?
+  private var dartReady = false
+  private var backgroundTasks = [UUID: UIBackgroundTaskIdentifier]()
+
+  private init() {}
+
+  func register(messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: "app.scheduled_tasks", binaryMessenger: messenger)
+    self.channel = channel
+    channel.setMethodCallHandler { [weak self] call, result in
+      guard let self else {
+        result(false)
+        return
+      }
+      switch call.method {
+      case "setReady":
+        self.dartReady = true
+        result(true)
+      case "consumePendingTriggers":
+        result(self.consumePendingTriggers())
+      case "openShortcutSetup":
+        self.openShortcutSetup(arguments: call.arguments, result: result)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  func execute(triggerId: String) async -> Bool {
+    let id = triggerId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !id.isEmpty else { return false }
+
+    // During a cold App Intent launch Flutter may still be booting. Wait a
+    // small bounded amount of time for Dart to install its channel handler.
+    for _ in 0..<24 {
+      if dartReady, channel != nil { break }
+      try? await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    guard dartReady, let channel else {
+      enqueue(triggerId: id)
+      return false
+    }
+
+    let backgroundToken = beginBackgroundTask()
+    defer { endBackgroundTask(backgroundToken) }
+
+    return await withCheckedContinuation { continuation in
+      channel.invokeMethod("executeTrigger", arguments: ["triggerId": id]) { response in
+        if response is FlutterError {
+          self.enqueue(triggerId: id)
+          continuation.resume(returning: false)
+          return
+        }
+        if let map = response as? [String: Any], map["handled"] as? Bool == true {
+          let title = (map["taskName"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "Cuplivo"
+          let body = (map["notificationBody"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+          self.showNotification(title: title.isEmpty ? "Cuplivo" : title, body: body)
+          continuation.resume(returning: map["success"] as? Bool ?? false)
+        } else {
+          // Unknown/disabled/completed/old Trigger IDs intentionally succeed
+          // silently so obsolete Personal Automations remain harmless.
+          continuation.resume(returning: true)
+        }
+      }
+    }
+  }
+
+  private func openShortcutSetup(arguments: Any?, result: @escaping FlutterResult) {
+    let args = arguments as? [String: Any] ?? [:]
+    let triggerId = (args["triggerId"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !triggerId.isEmpty else {
+      result(false)
+      return
+    }
+
+    // Ask for notification permission while the app is foregrounded. A later
+    // background App Intent cannot reliably present this permission sheet.
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _, _ in
+      DispatchQueue.main.async {
+        // Apple documents shortcuts://create-shortcut as the supported URL for
+        // entering the new-shortcut editor. Copy the exact Trigger ID so the
+        // user can paste it into the Cuplivo App Intent parameter.
+        UIPasteboard.general.string = triggerId
+        guard let url = URL(string: "shortcuts://create-shortcut") else {
+          result(false)
+          return
+        }
+        UIApplication.shared.open(url, options: [:]) { opened in
+          result(opened)
+        }
+      }
+    }
+  }
+
+  private func showNotification(title: String, body: String) {
+    let content = UNMutableNotificationContent()
+    content.title = title
+    content.body = body
+    content.sound = .default
+    let request = UNNotificationRequest(
+      identifier: "cuplivo.scheduled-task.\(UUID().uuidString)",
+      content: content,
+      trigger: nil
+    )
+    UNUserNotificationCenter.current().add(request)
+  }
+
+  private func enqueue(triggerId: String) {
+    var pending = UserDefaults.standard.stringArray(forKey: pendingKey) ?? []
+    if !pending.contains(triggerId) { pending.append(triggerId) }
+    UserDefaults.standard.set(pending, forKey: pendingKey)
+  }
+
+  private func consumePendingTriggers() -> [String] {
+    let pending = UserDefaults.standard.stringArray(forKey: pendingKey) ?? []
+    UserDefaults.standard.removeObject(forKey: pendingKey)
+    return pending
+  }
+
+  private func beginBackgroundTask() -> UUID? {
+    let token = UUID()
+    let identifier = UIApplication.shared.beginBackgroundTask(withName: "CuplivoScheduledTaskIntent") { [weak self] in
+      Task { @MainActor [weak self] in
+        self?.endBackgroundTask(token)
+      }
+    }
+    guard identifier != .invalid else { return nil }
+    backgroundTasks[token] = identifier
+    return token
+  }
+
+  private func endBackgroundTask(_ token: UUID?) {
+    guard let token, let identifier = backgroundTasks.removeValue(forKey: token) else { return }
+    UIApplication.shared.endBackgroundTask(identifier)
   }
 }

--- a/ios/Runner/en.lproj/Localizable.strings
+++ b/ios/Runner/en.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"Run Cuplivo Scheduled Task" = "Run Cuplivo Scheduled Task";
-"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "Runs one Cuplivo scheduled task in the background using its Trigger ID.";
-"Trigger ID" = "Trigger ID";
+"Run Due Cuplivo Scheduled Tasks" = "Run Due Cuplivo Scheduled Tasks";
+"Runs every Cuplivo scheduled task that is due at the current local time." = "Runs every Cuplivo scheduled task that is due at the current local time.";
+"Run Due Scheduled Tasks" = "Run Due Scheduled Tasks";

--- a/ios/Runner/en.lproj/Localizable.strings
+++ b/ios/Runner/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"Run Cuplivo Scheduled Task" = "Run Cuplivo Scheduled Task";
+"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "Runs one Cuplivo scheduled task in the background using its Trigger ID.";
+"Trigger ID" = "Trigger ID";

--- a/ios/Runner/zh-Hans.lproj/Localizable.strings
+++ b/ios/Runner/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"Run Cuplivo Scheduled Task" = "运行 Cuplivo 定时任务";
-"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "使用触发 ID 在后台运行一个 Cuplivo 定时任务。";
-"Trigger ID" = "触发 ID";
+"Run Due Cuplivo Scheduled Tasks" = "执行 Cuplivo 到期定时任务";
+"Runs every Cuplivo scheduled task that is due at the current local time." = "在后台执行当前本地时间已到期的所有 Cuplivo 定时任务。";
+"Run Due Scheduled Tasks" = "执行到期定时任务";

--- a/ios/Runner/zh-Hans.lproj/Localizable.strings
+++ b/ios/Runner/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"Run Cuplivo Scheduled Task" = "运行 Cuplivo 定时任务";
+"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "使用触发 ID 在后台运行一个 Cuplivo 定时任务。";
+"Trigger ID" = "触发 ID";

--- a/ios/Runner/zh-Hant.lproj/Localizable.strings
+++ b/ios/Runner/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"Run Cuplivo Scheduled Task" = "執行 Cuplivo 定時任務";
+"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "使用觸發 ID 在背景執行一個 Cuplivo 定時任務。";
+"Trigger ID" = "觸發 ID";

--- a/ios/Runner/zh-Hant.lproj/Localizable.strings
+++ b/ios/Runner/zh-Hant.lproj/Localizable.strings
@@ -1,3 +1,3 @@
-"Run Cuplivo Scheduled Task" = "執行 Cuplivo 定時任務";
-"Runs one Cuplivo scheduled task in the background using its Trigger ID." = "使用觸發 ID 在背景執行一個 Cuplivo 定時任務。";
-"Trigger ID" = "觸發 ID";
+"Run Due Cuplivo Scheduled Tasks" = "執行 Cuplivo 到期定時任務";
+"Runs every Cuplivo scheduled task that is due at the current local time." = "在背景執行目前本地時間已到期的所有 Cuplivo 定時任務。";
+"Run Due Scheduled Tasks" = "執行到期定時任務";

--- a/lib/core/models/scheduled_task.dart
+++ b/lib/core/models/scheduled_task.dart
@@ -1,0 +1,402 @@
+import 'dart:math' as math;
+
+/// Recurrence modes supported by iOS scheduled tasks.
+///
+/// Hourly recurrence is intentionally excluded from the first iOS version:
+/// Shortcuts' time-of-day automation is used as the daily wake-up gate, and
+/// Cuplivo decides whether the current local date belongs to the recurrence.
+enum ScheduledTaskFrequency { once, daily, weekly, monthly, yearly }
+
+enum ScheduledTaskExecutionStatus { success, failure }
+
+class ScheduledTaskLog {
+  const ScheduledTaskLog({
+    required this.id,
+    required this.triggeredAt,
+    required this.finishedAt,
+    required this.status,
+    this.conversationId,
+    this.error,
+  });
+
+  final String id;
+  final DateTime triggeredAt;
+  final DateTime finishedAt;
+  final ScheduledTaskExecutionStatus status;
+  final String? conversationId;
+  final String? error;
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'id': id,
+    'triggeredAt': triggeredAt.toIso8601String(),
+    'finishedAt': finishedAt.toIso8601String(),
+    'status': status.name,
+    if (conversationId != null) 'conversationId': conversationId,
+    if (error != null) 'error': error,
+  };
+
+  factory ScheduledTaskLog.fromJson(Map<String, dynamic> json) {
+    return ScheduledTaskLog(
+      id: (json['id'] ?? '').toString(),
+      triggeredAt:
+          DateTime.tryParse((json['triggeredAt'] ?? '').toString()) ??
+          DateTime.now(),
+      finishedAt:
+          DateTime.tryParse((json['finishedAt'] ?? '').toString()) ??
+          DateTime.now(),
+      status: ScheduledTaskExecutionStatus.values.firstWhere(
+        (value) => value.name == json['status'],
+        orElse: () => ScheduledTaskExecutionStatus.failure,
+      ),
+      conversationId: json['conversationId']?.toString(),
+      error: json['error']?.toString(),
+    );
+  }
+}
+
+class ScheduledTaskSchedule {
+  const ScheduledTaskSchedule({
+    required this.frequency,
+    required this.hour,
+    required this.minute,
+    this.interval = 1,
+    this.anchorDate,
+    this.weekdays = const <int>[],
+    this.monthDays = const <int>[],
+    this.yearMonth,
+    this.yearDay,
+    this.onceAt,
+  });
+
+  final ScheduledTaskFrequency frequency;
+  final int interval;
+  final int hour;
+  final int minute;
+
+  /// Local calendar anchor for every-N recurrence. Timezone is deliberately
+  /// not persisted: schedules follow the device's current local timezone.
+  final DateTime? anchorDate;
+
+  /// ISO weekdays: Monday=1 ... Sunday=7.
+  final List<int> weekdays;
+
+  /// Calendar days of month (1...31). Invalid dates in a particular month are
+  /// simply skipped for that month.
+  final List<int> monthDays;
+
+  final int? yearMonth;
+  final int? yearDay;
+  final DateTime? onceAt;
+
+  ScheduledTaskSchedule normalized() {
+    final normalizedInterval = math.max(1, interval);
+    final normalizedHour = hour.clamp(0, 23).toInt();
+    final normalizedMinute = minute.clamp(0, 59).toInt();
+    final now = DateTime.now();
+    final anchor = _dateOnly(anchorDate ?? onceAt ?? now);
+    final normalizedWeekdays = weekdays
+        .where((value) => value >= DateTime.monday && value <= DateTime.sunday)
+        .toSet()
+        .toList()
+      ..sort();
+    final normalizedMonthDays = monthDays
+        .where((value) => value >= 1 && value <= 31)
+        .toSet()
+        .toList()
+      ..sort();
+    final oneTime = onceAt;
+    return ScheduledTaskSchedule(
+      frequency: frequency,
+      interval: normalizedInterval,
+      hour: oneTime?.hour ?? normalizedHour,
+      minute: oneTime?.minute ?? normalizedMinute,
+      anchorDate: anchor,
+      weekdays: normalizedWeekdays,
+      monthDays: normalizedMonthDays,
+      yearMonth: (yearMonth ?? anchor.month).clamp(1, 12).toInt(),
+      yearDay: (yearDay ?? anchor.day).clamp(1, 31).toInt(),
+      onceAt: oneTime,
+    );
+  }
+
+  /// Whether a trigger received at [now] should execute this schedule.
+  ///
+  /// Shortcuts should invoke Cuplivo at the configured local clock time every
+  /// day. iOS may deliver an automation a little late, so a one-hour window is
+  /// accepted. The Trigger ID still identifies the exact task, so this window
+  /// never performs "nearest task" guessing.
+  bool matchesTrigger(DateTime now, {Duration tolerance = const Duration(hours: 1)}) {
+    final schedule = normalized();
+    final targetToday = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      schedule.hour,
+      schedule.minute,
+    );
+    final lateness = now.difference(targetToday);
+    if (lateness < const Duration(minutes: -1) || lateness > tolerance) {
+      return false;
+    }
+
+    final today = _dateOnly(now);
+    final anchor = _dateOnly(schedule.anchorDate ?? today);
+    if (today.isBefore(anchor) && schedule.frequency != ScheduledTaskFrequency.once) {
+      return false;
+    }
+
+    switch (schedule.frequency) {
+      case ScheduledTaskFrequency.once:
+        final once = schedule.onceAt;
+        if (once == null) return false;
+        return _sameDate(today, _dateOnly(once));
+      case ScheduledTaskFrequency.daily:
+        final days = _calendarDaysBetween(today, anchor);
+        return days >= 0 && days % schedule.interval == 0;
+      case ScheduledTaskFrequency.weekly:
+        final anchorWeek = anchor.subtract(Duration(days: anchor.weekday - 1));
+        final todayWeek = today.subtract(Duration(days: today.weekday - 1));
+        final weeks = _calendarDaysBetween(todayWeek, anchorWeek) ~/ 7;
+        final days = schedule.weekdays.isEmpty
+            ? <int>[anchor.weekday]
+            : schedule.weekdays;
+        return weeks >= 0 &&
+            weeks % schedule.interval == 0 &&
+            days.contains(today.weekday);
+      case ScheduledTaskFrequency.monthly:
+        final months = (today.year - anchor.year) * 12 + today.month - anchor.month;
+        final days = schedule.monthDays.isEmpty
+            ? <int>[anchor.day]
+            : schedule.monthDays;
+        return months >= 0 &&
+            months % schedule.interval == 0 &&
+            days.contains(today.day);
+      case ScheduledTaskFrequency.yearly:
+        final years = today.year - anchor.year;
+        return years >= 0 &&
+            years % schedule.interval == 0 &&
+            today.month == (schedule.yearMonth ?? anchor.month) &&
+            today.day == (schedule.yearDay ?? anchor.day);
+    }
+  }
+
+  /// Stable key for one due occurrence. Multiple Shortcuts may accidentally
+  /// point at the same Trigger ID, so execution claims this key before making
+  /// a model request and never retries that occurrence.
+  String? occurrenceKey(
+    DateTime now, {
+    Duration tolerance = const Duration(hours: 1),
+  }) {
+    if (!matchesTrigger(now, tolerance: tolerance)) return null;
+    final s = normalized();
+    final y = now.year.toString().padLeft(4, '0');
+    final m = now.month.toString().padLeft(2, '0');
+    final d = now.day.toString().padLeft(2, '0');
+    final h = s.hour.toString().padLeft(2, '0');
+    final min = s.minute.toString().padLeft(2, '0');
+    return '$y-$m-$d@$h:$min';
+  }
+
+  /// String used only for detecting whether editing a task invalidates the
+  /// existing Shortcut trigger binding.
+  String get triggerSignature {
+    final s = normalized();
+    return <Object?>[
+      s.frequency.name,
+      s.interval,
+      s.hour,
+      s.minute,
+      _dateKey(s.anchorDate),
+      s.weekdays.join(','),
+      s.monthDays.join(','),
+      s.yearMonth,
+      s.yearDay,
+      s.onceAt?.toIso8601String(),
+    ].join('|');
+  }
+
+  Map<String, dynamic> toJson() {
+    final s = normalized();
+    return <String, dynamic>{
+      'frequency': s.frequency.name,
+      'interval': s.interval,
+      'hour': s.hour,
+      'minute': s.minute,
+      if (s.anchorDate != null) 'anchorDate': _dateKey(s.anchorDate),
+      'weekdays': s.weekdays,
+      'monthDays': s.monthDays,
+      if (s.yearMonth != null) 'yearMonth': s.yearMonth,
+      if (s.yearDay != null) 'yearDay': s.yearDay,
+      if (s.onceAt != null) 'onceAt': s.onceAt!.toIso8601String(),
+    };
+  }
+
+  factory ScheduledTaskSchedule.fromJson(Map<String, dynamic> json) {
+    final frequency = ScheduledTaskFrequency.values.firstWhere(
+      (value) => value.name == json['frequency'],
+      orElse: () => ScheduledTaskFrequency.daily,
+    );
+    return ScheduledTaskSchedule(
+      frequency: frequency,
+      interval: (json['interval'] as num?)?.toInt() ?? 1,
+      hour: (json['hour'] as num?)?.toInt() ?? 8,
+      minute: (json['minute'] as num?)?.toInt() ?? 0,
+      anchorDate: _parseLocalDate(json['anchorDate']?.toString()),
+      weekdays: (json['weekdays'] as List? ?? const <dynamic>[])
+          .map((value) => (value as num).toInt())
+          .toList(growable: false),
+      monthDays: (json['monthDays'] as List? ?? const <dynamic>[])
+          .map((value) => (value as num).toInt())
+          .toList(growable: false),
+      yearMonth: (json['yearMonth'] as num?)?.toInt(),
+      yearDay: (json['yearDay'] as num?)?.toInt(),
+      onceAt: DateTime.tryParse((json['onceAt'] ?? '').toString()),
+    ).normalized();
+  }
+
+  static DateTime _dateOnly(DateTime value) =>
+      DateTime(value.year, value.month, value.day);
+
+  static bool _sameDate(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+
+  /// Calendar-day arithmetic deliberately uses UTC date shells so daylight
+  /// saving transitions cannot turn a local one-day step into 23 or 25 hours.
+  static int _calendarDaysBetween(DateTime a, DateTime b) {
+    final aUtc = DateTime.utc(a.year, a.month, a.day);
+    final bUtc = DateTime.utc(b.year, b.month, b.day);
+    return aUtc.difference(bUtc).inDays;
+  }
+
+  static String? _dateKey(DateTime? value) {
+    if (value == null) return null;
+    final y = value.year.toString().padLeft(4, '0');
+    final m = value.month.toString().padLeft(2, '0');
+    final d = value.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
+
+  static DateTime? _parseLocalDate(String? value) {
+    if (value == null || value.isEmpty) return null;
+    final parts = value.split('-');
+    if (parts.length != 3) return DateTime.tryParse(value);
+    final y = int.tryParse(parts[0]);
+    final m = int.tryParse(parts[1]);
+    final d = int.tryParse(parts[2]);
+    if (y == null || m == null || d == null) return null;
+    return DateTime(y, m, d);
+  }
+}
+
+class ScheduledTask {
+  const ScheduledTask({
+    required this.id,
+    required this.assistantId,
+    required this.name,
+    required this.prompt,
+    required this.schedule,
+    required this.triggerId,
+    required this.createdAt,
+    required this.updatedAt,
+    this.enabled = true,
+    this.connected = false,
+    this.completedAt,
+    this.lastAttemptOccurrenceKey,
+    this.logs = const <ScheduledTaskLog>[],
+  });
+
+  final String id;
+  final String assistantId;
+  final String name;
+  final String prompt;
+  final ScheduledTaskSchedule schedule;
+  final String triggerId;
+  final bool enabled;
+  final bool connected;
+  final DateTime? completedAt;
+  final String? lastAttemptOccurrenceKey;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final List<ScheduledTaskLog> logs;
+
+  bool get isCompleted =>
+      completedAt != null ||
+      (schedule.frequency == ScheduledTaskFrequency.once &&
+          lastAttemptOccurrenceKey != null);
+
+  ScheduledTask copyWith({
+    String? assistantId,
+    String? name,
+    String? prompt,
+    ScheduledTaskSchedule? schedule,
+    String? triggerId,
+    bool? enabled,
+    bool? connected,
+    DateTime? completedAt,
+    bool clearCompletedAt = false,
+    String? lastAttemptOccurrenceKey,
+    bool clearLastAttemptOccurrenceKey = false,
+    DateTime? updatedAt,
+    List<ScheduledTaskLog>? logs,
+  }) {
+    return ScheduledTask(
+      id: id,
+      assistantId: assistantId ?? this.assistantId,
+      name: name ?? this.name,
+      prompt: prompt ?? this.prompt,
+      schedule: schedule ?? this.schedule,
+      triggerId: triggerId ?? this.triggerId,
+      enabled: enabled ?? this.enabled,
+      connected: connected ?? this.connected,
+      completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
+      lastAttemptOccurrenceKey: clearLastAttemptOccurrenceKey
+          ? null
+          : (lastAttemptOccurrenceKey ?? this.lastAttemptOccurrenceKey),
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      logs: logs ?? this.logs,
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'id': id,
+    'assistantId': assistantId,
+    'name': name,
+    'prompt': prompt,
+    'schedule': schedule.toJson(),
+    'triggerId': triggerId,
+    'enabled': enabled,
+    'connected': connected,
+    if (completedAt != null) 'completedAt': completedAt!.toIso8601String(),
+    if (lastAttemptOccurrenceKey != null)
+      'lastAttemptOccurrenceKey': lastAttemptOccurrenceKey,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'logs': logs.map((log) => log.toJson()).toList(growable: false),
+  };
+
+  factory ScheduledTask.fromJson(Map<String, dynamic> json) {
+    final now = DateTime.now();
+    return ScheduledTask(
+      id: (json['id'] ?? '').toString(),
+      assistantId: (json['assistantId'] ?? '').toString(),
+      name: (json['name'] ?? '').toString(),
+      prompt: (json['prompt'] ?? '').toString(),
+      schedule: ScheduledTaskSchedule.fromJson(
+        (json['schedule'] as Map? ?? const <String, dynamic>{})
+            .cast<String, dynamic>(),
+      ),
+      triggerId: (json['triggerId'] ?? '').toString(),
+      enabled: json['enabled'] != false,
+      connected: json['connected'] == true,
+      completedAt: DateTime.tryParse((json['completedAt'] ?? '').toString()),
+      lastAttemptOccurrenceKey: json['lastAttemptOccurrenceKey']?.toString(),
+      createdAt: DateTime.tryParse((json['createdAt'] ?? '').toString()) ?? now,
+      updatedAt: DateTime.tryParse((json['updatedAt'] ?? '').toString()) ?? now,
+      logs: (json['logs'] as List? ?? const <dynamic>[])
+          .whereType<Map>()
+          .map((raw) => ScheduledTaskLog.fromJson(raw.cast<String, dynamic>()))
+          .toList(growable: false),
+    );
+  }
+}

--- a/lib/core/models/scheduled_task.dart
+++ b/lib/core/models/scheduled_task.dart
@@ -123,8 +123,8 @@ class ScheduledTaskSchedule {
   ///
   /// Shortcuts should invoke Cuplivo at the configured local clock time every
   /// day. iOS may deliver an automation a little late, so a one-hour window is
-  /// accepted. The Trigger ID still identifies the exact task, so this window
-  /// never performs "nearest task" guessing.
+  /// accepted. The shared Shortcut action scans all tasks, but only schedules
+  /// inside this local-time window are considered due.
   bool matchesTrigger(DateTime now, {Duration tolerance = const Duration(hours: 1)}) {
     final schedule = normalized();
     final targetToday = DateTime(
@@ -180,9 +180,9 @@ class ScheduledTaskSchedule {
     }
   }
 
-  /// Stable key for one due occurrence. Multiple Shortcuts may accidentally
-  /// point at the same Trigger ID, so execution claims this key before making
-  /// a model request and never retries that occurrence.
+  /// Stable key for one due occurrence. Multiple Personal Automations may
+  /// accidentally invoke the shared action around the same time, so execution
+  /// claims this key before making a model request and never retries it.
   String? occurrenceKey(
     DateTime now, {
     Duration tolerance = const Duration(hours: 1),

--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -419,7 +419,7 @@ class McpProvider extends ChangeNotifier {
   }) : oauthFlowService =
            oauthFlowService ??
            OAuthFlowService(clientFactory: oauthClientFactory) {
-    _load();
+    _initialLoad = _load();
   }
 
   final ChatService? chatService;
@@ -427,6 +427,12 @@ class McpProvider extends ChangeNotifier {
 
   /// Provider-agnostic OAuth flow orchestration (see ADR-0015).
   final OAuthFlowService oauthFlowService;
+
+  late final Future<void> _initialLoad;
+
+  /// Resolves after persisted MCP server configuration has been loaded and
+  /// automatic connection attempts have been started.
+  Future<void> ensureLoaded() => _initialLoad;
 
   final Map<String, mcp.Client> _clients = {};
   final Map<String, McpStatus> _status = {}; // id -> status

--- a/lib/core/providers/scheduled_task_provider.dart
+++ b/lib/core/providers/scheduled_task_provider.dart
@@ -175,14 +175,24 @@ class ScheduledTaskProvider extends ChangeNotifier {
     await ensureLoaded();
     final index = _tasks.indexWhere((task) => task.id == id);
     if (index < 0) return null;
-    final next = _tasks[index].copyWith(
-      connected: true,
-      updatedAt: DateTime.now(),
-    );
-    _tasks[index] = next;
+
+    // One iOS Personal Automation is enough for every task that uses the same
+    // local clock time. Mark the whole time slot connected so the UI does not
+    // ask the user to create duplicate automations for 08:00, for example.
+    final target = _tasks[index].schedule.normalized();
+    final connectedAt = DateTime.now();
+    for (var i = 0; i < _tasks.length; i++) {
+      final schedule = _tasks[i].schedule.normalized();
+      if (schedule.hour == target.hour && schedule.minute == target.minute) {
+        _tasks[i] = _tasks[i].copyWith(
+          connected: true,
+          updatedAt: connectedAt,
+        );
+      }
+    }
     await _persist();
     notifyListeners();
-    return next;
+    return getById(id);
   }
 
   Future<ScheduledTask?> setEnabled(String id, bool value) async {

--- a/lib/core/providers/scheduled_task_provider.dart
+++ b/lib/core/providers/scheduled_task_provider.dart
@@ -1,0 +1,263 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/scheduled_task.dart';
+
+class ScheduledTaskProvider extends ChangeNotifier {
+  static const String _tasksKey = 'ios_scheduled_tasks_v1';
+  static const String _allowAiKey = 'ios_scheduled_tasks_allow_ai_v1';
+  static const String _approvalKey = 'ios_scheduled_tasks_ai_approval_v1';
+  static const int _maxLogsPerTask = 100;
+  static const Uuid _uuid = Uuid();
+
+  final List<ScheduledTask> _tasks = <ScheduledTask>[];
+  bool _loaded = false;
+  Future<void>? _loadFuture;
+  bool _allowAiOperations = false;
+  bool _aiRequiresApproval = true;
+
+  bool get isLoaded => _loaded;
+  bool get allowAiOperations => _allowAiOperations;
+  bool get aiRequiresApproval => _aiRequiresApproval;
+
+  List<ScheduledTask> get tasks {
+    final copy = List<ScheduledTask>.of(_tasks);
+    copy.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return List.unmodifiable(copy);
+  }
+
+  Future<void> init() => ensureLoaded();
+
+  Future<void> ensureLoaded() {
+    if (_loaded) return Future<void>.value();
+    return _loadFuture ??= _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      _allowAiOperations = prefs.getBool(_allowAiKey) ?? false;
+      _aiRequiresApproval = prefs.getBool(_approvalKey) ?? true;
+      final raw = prefs.getString(_tasksKey);
+      if (raw != null && raw.isNotEmpty) {
+        final decoded = jsonDecode(raw);
+        if (decoded is List) {
+          _tasks
+            ..clear()
+            ..addAll(
+              decoded
+                  .whereType<Map>()
+                  .map(
+                    (entry) => ScheduledTask.fromJson(
+                      entry.cast<String, dynamic>(),
+                    ),
+                  )
+                  .where(
+                    (task) =>
+                        task.id.isNotEmpty &&
+                        task.assistantId.isNotEmpty &&
+                        task.triggerId.isNotEmpty,
+                  ),
+            );
+        }
+      }
+    } catch (error) {
+      debugPrint('[ScheduledTaskProvider] load failed: $error');
+    } finally {
+      _loaded = true;
+      _loadFuture = null;
+      notifyListeners();
+    }
+  }
+
+  Future<void> setAllowAiOperations(bool value) async {
+    await ensureLoaded();
+    if (_allowAiOperations == value) return;
+    _allowAiOperations = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_allowAiKey, value);
+    notifyListeners();
+  }
+
+  Future<void> setAiRequiresApproval(bool value) async {
+    await ensureLoaded();
+    if (_aiRequiresApproval == value) return;
+    _aiRequiresApproval = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_approvalKey, value);
+    notifyListeners();
+  }
+
+  Future<ScheduledTask> createTask({
+    required String assistantId,
+    required String name,
+    required String prompt,
+    required ScheduledTaskSchedule schedule,
+    bool enabled = true,
+  }) async {
+    await ensureLoaded();
+    final now = DateTime.now();
+    final task = ScheduledTask(
+      id: _uuid.v4(),
+      assistantId: assistantId,
+      name: name.trim(),
+      prompt: prompt.trim(),
+      schedule: schedule.normalized(),
+      triggerId: _newTriggerId(),
+      enabled: enabled,
+      connected: false,
+      createdAt: now,
+      updatedAt: now,
+    );
+    _tasks.add(task);
+    await _persist();
+    notifyListeners();
+    return task;
+  }
+
+  ScheduledTask? getById(String id) {
+    for (final task in _tasks) {
+      if (task.id == id) return task;
+    }
+    return null;
+  }
+
+  ScheduledTask? getByTriggerId(String triggerId) {
+    for (final task in _tasks) {
+      if (task.triggerId == triggerId) return task;
+    }
+    return null;
+  }
+
+  List<ScheduledTask> forAssistant(String assistantId) {
+    return tasks
+        .where((task) => task.assistantId == assistantId)
+        .toList(growable: false);
+  }
+
+  Future<ScheduledTask?> updateTask({
+    required String id,
+    String? assistantId,
+    String? name,
+    String? prompt,
+    ScheduledTaskSchedule? schedule,
+    bool? enabled,
+  }) async {
+    await ensureLoaded();
+    final index = _tasks.indexWhere((task) => task.id == id);
+    if (index < 0) return null;
+    final old = _tasks[index];
+    final nextSchedule = (schedule ?? old.schedule).normalized();
+    final scheduleChanged =
+        nextSchedule.triggerSignature != old.schedule.triggerSignature;
+    final next = old.copyWith(
+      assistantId: assistantId,
+      name: name?.trim(),
+      prompt: prompt?.trim(),
+      schedule: nextSchedule,
+      enabled: enabled,
+      triggerId: scheduleChanged ? _newTriggerId() : old.triggerId,
+      connected: scheduleChanged ? false : old.connected,
+      clearCompletedAt: scheduleChanged,
+      clearLastAttemptOccurrenceKey: scheduleChanged,
+      updatedAt: DateTime.now(),
+    );
+    _tasks[index] = next;
+    await _persist();
+    notifyListeners();
+    return next;
+  }
+
+  Future<ScheduledTask?> markConnected(String id) async {
+    await ensureLoaded();
+    final index = _tasks.indexWhere((task) => task.id == id);
+    if (index < 0) return null;
+    final next = _tasks[index].copyWith(
+      connected: true,
+      updatedAt: DateTime.now(),
+    );
+    _tasks[index] = next;
+    await _persist();
+    notifyListeners();
+    return next;
+  }
+
+  Future<ScheduledTask?> setEnabled(String id, bool value) async {
+    return updateTask(id: id, enabled: value);
+  }
+
+  Future<bool> deleteTask(String id) async {
+    await ensureLoaded();
+    final before = _tasks.length;
+    _tasks.removeWhere((task) => task.id == id);
+    if (_tasks.length == before) return false;
+    await _persist();
+    notifyListeners();
+    return true;
+  }
+
+  Future<bool> claimOccurrence({
+    required String taskId,
+    required String triggerId,
+    required String occurrenceKey,
+  }) async {
+    await ensureLoaded();
+    final index = _tasks.indexWhere((task) => task.id == taskId);
+    if (index < 0) return false;
+    final task = _tasks[index];
+    if (task.triggerId != triggerId ||
+        !task.enabled ||
+        task.isCompleted ||
+        task.lastAttemptOccurrenceKey == occurrenceKey) {
+      return false;
+    }
+    _tasks[index] = task.copyWith(
+      lastAttemptOccurrenceKey: occurrenceKey,
+      updatedAt: DateTime.now(),
+    );
+    await _persist();
+    notifyListeners();
+    return true;
+  }
+
+  Future<void> recordLog(String taskId, ScheduledTaskLog log) async {
+    await ensureLoaded();
+    final index = _tasks.indexWhere((task) => task.id == taskId);
+    if (index < 0) return;
+    final logs = <ScheduledTaskLog>[log, ..._tasks[index].logs];
+    if (logs.length > _maxLogsPerTask) {
+      logs.removeRange(_maxLogsPerTask, logs.length);
+    }
+    _tasks[index] = _tasks[index].copyWith(
+      logs: logs,
+      updatedAt: DateTime.now(),
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> markOnceCompleted(String taskId, DateTime completedAt) async {
+    await ensureLoaded();
+    final index = _tasks.indexWhere((task) => task.id == taskId);
+    if (index < 0) return;
+    _tasks[index] = _tasks[index].copyWith(
+      completedAt: completedAt,
+      updatedAt: DateTime.now(),
+    );
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _tasksKey,
+      jsonEncode(_tasks.map((task) => task.toJson()).toList(growable: false)),
+    );
+  }
+
+  static String _newTriggerId() => _uuid.v4().replaceAll('-', '');
+}

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -648,8 +648,16 @@ class SettingsProvider extends ChangeNotifier {
   int get appLaunchCount => _appLaunchCount;
 
   SettingsProvider() {
-    _load();
+    _initialLoad = _load();
   }
+
+  late final Future<void> _initialLoad;
+
+  /// Resolves once persisted settings and model/provider configuration have
+  /// finished loading. Normal UI callers do not need to await this, but a
+  /// cold iOS App Intent must not start a scheduled model request against the
+  /// constructor defaults before SharedPreferences has been restored.
+  Future<void> ensureLoaded() => _initialLoad;
 
   Future<_MigrationResult> _migrateEmbeddingModelOverrides(
     SharedPreferences prefs,

--- a/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
+++ b/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
@@ -77,6 +77,7 @@ class IosScheduledTaskBridge {
       final context = _contextProvider?.call();
       if (context != null) {
         return ScheduledTaskExecutionService.executeTrigger(
+          // ignore: use_build_context_synchronously (root context, valid for app lifetime)
           context: context,
           triggerId: triggerId,
         );

--- a/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
+++ b/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'scheduled_task_execution_service.dart';
+
+class IosScheduledTaskBridge {
+  IosScheduledTaskBridge._();
+
+  static final IosScheduledTaskBridge instance = IosScheduledTaskBridge._();
+  static const MethodChannel _channel = MethodChannel('app.scheduled_tasks');
+
+  bool _initialized = false;
+  BuildContext? Function()? _contextProvider;
+
+  bool get isSupported =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
+  Future<void> initialize(BuildContext? Function() contextProvider) async {
+    if (!isSupported) return;
+    _contextProvider = contextProvider;
+    if (_initialized) return;
+    _initialized = true;
+    _channel.setMethodCallHandler(_handleNativeCall);
+    try {
+      await _channel.invokeMethod<bool>('setReady');
+      final pending = await _channel.invokeListMethod<String>(
+        'consumePendingTriggers',
+      );
+      for (final triggerId in pending ?? const <String>[]) {
+        if (triggerId.trim().isEmpty) continue;
+        unawaited(_executeWhenContextReady(triggerId.trim()));
+      }
+    } catch (error) {
+      debugPrint('[ScheduledTaskBridge] initialization failed: $error');
+    }
+  }
+
+  Future<bool> openShortcutSetup({
+    required String triggerId,
+    required String taskName,
+  }) async {
+    if (!isSupported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('openShortcutSetup', <String, Object?>{
+            'triggerId': triggerId,
+            'taskName': taskName,
+          }) ??
+          false;
+    } catch (error) {
+      debugPrint('[ScheduledTaskBridge] open Shortcuts failed: $error');
+      return false;
+    }
+  }
+
+  Future<dynamic> _handleNativeCall(MethodCall call) async {
+    if (call.method != 'executeTrigger') return null;
+    final args = call.arguments;
+    final triggerId = args is Map ? args['triggerId']?.toString().trim() : null;
+    if (triggerId == null || triggerId.isEmpty) {
+      return const <String, dynamic>{'handled': false, 'success': false};
+    }
+    final result = await _executeWhenContextReady(triggerId);
+    return result.toMap();
+  }
+
+  Future<ScheduledTaskExecutionResult> _executeWhenContextReady(
+    String triggerId,
+  ) async {
+    // Flutter can receive an App Intent during cold startup before the first
+    // MaterialApp frame exposes navigatorKey.currentContext. Give startup a
+    // short bounded window; the native side also queues triggers until Dart
+    // declares itself ready.
+    for (var attempt = 0; attempt < 40; attempt++) {
+      final context = _contextProvider?.call();
+      if (context != null) {
+        return ScheduledTaskExecutionService.executeTrigger(
+          context: context,
+          triggerId: triggerId,
+        );
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    return const ScheduledTaskExecutionResult(
+      handled: false,
+      error: 'flutter_context_unavailable',
+    );
+  }
+}

--- a/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
+++ b/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
@@ -65,6 +65,7 @@ class IosScheduledTaskBridge {
     for (var attempt = 0; attempt < 40; attempt++) {
       final context = _contextProvider?.call();
       if (context != null) {
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         return ScheduledTaskExecutionService.executeDueTasks(context: context);
       }
       await Future<void>.delayed(const Duration(milliseconds: 100));

--- a/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
+++ b/lib/core/services/scheduled_tasks/ios_scheduled_task_bridge.dart
@@ -26,28 +26,23 @@ class IosScheduledTaskBridge {
     _channel.setMethodCallHandler(_handleNativeCall);
     try {
       await _channel.invokeMethod<bool>('setReady');
-      final pending = await _channel.invokeListMethod<String>(
-        'consumePendingTriggers',
-      );
-      for (final triggerId in pending ?? const <String>[]) {
-        if (triggerId.trim().isEmpty) continue;
-        unawaited(_executeWhenContextReady(triggerId.trim()));
+      final pending =
+          await _channel.invokeMethod<bool>('consumePendingDueSweep') ?? false;
+      if (pending) {
+        unawaited(_executeDueTasksWhenContextReady());
       }
     } catch (error) {
       debugPrint('[ScheduledTaskBridge] initialization failed: $error');
     }
   }
 
-  Future<bool> openShortcutSetup({
-    required String triggerId,
-    required String taskName,
-  }) async {
+  Future<bool> openShortcutSetup({required String taskName}) async {
     if (!isSupported) return false;
     try {
-      return await _channel.invokeMethod<bool>('openShortcutSetup', <String, Object?>{
-            'triggerId': triggerId,
-            'taskName': taskName,
-          }) ??
+      return await _channel.invokeMethod<bool>(
+            'openShortcutSetup',
+            <String, Object?>{'taskName': taskName},
+          ) ??
           false;
     } catch (error) {
       debugPrint('[ScheduledTaskBridge] open Shortcuts failed: $error');
@@ -56,37 +51,24 @@ class IosScheduledTaskBridge {
   }
 
   Future<dynamic> _handleNativeCall(MethodCall call) async {
-    if (call.method != 'executeTrigger') return null;
-    final args = call.arguments;
-    final triggerId = args is Map ? args['triggerId']?.toString().trim() : null;
-    if (triggerId == null || triggerId.isEmpty) {
-      return const <String, dynamic>{'handled': false, 'success': false};
-    }
-    final result = await _executeWhenContextReady(triggerId);
-    return result.toMap();
+    if (call.method != 'executeDueTasks') return null;
+    final results = await _executeDueTasksWhenContextReady();
+    return results.map((result) => result.toMap()).toList(growable: false);
   }
 
-  Future<ScheduledTaskExecutionResult> _executeWhenContextReady(
-    String triggerId,
-  ) async {
+  Future<List<ScheduledTaskExecutionResult>>
+  _executeDueTasksWhenContextReady() async {
     // Flutter can receive an App Intent during cold startup before the first
     // MaterialApp frame exposes navigatorKey.currentContext. Give startup a
-    // short bounded window; the native side also queues triggers until Dart
-    // declares itself ready.
+    // short bounded window; the native side also queues one due-task sweep
+    // until Dart declares itself ready.
     for (var attempt = 0; attempt < 40; attempt++) {
       final context = _contextProvider?.call();
       if (context != null) {
-        return ScheduledTaskExecutionService.executeTrigger(
-          // ignore: use_build_context_synchronously (root context, valid for app lifetime)
-          context: context,
-          triggerId: triggerId,
-        );
+        return ScheduledTaskExecutionService.executeDueTasks(context: context);
       }
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
-    return const ScheduledTaskExecutionResult(
-      handled: false,
-      error: 'flutter_context_unavailable',
-    );
+    return const <ScheduledTaskExecutionResult>[];
   }
 }

--- a/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
@@ -1,0 +1,402 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../features/home/services/local_tools_service.dart';
+import '../../../features/home/services/message_builder_service.dart';
+import '../../../features/home/services/message_generation_service.dart';
+import '../../../features/home/services/tool_handler_service.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../models/assistant.dart';
+import '../../models/scheduled_task.dart';
+import '../../models/workspace.dart';
+import '../../providers/assistant_provider.dart';
+import '../../providers/mcp_provider.dart';
+import '../../providers/scheduled_task_provider.dart';
+import '../../providers/settings_provider.dart';
+import '../../providers/workspace_provider.dart';
+import '../chat/chat_service.dart';
+import '../generation_engine.dart';
+import 'scheduled_task_tool_service.dart';
+
+class ScheduledTaskExecutionResult {
+  const ScheduledTaskExecutionResult({
+    required this.handled,
+    this.success = false,
+    this.taskName,
+    this.error,
+    this.notificationBody,
+  });
+
+  final bool handled;
+  final bool success;
+  final String? taskName;
+  final String? error;
+  final String? notificationBody;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+    'handled': handled,
+    'success': success,
+    if (taskName != null) 'taskName': taskName,
+    if (error != null) 'error': error,
+    if (notificationBody != null) 'notificationBody': notificationBody,
+  };
+}
+
+/// Executes a Shortcut-triggered task through the same tool-bearing generation
+/// engine used by normal chats and handoffs.
+///
+/// The task always creates a fresh conversation. Interactive tools are removed
+/// from the background tool list rather than being allowed to block forever on
+/// an approval/ask-user UI that cannot be answered while the app is headless.
+class ScheduledTaskExecutionService {
+  const ScheduledTaskExecutionService._();
+
+  static const Uuid _uuid = Uuid();
+
+  static Future<ScheduledTaskExecutionResult> executeTrigger({
+    required BuildContext context,
+    required String triggerId,
+  }) async {
+    final taskProvider = context.read<ScheduledTaskProvider>();
+    await taskProvider.ensureLoaded();
+
+    final task = taskProvider.getByTriggerId(triggerId);
+    if (task == null || !task.enabled || task.isCompleted) {
+      return const ScheduledTaskExecutionResult(handled: false);
+    }
+
+    final now = DateTime.now();
+    final occurrenceKey = task.schedule.occurrenceKey(now);
+    if (occurrenceKey == null) {
+      return const ScheduledTaskExecutionResult(handled: false);
+    }
+    final claimed = await taskProvider.claimOccurrence(
+      taskId: task.id,
+      triggerId: triggerId,
+      occurrenceKey: occurrenceKey,
+    );
+    if (!claimed) {
+      return const ScheduledTaskExecutionResult(handled: false);
+    }
+
+    final startedAt = now;
+    String? conversationId;
+    final l10n = AppLocalizations.of(context);
+
+    try {
+      final chatService = context.read<ChatService>();
+      await chatService.init();
+      final assistantProvider = context.read<AssistantProvider>();
+      await assistantProvider.ensureLoaded();
+      final assistant = assistantProvider.getById(task.assistantId);
+      if (assistant == null) {
+        throw StateError('assistant_not_found');
+      }
+
+      final conversation = await chatService.createConversation(
+        title: task.name,
+        assistantId: assistant.id,
+        mcpServerIds: assistant.mcpServerIds,
+        setAsCurrent: false,
+      );
+      conversationId = conversation.id;
+      await chatService.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: task.prompt,
+      );
+
+      // Cold App Intent launches can reach generation before lazily-loaded
+      // providers finish initialization. Wait for workspace metadata and the
+      // selected MCP connections for a short bounded window so the scheduled
+      // assistant inherits the same non-interactive capabilities it normally
+      // has in a foreground conversation.
+      final workspaceProvider = context.read<WorkspaceProvider>();
+      await workspaceProvider.init();
+      final mcpProvider = context.read<McpProvider>();
+      await mcpProvider.ensureLoaded();
+      await _waitForSelectedMcpConnections(mcpProvider, assistant);
+
+      final settings = context.read<SettingsProvider>();
+      await settings.ensureLoaded();
+      final providerKey =
+          assistant.chatModelProvider ?? settings.currentModelProvider;
+      final modelId = assistant.chatModelId ?? settings.currentModelId;
+      if (providerKey == null ||
+          providerKey.isEmpty ||
+          modelId == null ||
+          modelId.isEmpty) {
+        throw StateError('model_not_configured');
+      }
+      final config = settings.getProviderConfig(providerKey);
+
+      final builder = MessageBuilderService(
+        chatService: chatService,
+        contextProvider: context,
+      );
+      final messages = chatService.getMessages(conversation.id);
+      final apiMessages = builder.buildApiMessages(
+        messages: messages,
+        versionSelections: const <String, int>{},
+        currentConversation: conversation,
+      );
+      await builder.processUserMessagesForApi(
+        apiMessages,
+        settings,
+        assistant,
+        providerKey: providerKey,
+        modelId: modelId,
+      );
+      builder.injectSystemPrompt(apiMessages, assistant, modelId);
+      await builder.injectMemoryAndRecentChats(
+        apiMessages,
+        assistant,
+        currentConversationId: conversation.id,
+      );
+      final hasBuiltInSearch = builder.hasBuiltInSearch(
+        settings,
+        providerKey,
+        modelId,
+      );
+      builder.injectSearchPrompt(
+        apiMessages,
+        settings,
+        assistant,
+        hasBuiltInSearch,
+      );
+      await builder.injectInstructionPrompts(apiMessages, assistant.id);
+      await builder.injectWorldBookPrompts(apiMessages, assistant.id);
+      await builder.injectSkillListPrompt(apiMessages, assistant.id);
+      builder.injectTimeNote(apiMessages, assistant);
+      builder.applyContextLimit(apiMessages, assistant);
+      await builder.inlineLocalImages(apiMessages);
+
+      final toolHandler = ToolHandlerService(contextProvider: context);
+      var toolDefs = toolHandler.buildToolDefinitions(
+        settings,
+        assistant,
+        providerKey,
+        modelId,
+        hasBuiltInSearch,
+        isToolModel: (_, _) => true,
+      );
+      toolDefs = _removeInteractiveTools(
+        context: context,
+        assistant: assistant,
+        definitions: toolDefs,
+      );
+      final onToolCall = toolDefs.isEmpty
+          ? null
+          : toolHandler.buildToolCallHandler(
+              settings,
+              assistant,
+              approvalService: null,
+              askUserService: null,
+              conversationId: conversation.id,
+            );
+
+      final placeholder = await chatService.addMessage(
+        conversationId: conversation.id,
+        role: 'assistant',
+        content: '',
+        modelId: modelId,
+        providerId: providerKey,
+        isStreaming: true,
+      );
+
+      final engine = context.read<GenerationEngine>();
+      engine.startRound(
+        conversationId: conversation.id,
+        slots: <GenerationSlotRequest>[
+          GenerationSlotRequest(
+            assistantMessageId: placeholder.id,
+            apiMessages: apiMessages,
+            config: config,
+            modelId: modelId,
+            toolDefs: toolDefs.isEmpty ? null : toolDefs,
+            onToolCall: onToolCall,
+            assistant: assistant,
+            thinkingBudget:
+                assistant.thinkingBudget ?? settings.thinkingBudget,
+            temperature: assistant.temperature,
+            topP: assistant.topP,
+            maxTokens: assistant.maxTokens,
+            stream: assistant.streamOutput,
+            extraHeaders: buildConversationRequestHeaders(
+              conversationId: conversation.id,
+              customHeaders: _customHeaders(assistant),
+            ),
+            extraBody: _customBody(assistant),
+            autoCollapseThinking: settings.autoCollapseThinking,
+          ),
+        ],
+        wait: true,
+        targetName: assistant.name,
+      );
+
+      final result = await engine.waitFor(conversation.id);
+      if (result.cancelled) throw StateError('generation_cancelled');
+      if (result.error != null) throw StateError(result.error!);
+
+      final finishedAt = DateTime.now();
+      await taskProvider.recordLog(
+        task.id,
+        ScheduledTaskLog(
+          id: _uuid.v4(),
+          triggeredAt: startedAt,
+          finishedAt: finishedAt,
+          status: ScheduledTaskExecutionStatus.success,
+          conversationId: conversation.id,
+        ),
+      );
+      if (task.schedule.frequency == ScheduledTaskFrequency.once) {
+        await taskProvider.markOnceCompleted(task.id, finishedAt);
+      }
+      return ScheduledTaskExecutionResult(
+        handled: true,
+        success: true,
+        taskName: task.name,
+        notificationBody:
+            l10n?.scheduledTaskCompletedNotification ?? task.name,
+      );
+    } catch (error, stack) {
+      debugPrint('[ScheduledTask] execution failed: $error\n$stack');
+      final errorText = error.toString();
+      final failedAt = DateTime.now();
+      await taskProvider.recordLog(
+        task.id,
+        ScheduledTaskLog(
+          id: _uuid.v4(),
+          triggeredAt: startedAt,
+          finishedAt: failedAt,
+          status: ScheduledTaskExecutionStatus.failure,
+          conversationId: conversationId,
+          error: errorText,
+        ),
+      );
+      if (task.schedule.frequency == ScheduledTaskFrequency.once) {
+        await taskProvider.markOnceCompleted(task.id, failedAt);
+      }
+      return ScheduledTaskExecutionResult(
+        handled: true,
+        success: false,
+        taskName: task.name,
+        error: errorText,
+        notificationBody:
+            l10n?.scheduledTaskFailedNotification ?? errorText,
+      );
+    }
+  }
+
+  static Future<void> _waitForSelectedMcpConnections(
+    McpProvider provider,
+    Assistant assistant,
+  ) async {
+    final selectedIds = assistant.mcpServerIds.toSet();
+    if (selectedIds.isEmpty) return;
+
+    final deadline = DateTime.now().add(const Duration(seconds: 3));
+    while (DateTime.now().isBefore(deadline)) {
+      final selected = provider.servers.where(
+        (server) => selectedIds.contains(server.id) && server.enabled,
+      );
+      if (selected.isNotEmpty &&
+          selected.every((server) {
+            if (server.oauth != null && server.oauthToken == null) return true;
+            final status = provider.statusFor(server.id);
+            return status == McpStatus.connected || status == McpStatus.error;
+          })) {
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+  }
+
+  static List<Map<String, dynamic>> _removeInteractiveTools({
+    required BuildContext context,
+    required Assistant assistant,
+    required List<Map<String, dynamic>> definitions,
+  }) {
+    final denied = <String>{
+      LocalToolNames.askUser,
+      // Handoffs can spawn a child assistant that asks for approval/user
+      // input. Keep scheduled execution strictly non-interactive end-to-end.
+      LocalToolNames.handoff,
+      LocalToolNames.handoffSync,
+    };
+
+    try {
+      final mcp = context.read<McpProvider>();
+      final boundIds = assistant.mcpServerIds.toSet();
+      for (final server in mcp.connectedServers) {
+        if (!boundIds.contains(server.id) || !server.enabled) continue;
+        for (final tool in server.tools) {
+          if (!tool.enabled || !tool.needsApproval) continue;
+          denied.add(
+            server.toolPrefix.isEmpty
+                ? tool.name
+                : '${server.toolPrefix}_${tool.name}',
+          );
+        }
+      }
+    } catch (error) {
+      debugPrint('[ScheduledTask] MCP approval filter unavailable: $error');
+    }
+
+    if (assistant.workspaceEnabled) {
+      try {
+        final workspaces = context.read<WorkspaceProvider>();
+        final workspaceId = assistant.workspaceId;
+        final workspace = workspaceId == null
+            ? null
+            : workspaces.getById(workspaceId);
+        for (final name in WorkspaceToolNames.allTools) {
+          if (workspace?.isToolNeedsApproval(name) ??
+              WorkspaceToolNames.defaultApprovalFor(name)) {
+            denied.add(name);
+          }
+        }
+      } catch (error) {
+        debugPrint(
+          '[ScheduledTask] workspace approval filter unavailable: $error',
+        );
+      }
+    }
+
+    try {
+      final scheduled = context.read<ScheduledTaskProvider>();
+      if (scheduled.aiRequiresApproval) {
+        denied.addAll(ScheduledTaskToolNames.writes);
+      }
+    } catch (_) {}
+
+    return definitions.where((definition) {
+      final function = definition['function'];
+      if (function is! Map) return true;
+      final name = function['name']?.toString();
+      return name == null || !denied.contains(name);
+    }).toList(growable: false);
+  }
+
+  static Map<String, String>? _customHeaders(Assistant assistant) {
+    final headers = <String, String>{
+      for (final entry in assistant.customHeaders)
+        if ((entry['name'] ?? '').trim().isNotEmpty)
+          entry['name']!.trim(): entry['value'] ?? '',
+    };
+    return headers.isEmpty ? null : headers;
+  }
+
+  static Map<String, dynamic>? _customBody(Assistant assistant) {
+    final body = <String, dynamic>{
+      for (final entry in assistant.customBody)
+        if ((entry['key'] ?? '').trim().isNotEmpty)
+          entry['key']!.trim(): entry['value'] ?? '',
+    };
+    return body.isEmpty ? null : body;
+  }
+}

--- a/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -72,6 +71,7 @@ class ScheduledTaskExecutionService {
     final results = <ScheduledTaskExecutionResult>[];
     for (final task in dueTasks) {
       final result = await _executeTask(
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         context: context,
         taskProvider: taskProvider,
         task: task,
@@ -107,11 +107,14 @@ class ScheduledTaskExecutionService {
 
     final startedAt = now;
     String? conversationId;
+    // ignore: use_build_context_synchronously (root context, valid for app lifetime)
     final l10n = AppLocalizations.of(context);
 
     try {
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final chatService = context.read<ChatService>();
       await chatService.init();
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final assistantProvider = context.read<AssistantProvider>();
       await assistantProvider.ensureLoaded();
       final assistant = assistantProvider.getById(task.assistantId);
@@ -137,12 +140,15 @@ class ScheduledTaskExecutionService {
       // selected MCP connections for a short bounded window so the scheduled
       // assistant inherits the same non-interactive capabilities it normally
       // has in a foreground conversation.
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final workspaceProvider = context.read<WorkspaceProvider>();
       await workspaceProvider.init();
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final mcpProvider = context.read<McpProvider>();
       await mcpProvider.ensureLoaded();
       await _waitForSelectedMcpConnections(mcpProvider, assistant);
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final settings = context.read<SettingsProvider>();
       await settings.ensureLoaded();
       final providerKey =
@@ -158,6 +164,7 @@ class ScheduledTaskExecutionService {
 
       final builder = MessageBuilderService(
         chatService: chatService,
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         contextProvider: context,
       );
       final messages = chatService.getMessages(conversation.id);
@@ -197,6 +204,7 @@ class ScheduledTaskExecutionService {
       builder.applyContextLimit(apiMessages, assistant);
       await builder.inlineLocalImages(apiMessages);
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final toolHandler = ToolHandlerService(contextProvider: context);
       var toolDefs = toolHandler.buildToolDefinitions(
         settings,
@@ -207,6 +215,7 @@ class ScheduledTaskExecutionService {
         isToolModel: (_, _) => true,
       );
       toolDefs = _removeInteractiveTools(
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         context: context,
         assistant: assistant,
         definitions: toolDefs,
@@ -230,6 +239,7 @@ class ScheduledTaskExecutionService {
         isStreaming: true,
       );
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final engine = context.read<GenerationEngine>();
       engine.startRound(
         conversationId: conversation.id,

--- a/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -56,26 +57,48 @@ class ScheduledTaskExecutionService {
 
   static const Uuid _uuid = Uuid();
 
-  static Future<ScheduledTaskExecutionResult> executeTrigger({
+  static Future<List<ScheduledTaskExecutionResult>> executeDueTasks({
     required BuildContext context,
-    required String triggerId,
   }) async {
     final taskProvider = context.read<ScheduledTaskProvider>();
     await taskProvider.ensureLoaded();
 
-    final task = taskProvider.getByTriggerId(triggerId);
-    if (task == null || !task.enabled || task.isCompleted) {
+    final now = DateTime.now();
+    final dueTasks = taskProvider.tasks.where((task) {
+      if (!task.enabled || task.isCompleted) return false;
+      return task.schedule.occurrenceKey(now) != null;
+    }).toList(growable: false);
+
+    final results = <ScheduledTaskExecutionResult>[];
+    for (final task in dueTasks) {
+      final result = await _executeTask(
+        context: context,
+        taskProvider: taskProvider,
+        task: task,
+        now: now,
+      );
+      if (result.handled) results.add(result);
+    }
+    return results;
+  }
+
+  static Future<ScheduledTaskExecutionResult> _executeTask({
+    required BuildContext context,
+    required ScheduledTaskProvider taskProvider,
+    required ScheduledTask task,
+    required DateTime now,
+  }) async {
+    if (!task.enabled || task.isCompleted) {
       return const ScheduledTaskExecutionResult(handled: false);
     }
 
-    final now = DateTime.now();
     final occurrenceKey = task.schedule.occurrenceKey(now);
     if (occurrenceKey == null) {
       return const ScheduledTaskExecutionResult(handled: false);
     }
     final claimed = await taskProvider.claimOccurrence(
       taskId: task.id,
-      triggerId: triggerId,
+      triggerId: task.triggerId,
       occurrenceKey: occurrenceKey,
     );
     if (!claimed) {
@@ -84,14 +107,11 @@ class ScheduledTaskExecutionService {
 
     final startedAt = now;
     String? conversationId;
-    // ignore: use_build_context_synchronously (root context, valid for app lifetime)
     final l10n = AppLocalizations.of(context);
 
     try {
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final chatService = context.read<ChatService>();
       await chatService.init();
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final assistantProvider = context.read<AssistantProvider>();
       await assistantProvider.ensureLoaded();
       final assistant = assistantProvider.getById(task.assistantId);
@@ -117,15 +137,12 @@ class ScheduledTaskExecutionService {
       // selected MCP connections for a short bounded window so the scheduled
       // assistant inherits the same non-interactive capabilities it normally
       // has in a foreground conversation.
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final workspaceProvider = context.read<WorkspaceProvider>();
       await workspaceProvider.init();
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final mcpProvider = context.read<McpProvider>();
       await mcpProvider.ensureLoaded();
       await _waitForSelectedMcpConnections(mcpProvider, assistant);
 
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final settings = context.read<SettingsProvider>();
       await settings.ensureLoaded();
       final providerKey =
@@ -141,7 +158,6 @@ class ScheduledTaskExecutionService {
 
       final builder = MessageBuilderService(
         chatService: chatService,
-        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         contextProvider: context,
       );
       final messages = chatService.getMessages(conversation.id);
@@ -181,7 +197,6 @@ class ScheduledTaskExecutionService {
       builder.applyContextLimit(apiMessages, assistant);
       await builder.inlineLocalImages(apiMessages);
 
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final toolHandler = ToolHandlerService(contextProvider: context);
       var toolDefs = toolHandler.buildToolDefinitions(
         settings,
@@ -192,7 +207,6 @@ class ScheduledTaskExecutionService {
         isToolModel: (_, _) => true,
       );
       toolDefs = _removeInteractiveTools(
-        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         context: context,
         assistant: assistant,
         definitions: toolDefs,
@@ -216,7 +230,6 @@ class ScheduledTaskExecutionService {
         isStreaming: true,
       );
 
-      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final engine = context.read<GenerationEngine>();
       engine.startRound(
         conversationId: conversation.id,

--- a/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_execution_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -85,11 +84,14 @@ class ScheduledTaskExecutionService {
 
     final startedAt = now;
     String? conversationId;
+    // ignore: use_build_context_synchronously (root context, valid for app lifetime)
     final l10n = AppLocalizations.of(context);
 
     try {
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final chatService = context.read<ChatService>();
       await chatService.init();
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final assistantProvider = context.read<AssistantProvider>();
       await assistantProvider.ensureLoaded();
       final assistant = assistantProvider.getById(task.assistantId);
@@ -115,12 +117,15 @@ class ScheduledTaskExecutionService {
       // selected MCP connections for a short bounded window so the scheduled
       // assistant inherits the same non-interactive capabilities it normally
       // has in a foreground conversation.
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final workspaceProvider = context.read<WorkspaceProvider>();
       await workspaceProvider.init();
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final mcpProvider = context.read<McpProvider>();
       await mcpProvider.ensureLoaded();
       await _waitForSelectedMcpConnections(mcpProvider, assistant);
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final settings = context.read<SettingsProvider>();
       await settings.ensureLoaded();
       final providerKey =
@@ -136,6 +141,7 @@ class ScheduledTaskExecutionService {
 
       final builder = MessageBuilderService(
         chatService: chatService,
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         contextProvider: context,
       );
       final messages = chatService.getMessages(conversation.id);
@@ -175,6 +181,7 @@ class ScheduledTaskExecutionService {
       builder.applyContextLimit(apiMessages, assistant);
       await builder.inlineLocalImages(apiMessages);
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final toolHandler = ToolHandlerService(contextProvider: context);
       var toolDefs = toolHandler.buildToolDefinitions(
         settings,
@@ -185,6 +192,7 @@ class ScheduledTaskExecutionService {
         isToolModel: (_, _) => true,
       );
       toolDefs = _removeInteractiveTools(
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         context: context,
         assistant: assistant,
         definitions: toolDefs,
@@ -208,6 +216,7 @@ class ScheduledTaskExecutionService {
         isStreaming: true,
       );
 
+      // ignore: use_build_context_synchronously (root context, valid for app lifetime)
       final engine = context.read<GenerationEngine>();
       engine.startRound(
         conversationId: conversation.id,

--- a/lib/core/services/scheduled_tasks/scheduled_task_tool_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_tool_service.dart
@@ -1,0 +1,408 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/scheduled_task.dart';
+import '../../providers/scheduled_task_provider.dart';
+
+class ScheduledTaskToolNames {
+  const ScheduledTaskToolNames._();
+
+  static const String list = 'list_scheduled_tasks';
+  static const String create = 'create_scheduled_task';
+  static const String update = 'update_scheduled_task';
+  static const String delete = 'delete_scheduled_task';
+  static const String setEnabled = 'set_scheduled_task_enabled';
+
+  static const Set<String> all = <String>{
+    list,
+    create,
+    update,
+    delete,
+    setEnabled,
+  };
+
+  static const Set<String> writes = <String>{
+    create,
+    update,
+    delete,
+    setEnabled,
+  };
+}
+
+class ScheduledTaskToolService {
+  const ScheduledTaskToolService._();
+
+  static bool get isSupportedPlatform =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
+  static bool isToolName(String name) => ScheduledTaskToolNames.all.contains(name);
+
+  static bool requiresApproval(String name) =>
+      ScheduledTaskToolNames.writes.contains(name);
+
+  static List<Map<String, dynamic>> buildToolDefinitions() {
+    if (!isSupportedPlatform) return const <Map<String, dynamic>>[];
+    return <Map<String, dynamic>>[
+      {
+        'type': 'function',
+        'function': {
+          'name': ScheduledTaskToolNames.list,
+          'description':
+              'List scheduled tasks owned by this assistant. Use this before '
+              'editing, deleting, enabling, or disabling an existing task. '
+              'The assistant can only see its own scheduled tasks.',
+          'parameters': {'type': 'object', 'properties': <String, dynamic>{}},
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': ScheduledTaskToolNames.create,
+          'description':
+              'Create an iOS scheduled task owned by this assistant. The task '
+              'runs in a brand-new conversation when triggered. Hourly schedules '
+              'are not supported. Schedules follow the device current local '
+              'timezone. Use interval > 1 for every N days/weeks/months/years. '
+              'Weekly schedules may choose multiple ISO weekdays (Monday=1). '
+              'Monthly schedules may choose multiple calendar month days. '
+              'After creation the user still needs to connect the task to an '
+              'iOS Shortcuts personal automation from Cuplivo Settings.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'name': {
+                'type': 'string',
+                'description': 'Short human-readable task name.',
+              },
+              'prompt': {
+                'type': 'string',
+                'description':
+                    'The complete user message sent in the new conversation when the task runs.',
+              },
+              'schedule': _scheduleSchema,
+            },
+            'required': ['name', 'prompt', 'schedule'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': ScheduledTaskToolNames.update,
+          'description':
+              'Edit one scheduled task owned by this assistant. Call '
+              'list_scheduled_tasks first to obtain task_id. Changing any '
+              'schedule field invalidates the old iOS Shortcut Trigger ID and '
+              'the user must reconnect the task. Changing only name or prompt '
+              'does not require reconnection.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'task_id': {'type': 'string'},
+              'name': {'type': 'string'},
+              'prompt': {'type': 'string'},
+              'schedule': _scheduleSchema,
+            },
+            'required': ['task_id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': ScheduledTaskToolNames.delete,
+          'description':
+              'Delete one scheduled task owned by this assistant. Old iOS '
+              'Shortcut triggers become harmless: Cuplivo will no longer find '
+              'their Trigger ID and will silently ignore them.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'task_id': {'type': 'string'},
+            },
+            'required': ['task_id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': ScheduledTaskToolNames.setEnabled,
+          'description':
+              'Enable or disable one scheduled task owned by this assistant. '
+              'A disabled task silently ignores Shortcut triggers.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'task_id': {'type': 'string'},
+              'enabled': {'type': 'boolean'},
+            },
+            'required': ['task_id', 'enabled'],
+          },
+        },
+      },
+    ];
+  }
+
+  static const Map<String, dynamic> _scheduleSchema = <String, dynamic>{
+    'type': 'object',
+    'description':
+        'Schedule in the device current local timezone. frequency is once, daily, weekly, monthly, or yearly. Hourly is unsupported.',
+    'properties': <String, dynamic>{
+      'frequency': <String, dynamic>{
+        'type': 'string',
+        'enum': <String>['once', 'daily', 'weekly', 'monthly', 'yearly'],
+      },
+      'interval': <String, dynamic>{
+        'type': 'integer',
+        'description': 'Every N units. Minimum 1. Ignored for once.',
+      },
+      'hour': <String, dynamic>{
+        'type': 'integer',
+        'description': 'Local hour, 0-23. Required except when once_at is supplied.',
+      },
+      'minute': <String, dynamic>{
+        'type': 'integer',
+        'description': 'Local minute, 0-59. Required except when once_at is supplied.',
+      },
+      'anchor_date': <String, dynamic>{
+        'type': 'string',
+        'description':
+            'Local YYYY-MM-DD recurrence anchor. Defaults to today. Useful for every N units.',
+      },
+      'weekdays': <String, dynamic>{
+        'type': 'array',
+        'description': 'For weekly recurrence. ISO weekdays Monday=1 ... Sunday=7.',
+        'items': <String, dynamic>{'type': 'integer'},
+      },
+      'month_days': <String, dynamic>{
+        'type': 'array',
+        'description': 'For monthly recurrence. Calendar days 1...31.',
+        'items': <String, dynamic>{'type': 'integer'},
+      },
+      'month': <String, dynamic>{
+        'type': 'integer',
+        'description': 'For yearly recurrence, month 1...12.',
+      },
+      'day': <String, dynamic>{
+        'type': 'integer',
+        'description': 'For yearly recurrence, day 1...31.',
+      },
+      'once_at': <String, dynamic>{
+        'type': 'string',
+        'description':
+            'For once recurrence, local ISO date-time such as 2026-08-20T18:30:00.',
+      },
+    },
+    'required': <String>['frequency'],
+  };
+
+  static Future<String> execute({
+    required String name,
+    required Map<String, dynamic> arguments,
+    required String assistantId,
+    required ScheduledTaskProvider provider,
+  }) async {
+    await provider.ensureLoaded();
+    if (!provider.allowAiOperations) {
+      return _error('scheduled_tasks_disabled', 'AI scheduled-task access is disabled.');
+    }
+
+    switch (name) {
+      case ScheduledTaskToolNames.list:
+        final tasks = provider.forAssistant(assistantId);
+        return jsonEncode(<String, dynamic>{
+          'tasks': tasks.map(_taskForTool).toList(growable: false),
+        });
+      case ScheduledTaskToolNames.create:
+        final taskName = (arguments['name'] ?? '').toString().trim();
+        final prompt = (arguments['prompt'] ?? '').toString().trim();
+        if (taskName.isEmpty || prompt.isEmpty) {
+          return _error('invalid_arguments', 'name and prompt are required.');
+        }
+        final schedule = _parseSchedule(arguments['schedule']);
+        if (schedule == null) {
+          return _error('invalid_schedule', 'The schedule is invalid or incomplete.');
+        }
+        final task = await provider.createTask(
+          assistantId: assistantId,
+          name: taskName,
+          prompt: prompt,
+          schedule: schedule,
+        );
+        return jsonEncode(<String, dynamic>{
+          'success': true,
+          'task': _taskForTool(task),
+          'needs_shortcuts_connection': true,
+        });
+      case ScheduledTaskToolNames.update:
+        final task = _ownedTask(arguments, assistantId, provider);
+        if (task == null) return _notFound();
+        ScheduledTaskSchedule? schedule;
+        if (arguments.containsKey('schedule')) {
+          schedule = _parseSchedule(arguments['schedule']);
+          if (schedule == null) {
+            return _error('invalid_schedule', 'The schedule is invalid or incomplete.');
+          }
+        }
+        final nextName = arguments.containsKey('name')
+            ? arguments['name']?.toString().trim()
+            : null;
+        final nextPrompt = arguments.containsKey('prompt')
+            ? arguments['prompt']?.toString().trim()
+            : null;
+        if ((nextName != null && nextName.isEmpty) ||
+            (nextPrompt != null && nextPrompt.isEmpty)) {
+          return _error(
+            'invalid_arguments',
+            'name and prompt cannot be empty when supplied.',
+          );
+        }
+        final updated = await provider.updateTask(
+          id: task.id,
+          name: nextName,
+          prompt: nextPrompt,
+          schedule: schedule,
+        );
+        if (updated == null) return _notFound();
+        return jsonEncode(<String, dynamic>{
+          'success': true,
+          'task': _taskForTool(updated),
+          'needs_shortcuts_connection': !updated.connected,
+        });
+      case ScheduledTaskToolNames.delete:
+        final task = _ownedTask(arguments, assistantId, provider);
+        if (task == null) return _notFound();
+        await provider.deleteTask(task.id);
+        return jsonEncode(<String, dynamic>{'success': true, 'task_id': task.id});
+      case ScheduledTaskToolNames.setEnabled:
+        final task = _ownedTask(arguments, assistantId, provider);
+        if (task == null) return _notFound();
+        final enabled = arguments['enabled'];
+        if (enabled is! bool) {
+          return _error('invalid_arguments', 'enabled must be a boolean.');
+        }
+        final updated = await provider.setEnabled(task.id, enabled);
+        return jsonEncode(<String, dynamic>{
+          'success': updated != null,
+          if (updated != null) 'task': _taskForTool(updated),
+        });
+      default:
+        return _error('unknown_tool', 'Unknown scheduled-task tool: $name');
+    }
+  }
+
+  static ScheduledTask? _ownedTask(
+    Map<String, dynamic> arguments,
+    String assistantId,
+    ScheduledTaskProvider provider,
+  ) {
+    final id = (arguments['task_id'] ?? '').toString();
+    final task = provider.getById(id);
+    if (task == null || task.assistantId != assistantId) return null;
+    return task;
+  }
+
+  static Map<String, dynamic> _taskForTool(ScheduledTask task) => <String, dynamic>{
+    'task_id': task.id,
+    'name': task.name,
+    'prompt': task.prompt,
+    'enabled': task.enabled,
+    'connected': task.connected,
+    'completed': task.isCompleted,
+    'schedule': task.schedule.toJson(),
+  };
+
+  static ScheduledTaskSchedule? _parseSchedule(dynamic raw) {
+    if (raw is! Map) return null;
+    final map = raw.cast<String, dynamic>();
+    final frequencyName = (map['frequency'] ?? '').toString();
+    ScheduledTaskFrequency? frequency;
+    for (final candidate in ScheduledTaskFrequency.values) {
+      if (candidate.name == frequencyName) {
+        frequency = candidate;
+        break;
+      }
+    }
+    if (frequency == null) return null;
+
+    final now = DateTime.now();
+    final onceAtRaw = (map['once_at'] ?? '').toString().trim();
+    final parsedOnceAt = DateTime.tryParse(onceAtRaw);
+    final onceAt = parsedOnceAt?.toLocal();
+    if (frequency == ScheduledTaskFrequency.once && onceAt == null) return null;
+
+    final interval = _asInt(map['interval']) ?? 1;
+    if (interval < 1) return null;
+
+    final hour = onceAt?.hour ?? _asInt(map['hour']) ?? -1;
+    final minute = onceAt?.minute ?? _asInt(map['minute']) ?? -1;
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+    DateTime? anchor;
+    final anchorRaw = (map['anchor_date'] ?? '').toString();
+    if (anchorRaw.isNotEmpty) {
+      anchor = DateTime.tryParse(anchorRaw)?.toLocal();
+      if (anchor == null) return null;
+    }
+    anchor ??= onceAt ?? now;
+
+    List<int> intList(String key) {
+      final values = map[key];
+      if (values is! List) return const <int>[];
+      return values.map(_asInt).whereType<int>().toList(growable: false);
+    }
+
+    final weekdays = intList('weekdays');
+    if (weekdays.any((day) => day < DateTime.monday || day > DateTime.sunday)) {
+      return null;
+    }
+    final monthDays = intList('month_days');
+    if (monthDays.any((day) => day < 1 || day > 31)) return null;
+
+    final yearMonth = _asInt(map['month']);
+    final yearDay = _asInt(map['day']);
+    if (yearMonth != null && (yearMonth < 1 || yearMonth > 12)) return null;
+    if (yearDay != null && (yearDay < 1 || yearDay > 31)) return null;
+    if (frequency == ScheduledTaskFrequency.yearly &&
+        yearMonth != null &&
+        yearDay != null &&
+        !_isValidMonthDay(yearMonth, yearDay)) {
+      return null;
+    }
+
+    return ScheduledTaskSchedule(
+      frequency: frequency,
+      interval: interval,
+      hour: hour,
+      minute: minute,
+      anchorDate: anchor,
+      weekdays: weekdays,
+      monthDays: monthDays,
+      yearMonth: yearMonth,
+      yearDay: yearDay,
+      onceAt: onceAt,
+    ).normalized();
+  }
+
+  static bool _isValidMonthDay(int month, int day) {
+    final lastDay = DateTime(2024, month + 1, 0).day;
+    return day <= lastDay;
+  }
+
+  static int? _asInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '');
+  }
+
+  static String _notFound() =>
+      _error('task_not_found', 'The task does not exist or belongs to another assistant.');
+
+  static String _error(String code, String message) => jsonEncode(<String, dynamic>{
+    'success': false,
+    'error': code,
+    'message': message,
+  });
+}

--- a/lib/core/services/scheduled_tasks/scheduled_task_tool_service.dart
+++ b/lib/core/services/scheduled_tasks/scheduled_task_tool_service.dart
@@ -93,8 +93,9 @@ class ScheduledTaskToolService {
           'description':
               'Edit one scheduled task owned by this assistant. Call '
               'list_scheduled_tasks first to obtain task_id. Changing any '
-              'schedule field invalidates the old iOS Shortcut Trigger ID and '
-              'the user must reconnect the task. Changing only name or prompt '
+              'schedule field changes when the shared iOS Shortcut action '
+              'should run and the user must reconnect the task. Changing only '
+              'name or prompt '
               'does not require reconnection.',
           'parameters': {
             'type': 'object',
@@ -113,9 +114,9 @@ class ScheduledTaskToolService {
         'function': {
           'name': ScheduledTaskToolNames.delete,
           'description':
-              'Delete one scheduled task owned by this assistant. Old iOS '
-              'Shortcut triggers become harmless: Cuplivo will no longer find '
-              'their Trigger ID and will silently ignore them.',
+              'Delete one scheduled task owned by this assistant. Existing iOS '
+              'Personal Automations are harmless: the shared Cuplivo action will '
+              'simply find no matching due task and stay silent.',
           'parameters': {
             'type': 'object',
             'properties': {

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -687,6 +687,7 @@ class ToolHandlerService {
           }
           ScheduledTaskProvider scheduled;
           try {
+            // ignore: use_build_context_synchronously (root context, valid for app lifetime)
             scheduled = contextProvider.read<ScheduledTaskProvider>();
           } on ProviderNotFoundException {
             return _toolError(
@@ -745,7 +746,9 @@ class ToolHandlerService {
             } catch (_) {}
           }
           if (needsShortcutsConnection) {
+            // ignore: use_build_context_synchronously (root context, valid for app lifetime)
             final l10n = AppLocalizations.of(contextProvider);
+            // ignore: use_build_context_synchronously (root context, valid for app lifetime)
             final messenger = ScaffoldMessenger.maybeOf(contextProvider);
             if (l10n != null && messenger != null) {
               messenger.showSnackBar(

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/assistant_memory.dart';
@@ -11,6 +11,7 @@ import '../../../core/providers/download_progress_store.dart';
 import '../../../core/providers/mcp_provider.dart';
 import '../../../core/providers/memory_provider.dart';
 import '../../../core/providers/settings_provider.dart';
+import '../../../core/providers/scheduled_task_provider.dart';
 import '../../../core/providers/tts_provider.dart';
 import '../../../core/providers/workspace_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
@@ -18,12 +19,14 @@ import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../core/services/mcp/mcp_tool_service.dart';
 import '../../../core/services/search/search_tool_service.dart';
+import '../../../core/services/scheduled_tasks/scheduled_task_tool_service.dart';
 import '../../../core/services/workspace/linux_sandbox_service.dart';
 import '../../../core/services/workspace/workspace_tools_service.dart';
 import 'ask_user_interaction_service.dart';
 import 'handoff_tool_service.dart';
 import 'local_tools_service.dart';
 import 'tool_approval_service.dart';
+import '../../../l10n/app_localizations.dart';
 
 /// 工具调用处理服务
 ///
@@ -248,6 +251,9 @@ class ToolHandlerService {
     if (assistant.workspaceEnabled) {
       names.addAll(WorkspaceToolNames.allTools);
     }
+    if (ScheduledTaskToolService.isSupportedPlatform) {
+      names.addAll(ScheduledTaskToolNames.all);
+    }
     return names;
   }
 
@@ -366,6 +372,22 @@ class ToolHandlerService {
         discoverableAssistants: assistantProvider.assistants,
       ),
     );
+
+    // iOS scheduled-task tools are globally enabled from Settings. They are
+    // intentionally not stored per assistant; ownership is still enforced at
+    // execution time so each assistant can only manage its own tasks.
+    if (supportsTools &&
+        assistant != null &&
+        ScheduledTaskToolService.isSupportedPlatform) {
+      try {
+        final scheduled = contextProvider.read<ScheduledTaskProvider>();
+        if (scheduled.allowAiOperations) {
+          toolDefs.addAll(ScheduledTaskToolService.buildToolDefinitions());
+        }
+      } on ProviderNotFoundException catch (e) {
+        debugPrint('scheduled-task tools defs skipped: $e');
+      }
+    }
 
     // Workspace filesystem + shell tools
     try {
@@ -650,6 +672,88 @@ class ToolHandlerService {
         final memoryResult = await _handleMemoryToolCall(name, args, assistant);
         if (memoryResult != null) {
           return memoryResult;
+        }
+
+        // iOS scheduled-task tools. Write operations reuse the existing
+        // ToolApprovalService, controlled by the global setting on the
+        // Scheduled Tasks page.
+        if (ScheduledTaskToolService.isToolName(name)) {
+          if (assistant == null || !ScheduledTaskToolService.isSupportedPlatform) {
+            return _toolError(
+              error: 'scheduled_tasks_unavailable',
+              message: 'Scheduled tasks are unavailable for this assistant.',
+              tool: name,
+            );
+          }
+          ScheduledTaskProvider scheduled;
+          try {
+            scheduled = contextProvider.read<ScheduledTaskProvider>();
+          } on ProviderNotFoundException {
+            return _toolError(
+              error: 'scheduled_tasks_unavailable',
+              message: 'ScheduledTaskProvider is unavailable.',
+              tool: name,
+            );
+          }
+          await scheduled.ensureLoaded();
+          if (!scheduled.allowAiOperations) {
+            return _toolError(
+              error: 'scheduled_tasks_disabled',
+              message: 'AI scheduled-task access is disabled in Settings.',
+              tool: name,
+            );
+          }
+          if (ScheduledTaskToolService.requiresApproval(name) &&
+              scheduled.aiRequiresApproval) {
+            if (approvalService == null) {
+              return _toolError(
+                error: 'approval_unavailable',
+                message: 'This scheduled-task operation requires user approval.',
+                tool: name,
+              );
+            }
+            final callId = (toolCallId?.trim().isNotEmpty == true)
+                ? toolCallId!.trim()
+                : '${name}_${DateTime.now().microsecondsSinceEpoch}';
+            final approval = await approvalService.requestApproval(
+              toolCallId: callId,
+              toolName: name,
+              arguments: args,
+              conversationId: conversationId,
+            );
+            if (!approval.approved) {
+              return _toolError(
+                error: 'approval_denied',
+                message: approval.denyReason ?? 'User denied the tool call',
+                tool: name,
+              );
+            }
+          }
+          final result = await ScheduledTaskToolService.execute(
+            name: name,
+            arguments: args,
+            assistantId: assistant.id,
+            provider: scheduled,
+          );
+          var needsShortcutsConnection = false;
+          if (name == ScheduledTaskToolNames.create ||
+              name == ScheduledTaskToolNames.update) {
+            try {
+              final decoded = jsonDecode(result);
+              needsShortcutsConnection =
+                  decoded is Map && decoded['needs_shortcuts_connection'] == true;
+            } catch (_) {}
+          }
+          if (needsShortcutsConnection) {
+            final l10n = AppLocalizations.of(contextProvider);
+            final messenger = ScaffoldMessenger.maybeOf(contextProvider);
+            if (l10n != null && messenger != null) {
+              messenger.showSnackBar(
+                SnackBar(content: Text(l10n.scheduledTaskAiConnectHint)),
+              );
+            }
+          }
+          return result;
         }
 
         // Local tools

--- a/lib/features/scheduled_tasks/pages/scheduled_task_edit_page.dart
+++ b/lib/features/scheduled_tasks/pages/scheduled_task_edit_page.dart
@@ -1,0 +1,528 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+
+import '../../../core/models/scheduled_task.dart';
+import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/scheduled_task_provider.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+
+class ScheduledTaskEditPage extends StatefulWidget {
+  const ScheduledTaskEditPage({super.key, this.taskId});
+
+  final String? taskId;
+
+  @override
+  State<ScheduledTaskEditPage> createState() => _ScheduledTaskEditPageState();
+}
+
+class _ScheduledTaskEditPageState extends State<ScheduledTaskEditPage> {
+  final _nameController = TextEditingController();
+  final _promptController = TextEditingController();
+  final _intervalController = TextEditingController(text: '1');
+  String? _assistantId;
+  ScheduledTaskFrequency _frequency = ScheduledTaskFrequency.daily;
+  DateTime _anchorDate = DateTime.now();
+  DateTime _onceAt = DateTime.now().add(const Duration(hours: 1));
+  TimeOfDay _time = const TimeOfDay(hour: 8, minute: 0);
+  final Set<int> _weekdays = <int>{DateTime.monday};
+  final Set<int> _monthDays = <int>{1};
+  int _yearMonth = 1;
+  int _yearDay = 1;
+  bool _initialized = false;
+  bool _saving = false;
+
+  ScheduledTask? get _task => widget.taskId == null
+      ? null
+      : context.read<ScheduledTaskProvider>().getById(widget.taskId!);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _initialized = true;
+    final task = _task;
+    final assistants = context.read<AssistantProvider>().assistants;
+    if (task == null) {
+      _assistantId = assistants.isEmpty ? null : assistants.first.id;
+      _yearMonth = _anchorDate.month;
+      _yearDay = _anchorDate.day;
+      _monthDays
+        ..clear()
+        ..add(_anchorDate.day);
+      _weekdays
+        ..clear()
+        ..add(_anchorDate.weekday);
+      return;
+    }
+
+    final schedule = task.schedule.normalized();
+    _nameController.text = task.name;
+    _promptController.text = task.prompt;
+    _assistantId = task.assistantId;
+    _frequency = schedule.frequency;
+    _intervalController.text = schedule.interval.toString();
+    _anchorDate = schedule.anchorDate ?? task.createdAt;
+    _time = TimeOfDay(hour: schedule.hour, minute: schedule.minute);
+    _onceAt = schedule.onceAt ?? _anchorDate;
+    _weekdays
+      ..clear()
+      ..addAll(
+        schedule.weekdays.isEmpty
+            ? <int>[_anchorDate.weekday]
+            : schedule.weekdays,
+      );
+    _monthDays
+      ..clear()
+      ..addAll(
+        schedule.monthDays.isEmpty
+            ? <int>[_anchorDate.day]
+            : schedule.monthDays,
+      );
+    _yearMonth = schedule.yearMonth ?? _anchorDate.month;
+    _yearDay = schedule.yearDay ?? _anchorDate.day;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _promptController.dispose();
+    _intervalController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickTime() async {
+    final value = await showTimePicker(context: context, initialTime: _time);
+    if (value != null && mounted) setState(() => _time = value);
+  }
+
+  Future<void> _pickAnchorDate() async {
+    final value = await showDatePicker(
+      context: context,
+      initialDate: _anchorDate,
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2100),
+    );
+    if (value != null && mounted) setState(() => _anchorDate = value);
+  }
+
+  Future<void> _pickOnceDate() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _onceAt,
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime(2100),
+    );
+    if (date == null || !mounted) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_onceAt),
+    );
+    if (time == null || !mounted) return;
+    setState(() {
+      _onceAt = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+      _time = time;
+    });
+  }
+
+  Future<void> _pickYearDate() async {
+    final initial = DateTime(
+      2024,
+      _yearMonth,
+      _validDayForMonth(2024, _yearMonth, _yearDay),
+    );
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(2024),
+      lastDate: DateTime(2024, 12, 31),
+    );
+    if (date != null && mounted) {
+      setState(() {
+        _yearMonth = date.month;
+        _yearDay = date.day;
+      });
+    }
+  }
+
+  ScheduledTaskSchedule _buildSchedule() {
+    final interval = int.tryParse(_intervalController.text.trim()) ?? 1;
+    return ScheduledTaskSchedule(
+      frequency: _frequency,
+      interval: interval,
+      hour: _frequency == ScheduledTaskFrequency.once ? _onceAt.hour : _time.hour,
+      minute:
+          _frequency == ScheduledTaskFrequency.once ? _onceAt.minute : _time.minute,
+      anchorDate: _anchorDate,
+      weekdays: _weekdays.toList()..sort(),
+      monthDays: _monthDays.toList()..sort(),
+      yearMonth: _yearMonth,
+      yearDay: _yearDay,
+      onceAt: _frequency == ScheduledTaskFrequency.once ? _onceAt : null,
+    ).normalized();
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final l10n = AppLocalizations.of(context)!;
+    final name = _nameController.text.trim();
+    final prompt = _promptController.text.trim();
+    final interval = int.tryParse(_intervalController.text.trim()) ?? 0;
+    if (_assistantId == null || name.isEmpty || prompt.isEmpty || interval < 1) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.scheduledTaskInvalidForm)),
+      );
+      return;
+    }
+    if (_frequency == ScheduledTaskFrequency.weekly && _weekdays.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.scheduledTaskSelectWeekday)),
+      );
+      return;
+    }
+    if (_frequency == ScheduledTaskFrequency.monthly && _monthDays.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.scheduledTaskSelectMonthDay)),
+      );
+      return;
+    }
+
+    setState(() => _saving = true);
+    final provider = context.read<ScheduledTaskProvider>();
+    try {
+      if (widget.taskId == null) {
+        await provider.createTask(
+          assistantId: _assistantId!,
+          name: name,
+          prompt: prompt,
+          schedule: _buildSchedule(),
+        );
+      } else {
+        await provider.updateTask(
+          id: widget.taskId!,
+          assistantId: _assistantId!,
+          name: name,
+          prompt: prompt,
+          schedule: _buildSchedule(),
+        );
+      }
+      if (mounted) Navigator.of(context).pop();
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _delete() async {
+    final task = _task;
+    if (task == null) return;
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.scheduledTaskDeleteTitle),
+        content: Text(l10n.scheduledTaskDeleteMessage),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.scheduledTaskCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              l10n.scheduledTaskDelete,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    await context.read<ScheduledTaskProvider>().deleteTask(task.id);
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final assistants = context.watch<AssistantProvider>().assistants;
+    final task = widget.taskId == null
+        ? null
+        : context.watch<ScheduledTaskProvider>().getById(widget.taskId!);
+    if (widget.taskId != null && task == null) {
+      return Scaffold(
+        appBar: AppBar(title: Text(l10n.scheduledTaskEdit)),
+        body: Center(child: Text(l10n.scheduledTaskNotFound)),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.taskId == null
+              ? l10n.scheduledTaskCreate
+              : l10n.scheduledTaskEdit,
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: _saving ? null : _save,
+            child: Text(l10n.scheduledTaskSave),
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+        children: <Widget>[
+          TextField(
+            controller: _nameController,
+            decoration: InputDecoration(
+              labelText: l10n.scheduledTaskName,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            initialValue: assistants.any((a) => a.id == _assistantId)
+                ? _assistantId
+                : null,
+            decoration: InputDecoration(
+              labelText: l10n.scheduledTaskAssistant,
+              border: const OutlineInputBorder(),
+            ),
+            items: assistants
+                .map(
+                  (assistant) => DropdownMenuItem<String>(
+                    value: assistant.id,
+                    child: Text(assistant.name),
+                  ),
+                )
+                .toList(growable: false),
+            onChanged: (value) => setState(() => _assistantId = value),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _promptController,
+            minLines: 5,
+            maxLines: 10,
+            decoration: InputDecoration(
+              labelText: l10n.scheduledTaskPrompt,
+              alignLabelWithHint: true,
+              border: const OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 18),
+          DropdownButtonFormField<ScheduledTaskFrequency>(
+            initialValue: _frequency,
+            decoration: InputDecoration(
+              labelText: l10n.scheduledTaskFrequency,
+              border: const OutlineInputBorder(),
+            ),
+            items: ScheduledTaskFrequency.values
+                .map(
+                  (frequency) => DropdownMenuItem<ScheduledTaskFrequency>(
+                    value: frequency,
+                    child: Text(_frequencyLabel(l10n, frequency)),
+                  ),
+                )
+                .toList(growable: false),
+            onChanged: (value) {
+              if (value != null) setState(() => _frequency = value);
+            },
+          ),
+          if (_frequency != ScheduledTaskFrequency.once) ...<Widget>[
+            const SizedBox(height: 12),
+            TextField(
+              controller: _intervalController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: l10n.scheduledTaskInterval,
+                helperText: _intervalHelper(l10n),
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            _PickerTile(
+              icon: Lucide.Calendar,
+              title: l10n.scheduledTaskStartDate,
+              value: MaterialLocalizations.of(context).formatMediumDate(
+                _anchorDate,
+              ),
+              onTap: _pickAnchorDate,
+            ),
+          ],
+          const SizedBox(height: 12),
+          if (_frequency == ScheduledTaskFrequency.once)
+            _PickerTile(
+              icon: Lucide.Calendar,
+              title: l10n.scheduledTaskRunOnceAt,
+              value:
+                  '${MaterialLocalizations.of(context).formatMediumDate(_onceAt)} · ${TimeOfDay.fromDateTime(_onceAt).format(context)}',
+              onTap: _pickOnceDate,
+            )
+          else
+            _PickerTile(
+              icon: Lucide.Timer,
+              title: l10n.scheduledTaskTime,
+              value: _time.format(context),
+              onTap: _pickTime,
+            ),
+          if (_frequency == ScheduledTaskFrequency.weekly) ...<Widget>[
+            const SizedBox(height: 16),
+            Text(l10n.scheduledTaskWeekdays),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: List<Widget>.generate(7, (index) {
+                final weekday = index + 1;
+                final narrow = MaterialLocalizations.of(context).narrowWeekdays;
+                final label = narrow[weekday == DateTime.sunday ? 0 : weekday];
+                return FilterChip(
+                  label: Text(label),
+                  selected: _weekdays.contains(weekday),
+                  onSelected: (selected) {
+                    setState(() {
+                      if (selected) {
+                        _weekdays.add(weekday);
+                      } else {
+                        _weekdays.remove(weekday);
+                      }
+                    });
+                  },
+                );
+              }),
+            ),
+          ],
+          if (_frequency == ScheduledTaskFrequency.monthly) ...<Widget>[
+            const SizedBox(height: 16),
+            Text(l10n.scheduledTaskMonthDaysLabel),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: List<Widget>.generate(31, (index) {
+                final day = index + 1;
+                return FilterChip(
+                  label: Text(day.toString()),
+                  selected: _monthDays.contains(day),
+                  onSelected: (selected) {
+                    setState(() {
+                      if (selected) {
+                        _monthDays.add(day);
+                      } else {
+                        _monthDays.remove(day);
+                      }
+                    });
+                  },
+                );
+              }),
+            ),
+          ],
+          if (_frequency == ScheduledTaskFrequency.yearly) ...<Widget>[
+            const SizedBox(height: 12),
+            _PickerTile(
+              icon: Lucide.Calendar,
+              title: l10n.scheduledTaskYearDate,
+              value: DateFormat.MMMd(
+                Localizations.localeOf(context).toString(),
+              ).format(
+                DateTime(
+                  2024,
+                  _yearMonth,
+                  _validDayForMonth(2024, _yearMonth, _yearDay),
+                ),
+              ),
+              onTap: _pickYearDate,
+            ),
+          ],
+          const SizedBox(height: 14),
+          Text(
+            l10n.scheduledTaskTimezoneNote,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.6),
+            ),
+          ),
+          if (widget.taskId != null) ...<Widget>[
+            const SizedBox(height: 28),
+            OutlinedButton.icon(
+              onPressed: _delete,
+              icon: const Icon(Lucide.Trash2),
+              label: Text(l10n.scheduledTaskDelete),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _intervalHelper(AppLocalizations l10n) {
+    switch (_frequency) {
+      case ScheduledTaskFrequency.daily:
+        return l10n.scheduledTaskIntervalDayHelp;
+      case ScheduledTaskFrequency.weekly:
+        return l10n.scheduledTaskIntervalWeekHelp;
+      case ScheduledTaskFrequency.monthly:
+        return l10n.scheduledTaskIntervalMonthHelp;
+      case ScheduledTaskFrequency.yearly:
+        return l10n.scheduledTaskIntervalYearHelp;
+      case ScheduledTaskFrequency.once:
+        return '';
+    }
+  }
+}
+
+class _PickerTile extends StatelessWidget {
+  const _PickerTile({
+    required this.icon,
+    required this.title,
+    required this.value,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String value;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: ListTile(
+        leading: Icon(icon),
+        title: Text(title),
+        subtitle: Text(value),
+        trailing: const Icon(Lucide.ChevronRight, size: 18),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+String _frequencyLabel(
+  AppLocalizations l10n,
+  ScheduledTaskFrequency frequency,
+) {
+  switch (frequency) {
+    case ScheduledTaskFrequency.once:
+      return l10n.scheduledTaskFrequencyOnce;
+    case ScheduledTaskFrequency.daily:
+      return l10n.scheduledTaskFrequencyDaily;
+    case ScheduledTaskFrequency.weekly:
+      return l10n.scheduledTaskFrequencyWeekly;
+    case ScheduledTaskFrequency.monthly:
+      return l10n.scheduledTaskFrequencyMonthly;
+    case ScheduledTaskFrequency.yearly:
+      return l10n.scheduledTaskFrequencyYearly;
+  }
+}
+
+int _validDayForMonth(int year, int month, int day) {
+  final lastDay = DateTime(year, month + 1, 0).day;
+  return day.clamp(1, lastDay).toInt();
+}

--- a/lib/features/scheduled_tasks/pages/scheduled_task_logs_page.dart
+++ b/lib/features/scheduled_tasks/pages/scheduled_task_logs_page.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/scheduled_task.dart';
+import '../../../core/providers/scheduled_task_provider.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+
+class ScheduledTaskLogsPage extends StatelessWidget {
+  const ScheduledTaskLogsPage({super.key, required this.taskId});
+
+  final String taskId;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final task = context.watch<ScheduledTaskProvider>().getById(taskId);
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.scheduledTaskLogs)),
+      body: task == null
+          ? Center(child: Text(l10n.scheduledTaskNotFound))
+          : task.logs.isEmpty
+          ? Center(child: Text(l10n.scheduledTaskNoLogs))
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: task.logs.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 8),
+              itemBuilder: (context, index) {
+                final log = task.logs[index];
+                final success =
+                    log.status == ScheduledTaskExecutionStatus.success;
+                final locale = Localizations.localeOf(context).toString();
+                final when =
+                    '${DateFormat.yMMMd(locale).format(log.finishedAt)} ${TimeOfDay.fromDateTime(log.finishedAt).format(context)}';
+                return Card(
+                  margin: EdgeInsets.zero,
+                  child: ListTile(
+                    leading: Icon(
+                      success ? Lucide.CheckCircle : Lucide.CircleX,
+                      color: success
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.error,
+                    ),
+                    title: Text(
+                      success
+                          ? l10n.scheduledTaskLogSuccess
+                          : l10n.scheduledTaskLogFailure,
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(when),
+                        if (!success && (log.error?.isNotEmpty ?? false))
+                          Text(
+                            log.error!,
+                            maxLines: 4,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/features/scheduled_tasks/pages/scheduled_tasks_page.dart
+++ b/lib/features/scheduled_tasks/pages/scheduled_tasks_page.dart
@@ -144,7 +144,6 @@ class _ScheduledTaskCardState extends State<_ScheduledTaskCard> {
       await Future<void>.delayed(const Duration(milliseconds: 180));
     }
     await IosScheduledTaskBridge.instance.openShortcutSetup(
-      triggerId: widget.task.triggerId,
       taskName: widget.task.name,
     );
     if (mounted) setState(() => _connecting = false);

--- a/lib/features/scheduled_tasks/pages/scheduled_tasks_page.dart
+++ b/lib/features/scheduled_tasks/pages/scheduled_tasks_page.dart
@@ -1,0 +1,354 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/scheduled_task.dart';
+import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/scheduled_task_provider.dart';
+import '../../../core/services/scheduled_tasks/ios_scheduled_task_bridge.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+import 'scheduled_task_edit_page.dart';
+import 'scheduled_task_logs_page.dart';
+
+class ScheduledTasksPage extends StatelessWidget {
+  const ScheduledTasksPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final provider = context.watch<ScheduledTaskProvider>();
+    final assistants = context.watch<AssistantProvider>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.scheduledTaskPageTitle),
+        actions: <Widget>[
+          IconButton(
+            tooltip: l10n.scheduledTaskCreate,
+            icon: const Icon(Lucide.Plus),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const ScheduledTaskEditPage(),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: provider.isLoaded
+          ? ListView(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+              children: <Widget>[
+                Card(
+                  margin: EdgeInsets.zero,
+                  child: Column(
+                    children: <Widget>[
+                      SwitchListTile.adaptive(
+                        secondary: const Icon(Lucide.Bot),
+                        title: Text(l10n.scheduledTaskAllowAi),
+                        subtitle: Text(l10n.scheduledTaskAllowAiSubtitle),
+                        value: provider.allowAiOperations,
+                        onChanged: provider.setAllowAiOperations,
+                      ),
+                      const Divider(height: 1),
+                      SwitchListTile.adaptive(
+                        secondary: const Icon(Lucide.Shield),
+                        title: Text(l10n.scheduledTaskRequireApproval),
+                        subtitle: Text(
+                          l10n.scheduledTaskRequireApprovalSubtitle,
+                        ),
+                        value: provider.aiRequiresApproval,
+                        onChanged: provider.allowAiOperations
+                            ? provider.setAiRequiresApproval
+                            : null,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.scheduledTaskShortcutHelp,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.65),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                if (provider.tasks.isEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 64),
+                    child: Column(
+                      children: <Widget>[
+                        Icon(
+                          Lucide.Timer,
+                          size: 42,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurface
+                              .withValues(alpha: 0.35),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(l10n.scheduledTaskEmpty),
+                      ],
+                    ),
+                  )
+                else
+                  ...provider.tasks.map((task) {
+                    final assistant = assistants.getById(task.assistantId);
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: _ScheduledTaskCard(
+                        key: ValueKey<String>(task.id),
+                        task: task,
+                        assistantName:
+                            assistant?.name ?? l10n.scheduledTaskUnknownAssistant,
+                      ),
+                    );
+                  }),
+              ],
+            )
+          : const Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+
+class _ScheduledTaskCard extends StatefulWidget {
+  const _ScheduledTaskCard({
+    super.key,
+    required this.task,
+    required this.assistantName,
+  });
+
+  final ScheduledTask task;
+  final String assistantName;
+
+  @override
+  State<_ScheduledTaskCard> createState() => _ScheduledTaskCardState();
+}
+
+class _ScheduledTaskCardState extends State<_ScheduledTaskCard> {
+  bool _connecting = false;
+
+  Future<void> _connect() async {
+    if (_connecting) return;
+    setState(() => _connecting = true);
+    final provider = context.read<ScheduledTaskProvider>();
+    await provider.markConnected(widget.task.id);
+    if (mounted) {
+      // Let AnimatedSwitcher show the compact connected state before iOS
+      // transfers the user to Shortcuts.
+      await Future<void>.delayed(const Duration(milliseconds: 180));
+    }
+    await IosScheduledTaskBridge.instance.openShortcutSetup(
+      triggerId: widget.task.triggerId,
+      taskName: widget.task.name,
+    );
+    if (mounted) setState(() => _connecting = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final task = widget.task;
+    final cs = Theme.of(context).colorScheme;
+    final muted = cs.onSurface.withValues(alpha: 0.55);
+    final latest = task.logs.isEmpty ? null : task.logs.first;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ScheduledTaskEditPage(taskId: task.id),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      task.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        color: task.isCompleted ? muted : cs.onSurface,
+                        decoration:
+                            task.isCompleted ? TextDecoration.lineThrough : null,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '${widget.assistantName} · ${formatScheduledTaskSchedule(context, task.schedule)}',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(fontSize: 12, color: muted),
+                    ),
+                    if (task.isCompleted) ...<Widget>[
+                      const SizedBox(height: 3),
+                      Text(
+                        l10n.scheduledTaskCompleted,
+                        style: TextStyle(fontSize: 12, color: muted),
+                      ),
+                    ] else if (latest != null) ...<Widget>[
+                      const SizedBox(height: 3),
+                      Text(
+                        latest.status == ScheduledTaskExecutionStatus.success
+                            ? l10n.scheduledTaskLastSuccess(
+                                _formatDateTime(context, latest.finishedAt),
+                              )
+                            : l10n.scheduledTaskLastFailure(
+                                _formatDateTime(context, latest.finishedAt),
+                              ),
+                        style: TextStyle(fontSize: 12, color: muted),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 6),
+              Tooltip(
+                message: task.connected
+                    ? l10n.scheduledTaskReconnect
+                    : l10n.scheduledTaskConnect,
+                child: TextButton(
+                  onPressed: _connecting ? null : _connect,
+                  style: TextButton.styleFrom(
+                    minimumSize: const Size(40, 40),
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                  ),
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 180),
+                    child: task.connected
+                        ? const Icon(
+                            Lucide.Link,
+                            key: ValueKey<String>('connected'),
+                            size: 19,
+                          )
+                        : Row(
+                            key: const ValueKey<String>('connect'),
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              const Icon(Lucide.Link, size: 18),
+                              const SizedBox(width: 4),
+                              Text(l10n.scheduledTaskConnect),
+                            ],
+                          ),
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: l10n.scheduledTaskLogs,
+                icon: const Icon(Lucide.History, size: 20),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => ScheduledTaskLogsPage(taskId: task.id),
+                  ),
+                ),
+              ),
+              Switch.adaptive(
+                value: task.enabled,
+                onChanged: task.isCompleted
+                    ? null
+                    : (value) => context
+                          .read<ScheduledTaskProvider>()
+                          .setEnabled(task.id, value),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String formatScheduledTaskSchedule(
+  BuildContext context,
+  ScheduledTaskSchedule schedule,
+) {
+  final l10n = AppLocalizations.of(context)!;
+  final s = schedule.normalized();
+  final time = TimeOfDay(hour: s.hour, minute: s.minute).format(context);
+  String frequency;
+  switch (s.frequency) {
+    case ScheduledTaskFrequency.once:
+      final at = s.onceAt;
+      if (at == null) return l10n.scheduledTaskFrequencyOnce;
+      final locale = Localizations.localeOf(context).toString();
+      return '${DateFormat.yMMMd(locale).format(at)} · ${TimeOfDay.fromDateTime(at).format(context)}';
+    case ScheduledTaskFrequency.daily:
+      frequency = s.interval == 1
+          ? l10n.scheduledTaskFrequencyDaily
+          : l10n.scheduledTaskEveryN(
+              s.interval,
+              l10n.scheduledTaskUnitDay,
+            );
+      break;
+    case ScheduledTaskFrequency.weekly:
+      frequency = s.interval == 1
+          ? l10n.scheduledTaskFrequencyWeekly
+          : l10n.scheduledTaskEveryN(
+              s.interval,
+              l10n.scheduledTaskUnitWeek,
+            );
+      final weekdays = _weekdayLabels(context, s.weekdays);
+      if (weekdays.isNotEmpty) frequency = '$frequency · $weekdays';
+      break;
+    case ScheduledTaskFrequency.monthly:
+      frequency = s.interval == 1
+          ? l10n.scheduledTaskFrequencyMonthly
+          : l10n.scheduledTaskEveryN(
+              s.interval,
+              l10n.scheduledTaskUnitMonth,
+            );
+      if (s.monthDays.isNotEmpty) {
+        frequency = '$frequency · ${l10n.scheduledTaskMonthDays(s.monthDays.join(', '))}';
+      }
+      break;
+    case ScheduledTaskFrequency.yearly:
+      frequency = s.interval == 1
+          ? l10n.scheduledTaskFrequencyYearly
+          : l10n.scheduledTaskEveryN(
+              s.interval,
+              l10n.scheduledTaskUnitYear,
+            );
+      final date = DateTime(
+        2024,
+        s.yearMonth ?? 1,
+        _validDayForMonth(2024, s.yearMonth ?? 1, s.yearDay ?? 1),
+      );
+      frequency =
+          '$frequency · ${DateFormat.MMMd(Localizations.localeOf(context).toString()).format(date)}';
+      break;
+  }
+  return '$frequency · $time';
+}
+
+String _weekdayLabels(BuildContext context, List<int> weekdays) {
+  if (weekdays.isEmpty) return '';
+  final labels = MaterialLocalizations.of(context).narrowWeekdays;
+  return weekdays.map((weekday) {
+    // narrowWeekdays begins with Sunday.
+    final index = weekday == DateTime.sunday ? 0 : weekday;
+    return labels[index];
+  }).join(' ');
+}
+
+String _formatDateTime(BuildContext context, DateTime value) {
+  final locale = Localizations.localeOf(context).toString();
+  return '${DateFormat.Md(locale).format(value)} ${TimeOfDay.fromDateTime(value).format(context)}';
+}
+
+int _validDayForMonth(int year, int month, int day) {
+  final lastDay = DateTime(year, month + 1, 0).day;
+  return day.clamp(1, lastDay).toInt();
+}

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../../../utils/format.dart';
 import '../../../l10n/app_localizations.dart';
@@ -9,6 +10,7 @@ import '../../provider/pages/providers_page.dart';
 import 'display_settings_page.dart';
 import '../../mcp/pages/mcp_page.dart';
 import '../../assistant/pages/assistant_settings_page.dart';
+import '../../scheduled_tasks/pages/scheduled_tasks_page.dart';
 import 'about_page.dart';
 import 'tts_services_page.dart';
 import 'sponsor_page.dart';
@@ -188,6 +190,22 @@ class SettingsPage extends StatelessWidget {
                   );
                 },
               ),
+              if (!kIsWeb &&
+                  defaultTargetPlatform == TargetPlatform.iOS) ...<Widget>[
+                _iosDivider(context),
+                _iosNavRow(
+                  context,
+                  icon: Lucide.Timer,
+                  label: l10n.settingsPageScheduledTasks,
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const ScheduledTasksPage(),
+                      ),
+                    );
+                  },
+                ),
+              ],
             ],
           ),
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3706,5 +3706,95 @@
   "workspaceToolUnzipUserDesc": "Extract zip archives",
   "workspaceToolDownloadTitle": "Download",
   "workspaceToolDownloadUserDesc": "Download a URL into the workspace",
-  "assistantEditLocalToolWorkspaceTitle": "Workspace"
+  "assistantEditLocalToolWorkspaceTitle": "Workspace",
+  "settingsPageScheduledTasks": "Scheduled Tasks",
+  "scheduledTaskPageTitle": "Scheduled Tasks",
+  "scheduledTaskCreate": "Create Task",
+  "scheduledTaskEdit": "Edit Task",
+  "scheduledTaskSave": "Save",
+  "scheduledTaskName": "Task Name",
+  "scheduledTaskAssistant": "Assistant",
+  "scheduledTaskPrompt": "Task Content",
+  "scheduledTaskFrequency": "Repeat",
+  "scheduledTaskFrequencyOnce": "Once",
+  "scheduledTaskFrequencyDaily": "Daily",
+  "scheduledTaskFrequencyWeekly": "Weekly",
+  "scheduledTaskFrequencyMonthly": "Monthly",
+  "scheduledTaskFrequencyYearly": "Yearly",
+  "scheduledTaskInterval": "Interval",
+  "scheduledTaskIntervalDayHelp": "1 = every day, 2 = every 2 days, and so on.",
+  "scheduledTaskIntervalWeekHelp": "1 = every week, 2 = every 2 weeks, and so on.",
+  "scheduledTaskIntervalMonthHelp": "1 = every month, 2 = every 2 months, and so on.",
+  "scheduledTaskIntervalYearHelp": "1 = every year, 2 = every 2 years, and so on.",
+  "scheduledTaskStartDate": "Start Date",
+  "scheduledTaskRunOnceAt": "Run Once At",
+  "scheduledTaskTime": "Time",
+  "scheduledTaskWeekdays": "Weekdays",
+  "scheduledTaskMonthDaysLabel": "Days of Month",
+  "scheduledTaskYearDate": "Month and Day",
+  "scheduledTaskTimezoneNote": "Times follow the device’s current local timezone.",
+  "scheduledTaskDelete": "Delete Task",
+  "scheduledTaskDeleteTitle": "Delete scheduled task?",
+  "scheduledTaskDeleteMessage": "The task will be removed from Cuplivo. Any old Shortcut trigger will be ignored silently.",
+  "scheduledTaskCancel": "Cancel",
+  "scheduledTaskInvalidForm": "Complete the task name, assistant, content, and a valid interval.",
+  "scheduledTaskSelectWeekday": "Select at least one weekday.",
+  "scheduledTaskSelectMonthDay": "Select at least one day of the month.",
+  "scheduledTaskAllowAi": "Allow AI to manage scheduled tasks",
+  "scheduledTaskAllowAiSubtitle": "All assistants may manage only their own scheduled tasks.",
+  "scheduledTaskRequireApproval": "Require approval for AI changes",
+  "scheduledTaskRequireApprovalSubtitle": "Creating, editing, deleting, enabling, or disabling a task must be approved first.",
+  "scheduledTaskShortcutHelp": "Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.",
+  "scheduledTaskEmpty": "No scheduled tasks yet.",
+  "scheduledTaskUnknownAssistant": "Unknown assistant",
+  "scheduledTaskCompleted": "Executed",
+  "scheduledTaskConnect": "Connect",
+  "scheduledTaskReconnect": "Reconnect",
+  "scheduledTaskLogs": "Execution Logs",
+  "scheduledTaskNotFound": "This scheduled task no longer exists.",
+  "scheduledTaskNoLogs": "No execution logs yet.",
+  "scheduledTaskLogSuccess": "Success",
+  "scheduledTaskLogFailure": "Failed",
+  "scheduledTaskUnitDay": "days",
+  "scheduledTaskUnitWeek": "weeks",
+  "scheduledTaskUnitMonth": "months",
+  "scheduledTaskUnitYear": "years",
+  "scheduledTaskAiConnectHint": "Scheduled task saved. Go to Settings → Scheduled Tasks to connect it to Shortcuts.",
+  "scheduledTaskCompletedNotification": "Scheduled task completed.",
+  "scheduledTaskFailedNotification": "Scheduled task failed. Open Cuplivo to view the execution log.",
+  "scheduledTaskLastSuccess": "Last: {time} · Success",
+  "@scheduledTaskLastSuccess": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskLastFailure": "Last: {time} · Failed",
+  "@scheduledTaskLastFailure": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskEveryN": "Every {count} {unit}",
+  "@scheduledTaskEveryN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskMonthDays": "Days {days}",
+  "@scheduledTaskMonthDays": {
+    "placeholders": {
+      "days": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3744,7 +3744,7 @@
   "scheduledTaskAllowAiSubtitle": "All assistants may manage only their own scheduled tasks.",
   "scheduledTaskRequireApproval": "Require approval for AI changes",
   "scheduledTaskRequireApprovalSubtitle": "Creating, editing, deleting, enabling, or disabling a task must be approved first.",
-  "scheduledTaskShortcutHelp": "Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.",
+  "scheduledTaskShortcutHelp": "Connect opens Shortcuts. Create a Personal Automation that runs every day at this task’s time, then add Cuplivo’s “Run Due Scheduled Tasks” action. One automation per clock time is enough; Cuplivo will run every task due at that time and silently skip dates that do not match each task’s recurrence.",
   "scheduledTaskEmpty": "No scheduled tasks yet.",
   "scheduledTaskUnknownAssistant": "Unknown assistant",
   "scheduledTaskCompleted": "Executed",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14903,6 +14903,360 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Workspace'**
   String get assistantEditLocalToolWorkspaceTitle;
+
+  /// No description provided for @settingsPageScheduledTasks.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled Tasks'**
+  String get settingsPageScheduledTasks;
+
+  /// No description provided for @scheduledTaskPageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled Tasks'**
+  String get scheduledTaskPageTitle;
+
+  /// No description provided for @scheduledTaskCreate.
+  ///
+  /// In en, this message translates to:
+  /// **'Create Task'**
+  String get scheduledTaskCreate;
+
+  /// No description provided for @scheduledTaskEdit.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit Task'**
+  String get scheduledTaskEdit;
+
+  /// No description provided for @scheduledTaskSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get scheduledTaskSave;
+
+  /// No description provided for @scheduledTaskName.
+  ///
+  /// In en, this message translates to:
+  /// **'Task Name'**
+  String get scheduledTaskName;
+
+  /// No description provided for @scheduledTaskAssistant.
+  ///
+  /// In en, this message translates to:
+  /// **'Assistant'**
+  String get scheduledTaskAssistant;
+
+  /// No description provided for @scheduledTaskPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Task Content'**
+  String get scheduledTaskPrompt;
+
+  /// No description provided for @scheduledTaskFrequency.
+  ///
+  /// In en, this message translates to:
+  /// **'Repeat'**
+  String get scheduledTaskFrequency;
+
+  /// No description provided for @scheduledTaskFrequencyOnce.
+  ///
+  /// In en, this message translates to:
+  /// **'Once'**
+  String get scheduledTaskFrequencyOnce;
+
+  /// No description provided for @scheduledTaskFrequencyDaily.
+  ///
+  /// In en, this message translates to:
+  /// **'Daily'**
+  String get scheduledTaskFrequencyDaily;
+
+  /// No description provided for @scheduledTaskFrequencyWeekly.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly'**
+  String get scheduledTaskFrequencyWeekly;
+
+  /// No description provided for @scheduledTaskFrequencyMonthly.
+  ///
+  /// In en, this message translates to:
+  /// **'Monthly'**
+  String get scheduledTaskFrequencyMonthly;
+
+  /// No description provided for @scheduledTaskFrequencyYearly.
+  ///
+  /// In en, this message translates to:
+  /// **'Yearly'**
+  String get scheduledTaskFrequencyYearly;
+
+  /// No description provided for @scheduledTaskInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'Interval'**
+  String get scheduledTaskInterval;
+
+  /// No description provided for @scheduledTaskIntervalDayHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'1 = every day, 2 = every 2 days, and so on.'**
+  String get scheduledTaskIntervalDayHelp;
+
+  /// No description provided for @scheduledTaskIntervalWeekHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'1 = every week, 2 = every 2 weeks, and so on.'**
+  String get scheduledTaskIntervalWeekHelp;
+
+  /// No description provided for @scheduledTaskIntervalMonthHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'1 = every month, 2 = every 2 months, and so on.'**
+  String get scheduledTaskIntervalMonthHelp;
+
+  /// No description provided for @scheduledTaskIntervalYearHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'1 = every year, 2 = every 2 years, and so on.'**
+  String get scheduledTaskIntervalYearHelp;
+
+  /// No description provided for @scheduledTaskStartDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Date'**
+  String get scheduledTaskStartDate;
+
+  /// No description provided for @scheduledTaskRunOnceAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Run Once At'**
+  String get scheduledTaskRunOnceAt;
+
+  /// No description provided for @scheduledTaskTime.
+  ///
+  /// In en, this message translates to:
+  /// **'Time'**
+  String get scheduledTaskTime;
+
+  /// No description provided for @scheduledTaskWeekdays.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekdays'**
+  String get scheduledTaskWeekdays;
+
+  /// No description provided for @scheduledTaskMonthDaysLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Days of Month'**
+  String get scheduledTaskMonthDaysLabel;
+
+  /// No description provided for @scheduledTaskYearDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Month and Day'**
+  String get scheduledTaskYearDate;
+
+  /// No description provided for @scheduledTaskTimezoneNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Times follow the device’s current local timezone.'**
+  String get scheduledTaskTimezoneNote;
+
+  /// No description provided for @scheduledTaskDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Task'**
+  String get scheduledTaskDelete;
+
+  /// No description provided for @scheduledTaskDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete scheduled task?'**
+  String get scheduledTaskDeleteTitle;
+
+  /// No description provided for @scheduledTaskDeleteMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'The task will be removed from Cuplivo. Any old Shortcut trigger will be ignored silently.'**
+  String get scheduledTaskDeleteMessage;
+
+  /// No description provided for @scheduledTaskCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get scheduledTaskCancel;
+
+  /// No description provided for @scheduledTaskInvalidForm.
+  ///
+  /// In en, this message translates to:
+  /// **'Complete the task name, assistant, content, and a valid interval.'**
+  String get scheduledTaskInvalidForm;
+
+  /// No description provided for @scheduledTaskSelectWeekday.
+  ///
+  /// In en, this message translates to:
+  /// **'Select at least one weekday.'**
+  String get scheduledTaskSelectWeekday;
+
+  /// No description provided for @scheduledTaskSelectMonthDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Select at least one day of the month.'**
+  String get scheduledTaskSelectMonthDay;
+
+  /// No description provided for @scheduledTaskAllowAi.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow AI to manage scheduled tasks'**
+  String get scheduledTaskAllowAi;
+
+  /// No description provided for @scheduledTaskAllowAiSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'All assistants may manage only their own scheduled tasks.'**
+  String get scheduledTaskAllowAiSubtitle;
+
+  /// No description provided for @scheduledTaskRequireApproval.
+  ///
+  /// In en, this message translates to:
+  /// **'Require approval for AI changes'**
+  String get scheduledTaskRequireApproval;
+
+  /// No description provided for @scheduledTaskRequireApprovalSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Creating, editing, deleting, enabling, or disabling a task must be approved first.'**
+  String get scheduledTaskRequireApprovalSubtitle;
+
+  /// No description provided for @scheduledTaskShortcutHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.'**
+  String get scheduledTaskShortcutHelp;
+
+  /// No description provided for @scheduledTaskEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No scheduled tasks yet.'**
+  String get scheduledTaskEmpty;
+
+  /// No description provided for @scheduledTaskUnknownAssistant.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown assistant'**
+  String get scheduledTaskUnknownAssistant;
+
+  /// No description provided for @scheduledTaskCompleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Executed'**
+  String get scheduledTaskCompleted;
+
+  /// No description provided for @scheduledTaskConnect.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect'**
+  String get scheduledTaskConnect;
+
+  /// No description provided for @scheduledTaskReconnect.
+  ///
+  /// In en, this message translates to:
+  /// **'Reconnect'**
+  String get scheduledTaskReconnect;
+
+  /// No description provided for @scheduledTaskLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'Execution Logs'**
+  String get scheduledTaskLogs;
+
+  /// No description provided for @scheduledTaskNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'This scheduled task no longer exists.'**
+  String get scheduledTaskNotFound;
+
+  /// No description provided for @scheduledTaskNoLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'No execution logs yet.'**
+  String get scheduledTaskNoLogs;
+
+  /// No description provided for @scheduledTaskLogSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Success'**
+  String get scheduledTaskLogSuccess;
+
+  /// No description provided for @scheduledTaskLogFailure.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed'**
+  String get scheduledTaskLogFailure;
+
+  /// No description provided for @scheduledTaskUnitDay.
+  ///
+  /// In en, this message translates to:
+  /// **'days'**
+  String get scheduledTaskUnitDay;
+
+  /// No description provided for @scheduledTaskUnitWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'weeks'**
+  String get scheduledTaskUnitWeek;
+
+  /// No description provided for @scheduledTaskUnitMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'months'**
+  String get scheduledTaskUnitMonth;
+
+  /// No description provided for @scheduledTaskUnitYear.
+  ///
+  /// In en, this message translates to:
+  /// **'years'**
+  String get scheduledTaskUnitYear;
+
+  /// No description provided for @scheduledTaskAiConnectHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled task saved. Go to Settings → Scheduled Tasks to connect it to Shortcuts.'**
+  String get scheduledTaskAiConnectHint;
+
+  /// No description provided for @scheduledTaskCompletedNotification.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled task completed.'**
+  String get scheduledTaskCompletedNotification;
+
+  /// No description provided for @scheduledTaskFailedNotification.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled task failed. Open Cuplivo to view the execution log.'**
+  String get scheduledTaskFailedNotification;
+
+  /// No description provided for @scheduledTaskLastSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Last: {time} · Success'**
+  String scheduledTaskLastSuccess(String time);
+
+  /// No description provided for @scheduledTaskLastFailure.
+  ///
+  /// In en, this message translates to:
+  /// **'Last: {time} · Failed'**
+  String scheduledTaskLastFailure(String time);
+
+  /// No description provided for @scheduledTaskEveryN.
+  ///
+  /// In en, this message translates to:
+  /// **'Every {count} {unit}'**
+  String scheduledTaskEveryN(int count, String unit);
+
+  /// No description provided for @scheduledTaskMonthDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Days {days}'**
+  String scheduledTaskMonthDays(String days);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15129,7 +15129,7 @@ abstract class AppLocalizations {
   /// No description provided for @scheduledTaskShortcutHelp.
   ///
   /// In en, this message translates to:
-  /// **'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.'**
+  /// **'Connect opens Shortcuts. Create a Personal Automation that runs every day at this task’s time, then add Cuplivo’s “Run Due Scheduled Tasks” action. One automation per clock time is enough; Cuplivo will run every task due at that time and silently skip dates that do not match each task’s recurrence.'**
   String get scheduledTaskShortcutHelp;
 
   /// No description provided for @scheduledTaskEmpty.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8281,16 +8281,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scheduledTaskInterval => 'Interval';
 
   @override
-  String get scheduledTaskIntervalDayHelp => '1 = every day, 2 = every 2 days, and so on.';
+  String get scheduledTaskIntervalDayHelp =>
+      '1 = every day, 2 = every 2 days, and so on.';
 
   @override
-  String get scheduledTaskIntervalWeekHelp => '1 = every week, 2 = every 2 weeks, and so on.';
+  String get scheduledTaskIntervalWeekHelp =>
+      '1 = every week, 2 = every 2 weeks, and so on.';
 
   @override
-  String get scheduledTaskIntervalMonthHelp => '1 = every month, 2 = every 2 months, and so on.';
+  String get scheduledTaskIntervalMonthHelp =>
+      '1 = every month, 2 = every 2 months, and so on.';
 
   @override
-  String get scheduledTaskIntervalYearHelp => '1 = every year, 2 = every 2 years, and so on.';
+  String get scheduledTaskIntervalYearHelp =>
+      '1 = every year, 2 = every 2 years, and so on.';
 
   @override
   String get scheduledTaskStartDate => 'Start Date';
@@ -8311,7 +8315,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scheduledTaskYearDate => 'Month and Day';
 
   @override
-  String get scheduledTaskTimezoneNote => 'Times follow the device’s current local timezone.';
+  String get scheduledTaskTimezoneNote =>
+      'Times follow the device’s current local timezone.';
 
   @override
   String get scheduledTaskDelete => 'Delete Task';
@@ -8320,34 +8325,40 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scheduledTaskDeleteTitle => 'Delete scheduled task?';
 
   @override
-  String get scheduledTaskDeleteMessage => 'The task will be removed from Cuplivo. Any old Shortcut trigger will be ignored silently.';
+  String get scheduledTaskDeleteMessage =>
+      'The task will be removed from Cuplivo. Any old Shortcut trigger will be ignored silently.';
 
   @override
   String get scheduledTaskCancel => 'Cancel';
 
   @override
-  String get scheduledTaskInvalidForm => 'Complete the task name, assistant, content, and a valid interval.';
+  String get scheduledTaskInvalidForm =>
+      'Complete the task name, assistant, content, and a valid interval.';
 
   @override
   String get scheduledTaskSelectWeekday => 'Select at least one weekday.';
 
   @override
-  String get scheduledTaskSelectMonthDay => 'Select at least one day of the month.';
+  String get scheduledTaskSelectMonthDay =>
+      'Select at least one day of the month.';
 
   @override
   String get scheduledTaskAllowAi => 'Allow AI to manage scheduled tasks';
 
   @override
-  String get scheduledTaskAllowAiSubtitle => 'All assistants may manage only their own scheduled tasks.';
+  String get scheduledTaskAllowAiSubtitle =>
+      'All assistants may manage only their own scheduled tasks.';
 
   @override
   String get scheduledTaskRequireApproval => 'Require approval for AI changes';
 
   @override
-  String get scheduledTaskRequireApprovalSubtitle => 'Creating, editing, deleting, enabling, or disabling a task must be approved first.';
+  String get scheduledTaskRequireApprovalSubtitle =>
+      'Creating, editing, deleting, enabling, or disabling a task must be approved first.';
 
   @override
-  String get scheduledTaskShortcutHelp => 'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.';
+  String get scheduledTaskShortcutHelp =>
+      'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.';
 
   @override
   String get scheduledTaskEmpty => 'No scheduled tasks yet.';
@@ -8392,31 +8403,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get scheduledTaskUnitYear => 'years';
 
   @override
-  String get scheduledTaskAiConnectHint => 'Scheduled task saved. Go to Settings → Scheduled Tasks to connect it to Shortcuts.';
+  String get scheduledTaskAiConnectHint =>
+      'Scheduled task saved. Go to Settings → Scheduled Tasks to connect it to Shortcuts.';
 
   @override
   String get scheduledTaskCompletedNotification => 'Scheduled task completed.';
 
   @override
-  String get scheduledTaskFailedNotification => 'Scheduled task failed. Open Cuplivo to view the execution log.';
+  String get scheduledTaskFailedNotification =>
+      'Scheduled task failed. Open Cuplivo to view the execution log.';
 
   @override
   String scheduledTaskLastSuccess(String time) {
-    return 'Last: ${time} · Success';
+    return 'Last: $time · Success';
   }
 
   @override
   String scheduledTaskLastFailure(String time) {
-    return 'Last: ${time} · Failed';
+    return 'Last: $time · Failed';
   }
 
   @override
   String scheduledTaskEveryN(int count, String unit) {
-    return 'Every ${count} ${unit}';
+    return 'Every $count $unit';
   }
 
   @override
   String scheduledTaskMonthDays(String days) {
-    return 'Days ${days}';
+    return 'Days $days';
   }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8358,7 +8358,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scheduledTaskShortcutHelp =>
-      'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.';
+      'Connect opens Shortcuts. Create a Personal Automation that runs every day at this task’s time, then add Cuplivo’s “Run Due Scheduled Tasks” action. One automation per clock time is enough; Cuplivo will run every task due at that time and silently skip dates that do not match each task’s recurrence.';
 
   @override
   String get scheduledTaskEmpty => 'No scheduled tasks yet.';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8234,4 +8234,189 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => 'Workspace';
+
+  @override
+  String get settingsPageScheduledTasks => 'Scheduled Tasks';
+
+  @override
+  String get scheduledTaskPageTitle => 'Scheduled Tasks';
+
+  @override
+  String get scheduledTaskCreate => 'Create Task';
+
+  @override
+  String get scheduledTaskEdit => 'Edit Task';
+
+  @override
+  String get scheduledTaskSave => 'Save';
+
+  @override
+  String get scheduledTaskName => 'Task Name';
+
+  @override
+  String get scheduledTaskAssistant => 'Assistant';
+
+  @override
+  String get scheduledTaskPrompt => 'Task Content';
+
+  @override
+  String get scheduledTaskFrequency => 'Repeat';
+
+  @override
+  String get scheduledTaskFrequencyOnce => 'Once';
+
+  @override
+  String get scheduledTaskFrequencyDaily => 'Daily';
+
+  @override
+  String get scheduledTaskFrequencyWeekly => 'Weekly';
+
+  @override
+  String get scheduledTaskFrequencyMonthly => 'Monthly';
+
+  @override
+  String get scheduledTaskFrequencyYearly => 'Yearly';
+
+  @override
+  String get scheduledTaskInterval => 'Interval';
+
+  @override
+  String get scheduledTaskIntervalDayHelp => '1 = every day, 2 = every 2 days, and so on.';
+
+  @override
+  String get scheduledTaskIntervalWeekHelp => '1 = every week, 2 = every 2 weeks, and so on.';
+
+  @override
+  String get scheduledTaskIntervalMonthHelp => '1 = every month, 2 = every 2 months, and so on.';
+
+  @override
+  String get scheduledTaskIntervalYearHelp => '1 = every year, 2 = every 2 years, and so on.';
+
+  @override
+  String get scheduledTaskStartDate => 'Start Date';
+
+  @override
+  String get scheduledTaskRunOnceAt => 'Run Once At';
+
+  @override
+  String get scheduledTaskTime => 'Time';
+
+  @override
+  String get scheduledTaskWeekdays => 'Weekdays';
+
+  @override
+  String get scheduledTaskMonthDaysLabel => 'Days of Month';
+
+  @override
+  String get scheduledTaskYearDate => 'Month and Day';
+
+  @override
+  String get scheduledTaskTimezoneNote => 'Times follow the device’s current local timezone.';
+
+  @override
+  String get scheduledTaskDelete => 'Delete Task';
+
+  @override
+  String get scheduledTaskDeleteTitle => 'Delete scheduled task?';
+
+  @override
+  String get scheduledTaskDeleteMessage => 'The task will be removed from Cuplivo. Any old Shortcut trigger will be ignored silently.';
+
+  @override
+  String get scheduledTaskCancel => 'Cancel';
+
+  @override
+  String get scheduledTaskInvalidForm => 'Complete the task name, assistant, content, and a valid interval.';
+
+  @override
+  String get scheduledTaskSelectWeekday => 'Select at least one weekday.';
+
+  @override
+  String get scheduledTaskSelectMonthDay => 'Select at least one day of the month.';
+
+  @override
+  String get scheduledTaskAllowAi => 'Allow AI to manage scheduled tasks';
+
+  @override
+  String get scheduledTaskAllowAiSubtitle => 'All assistants may manage only their own scheduled tasks.';
+
+  @override
+  String get scheduledTaskRequireApproval => 'Require approval for AI changes';
+
+  @override
+  String get scheduledTaskRequireApprovalSubtitle => 'Creating, editing, deleting, enabling, or disabling a task must be approved first.';
+
+  @override
+  String get scheduledTaskShortcutHelp => 'Connect copies this task’s Trigger ID and opens Shortcuts. Add “Run Cuplivo Scheduled Task”, paste the Trigger ID, then create a Personal Automation that runs it every day at this task’s time. Cuplivo will decide whether the current date matches the recurrence.';
+
+  @override
+  String get scheduledTaskEmpty => 'No scheduled tasks yet.';
+
+  @override
+  String get scheduledTaskUnknownAssistant => 'Unknown assistant';
+
+  @override
+  String get scheduledTaskCompleted => 'Executed';
+
+  @override
+  String get scheduledTaskConnect => 'Connect';
+
+  @override
+  String get scheduledTaskReconnect => 'Reconnect';
+
+  @override
+  String get scheduledTaskLogs => 'Execution Logs';
+
+  @override
+  String get scheduledTaskNotFound => 'This scheduled task no longer exists.';
+
+  @override
+  String get scheduledTaskNoLogs => 'No execution logs yet.';
+
+  @override
+  String get scheduledTaskLogSuccess => 'Success';
+
+  @override
+  String get scheduledTaskLogFailure => 'Failed';
+
+  @override
+  String get scheduledTaskUnitDay => 'days';
+
+  @override
+  String get scheduledTaskUnitWeek => 'weeks';
+
+  @override
+  String get scheduledTaskUnitMonth => 'months';
+
+  @override
+  String get scheduledTaskUnitYear => 'years';
+
+  @override
+  String get scheduledTaskAiConnectHint => 'Scheduled task saved. Go to Settings → Scheduled Tasks to connect it to Shortcuts.';
+
+  @override
+  String get scheduledTaskCompletedNotification => 'Scheduled task completed.';
+
+  @override
+  String get scheduledTaskFailedNotification => 'Scheduled task failed. Open Cuplivo to view the execution log.';
+
+  @override
+  String scheduledTaskLastSuccess(String time) {
+    return 'Last: ${time} · Success';
+  }
+
+  @override
+  String scheduledTaskLastFailure(String time) {
+    return 'Last: ${time} · Failed';
+  }
+
+  @override
+  String scheduledTaskEveryN(int count, String unit) {
+    return 'Every ${count} ${unit}';
+  }
+
+  @override
+  String scheduledTaskMonthDays(String days) {
+    return 'Days ${days}';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7873,6 +7873,191 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get settingsPageScheduledTasks => '定时任务';
+
+  @override
+  String get scheduledTaskPageTitle => '定时任务';
+
+  @override
+  String get scheduledTaskCreate => '新建定时任务';
+
+  @override
+  String get scheduledTaskEdit => '编辑定时任务';
+
+  @override
+  String get scheduledTaskSave => '保存';
+
+  @override
+  String get scheduledTaskName => '任务名称';
+
+  @override
+  String get scheduledTaskAssistant => '助手';
+
+  @override
+  String get scheduledTaskPrompt => '任务内容';
+
+  @override
+  String get scheduledTaskFrequency => '重复方式';
+
+  @override
+  String get scheduledTaskFrequencyOnce => '仅一次';
+
+  @override
+  String get scheduledTaskFrequencyDaily => '每天';
+
+  @override
+  String get scheduledTaskFrequencyWeekly => '每周';
+
+  @override
+  String get scheduledTaskFrequencyMonthly => '每月';
+
+  @override
+  String get scheduledTaskFrequencyYearly => '每年';
+
+  @override
+  String get scheduledTaskInterval => '间隔';
+
+  @override
+  String get scheduledTaskIntervalDayHelp => '1 表示每天，2 表示每 2 天，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalWeekHelp => '1 表示每周，2 表示每 2 周，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalMonthHelp => '1 表示每月，2 表示每 2 个月，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalYearHelp => '1 表示每年，2 表示每 2 年，以此类推。';
+
+  @override
+  String get scheduledTaskStartDate => '起始日期';
+
+  @override
+  String get scheduledTaskRunOnceAt => '执行时间';
+
+  @override
+  String get scheduledTaskTime => '时间';
+
+  @override
+  String get scheduledTaskWeekdays => '星期';
+
+  @override
+  String get scheduledTaskMonthDaysLabel => '每月日期';
+
+  @override
+  String get scheduledTaskYearDate => '月和日';
+
+  @override
+  String get scheduledTaskTimezoneNote => '时间跟随设备当前所在时区。';
+
+  @override
+  String get scheduledTaskDelete => '删除任务';
+
+  @override
+  String get scheduledTaskDeleteTitle => '删除定时任务？';
+
+  @override
+  String get scheduledTaskDeleteMessage => '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
+
+  @override
+  String get scheduledTaskCancel => '取消';
+
+  @override
+  String get scheduledTaskInvalidForm => '请填写任务名称、助手、任务内容，并设置有效的间隔。';
+
+  @override
+  String get scheduledTaskSelectWeekday => '请至少选择一个星期。';
+
+  @override
+  String get scheduledTaskSelectMonthDay => '请至少选择一个每月日期。';
+
+  @override
+  String get scheduledTaskAllowAi => '允许 AI 操作定时任务';
+
+  @override
+  String get scheduledTaskAllowAiSubtitle => '开启后，所有助手都只能管理各自创建或所属的定时任务。';
+
+  @override
+  String get scheduledTaskRequireApproval => 'AI 操作前需要审批';
+
+  @override
+  String get scheduledTaskRequireApprovalSubtitle => '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
+
+  @override
+  String get scheduledTaskShortcutHelp => '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+
+  @override
+  String get scheduledTaskEmpty => '还没有定时任务。';
+
+  @override
+  String get scheduledTaskUnknownAssistant => '未知助手';
+
+  @override
+  String get scheduledTaskCompleted => '已执行';
+
+  @override
+  String get scheduledTaskConnect => '连接';
+
+  @override
+  String get scheduledTaskReconnect => '重新连接';
+
+  @override
+  String get scheduledTaskLogs => '执行日志';
+
+  @override
+  String get scheduledTaskNotFound => '这个定时任务已不存在。';
+
+  @override
+  String get scheduledTaskNoLogs => '还没有执行日志。';
+
+  @override
+  String get scheduledTaskLogSuccess => '成功';
+
+  @override
+  String get scheduledTaskLogFailure => '失败';
+
+  @override
+  String get scheduledTaskUnitDay => '天';
+
+  @override
+  String get scheduledTaskUnitWeek => '周';
+
+  @override
+  String get scheduledTaskUnitMonth => '个月';
+
+  @override
+  String get scheduledTaskUnitYear => '年';
+
+  @override
+  String get scheduledTaskAiConnectHint => '定时任务已保存，请到“设置 → 定时任务”中连接快捷指令。';
+
+  @override
+  String get scheduledTaskCompletedNotification => '定时任务已执行完成。';
+
+  @override
+  String get scheduledTaskFailedNotification => '定时任务执行失败，请打开 Cuplivo 查看执行日志。';
+
+  @override
+  String scheduledTaskLastSuccess(String time) {
+    return '上次：${time} · 成功';
+  }
+
+  @override
+  String scheduledTaskLastFailure(String time) {
+    return '上次：${time} · 失败';
+  }
+
+  @override
+  String scheduledTaskEveryN(int count, String unit) {
+    return '每 ${count} ${unit}';
+  }
+
+  @override
+  String scheduledTaskMonthDays(String days) {
+    return '每月 ${days} 日';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -15744,6 +15929,191 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get settingsPageScheduledTasks => '定时任务';
+
+  @override
+  String get scheduledTaskPageTitle => '定时任务';
+
+  @override
+  String get scheduledTaskCreate => '新建定时任务';
+
+  @override
+  String get scheduledTaskEdit => '编辑定时任务';
+
+  @override
+  String get scheduledTaskSave => '保存';
+
+  @override
+  String get scheduledTaskName => '任务名称';
+
+  @override
+  String get scheduledTaskAssistant => '助手';
+
+  @override
+  String get scheduledTaskPrompt => '任务内容';
+
+  @override
+  String get scheduledTaskFrequency => '重复方式';
+
+  @override
+  String get scheduledTaskFrequencyOnce => '仅一次';
+
+  @override
+  String get scheduledTaskFrequencyDaily => '每天';
+
+  @override
+  String get scheduledTaskFrequencyWeekly => '每周';
+
+  @override
+  String get scheduledTaskFrequencyMonthly => '每月';
+
+  @override
+  String get scheduledTaskFrequencyYearly => '每年';
+
+  @override
+  String get scheduledTaskInterval => '间隔';
+
+  @override
+  String get scheduledTaskIntervalDayHelp => '1 表示每天，2 表示每 2 天，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalWeekHelp => '1 表示每周，2 表示每 2 周，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalMonthHelp => '1 表示每月，2 表示每 2 个月，以此类推。';
+
+  @override
+  String get scheduledTaskIntervalYearHelp => '1 表示每年，2 表示每 2 年，以此类推。';
+
+  @override
+  String get scheduledTaskStartDate => '起始日期';
+
+  @override
+  String get scheduledTaskRunOnceAt => '执行时间';
+
+  @override
+  String get scheduledTaskTime => '时间';
+
+  @override
+  String get scheduledTaskWeekdays => '星期';
+
+  @override
+  String get scheduledTaskMonthDaysLabel => '每月日期';
+
+  @override
+  String get scheduledTaskYearDate => '月和日';
+
+  @override
+  String get scheduledTaskTimezoneNote => '时间跟随设备当前所在时区。';
+
+  @override
+  String get scheduledTaskDelete => '删除任务';
+
+  @override
+  String get scheduledTaskDeleteTitle => '删除定时任务？';
+
+  @override
+  String get scheduledTaskDeleteMessage => '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
+
+  @override
+  String get scheduledTaskCancel => '取消';
+
+  @override
+  String get scheduledTaskInvalidForm => '请填写任务名称、助手、任务内容，并设置有效的间隔。';
+
+  @override
+  String get scheduledTaskSelectWeekday => '请至少选择一个星期。';
+
+  @override
+  String get scheduledTaskSelectMonthDay => '请至少选择一个每月日期。';
+
+  @override
+  String get scheduledTaskAllowAi => '允许 AI 操作定时任务';
+
+  @override
+  String get scheduledTaskAllowAiSubtitle => '开启后，所有助手都只能管理各自创建或所属的定时任务。';
+
+  @override
+  String get scheduledTaskRequireApproval => 'AI 操作前需要审批';
+
+  @override
+  String get scheduledTaskRequireApprovalSubtitle => '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
+
+  @override
+  String get scheduledTaskShortcutHelp => '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+
+  @override
+  String get scheduledTaskEmpty => '还没有定时任务。';
+
+  @override
+  String get scheduledTaskUnknownAssistant => '未知助手';
+
+  @override
+  String get scheduledTaskCompleted => '已执行';
+
+  @override
+  String get scheduledTaskConnect => '连接';
+
+  @override
+  String get scheduledTaskReconnect => '重新连接';
+
+  @override
+  String get scheduledTaskLogs => '执行日志';
+
+  @override
+  String get scheduledTaskNotFound => '这个定时任务已不存在。';
+
+  @override
+  String get scheduledTaskNoLogs => '还没有执行日志。';
+
+  @override
+  String get scheduledTaskLogSuccess => '成功';
+
+  @override
+  String get scheduledTaskLogFailure => '失败';
+
+  @override
+  String get scheduledTaskUnitDay => '天';
+
+  @override
+  String get scheduledTaskUnitWeek => '周';
+
+  @override
+  String get scheduledTaskUnitMonth => '个月';
+
+  @override
+  String get scheduledTaskUnitYear => '年';
+
+  @override
+  String get scheduledTaskAiConnectHint => '定时任务已保存，请到“设置 → 定时任务”中连接快捷指令。';
+
+  @override
+  String get scheduledTaskCompletedNotification => '定时任务已执行完成。';
+
+  @override
+  String get scheduledTaskFailedNotification => '定时任务执行失败，请打开 Cuplivo 查看执行日志。';
+
+  @override
+  String scheduledTaskLastSuccess(String time) {
+    return '上次：${time} · 成功';
+  }
+
+  @override
+  String scheduledTaskLastFailure(String time) {
+    return '上次：${time} · 失败';
+  }
+
+  @override
+  String scheduledTaskEveryN(int count, String unit) {
+    return '每 ${count} ${unit}';
+  }
+
+  @override
+  String scheduledTaskMonthDays(String days) {
+    return '每月 ${days} 日';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -23615,4 +23985,189 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作區';
+
+  @override
+  String get settingsPageScheduledTasks => '定時任務';
+
+  @override
+  String get scheduledTaskPageTitle => '定時任務';
+
+  @override
+  String get scheduledTaskCreate => '新增定時任務';
+
+  @override
+  String get scheduledTaskEdit => '編輯定時任務';
+
+  @override
+  String get scheduledTaskSave => '儲存';
+
+  @override
+  String get scheduledTaskName => '任務名稱';
+
+  @override
+  String get scheduledTaskAssistant => '助手';
+
+  @override
+  String get scheduledTaskPrompt => '任務內容';
+
+  @override
+  String get scheduledTaskFrequency => '重複方式';
+
+  @override
+  String get scheduledTaskFrequencyOnce => '僅一次';
+
+  @override
+  String get scheduledTaskFrequencyDaily => '每天';
+
+  @override
+  String get scheduledTaskFrequencyWeekly => '每週';
+
+  @override
+  String get scheduledTaskFrequencyMonthly => '每月';
+
+  @override
+  String get scheduledTaskFrequencyYearly => '每年';
+
+  @override
+  String get scheduledTaskInterval => '間隔';
+
+  @override
+  String get scheduledTaskIntervalDayHelp => '1 表示每天，2 表示每 2 天，以此類推。';
+
+  @override
+  String get scheduledTaskIntervalWeekHelp => '1 表示每週，2 表示每 2 週，以此類推。';
+
+  @override
+  String get scheduledTaskIntervalMonthHelp => '1 表示每月，2 表示每 2 個月，以此類推。';
+
+  @override
+  String get scheduledTaskIntervalYearHelp => '1 表示每年，2 表示每 2 年，以此類推。';
+
+  @override
+  String get scheduledTaskStartDate => '起始日期';
+
+  @override
+  String get scheduledTaskRunOnceAt => '執行時間';
+
+  @override
+  String get scheduledTaskTime => '時間';
+
+  @override
+  String get scheduledTaskWeekdays => '星期';
+
+  @override
+  String get scheduledTaskMonthDaysLabel => '每月日期';
+
+  @override
+  String get scheduledTaskYearDate => '月和日';
+
+  @override
+  String get scheduledTaskTimezoneNote => '時間跟隨裝置目前所在時區。';
+
+  @override
+  String get scheduledTaskDelete => '刪除任務';
+
+  @override
+  String get scheduledTaskDeleteTitle => '刪除定時任務？';
+
+  @override
+  String get scheduledTaskDeleteMessage => '任務會從 Cuplivo 中刪除。舊的捷徑觸發器之後會被靜默忽略。';
+
+  @override
+  String get scheduledTaskCancel => '取消';
+
+  @override
+  String get scheduledTaskInvalidForm => '請填寫任務名稱、助手、任務內容，並設定有效的間隔。';
+
+  @override
+  String get scheduledTaskSelectWeekday => '請至少選擇一個星期。';
+
+  @override
+  String get scheduledTaskSelectMonthDay => '請至少選擇一個每月日期。';
+
+  @override
+  String get scheduledTaskAllowAi => '允許 AI 操作定時任務';
+
+  @override
+  String get scheduledTaskAllowAiSubtitle => '開啟後，所有助手都只能管理各自建立或所屬的定時任務。';
+
+  @override
+  String get scheduledTaskRequireApproval => 'AI 操作前需要審批';
+
+  @override
+  String get scheduledTaskRequireApprovalSubtitle => '建立、修改、刪除、啟用或停用任務前，都需要先經過審批。';
+
+  @override
+  String get scheduledTaskShortcutHelp => '點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。';
+
+  @override
+  String get scheduledTaskEmpty => '還沒有定時任務。';
+
+  @override
+  String get scheduledTaskUnknownAssistant => '未知助手';
+
+  @override
+  String get scheduledTaskCompleted => '已執行';
+
+  @override
+  String get scheduledTaskConnect => '連接';
+
+  @override
+  String get scheduledTaskReconnect => '重新連接';
+
+  @override
+  String get scheduledTaskLogs => '執行日誌';
+
+  @override
+  String get scheduledTaskNotFound => '這個定時任務已不存在。';
+
+  @override
+  String get scheduledTaskNoLogs => '還沒有執行日誌。';
+
+  @override
+  String get scheduledTaskLogSuccess => '成功';
+
+  @override
+  String get scheduledTaskLogFailure => '失敗';
+
+  @override
+  String get scheduledTaskUnitDay => '天';
+
+  @override
+  String get scheduledTaskUnitWeek => '週';
+
+  @override
+  String get scheduledTaskUnitMonth => '個月';
+
+  @override
+  String get scheduledTaskUnitYear => '年';
+
+  @override
+  String get scheduledTaskAiConnectHint => '定時任務已儲存，請到「設定 → 定時任務」中連接捷徑。';
+
+  @override
+  String get scheduledTaskCompletedNotification => '定時任務已執行完成。';
+
+  @override
+  String get scheduledTaskFailedNotification => '定時任務執行失敗，請開啟 Cuplivo 查看執行日誌。';
+
+  @override
+  String scheduledTaskLastSuccess(String time) {
+    return '上次：${time} · 成功';
+  }
+
+  @override
+  String scheduledTaskLastFailure(String time) {
+    return '上次：${time} · 失敗';
+  }
+
+  @override
+  String scheduledTaskEveryN(int count, String unit) {
+    return '每 ${count} ${unit}';
+  }
+
+  @override
+  String scheduledTaskMonthDays(String days) {
+    return '每月 ${days} 日';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7959,7 +7959,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get scheduledTaskDeleteTitle => '删除定时任务？';
 
   @override
-  String get scheduledTaskDeleteMessage => '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
+  String get scheduledTaskDeleteMessage =>
+      '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
 
   @override
   String get scheduledTaskCancel => '取消';
@@ -7983,10 +7984,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get scheduledTaskRequireApproval => 'AI 操作前需要审批';
 
   @override
-  String get scheduledTaskRequireApprovalSubtitle => '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
+  String get scheduledTaskRequireApprovalSubtitle =>
+      '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
 
   @override
-  String get scheduledTaskShortcutHelp => '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+  String get scheduledTaskShortcutHelp =>
+      '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
 
   @override
   String get scheduledTaskEmpty => '还没有定时任务。';
@@ -8041,22 +8044,22 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String scheduledTaskLastSuccess(String time) {
-    return '上次：${time} · 成功';
+    return '上次：$time · 成功';
   }
 
   @override
   String scheduledTaskLastFailure(String time) {
-    return '上次：${time} · 失败';
+    return '上次：$time · 失败';
   }
 
   @override
   String scheduledTaskEveryN(int count, String unit) {
-    return '每 ${count} ${unit}';
+    return '每 $count $unit';
   }
 
   @override
   String scheduledTaskMonthDays(String days) {
-    return '每月 ${days} 日';
+    return '每月 $days 日';
   }
 }
 
@@ -16015,7 +16018,8 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get scheduledTaskDeleteTitle => '删除定时任务？';
 
   @override
-  String get scheduledTaskDeleteMessage => '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
+  String get scheduledTaskDeleteMessage =>
+      '任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。';
 
   @override
   String get scheduledTaskCancel => '取消';
@@ -16039,10 +16043,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get scheduledTaskRequireApproval => 'AI 操作前需要审批';
 
   @override
-  String get scheduledTaskRequireApprovalSubtitle => '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
+  String get scheduledTaskRequireApprovalSubtitle =>
+      '创建、修改、删除、启用或停用任务前，都需要先经过审批。';
 
   @override
-  String get scheduledTaskShortcutHelp => '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+  String get scheduledTaskShortcutHelp =>
+      '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
 
   @override
   String get scheduledTaskEmpty => '还没有定时任务。';
@@ -16097,22 +16103,22 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String scheduledTaskLastSuccess(String time) {
-    return '上次：${time} · 成功';
+    return '上次：$time · 成功';
   }
 
   @override
   String scheduledTaskLastFailure(String time) {
-    return '上次：${time} · 失败';
+    return '上次：$time · 失败';
   }
 
   @override
   String scheduledTaskEveryN(int count, String unit) {
-    return '每 ${count} ${unit}';
+    return '每 $count $unit';
   }
 
   @override
   String scheduledTaskMonthDays(String days) {
-    return '每月 ${days} 日';
+    return '每月 $days 日';
   }
 }
 
@@ -24095,10 +24101,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get scheduledTaskRequireApproval => 'AI 操作前需要審批';
 
   @override
-  String get scheduledTaskRequireApprovalSubtitle => '建立、修改、刪除、啟用或停用任務前，都需要先經過審批。';
+  String get scheduledTaskRequireApprovalSubtitle =>
+      '建立、修改、刪除、啟用或停用任務前，都需要先經過審批。';
 
   @override
-  String get scheduledTaskShortcutHelp => '點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。';
+  String get scheduledTaskShortcutHelp =>
+      '點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。';
 
   @override
   String get scheduledTaskEmpty => '還沒有定時任務。';
@@ -24153,21 +24161,21 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String scheduledTaskLastSuccess(String time) {
-    return '上次：${time} · 成功';
+    return '上次：$time · 成功';
   }
 
   @override
   String scheduledTaskLastFailure(String time) {
-    return '上次：${time} · 失敗';
+    return '上次：$time · 失敗';
   }
 
   @override
   String scheduledTaskEveryN(int count, String unit) {
-    return '每 ${count} ${unit}';
+    return '每 $count $unit';
   }
 
   @override
   String scheduledTaskMonthDays(String days) {
-    return '每月 ${days} 日';
+    return '每月 $days 日';
   }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7989,7 +7989,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get scheduledTaskShortcutHelp =>
-      '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+      '点击连接会打开快捷指令。创建一个每天在该任务时间运行的个人自动化，然后添加 Cuplivo 的“执行到期定时任务”操作。同一时间点只需要一个自动化；Cuplivo 会执行该时刻所有到期任务，并静默跳过不符合各自重复规则的日期。';
 
   @override
   String get scheduledTaskEmpty => '还没有定时任务。';
@@ -16048,7 +16048,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get scheduledTaskShortcutHelp =>
-      '点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。';
+      '点击连接会打开快捷指令。创建一个每天在该任务时间运行的个人自动化，然后添加 Cuplivo 的“执行到期定时任务”操作。同一时间点只需要一个自动化；Cuplivo 会执行该时刻所有到期任务，并静默跳过不符合各自重复规则的日期。';
 
   @override
   String get scheduledTaskEmpty => '还没有定时任务。';
@@ -24106,7 +24106,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get scheduledTaskShortcutHelp =>
-      '點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。';
+      '點擊連接會開啟「捷徑」。建立一個每天在該任務時間執行的個人自動化，然後加入 Cuplivo 的「執行到期定時任務」操作。同一時間點只需要一個自動化；Cuplivo 會執行該時刻所有到期任務，並靜默略過不符合各自重複規則的日期。';
 
   @override
   String get scheduledTaskEmpty => '還沒有定時任務。';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3122,5 +3122,95 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "settingsPageScheduledTasks": "定时任务",
+  "scheduledTaskPageTitle": "定时任务",
+  "scheduledTaskCreate": "新建定时任务",
+  "scheduledTaskEdit": "编辑定时任务",
+  "scheduledTaskSave": "保存",
+  "scheduledTaskName": "任务名称",
+  "scheduledTaskAssistant": "助手",
+  "scheduledTaskPrompt": "任务内容",
+  "scheduledTaskFrequency": "重复方式",
+  "scheduledTaskFrequencyOnce": "仅一次",
+  "scheduledTaskFrequencyDaily": "每天",
+  "scheduledTaskFrequencyWeekly": "每周",
+  "scheduledTaskFrequencyMonthly": "每月",
+  "scheduledTaskFrequencyYearly": "每年",
+  "scheduledTaskInterval": "间隔",
+  "scheduledTaskIntervalDayHelp": "1 表示每天，2 表示每 2 天，以此类推。",
+  "scheduledTaskIntervalWeekHelp": "1 表示每周，2 表示每 2 周，以此类推。",
+  "scheduledTaskIntervalMonthHelp": "1 表示每月，2 表示每 2 个月，以此类推。",
+  "scheduledTaskIntervalYearHelp": "1 表示每年，2 表示每 2 年，以此类推。",
+  "scheduledTaskStartDate": "起始日期",
+  "scheduledTaskRunOnceAt": "执行时间",
+  "scheduledTaskTime": "时间",
+  "scheduledTaskWeekdays": "星期",
+  "scheduledTaskMonthDaysLabel": "每月日期",
+  "scheduledTaskYearDate": "月和日",
+  "scheduledTaskTimezoneNote": "时间跟随设备当前所在时区。",
+  "scheduledTaskDelete": "删除任务",
+  "scheduledTaskDeleteTitle": "删除定时任务？",
+  "scheduledTaskDeleteMessage": "任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。",
+  "scheduledTaskCancel": "取消",
+  "scheduledTaskInvalidForm": "请填写任务名称、助手、任务内容，并设置有效的间隔。",
+  "scheduledTaskSelectWeekday": "请至少选择一个星期。",
+  "scheduledTaskSelectMonthDay": "请至少选择一个每月日期。",
+  "scheduledTaskAllowAi": "允许 AI 操作定时任务",
+  "scheduledTaskAllowAiSubtitle": "开启后，所有助手都只能管理各自创建或所属的定时任务。",
+  "scheduledTaskRequireApproval": "AI 操作前需要审批",
+  "scheduledTaskRequireApprovalSubtitle": "创建、修改、删除、启用或停用任务前，都需要先经过审批。",
+  "scheduledTaskShortcutHelp": "点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。",
+  "scheduledTaskEmpty": "还没有定时任务。",
+  "scheduledTaskUnknownAssistant": "未知助手",
+  "scheduledTaskCompleted": "已执行",
+  "scheduledTaskConnect": "连接",
+  "scheduledTaskReconnect": "重新连接",
+  "scheduledTaskLogs": "执行日志",
+  "scheduledTaskNotFound": "这个定时任务已不存在。",
+  "scheduledTaskNoLogs": "还没有执行日志。",
+  "scheduledTaskLogSuccess": "成功",
+  "scheduledTaskLogFailure": "失败",
+  "scheduledTaskUnitDay": "天",
+  "scheduledTaskUnitWeek": "周",
+  "scheduledTaskUnitMonth": "个月",
+  "scheduledTaskUnitYear": "年",
+  "scheduledTaskAiConnectHint": "定时任务已保存，请到“设置 → 定时任务”中连接快捷指令。",
+  "scheduledTaskCompletedNotification": "定时任务已执行完成。",
+  "scheduledTaskFailedNotification": "定时任务执行失败，请打开 Cuplivo 查看执行日志。",
+  "scheduledTaskLastSuccess": "上次：{time} · 成功",
+  "@scheduledTaskLastSuccess": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskLastFailure": "上次：{time} · 失败",
+  "@scheduledTaskLastFailure": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskEveryN": "每 {count} {unit}",
+  "@scheduledTaskEveryN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskMonthDays": "每月 {days} 日",
+  "@scheduledTaskMonthDays": {
+    "placeholders": {
+      "days": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3160,7 +3160,7 @@
   "scheduledTaskAllowAiSubtitle": "开启后，所有助手都只能管理各自创建或所属的定时任务。",
   "scheduledTaskRequireApproval": "AI 操作前需要审批",
   "scheduledTaskRequireApprovalSubtitle": "创建、修改、删除、启用或停用任务前，都需要先经过审批。",
-  "scheduledTaskShortcutHelp": "点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。",
+  "scheduledTaskShortcutHelp": "点击连接会打开快捷指令。创建一个每天在该任务时间运行的个人自动化，然后添加 Cuplivo 的“执行到期定时任务”操作。同一时间点只需要一个自动化；Cuplivo 会执行该时刻所有到期任务，并静默跳过不符合各自重复规则的日期。",
   "scheduledTaskEmpty": "还没有定时任务。",
   "scheduledTaskUnknownAssistant": "未知助手",
   "scheduledTaskCompleted": "已执行",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3123,5 +3123,95 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "settingsPageScheduledTasks": "定时任务",
+  "scheduledTaskPageTitle": "定时任务",
+  "scheduledTaskCreate": "新建定时任务",
+  "scheduledTaskEdit": "编辑定时任务",
+  "scheduledTaskSave": "保存",
+  "scheduledTaskName": "任务名称",
+  "scheduledTaskAssistant": "助手",
+  "scheduledTaskPrompt": "任务内容",
+  "scheduledTaskFrequency": "重复方式",
+  "scheduledTaskFrequencyOnce": "仅一次",
+  "scheduledTaskFrequencyDaily": "每天",
+  "scheduledTaskFrequencyWeekly": "每周",
+  "scheduledTaskFrequencyMonthly": "每月",
+  "scheduledTaskFrequencyYearly": "每年",
+  "scheduledTaskInterval": "间隔",
+  "scheduledTaskIntervalDayHelp": "1 表示每天，2 表示每 2 天，以此类推。",
+  "scheduledTaskIntervalWeekHelp": "1 表示每周，2 表示每 2 周，以此类推。",
+  "scheduledTaskIntervalMonthHelp": "1 表示每月，2 表示每 2 个月，以此类推。",
+  "scheduledTaskIntervalYearHelp": "1 表示每年，2 表示每 2 年，以此类推。",
+  "scheduledTaskStartDate": "起始日期",
+  "scheduledTaskRunOnceAt": "执行时间",
+  "scheduledTaskTime": "时间",
+  "scheduledTaskWeekdays": "星期",
+  "scheduledTaskMonthDaysLabel": "每月日期",
+  "scheduledTaskYearDate": "月和日",
+  "scheduledTaskTimezoneNote": "时间跟随设备当前所在时区。",
+  "scheduledTaskDelete": "删除任务",
+  "scheduledTaskDeleteTitle": "删除定时任务？",
+  "scheduledTaskDeleteMessage": "任务会从 Cuplivo 中删除。旧的快捷指令触发器之后会被静默忽略。",
+  "scheduledTaskCancel": "取消",
+  "scheduledTaskInvalidForm": "请填写任务名称、助手、任务内容，并设置有效的间隔。",
+  "scheduledTaskSelectWeekday": "请至少选择一个星期。",
+  "scheduledTaskSelectMonthDay": "请至少选择一个每月日期。",
+  "scheduledTaskAllowAi": "允许 AI 操作定时任务",
+  "scheduledTaskAllowAiSubtitle": "开启后，所有助手都只能管理各自创建或所属的定时任务。",
+  "scheduledTaskRequireApproval": "AI 操作前需要审批",
+  "scheduledTaskRequireApprovalSubtitle": "创建、修改、删除、启用或停用任务前，都需要先经过审批。",
+  "scheduledTaskShortcutHelp": "点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。",
+  "scheduledTaskEmpty": "还没有定时任务。",
+  "scheduledTaskUnknownAssistant": "未知助手",
+  "scheduledTaskCompleted": "已执行",
+  "scheduledTaskConnect": "连接",
+  "scheduledTaskReconnect": "重新连接",
+  "scheduledTaskLogs": "执行日志",
+  "scheduledTaskNotFound": "这个定时任务已不存在。",
+  "scheduledTaskNoLogs": "还没有执行日志。",
+  "scheduledTaskLogSuccess": "成功",
+  "scheduledTaskLogFailure": "失败",
+  "scheduledTaskUnitDay": "天",
+  "scheduledTaskUnitWeek": "周",
+  "scheduledTaskUnitMonth": "个月",
+  "scheduledTaskUnitYear": "年",
+  "scheduledTaskAiConnectHint": "定时任务已保存，请到“设置 → 定时任务”中连接快捷指令。",
+  "scheduledTaskCompletedNotification": "定时任务已执行完成。",
+  "scheduledTaskFailedNotification": "定时任务执行失败，请打开 Cuplivo 查看执行日志。",
+  "scheduledTaskLastSuccess": "上次：{time} · 成功",
+  "@scheduledTaskLastSuccess": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskLastFailure": "上次：{time} · 失败",
+  "@scheduledTaskLastFailure": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskEveryN": "每 {count} {unit}",
+  "@scheduledTaskEveryN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskMonthDays": "每月 {days} 日",
+  "@scheduledTaskMonthDays": {
+    "placeholders": {
+      "days": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3161,7 +3161,7 @@
   "scheduledTaskAllowAiSubtitle": "开启后，所有助手都只能管理各自创建或所属的定时任务。",
   "scheduledTaskRequireApproval": "AI 操作前需要审批",
   "scheduledTaskRequireApprovalSubtitle": "创建、修改、删除、启用或停用任务前，都需要先经过审批。",
-  "scheduledTaskShortcutHelp": "点击连接会复制该任务的 Trigger ID 并打开快捷指令。添加“Run Cuplivo Scheduled Task”操作并粘贴 Trigger ID，再创建一个每天在该任务时间运行它的个人自动化；Cuplivo 会自行判断当天是否符合重复规则。",
+  "scheduledTaskShortcutHelp": "点击连接会打开快捷指令。创建一个每天在该任务时间运行的个人自动化，然后添加 Cuplivo 的“执行到期定时任务”操作。同一时间点只需要一个自动化；Cuplivo 会执行该时刻所有到期任务，并静默跳过不符合各自重复规则的日期。",
   "scheduledTaskEmpty": "还没有定时任务。",
   "scheduledTaskUnknownAssistant": "未知助手",
   "scheduledTaskCompleted": "已执行",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3123,5 +3123,95 @@
   "workspaceToolUnzipUserDesc": "解壓 zip 壓縮檔",
   "workspaceToolDownloadTitle": "下載",
   "workspaceToolDownloadUserDesc": "將 URL 下載到工作區",
-  "assistantEditLocalToolWorkspaceTitle": "工作區"
+  "assistantEditLocalToolWorkspaceTitle": "工作區",
+  "settingsPageScheduledTasks": "定時任務",
+  "scheduledTaskPageTitle": "定時任務",
+  "scheduledTaskCreate": "新增定時任務",
+  "scheduledTaskEdit": "編輯定時任務",
+  "scheduledTaskSave": "儲存",
+  "scheduledTaskName": "任務名稱",
+  "scheduledTaskAssistant": "助手",
+  "scheduledTaskPrompt": "任務內容",
+  "scheduledTaskFrequency": "重複方式",
+  "scheduledTaskFrequencyOnce": "僅一次",
+  "scheduledTaskFrequencyDaily": "每天",
+  "scheduledTaskFrequencyWeekly": "每週",
+  "scheduledTaskFrequencyMonthly": "每月",
+  "scheduledTaskFrequencyYearly": "每年",
+  "scheduledTaskInterval": "間隔",
+  "scheduledTaskIntervalDayHelp": "1 表示每天，2 表示每 2 天，以此類推。",
+  "scheduledTaskIntervalWeekHelp": "1 表示每週，2 表示每 2 週，以此類推。",
+  "scheduledTaskIntervalMonthHelp": "1 表示每月，2 表示每 2 個月，以此類推。",
+  "scheduledTaskIntervalYearHelp": "1 表示每年，2 表示每 2 年，以此類推。",
+  "scheduledTaskStartDate": "起始日期",
+  "scheduledTaskRunOnceAt": "執行時間",
+  "scheduledTaskTime": "時間",
+  "scheduledTaskWeekdays": "星期",
+  "scheduledTaskMonthDaysLabel": "每月日期",
+  "scheduledTaskYearDate": "月和日",
+  "scheduledTaskTimezoneNote": "時間跟隨裝置目前所在時區。",
+  "scheduledTaskDelete": "刪除任務",
+  "scheduledTaskDeleteTitle": "刪除定時任務？",
+  "scheduledTaskDeleteMessage": "任務會從 Cuplivo 中刪除。舊的捷徑觸發器之後會被靜默忽略。",
+  "scheduledTaskCancel": "取消",
+  "scheduledTaskInvalidForm": "請填寫任務名稱、助手、任務內容，並設定有效的間隔。",
+  "scheduledTaskSelectWeekday": "請至少選擇一個星期。",
+  "scheduledTaskSelectMonthDay": "請至少選擇一個每月日期。",
+  "scheduledTaskAllowAi": "允許 AI 操作定時任務",
+  "scheduledTaskAllowAiSubtitle": "開啟後，所有助手都只能管理各自建立或所屬的定時任務。",
+  "scheduledTaskRequireApproval": "AI 操作前需要審批",
+  "scheduledTaskRequireApprovalSubtitle": "建立、修改、刪除、啟用或停用任務前，都需要先經過審批。",
+  "scheduledTaskShortcutHelp": "點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。",
+  "scheduledTaskEmpty": "還沒有定時任務。",
+  "scheduledTaskUnknownAssistant": "未知助手",
+  "scheduledTaskCompleted": "已執行",
+  "scheduledTaskConnect": "連接",
+  "scheduledTaskReconnect": "重新連接",
+  "scheduledTaskLogs": "執行日誌",
+  "scheduledTaskNotFound": "這個定時任務已不存在。",
+  "scheduledTaskNoLogs": "還沒有執行日誌。",
+  "scheduledTaskLogSuccess": "成功",
+  "scheduledTaskLogFailure": "失敗",
+  "scheduledTaskUnitDay": "天",
+  "scheduledTaskUnitWeek": "週",
+  "scheduledTaskUnitMonth": "個月",
+  "scheduledTaskUnitYear": "年",
+  "scheduledTaskAiConnectHint": "定時任務已儲存，請到「設定 → 定時任務」中連接捷徑。",
+  "scheduledTaskCompletedNotification": "定時任務已執行完成。",
+  "scheduledTaskFailedNotification": "定時任務執行失敗，請開啟 Cuplivo 查看執行日誌。",
+  "scheduledTaskLastSuccess": "上次：{time} · 成功",
+  "@scheduledTaskLastSuccess": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskLastFailure": "上次：{time} · 失敗",
+  "@scheduledTaskLastFailure": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskEveryN": "每 {count} {unit}",
+  "@scheduledTaskEveryN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "unit": {
+        "type": "String"
+      }
+    }
+  },
+  "scheduledTaskMonthDays": "每月 {days} 日",
+  "@scheduledTaskMonthDays": {
+    "placeholders": {
+      "days": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3161,7 +3161,7 @@
   "scheduledTaskAllowAiSubtitle": "開啟後，所有助手都只能管理各自建立或所屬的定時任務。",
   "scheduledTaskRequireApproval": "AI 操作前需要審批",
   "scheduledTaskRequireApprovalSubtitle": "建立、修改、刪除、啟用或停用任務前，都需要先經過審批。",
-  "scheduledTaskShortcutHelp": "點擊連接會複製該任務的 Trigger ID 並開啟「捷徑」。加入「Run Cuplivo Scheduled Task」操作並貼上 Trigger ID，再建立一個每天在該任務時間執行它的個人自動化；Cuplivo 會自行判斷當天是否符合重複規則。",
+  "scheduledTaskShortcutHelp": "點擊連接會開啟「捷徑」。建立一個每天在該任務時間執行的個人自動化，然後加入 Cuplivo 的「執行到期定時任務」操作。同一時間點只需要一個自動化；Cuplivo 會執行該時刻所有到期任務，並靜默略過不符合各自重複規則的日期。",
   "scheduledTaskEmpty": "還沒有定時任務。",
   "scheduledTaskUnknownAssistant": "未知助手",
   "scheduledTaskCompleted": "已執行",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,7 @@ import 'core/providers/backup_reminder_provider.dart';
 import 'core/providers/hotkey_provider.dart';
 import 'core/providers/download_progress_store.dart';
 import 'core/providers/input_status_provider.dart';
+import 'core/providers/scheduled_task_provider.dart';
 import 'core/services/chat/chat_service.dart';
 import 'core/services/trash_restore_coordinator.dart';
 import 'core/services/mcp/mcp_tool_service.dart';
@@ -60,6 +61,7 @@ import 'core/services/android_background.dart';
 import 'core/services/notification_service.dart';
 import 'core/services/proactive_care_alarm_service.dart';
 import 'core/services/proactive_care_message_flow.dart';
+import 'core/services/scheduled_tasks/ios_scheduled_task_bridge.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 
@@ -224,6 +226,14 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
         ChangeNotifierProvider(create: (_) => DownloadProgressStore()),
         ChangeNotifierProvider(create: (_) => InputStatusProvider()),
+        if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS)
+          ChangeNotifierProvider(
+            create: (_) {
+              final provider = ScheduledTaskProvider();
+              unawaited(provider.init());
+              return provider;
+            },
+          ),
         ChangeNotifierProvider(
           create: (ctx) => GenerationEngine(
             chatService: ctx.read<ChatService>(),
@@ -363,6 +373,18 @@ class MyApp extends StatelessWidget {
                 try {
                   settings.setDynamicColorSupported(dynSupported);
                 } catch (_) {}
+              });
+
+              // iOS Shortcuts -> Flutter scheduled-task bridge. It is safe to
+              // call on every rebuild; the bridge initializes only once.
+              WidgetsBinding.instance.addPostFrameCallback((_) async {
+                try {
+                  await IosScheduledTaskBridge.instance.initialize(
+                    () => navigatorKey.currentContext,
+                  );
+                } catch (e) {
+                  debugPrint('[ScheduledTaskBridge] startup failed: $e');
+                }
               });
 
               // Initialize desktop hotkeys on supported platforms

--- a/test/core/models/scheduled_task_test.dart
+++ b/test/core/models/scheduled_task_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/core/models/scheduled_task.dart';
+
+void main() {
+  group('ScheduledTaskSchedule.matchesTrigger', () {
+    test('once runs only on its local calendar date and time window', () {
+      final schedule = ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.once,
+        hour: 8,
+        minute: 30,
+        onceAt: DateTime(2026, 8, 20, 8, 30),
+      );
+
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 20, 8, 30)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 20, 9, 15)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 20, 8, 20)), isFalse);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 21, 8, 30)), isFalse);
+    });
+
+    test('daily interval is anchored to the selected start date', () {
+      final schedule = ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.daily,
+        interval: 3,
+        hour: 8,
+        minute: 0,
+        anchorDate: DateTime(2026, 8, 1),
+      );
+
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 1, 8)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 2, 8)), isFalse);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 4, 8)), isTrue);
+    });
+
+    test('weekly interval supports multiple weekdays', () {
+      final schedule = ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.weekly,
+        interval: 2,
+        hour: 7,
+        minute: 45,
+        anchorDate: DateTime(2026, 8, 3), // Monday
+        weekdays: const <int>[DateTime.monday, DateTime.friday],
+      );
+
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 3, 7, 45)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 7, 7, 45)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 10, 7, 45)), isFalse);
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 17, 7, 45)), isTrue);
+    });
+
+    test('monthly interval supports multiple month days', () {
+      final schedule = ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.monthly,
+        interval: 2,
+        hour: 12,
+        minute: 0,
+        anchorDate: DateTime(2026, 1, 1),
+        monthDays: const <int>[1, 15],
+      );
+
+      expect(schedule.matchesTrigger(DateTime(2026, 1, 15, 12)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2026, 2, 15, 12)), isFalse);
+      expect(schedule.matchesTrigger(DateTime(2026, 3, 1, 12)), isTrue);
+    });
+
+    test('yearly interval follows month and day', () {
+      final schedule = ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.yearly,
+        interval: 2,
+        hour: 9,
+        minute: 0,
+        anchorDate: DateTime(2026, 8, 14),
+        yearMonth: 8,
+        yearDay: 14,
+      );
+
+      expect(schedule.matchesTrigger(DateTime(2026, 8, 14, 9)), isTrue);
+      expect(schedule.matchesTrigger(DateTime(2027, 8, 14, 9)), isFalse);
+      expect(schedule.matchesTrigger(DateTime(2028, 8, 14, 9)), isTrue);
+    });
+  });
+}

--- a/test/core/providers/scheduled_task_provider_test.dart
+++ b/test/core/providers/scheduled_task_provider_test.dart
@@ -138,4 +138,52 @@ void main() {
     );
   });
 
+  test(
+    'connecting one task connects every task at the same clock time',
+    () async {
+      final provider = ScheduledTaskProvider();
+      await provider.init();
+
+      final first = await provider.createTask(
+        assistantId: 'assistant-a',
+        name: 'First 8 AM task',
+        prompt: 'First',
+        schedule: ScheduledTaskSchedule(
+          frequency: ScheduledTaskFrequency.daily,
+          hour: 8,
+          minute: 0,
+          anchorDate: DateTime(2026, 8, 14),
+        ),
+      );
+      final second = await provider.createTask(
+        assistantId: 'assistant-b',
+        name: 'Second 8 AM task',
+        prompt: 'Second',
+        schedule: ScheduledTaskSchedule(
+          frequency: ScheduledTaskFrequency.weekly,
+          hour: 8,
+          minute: 0,
+          anchorDate: DateTime(2026, 8, 14),
+          weekdays: const <int>[DateTime.friday],
+        ),
+      );
+      final differentTime = await provider.createTask(
+        assistantId: 'assistant-a',
+        name: '9 AM task',
+        prompt: 'Later',
+        schedule: ScheduledTaskSchedule(
+          frequency: ScheduledTaskFrequency.daily,
+          hour: 9,
+          minute: 0,
+          anchorDate: DateTime(2026, 8, 14),
+        ),
+      );
+
+      await provider.markConnected(first.id);
+
+      expect(provider.getById(first.id)!.connected, isTrue);
+      expect(provider.getById(second.id)!.connected, isTrue);
+      expect(provider.getById(differentTime.id)!.connected, isFalse);
+    },
+  );
 }

--- a/test/core/providers/scheduled_task_provider_test.dart
+++ b/test/core/providers/scheduled_task_provider_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:Cuplivo/core/models/scheduled_task.dart';
+import 'package:Cuplivo/core/providers/scheduled_task_provider.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('schedule edits invalidate the Trigger ID but content edits do not', () async {
+    final provider = ScheduledTaskProvider();
+    await provider.init();
+
+    final task = await provider.createTask(
+      assistantId: 'assistant-a',
+      name: 'Morning task',
+      prompt: 'Do the thing',
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.daily,
+        hour: 8,
+        minute: 0,
+        anchorDate: DateTime(2026, 8, 14),
+      ),
+    );
+    await provider.markConnected(task.id);
+    final connected = provider.getById(task.id)!;
+
+    final contentEdit = await provider.updateTask(
+      id: task.id,
+      name: 'Renamed task',
+      prompt: 'Do the improved thing',
+    );
+    expect(contentEdit!.triggerId, connected.triggerId);
+    expect(contentEdit.connected, isTrue);
+
+    final oldTrigger = contentEdit.triggerId;
+    final scheduleEdit = await provider.updateTask(
+      id: task.id,
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.daily,
+        hour: 9,
+        minute: 0,
+        anchorDate: DateTime(2026, 8, 14),
+      ),
+    );
+    expect(scheduleEdit!.triggerId, isNot(oldTrigger));
+    expect(scheduleEdit.connected, isFalse);
+    expect(provider.getByTriggerId(oldTrigger), isNull);
+  });
+
+  test('deleting a task makes an old Trigger ID harmless', () async {
+    final provider = ScheduledTaskProvider();
+    await provider.init();
+    final task = await provider.createTask(
+      assistantId: 'assistant-a',
+      name: 'One shot',
+      prompt: 'Run once',
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.once,
+        hour: 10,
+        minute: 0,
+        onceAt: DateTime(2026, 8, 20, 10),
+      ),
+    );
+
+    expect(await provider.deleteTask(task.id), isTrue);
+    expect(provider.getByTriggerId(task.triggerId), isNull);
+  });
+
+  test('rescheduling a completed once task makes it runnable again', () async {
+    final provider = ScheduledTaskProvider();
+    await provider.init();
+    final task = await provider.createTask(
+      assistantId: 'assistant-a',
+      name: 'One shot',
+      prompt: 'Run once',
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.once,
+        hour: 10,
+        minute: 0,
+        onceAt: DateTime(2026, 8, 20, 10),
+      ),
+    );
+
+    await provider.markOnceCompleted(task.id, DateTime(2026, 8, 20, 10, 1));
+    expect(provider.getById(task.id)!.isCompleted, isTrue);
+
+    final updated = await provider.updateTask(
+      id: task.id,
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.once,
+        hour: 11,
+        minute: 0,
+        onceAt: DateTime(2026, 8, 21, 11),
+      ),
+    );
+    expect(updated!.isCompleted, isFalse);
+  });
+  test('the same recurrence occurrence can only be claimed once', () async {
+    final provider = ScheduledTaskProvider();
+    await provider.init();
+    final task = await provider.createTask(
+      assistantId: 'assistant-a',
+      name: 'Daily task',
+      prompt: 'Run daily',
+      schedule: ScheduledTaskSchedule(
+        frequency: ScheduledTaskFrequency.daily,
+        hour: 8,
+        minute: 0,
+        anchorDate: DateTime(2026, 8, 14),
+      ),
+    );
+
+    expect(
+      await provider.claimOccurrence(
+        taskId: task.id,
+        triggerId: task.triggerId,
+        occurrenceKey: '2026-08-14@08:00',
+      ),
+      isTrue,
+    );
+    expect(
+      await provider.claimOccurrence(
+        taskId: task.id,
+        triggerId: task.triggerId,
+        occurrenceKey: '2026-08-14@08:00',
+      ),
+      isFalse,
+    );
+    expect(
+      await provider.claimOccurrence(
+        taskId: task.id,
+        triggerId: task.triggerId,
+        occurrenceKey: '2026-08-15@08:00',
+      ),
+      isTrue,
+    );
+  });
+
+}


### PR DESCRIPTION
## Summary
Adds an iOS scheduled-task system driven by Shortcuts personal automations. A task runs a prompt through a fresh conversation with the normal tool-bearing generation engine, in the background, at recurring times.

## Changes
- **Native (iOS)**: AppDelegate `AppIntent` bridge — `Run Cuplivo Scheduled Task` Shortcut action forwards a Trigger ID over a MethodChannel; pending-trigger queue covers cold launches; background-task protection while executing; notification on completion/failure
- **Model** (`scheduled_task.dart`): once/daily/weekly/monthly/yearly recurrence, interval multipliers, multiple weekdays & month days, occurrence-key dedup (no double runs per day), device-local timezone
- **Provider** (`scheduled_task_provider.dart`): persisted via SharedPreferences, per-assistant ownership, global toggles (allow AI ops / require approval)
- **AI tools**: `list/create/update/delete/set_enabled_scheduled_task` — write ops gated by `ToolApprovalService`; tools only exposed on iOS and when enabled in Settings
- **UI**: Scheduled Tasks list/edit/logs pages (Settings → 定时任务 on iOS), Shortcuts connection flow that copies the Trigger ID and opens `shortcuts://create-shortcut`
- **l10n**: 59 new keys in 4 ARBs + regenerated `app_localizations*.dart` (abstract, en, zh, zh-Hans, zh-Hant)
- **Tests**: schedule matching + provider persistence

## Notes
- iOS-only feature; on other platforms nothing is exposed (no new tools, no settings row, provider not registered)
- Timezone intentionally not persisted — schedules follow the device's current local timezone
- Hourly schedules are not supported (Shortcuts personal automations can't run hourly reliably); daily is the finest granularity via the automation
- Old/disabled/completed Trigger IDs resolve silently so obsolete automations stay harmless
- The iOS Xcode project now bundles `Localizable.strings` (en/zh-Hans/zh-Hant) for the AppIntent display name