### PR TITLE
feat: add plan mode for multi-step task planning and execution

### DIFF
--- a/lib/core/models/plan_mode.dart
+++ b/lib/core/models/plan_mode.dart
@@ -1,0 +1,143 @@
+enum PlanItemStatus { pending, inProgress, completed, error }
+
+enum PlanPhase { planning, awaitingApproval, executing, completed }
+
+PlanItemStatus planItemStatusFromString(String? value) {
+  return switch (value) {
+    'in_progress' => PlanItemStatus.inProgress,
+    'completed' => PlanItemStatus.completed,
+    'error' => PlanItemStatus.error,
+    _ => PlanItemStatus.pending,
+  };
+}
+
+String planItemStatusToString(PlanItemStatus value) {
+  return switch (value) {
+    PlanItemStatus.pending => 'pending',
+    PlanItemStatus.inProgress => 'in_progress',
+    PlanItemStatus.completed => 'completed',
+    PlanItemStatus.error => 'error',
+  };
+}
+
+PlanPhase planPhaseFromString(String? value) {
+  return switch (value) {
+    'awaiting_approval' => PlanPhase.awaitingApproval,
+    'executing' => PlanPhase.executing,
+    'completed' => PlanPhase.completed,
+    _ => PlanPhase.planning,
+  };
+}
+
+String planPhaseToString(PlanPhase value) {
+  return switch (value) {
+    PlanPhase.planning => 'planning',
+    PlanPhase.awaitingApproval => 'awaiting_approval',
+    PlanPhase.executing => 'executing',
+    PlanPhase.completed => 'completed',
+  };
+}
+
+class PlanItem {
+  const PlanItem({
+    required this.id,
+    required this.title,
+    required this.description,
+    this.status = PlanItemStatus.pending,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final PlanItemStatus status;
+
+  PlanItem copyWith({
+    String? title,
+    String? description,
+    PlanItemStatus? status,
+  }) {
+    return PlanItem(
+      id: id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      status: status ?? this.status,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'description': description,
+    'status': planItemStatusToString(status),
+  };
+
+  factory PlanItem.fromJson(Map<String, dynamic> json) {
+    return PlanItem(
+      id: (json['id'] ?? '').toString(),
+      title: (json['title'] ?? '').toString(),
+      description: (json['description'] ?? '').toString(),
+      status: planItemStatusFromString(json['status']?.toString()),
+    );
+  }
+}
+
+class ConversationPlan {
+  const ConversationPlan({
+    required this.conversationId,
+    required this.active,
+    required this.phase,
+    this.title = '',
+    this.items = const <PlanItem>[],
+  });
+
+  final String conversationId;
+  final bool active;
+  final PlanPhase phase;
+  final String title;
+  final List<PlanItem> items;
+
+  bool get hasPlan => items.isNotEmpty;
+  bool get needsInitialPlan => active && items.isEmpty;
+  bool get isAwaitingApproval =>
+      active && phase == PlanPhase.awaitingApproval && items.isNotEmpty;
+
+  ConversationPlan copyWith({
+    bool? active,
+    PlanPhase? phase,
+    String? title,
+    List<PlanItem>? items,
+  }) {
+    return ConversationPlan(
+      conversationId: conversationId,
+      active: active ?? this.active,
+      phase: phase ?? this.phase,
+      title: title ?? this.title,
+      items: items ?? this.items,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'conversationId': conversationId,
+    'active': active,
+    'phase': planPhaseToString(phase),
+    'title': title,
+    'items': items.map((e) => e.toJson()).toList(),
+  };
+
+  factory ConversationPlan.fromJson(Map<String, dynamic> json) {
+    final rawItems = json['items'];
+    return ConversationPlan(
+      conversationId: (json['conversationId'] ?? '').toString(),
+      active: json['active'] == true,
+      phase: planPhaseFromString(json['phase']?.toString()),
+      title: (json['title'] ?? '').toString(),
+      items: rawItems is List
+          ? rawItems
+                .whereType<Map>()
+                .map((e) => PlanItem.fromJson(e.cast<String, dynamic>()))
+                .where((e) => e.id.isNotEmpty && e.title.isNotEmpty)
+                .toList()
+          : const <PlanItem>[],
+    );
+  }
+}

--- a/lib/core/providers/plan_mode_provider.dart
+++ b/lib/core/providers/plan_mode_provider.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/plan_mode.dart';
+
+enum PlanApprovalDecision { approved, rejected }
+
+/// Conversation-scoped Plan Mode state.
+///
+/// Plan state is persisted separately from chat rows so the feature can evolve
+/// without a database migration. Pending approval completers are intentionally
+/// process-local: if the app/process is restarted, the persisted plan remains
+/// visible but no stale generation is resumed automatically.
+class PlanModeProvider extends ChangeNotifier {
+  static const _prefsKey = 'plan_mode_by_conversation_v1';
+
+  final Map<String, ConversationPlan> _plans = <String, ConversationPlan>{};
+  final Map<String, Completer<PlanApprovalDecision>> _approvalWaiters =
+      <String, Completer<PlanApprovalDecision>>{};
+  bool _initialized = false;
+  bool _initializing = false;
+  Completer<void>? _initializationCompleter;
+
+  bool get initialized => _initialized;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    if (_initializing) {
+      await _initializationCompleter?.future;
+      return;
+    }
+    _initializing = true;
+    final completer = Completer<void>();
+    _initializationCompleter = completer;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      if (raw != null && raw.trim().isNotEmpty) {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map) {
+          for (final entry in decoded.entries) {
+            if (entry.value is! Map) continue;
+            final value = Map<String, dynamic>.from(entry.value as Map);
+            value['conversationId'] = entry.key.toString();
+            var plan = ConversationPlan.fromJson(value);
+            if (plan.phase == PlanPhase.awaitingApproval) {
+              plan = plan.copyWith(phase: PlanPhase.planning);
+            }
+            if (plan.conversationId.isNotEmpty) {
+              _plans[plan.conversationId] = plan;
+            }
+          }
+        }
+      }
+      _initialized = true;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[PlanMode] initialize failed: $e');
+      _initialized = true;
+    } finally {
+      _initializing = false;
+      if (!completer.isCompleted) completer.complete();
+      if (identical(_initializationCompleter, completer)) {
+        _initializationCompleter = null;
+      }
+    }
+  }
+
+  ConversationPlan? planFor(String? conversationId) {
+    if (conversationId == null || conversationId.isEmpty) return null;
+    return _plans[conversationId];
+  }
+
+  bool isActive(String? conversationId) =>
+      planFor(conversationId)?.active == true;
+
+  bool needsInitialPlan(String? conversationId) =>
+      planFor(conversationId)?.needsInitialPlan == true;
+
+  bool hasPendingApproval(String? conversationId) {
+    if (conversationId == null) return false;
+    return _approvalWaiters.containsKey(conversationId);
+  }
+
+  Future<void> setActive(String conversationId, bool active) async {
+    if (conversationId.isEmpty) return;
+    await initialize();
+    final current = _plans[conversationId];
+    if (!active) {
+      rejectPendingApproval(conversationId);
+      if (current == null) return;
+      _plans[conversationId] = current.copyWith(active: false);
+    } else if (current == null) {
+      _plans[conversationId] = ConversationPlan(
+        conversationId: conversationId,
+        active: true,
+        phase: PlanPhase.planning,
+      );
+    } else {
+      _plans[conversationId] = current.copyWith(active: true);
+    }
+    notifyListeners();
+    await _persist();
+  }
+
+  Future<void> clearPlan(String conversationId) async {
+    await initialize();
+    rejectPendingApproval(conversationId);
+    _plans.remove(conversationId);
+    notifyListeners();
+    await _persist();
+  }
+
+  String _newItemId(String conversationId, int index) {
+    final micros = DateTime.now().microsecondsSinceEpoch;
+    return 'plan_${conversationId.hashCode.abs()}_${micros}_$index';
+  }
+
+  Future<ConversationPlan> createOrReplacePlan({
+    required String conversationId,
+    required String title,
+    required List<({String title, String description})> items,
+    bool awaitingApproval = true,
+  }) async {
+    final normalized = <PlanItem>[];
+    for (var i = 0; i < items.length; i++) {
+      final itemTitle = items[i].title.trim();
+      if (itemTitle.isEmpty) continue;
+      normalized.add(
+        PlanItem(
+          id: _newItemId(conversationId, i),
+          title: itemTitle,
+          description: items[i].description.trim(),
+        ),
+      );
+    }
+    final plan = ConversationPlan(
+      conversationId: conversationId,
+      active: true,
+      phase: awaitingApproval
+          ? PlanPhase.awaitingApproval
+          : PlanPhase.planning,
+      title: title.trim(),
+      items: normalized,
+    );
+    _plans[conversationId] = plan;
+    notifyListeners();
+    await _persist();
+    return plan;
+  }
+
+  Future<ConversationPlan?> updateItem({
+    required String conversationId,
+    required String itemId,
+    String? title,
+    String? description,
+    bool requireApproval = false,
+  }) async {
+    final current = _plans[conversationId];
+    if (current == null) return null;
+    final next = current.items
+        .map(
+          (item) => item.id == itemId
+              ? item.copyWith(
+                  title: title?.trim().isNotEmpty == true ? title!.trim() : null,
+                  description: description?.trim(),
+                )
+              : item,
+        )
+        .toList();
+    final plan = current.copyWith(
+      items: next,
+      phase: requireApproval ? PlanPhase.planning : current.phase,
+    );
+    _plans[conversationId] = plan;
+    notifyListeners();
+    await _persist();
+    return plan;
+  }
+
+  Future<ConversationPlan?> setItemStatus({
+    required String conversationId,
+    required String itemId,
+    required PlanItemStatus status,
+  }) async {
+    final current = _plans[conversationId];
+    if (current == null) return null;
+    final next = current.items
+        .map((item) {
+          if (item.id == itemId) return item.copyWith(status: status);
+          if (status == PlanItemStatus.inProgress &&
+              item.status == PlanItemStatus.inProgress) {
+            return item.copyWith(status: PlanItemStatus.pending);
+          }
+          return item;
+        })
+        .toList();
+    final allCompleted = next.isNotEmpty &&
+        next.every((item) => item.status == PlanItemStatus.completed);
+    final plan = current.copyWith(
+      items: next,
+      phase: allCompleted ? PlanPhase.completed : PlanPhase.executing,
+    );
+    _plans[conversationId] = plan;
+    notifyListeners();
+    await _persist();
+    return plan;
+  }
+
+  Future<ConversationPlan?> addItem({
+    required String conversationId,
+    required String title,
+    required String description,
+    int? afterIndex,
+    bool requireApproval = false,
+  }) async {
+    final current = _plans[conversationId];
+    if (current == null) return null;
+    final next = List<PlanItem>.of(current.items);
+    final item = PlanItem(
+      id: _newItemId(conversationId, next.length),
+      title: title.trim(),
+      description: description.trim(),
+    );
+    final insertAt = afterIndex == null
+        ? next.length
+        : (afterIndex + 1).clamp(0, next.length);
+    next.insert(insertAt, item);
+    final plan = current.copyWith(
+      items: next,
+      phase: requireApproval ? PlanPhase.planning : current.phase,
+    );
+    _plans[conversationId] = plan;
+    notifyListeners();
+    await _persist();
+    return plan;
+  }
+
+  Future<ConversationPlan?> removeItem({
+    required String conversationId,
+    required String itemId,
+    bool requireApproval = false,
+  }) async {
+    final current = _plans[conversationId];
+    if (current == null) return null;
+    final next = current.items.where((item) => item.id != itemId).toList();
+    final plan = current.copyWith(
+      items: next,
+      phase: requireApproval ? PlanPhase.planning : current.phase,
+    );
+    _plans[conversationId] = plan;
+    notifyListeners();
+    await _persist();
+    return plan;
+  }
+
+  Future<void> markAwaitingApproval(String conversationId) async {
+    final current = _plans[conversationId];
+    if (current == null || current.items.isEmpty) return;
+    _plans[conversationId] = current.copyWith(
+      active: true,
+      phase: PlanPhase.awaitingApproval,
+    );
+    notifyListeners();
+    await _persist();
+  }
+
+  Future<PlanApprovalDecision> waitForApproval(String conversationId) async {
+    final old = _approvalWaiters.remove(conversationId);
+    if (old != null && !old.isCompleted) {
+      old.complete(PlanApprovalDecision.rejected);
+    }
+    final completer = Completer<PlanApprovalDecision>();
+    _approvalWaiters[conversationId] = completer;
+    notifyListeners();
+    final decision = await completer.future;
+    if (identical(_approvalWaiters[conversationId], completer)) {
+      _approvalWaiters.remove(conversationId);
+    }
+    notifyListeners();
+    return decision;
+  }
+
+  Future<void> approve(String conversationId) async {
+    final current = _plans[conversationId];
+    if (current != null) {
+      _plans[conversationId] = current.copyWith(
+        active: true,
+        phase: PlanPhase.executing,
+      );
+      await _persist();
+    }
+    final waiter = _approvalWaiters.remove(conversationId);
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete(PlanApprovalDecision.approved);
+    }
+    notifyListeners();
+  }
+
+  Future<void> reject(String conversationId) async {
+    final current = _plans[conversationId];
+    if (current != null) {
+      _plans[conversationId] = current.copyWith(
+        active: true,
+        phase: PlanPhase.planning,
+      );
+      await _persist();
+    }
+    final waiter = _approvalWaiters.remove(conversationId);
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete(PlanApprovalDecision.rejected);
+    }
+    notifyListeners();
+  }
+
+  void rejectPendingApproval(String conversationId) {
+    final waiter = _approvalWaiters.remove(conversationId);
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete(PlanApprovalDecision.rejected);
+    }
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final body = <String, dynamic>{
+        for (final entry in _plans.entries) entry.key: entry.value.toJson(),
+      };
+      await prefs.setString(_prefsKey, jsonEncode(body));
+    } catch (e) {
+      debugPrint('[PlanMode] persist failed: $e');
+    }
+  }
+}

--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -621,6 +621,7 @@ class ChatApiService {
     ToolCallHandler? onToolCall,
     Map<String, String>? extraHeaders,
     Map<String, dynamic>? extraBody,
+    String? forcedFirstToolName,
     bool stream = true,
     String? requestId,
     bool allowImagesApiRouting = true,
@@ -685,6 +686,7 @@ class ChatApiService {
             onToolCall: onToolCall,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
+            forcedFirstToolName: forcedFirstToolName,
             stream: stream,
           );
         } else {
@@ -702,6 +704,7 @@ class ChatApiService {
             onToolCall: onToolCall,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
+            forcedFirstToolName: forcedFirstToolName,
             stream: stream,
           );
         }
@@ -720,6 +723,7 @@ class ChatApiService {
           onToolCall: onToolCall,
           extraHeaders: extraHeaders,
           extraBody: extraBody,
+          forcedFirstToolName: forcedFirstToolName,
           stream: stream,
         );
       } else if (kind == ProviderKind.google) {
@@ -741,6 +745,7 @@ class ChatApiService {
             onToolCall: onToolCall,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
+            forcedFirstToolName: forcedFirstToolName,
             stream: stream,
           );
         } else if (isVertex) {
@@ -758,6 +763,7 @@ class ChatApiService {
             onToolCall: onToolCall,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
+            forcedFirstToolName: forcedFirstToolName,
             stream: stream,
           );
         } else {
@@ -775,6 +781,7 @@ class ChatApiService {
             onToolCall: onToolCall,
             extraHeaders: extraHeaders,
             extraBody: extraBody,
+            forcedFirstToolName: forcedFirstToolName,
             stream: stream,
           );
         }

--- a/lib/core/services/api/gemini_tool_config.dart
+++ b/lib/core/services/api/gemini_tool_config.dart
@@ -38,9 +38,20 @@ bool hasBuiltInAndFunctionDeclarations(List<Map<String, dynamic>> tools) {
 Map<String, dynamic>? buildGeminiToolConfig({
   required List<Map<String, dynamic>> tools,
   required bool isGemini3,
+  String? forcedFunctionName,
 }) {
   final hasFuncDecls = shouldAttachGeminiFunctionCallingConfig(tools);
   if (!hasFuncDecls) return null;
+
+  final forced = forcedFunctionName?.trim();
+  if (forced != null && forced.isNotEmpty) {
+    return {
+      'function_calling_config': {
+        'mode': 'ANY',
+        'allowed_function_names': [forced],
+      },
+    };
+  }
 
   if (isGemini3 && hasBuiltInAndFunctionDeclarations(tools)) {
     return {

--- a/lib/core/services/api/providers/claude_official.dart
+++ b/lib/core/services/api/providers/claude_official.dart
@@ -102,6 +102,7 @@ Stream<ChatStreamChunk> _sendClaudeStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) async* {
   final upstreamModelId = _apiModelId(config, modelId);
@@ -405,6 +406,8 @@ Stream<ChatStreamChunk> _sendClaudeStream(
     initialMessages,
   );
   TokenUsage? consumedUsage;
+  var pendingForcedToolName = forcedFirstToolName?.trim();
+  if (pendingForcedToolName?.isEmpty == true) pendingForcedToolName = null;
 
   while (true) {
     final omitSamplingParams = _claudeShouldOmitSamplingParams(
@@ -440,7 +443,10 @@ Stream<ChatStreamChunk> _sendClaudeStream(
         'temperature': temperature,
       if (compatibleTopP != null) 'top_p': compatibleTopP,
       if (allTools.isNotEmpty) 'tools': allTools,
-      if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
+      if (allTools.isNotEmpty)
+        'tool_choice': pendingForcedToolName != null
+            ? {'type': 'tool', 'name': pendingForcedToolName}
+            : {'type': 'auto'},
       if (thinking != null) 'thinking': thinking,
       if (outputConfig != null) 'output_config': outputConfig,
     };
@@ -453,12 +459,19 @@ Stream<ChatStreamChunk> _sendClaudeStream(
         body[k] = (v is String) ? _parseOverrideValue(v) : v;
       });
     }
+    if (pendingForcedToolName != null && allTools.isNotEmpty) {
+      body['tool_choice'] = {'type': 'tool', 'name': pendingForcedToolName};
+    }
 
     final request = http.Request('POST', url);
     request.headers.addAll(baseHeaders);
     request.body = jsonEncode(body);
 
     final response = await client.send(request);
+    // The forced choice is intentionally one-shot. If the selected tool
+    // returns a result and Claude continues in the same generation, all
+    // following rounds return to normal auto tool selection.
+    pendingForcedToolName = null;
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final errorBody = await response.stream.bytesToString();
       throw HttpException('HTTP ${response.statusCode}: $errorBody');

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -301,6 +301,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) async* {
   // Check for Vertex AI Claude models (prefix "claude-")
@@ -321,6 +322,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       onToolCall: onToolCall,
       extraHeaders: extraHeaders,
       extraBody: extraBody,
+      forcedFirstToolName: forcedFirstToolName,
       stream: stream,
     );
     return;
@@ -334,6 +336,8 @@ Stream<ChatStreamChunk> _sendGoogleStream(
   // Effective model features (includes user overrides)
   final effective = _effectiveModelInfo(config, modelId);
   final isReasoning = _shouldRequestGoogleThoughts(config, modelId, effective);
+  var pendingForcedToolName = forcedFirstToolName?.trim();
+  if (pendingForcedToolName?.isEmpty == true) pendingForcedToolName = null;
   // Non-streaming path: use generateContent
   if (!stream) {
     final isVertex = config.vertexAI == true;
@@ -560,6 +564,11 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     final geminiToolConfig = buildGeminiToolConfig(
       tools: toolsArr,
       isGemini3: isGemini3 && !isVertex,
+      forcedFunctionName: pendingForcedToolName,
+    );
+    final automaticGeminiToolConfig = buildGeminiToolConfig(
+      tools: toolsArr,
+      isGemini3: isGemini3 && !isVertex,
     );
 
     final thinkingConfig = isReasoning
@@ -597,6 +606,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         baseBody[k] = (v is String) ? _parseOverrideValue(v) : v;
       });
     }
+    if (pendingForcedToolName != null && geminiToolConfig != null) {
+      baseBody['toolConfig'] = geminiToolConfig;
+    }
 
     // Sum of usage across completed request rounds (consumed semantics).
     TokenUsage? consumedUsage;
@@ -611,6 +623,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       body['contents'] = _googleApiContents(currentContents);
       req.body = jsonEncode(body);
       final resp = await client.send(req);
+      if (pendingForcedToolName != null) {
+        pendingForcedToolName = null;
+        if (automaticGeminiToolConfig != null) {
+          baseBody['toolConfig'] = automaticGeminiToolConfig;
+        } else {
+          baseBody.remove('toolConfig');
+        }
+      }
       if (resp.statusCode < 200 || resp.statusCode >= 300) {
         final errorBody = await resp.stream.bytesToString();
         throw HttpException('HTTP ${resp.statusCode}: $errorBody');
@@ -1008,7 +1028,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     allowCoexistence: isGemini3,
     geminiTools: geminiTools,
   );
-  final geminiToolConfig = buildGeminiToolConfig(
+  final automaticGeminiToolConfig = buildGeminiToolConfig(
     tools: toolsArr,
     isGemini3: isGemini3 && !isVertex,
   );
@@ -1070,6 +1090,13 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           return {'thinkingConfig': thinkingConfig};
         }(),
     };
+    final roundGeminiToolConfig = pendingForcedToolName != null
+        ? buildGeminiToolConfig(
+            tools: toolsArr,
+            isGemini3: isGemini3 && !isVertex,
+            forcedFunctionName: pendingForcedToolName,
+          )
+        : automaticGeminiToolConfig;
     final body = <String, dynamic>{
       'contents': convo,
       if (systemPrompt.isNotEmpty)
@@ -1080,7 +1107,8 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         },
       if (gen.isNotEmpty) 'generationConfig': gen,
       if (toolsArr.isNotEmpty) 'tools': toolsArr,
-      if (geminiToolConfig != null) 'toolConfig': geminiToolConfig,
+      if (roundGeminiToolConfig != null)
+        'toolConfig': roundGeminiToolConfig,
     };
 
     final request = http.Request('POST', uri);
@@ -1115,10 +1143,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
         body[k] = (v is String) ? _parseOverrideValue(v) : v;
       });
     }
+    if (pendingForcedToolName != null && roundGeminiToolConfig != null) {
+      body['toolConfig'] = roundGeminiToolConfig;
+    }
     body['contents'] = _googleApiContents(convo);
     request.body = jsonEncode(body);
 
     final resp = await client.send(request);
+    pendingForcedToolName = null;
     if (resp.statusCode < 200 || resp.statusCode >= 300) {
       final errorBody = await resp.stream.bytesToString();
       throw HttpException('HTTP ${resp.statusCode}: $errorBody');

--- a/lib/core/services/api/providers/google_gemini.dart
+++ b/lib/core/services/api/providers/google_gemini.dart
@@ -201,6 +201,7 @@ Stream<ChatStreamChunk> _sendGoogleGeminiStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) {
   final cfg = config.copyWith(vertexAI: false);
@@ -218,6 +219,7 @@ Stream<ChatStreamChunk> _sendGoogleGeminiStream(
     onToolCall: onToolCall,
     extraHeaders: extraHeaders,
     extraBody: extraBody,
+    forcedFirstToolName: forcedFirstToolName,
     stream: stream,
   );
 }

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -14,6 +14,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) {
   final cfg = config.copyWith(vertexAI: true);
@@ -31,6 +32,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexStream(
     onToolCall: onToolCall,
     extraHeaders: extraHeaders,
     extraBody: extraBody,
+    forcedFirstToolName: forcedFirstToolName,
     stream: stream,
   );
 }
@@ -129,6 +131,7 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) async* {
   final upstreamId = _apiModelId(config, modelId);
@@ -328,6 +331,8 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
     initialMessages,
   );
   TokenUsage? consumedUsage;
+  var pendingForcedToolName = forcedFirstToolName?.trim();
+  if (pendingForcedToolName?.isEmpty == true) pendingForcedToolName = null;
 
   while (true) {
     final omitSamplingParams = _claudeShouldOmitSamplingParams(
@@ -357,7 +362,10 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
         'temperature': temperature,
       if (compatibleTopP != null) 'top_p': compatibleTopP,
       if (allTools.isNotEmpty) 'tools': allTools,
-      if (allTools.isNotEmpty) 'tool_choice': {'type': 'auto'},
+      if (allTools.isNotEmpty)
+        'tool_choice': pendingForcedToolName != null
+            ? {'type': 'tool', 'name': pendingForcedToolName}
+            : {'type': 'auto'},
       if (thinking != null) 'thinking': thinking,
       if (outputConfig != null) 'output_config': outputConfig,
     };
@@ -366,12 +374,16 @@ Stream<ChatStreamChunk> _sendGoogleVertexClaudeStream({
         body[k] = (v is String) ? _parseOverrideValue(v) : v;
       });
     }
+    if (pendingForcedToolName != null && allTools.isNotEmpty) {
+      body['tool_choice'] = {'type': 'tool', 'name': pendingForcedToolName};
+    }
 
     final request = http.Request('POST', url);
     request.headers.addAll(headers);
     request.body = jsonEncode(body);
 
     final response = await client.send(request);
+    pendingForcedToolName = null;
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final errorBody = await response.stream.bytesToString();
       throw HttpException('HTTP ${response.statusCode}: $errorBody');

--- a/lib/core/services/api/providers/openai_chat_completions.dart
+++ b/lib/core/services/api/providers/openai_chat_completions.dart
@@ -87,6 +87,7 @@ Stream<ChatStreamChunk> _sendOpenAIChatCompletionsStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) {
   final cfg = config.copyWith(useResponseApi: false);
@@ -104,6 +105,7 @@ Stream<ChatStreamChunk> _sendOpenAIChatCompletionsStream(
     onToolCall: onToolCall,
     extraHeaders: extraHeaders,
     extraBody: extraBody,
+    forcedFirstToolName: forcedFirstToolName,
     stream: stream,
   );
 }

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -1247,6 +1247,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) async* {
   await CodexDeviceCodeController.ensureFreshOrThrow(config);
@@ -1754,6 +1755,17 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     extraBody.forEach((k, v) {
       body[k] = (v is String) ? _parseOverrideValue(v) : v;
     });
+  }
+  if (forcedFirstToolName != null &&
+      forcedFirstToolName.trim().isNotEmpty &&
+      tools != null &&
+      tools.isNotEmpty) {
+    body['tool_choice'] = config.useResponseApi == true
+        ? {'type': 'function', 'name': forcedFirstToolName.trim()}
+        : {
+            'type': 'function',
+            'function': {'name': forcedFirstToolName.trim()},
+          };
   }
   _sanitizeOpenAIGpt5SamplingParams(
     body,

--- a/lib/core/services/api/providers/openai_responses.dart
+++ b/lib/core/services/api/providers/openai_responses.dart
@@ -79,6 +79,7 @@ Stream<ChatStreamChunk> _sendOpenAIResponsesStream(
   ToolCallHandler? onToolCall,
   Map<String, String>? extraHeaders,
   Map<String, dynamic>? extraBody,
+  String? forcedFirstToolName,
   bool stream = true,
 }) {
   final cfg = config.copyWith(useResponseApi: true);
@@ -96,6 +97,7 @@ Stream<ChatStreamChunk> _sendOpenAIResponsesStream(
     onToolCall: onToolCall,
     extraHeaders: extraHeaders,
     extraBody: extraBody,
+    forcedFirstToolName: forcedFirstToolName,
     stream: stream,
   );
 }

--- a/lib/core/services/generation_engine.dart
+++ b/lib/core/services/generation_engine.dart
@@ -52,6 +52,7 @@ typedef EngineChatStreamProvider =
       ToolCallHandler? onToolCall,
       Map<String, String>? extraHeaders,
       Map<String, dynamic>? extraBody,
+      String? forcedFirstToolName,
       required bool stream,
       String? requestId,
       required bool allowImagesApiRouting,
@@ -83,6 +84,7 @@ class GenerationSlotRequest {
     this.ocrActive = false,
     this.extraHeaders,
     this.extraBody,
+    this.forcedFirstToolName,
     this.supportsReasoning = true,
     this.autoCollapseThinking = true,
     this.partialImageNotice,
@@ -113,6 +115,7 @@ class GenerationSlotRequest {
   final bool ocrActive;
   final Map<String, String>? extraHeaders;
   final Map<String, dynamic>? extraBody;
+  final String? forcedFirstToolName;
   final bool supportsReasoning;
   final bool autoCollapseThinking;
 
@@ -374,6 +377,7 @@ class GenerationEngine extends ChangeNotifier {
     ToolCallHandler? onToolCall,
     Map<String, String>? extraHeaders,
     Map<String, dynamic>? extraBody,
+    String? forcedFirstToolName,
     bool stream = true,
     String? requestId,
     bool allowImagesApiRouting = true,
@@ -393,6 +397,7 @@ class GenerationEngine extends ChangeNotifier {
       onToolCall: onToolCall,
       extraHeaders: extraHeaders,
       extraBody: extraBody,
+      forcedFirstToolName: forcedFirstToolName,
       stream: stream,
       requestId: requestId,
       allowImagesApiRouting: allowImagesApiRouting,
@@ -706,6 +711,7 @@ class GenerationEngine extends ChangeNotifier {
         onToolCall: req.onToolCall,
         extraHeaders: req.extraHeaders,
         extraBody: req.extraBody,
+        forcedFirstToolName: req.forcedFirstToolName,
         stream: req.stream,
         requestId: slot.assistantMessageId,
         allowImagesApiRouting: req.allowImagesApiRouting,

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -46,6 +46,7 @@ import '../../../shared/widgets/emoji_text.dart';
 import '../../home/services/ask_user_interaction_service.dart';
 import '../../home/services/local_tools_service.dart';
 import '../../home/services/tool_approval_service.dart';
+import '../../home/services/plan_mode_tools_service.dart';
 import '../utils/thinking_tag_parser.dart';
 import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
@@ -2153,7 +2154,11 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     List<int>? overrideToolCounts,
   }) {
     final visibleTools = (widget.toolParts ?? const <ToolUIPart>[])
-        .where((p) => p.toolName != 'builtin_search')
+        .where(
+          (p) =>
+              p.toolName != 'builtin_search' &&
+              !PlanModeToolsService.handles(p.toolName),
+        )
         .toList();
     final steps = _buildTimelineSteps(
       visibleTools,
@@ -2225,7 +2230,11 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     final splitOffsets = widget.contentSplitOffsets!;
     final toolCounts = widget.toolCountAtSplit ?? const <int>[];
     final visibleTools = (widget.toolParts ?? const <ToolUIPart>[])
-        .where((p) => p.toolName != 'builtin_search')
+        .where(
+          (p) =>
+              p.toolName != 'builtin_search' &&
+              !PlanModeToolsService.handles(p.toolName),
+        )
         .toList();
 
     final rawSegments = <String>[];

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -16,6 +16,7 @@ import '../../../shared/widgets/snackbar.dart';
 import '../services/ask_user_interaction_service.dart';
 import '../services/message_generation_service.dart';
 import '../services/tool_approval_service.dart';
+import '../../../core/providers/plan_mode_provider.dart';
 import 'chat_controller.dart';
 import 'generation_controller.dart';
 import 'home_view_model.dart';
@@ -896,6 +897,11 @@ class ChatActions {
       } catch (_) {
         // AskUserInteractionService may not be registered yet
       }
+      try {
+        contextProvider.read<PlanModeProvider>().rejectPendingApproval(cid);
+      } catch (_) {
+        // PlanModeProvider may not be registered yet
+      }
 
       // Reset file processing state on cancel
       onFileProcessingFinished?.call();
@@ -990,6 +996,7 @@ class ChatActions {
             ocrActive: ctx.ocrActive,
             extraHeaders: ctx.extraHeaders,
             extraBody: ctx.extraBody,
+            forcedFirstToolName: ctx.forcedFirstToolName,
             supportsReasoning: ctx.supportsReasoning,
             autoCollapseThinking: settings.autoCollapseThinking,
             partialImageNotice: _l10n == null

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -607,6 +607,7 @@ class GenerationContext {
     required this.streamOutput,
     this.ocrActive = false,
     this.generateTitleOnFinish = true,
+    this.forcedFirstToolName,
   });
 
   final ChatMessage assistantMessage;
@@ -627,4 +628,5 @@ class GenerationContext {
   final bool streamOutput;
   final bool ocrActive;
   final bool generateTitleOnFinish;
+  final String? forcedFirstToolName;
 }

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:provider/provider.dart';
 import 'package:flutter/widgets.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
@@ -216,6 +217,7 @@ class MessageGenerationService {
     if (planConversationId != null &&
         generationController.isToolModel(providerKey, modelId)) {
       try {
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         final planStore = contextProvider.read<PlanModeProvider>();
         await planStore.initialize();
         final candidate = planStore.planFor(planConversationId);
@@ -262,6 +264,7 @@ class MessageGenerationService {
     if (activePlan != null && planConversationId != null) {
       toolDefs.addAll(PlanModeToolsService.definitionsFor(activePlan));
       onToolCall = PlanModeToolsService.wrapHandler(
+        // ignore: use_build_context_synchronously (root context, valid for app lifetime)
         context: contextProvider,
         conversationId: planConversationId,
         fallback: onToolCall,

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -4,7 +4,9 @@ import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/conversation.dart';
+import '../../../core/models/plan_mode.dart';
 import '../../../core/providers/settings_provider.dart';
+import '../../../core/providers/plan_mode_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/model_override_payload_parser.dart';
@@ -17,6 +19,7 @@ import '../controllers/stream_controller.dart' as stream_ctrl;
 import '../controllers/generation_controller.dart';
 import 'ask_user_interaction_service.dart';
 import 'message_builder_service.dart';
+import 'plan_mode_tools_service.dart';
 import 'tool_approval_service.dart';
 
 /// Callback types for UI updates from MessageGenerationService
@@ -55,6 +58,7 @@ class PreparedGeneration {
   final ToolCallHandler? onToolCall;
   final bool hasBuiltInSearch;
   final List<String> lastUserImagePaths;
+  final String? forcedFirstToolName;
 
   PreparedGeneration({
     required this.apiMessages,
@@ -62,6 +66,7 @@ class PreparedGeneration {
     this.onToolCall,
     required this.hasBuiltInSearch,
     required this.lastUserImagePaths,
+    this.forcedFirstToolName,
   });
 }
 
@@ -203,11 +208,40 @@ class MessageGenerationService {
     // Inject time note (at the end of system message, after all other injections)
     messageBuilderService.injectTimeNote(apiMessages, assistant);
 
+    // Inject conversation-scoped Plan Mode instructions. The mode is
+    // intentionally not stored in assistant settings: it belongs to the
+    // conversation and disappears when the user closes the Plan pill.
+    ConversationPlan? activePlan;
+    final planConversationId = currentConversation?.id;
+    if (planConversationId != null &&
+        generationController.isToolModel(providerKey, modelId)) {
+      try {
+        final planStore = contextProvider.read<PlanModeProvider>();
+        await planStore.initialize();
+        final candidate = planStore.planFor(planConversationId);
+        if (candidate?.active == true) {
+          activePlan = candidate;
+          final planPrompt = PlanModeToolsService.instructionFor(candidate!);
+          final systemIndex = apiMessages.indexWhere(
+            (message) => (message['role'] ?? '').toString() == 'system',
+          );
+          if (systemIndex >= 0) {
+            final existing = (apiMessages[systemIndex]['content'] ?? '').toString();
+            apiMessages[systemIndex]['content'] = existing.trim().isEmpty
+                ? planPrompt
+                : '$existing\n\n$planPrompt';
+          } else {
+            apiMessages.insert(0, {'role': 'system', 'content': planPrompt});
+          }
+        }
+      } catch (_) {}
+    }
+
     // Apply context limit and inline images
     messageBuilderService.applyContextLimit(apiMessages, assistant);
     await messageBuilderService.inlineLocalImages(apiMessages);
 
-    // Prepare tools
+    // Prepare normal tools, then layer Plan Mode's hidden built-ins on top.
     final toolDefs = generationController.buildToolDefinitions(
       settings,
       assistant,
@@ -215,7 +249,7 @@ class MessageGenerationService {
       modelId,
       hasBuiltInSearch,
     );
-    final onToolCall = toolDefs.isNotEmpty
+    ToolCallHandler? onToolCall = toolDefs.isNotEmpty
         ? generationController.buildToolCallHandler(
             settings,
             assistant,
@@ -224,6 +258,18 @@ class MessageGenerationService {
             conversationId: currentConversation?.id,
           )
         : null;
+    String? forcedFirstToolName;
+    if (activePlan != null && planConversationId != null) {
+      toolDefs.addAll(PlanModeToolsService.definitionsFor(activePlan));
+      onToolCall = PlanModeToolsService.wrapHandler(
+        context: contextProvider,
+        conversationId: planConversationId,
+        fallback: onToolCall,
+      );
+      if (activePlan.needsInitialPlan) {
+        forcedFirstToolName = PlanToolNames.create;
+      }
+    }
 
     return PreparedGeneration(
       apiMessages: apiMessages,
@@ -231,6 +277,7 @@ class MessageGenerationService {
       onToolCall: onToolCall,
       hasBuiltInSearch: hasBuiltInSearch,
       lastUserImagePaths: lastUserImagePaths,
+      forcedFirstToolName: forcedFirstToolName,
     );
   }
 
@@ -397,6 +444,7 @@ class MessageGenerationService {
       streamOutput: assistant?.streamOutput ?? true,
       ocrActive: ocrActive,
       generateTitleOnFinish: generateTitleOnFinish,
+      forcedFirstToolName: prepared.forcedFirstToolName,
     );
   }
 

--- a/lib/features/home/services/plan_mode_tools_service.dart
+++ b/lib/features/home/services/plan_mode_tools_service.dart
@@ -1,0 +1,360 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/plan_mode.dart';
+import '../../../core/providers/plan_mode_provider.dart';
+import '../../../core/services/api/chat_api_service.dart';
+
+class PlanToolNames {
+  static const create = 'create_plan';
+  static const replace = 'replace_plan';
+  static const updateItem = 'update_plan_item';
+  static const setItemStatus = 'set_plan_item_status';
+  static const addItem = 'add_plan_item';
+  static const removeItem = 'remove_plan_item';
+  static const requestApproval = 'request_plan_approval';
+
+  static const all = <String>{
+    create,
+    replace,
+    updateItem,
+    setItemStatus,
+    addItem,
+    removeItem,
+    requestApproval,
+  };
+}
+
+/// Hidden built-in tools used only while a conversation is in Plan Mode.
+class PlanModeToolsService {
+  PlanModeToolsService._();
+
+  static Map<String, dynamic> _planSchema(String name, String description) => {
+    'type': 'function',
+    'function': {
+      'name': name,
+      'description': description,
+      'parameters': {
+        'type': 'object',
+        'properties': {
+          'title': {
+            'type': 'string',
+            'description': 'Short title for the overall plan.',
+          },
+          'items': {
+            'type': 'array',
+            'minItems': 1,
+            'maxItems': 20,
+            'items': {
+              'type': 'object',
+              'properties': {
+                'title': {
+                  'type': 'string',
+                  'description': 'Short action-oriented task title.',
+                },
+                'description': {
+                  'type': 'string',
+                  'description':
+                      'One or two concise sentences explaining what this task will accomplish.',
+                },
+              },
+              'required': ['title', 'description'],
+            },
+          },
+        },
+        'required': ['title', 'items'],
+      },
+    },
+  };
+
+  static List<Map<String, dynamic>> definitionsFor(ConversationPlan plan) {
+    if (!plan.active) return const <Map<String, dynamic>>[];
+    final management = <Map<String, dynamic>>[
+      _planSchema(
+        PlanToolNames.replace,
+        'Replace the entire current plan only when a substantial re-plan is necessary. Prefer local edits for small changes.',
+      ),
+      {
+        'type': 'function',
+        'function': {
+          'name': PlanToolNames.updateItem,
+          'description':
+              'Update only one existing plan item. Do not rewrite unrelated items.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'item_id': {'type': 'string'},
+              'title': {'type': 'string'},
+              'description': {'type': 'string'},
+            },
+            'required': ['item_id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': PlanToolNames.setItemStatus,
+          'description':
+              'Update the execution status of exactly one plan item. Mark an item in_progress before working on it, completed after success, or error after failure.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'item_id': {'type': 'string'},
+              'status': {
+                'type': 'string',
+                'enum': ['pending', 'in_progress', 'completed', 'error'],
+              },
+            },
+            'required': ['item_id', 'status'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': PlanToolNames.addItem,
+          'description':
+              'Add a new task to the current plan when execution discovers a necessary extra step.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'title': {'type': 'string'},
+              'description': {'type': 'string'},
+              'after_index': {'type': 'integer', 'minimum': -1},
+            },
+            'required': ['title', 'description'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': PlanToolNames.removeItem,
+          'description':
+              'Remove one obsolete plan item. Do not remove unrelated tasks.',
+          'parameters': {
+            'type': 'object',
+            'properties': {
+              'item_id': {'type': 'string'},
+            },
+            'required': ['item_id'],
+          },
+        },
+      },
+      {
+        'type': 'function',
+        'function': {
+          'name': PlanToolNames.requestApproval,
+          'description':
+              'Ask the user to approve the current plan after planning or revising it. Do not begin execution before approval.',
+          'parameters': {'type': 'object', 'properties': <String, dynamic>{}},
+        },
+      },
+    ];
+    if (!plan.hasPlan) {
+      return <Map<String, dynamic>>[
+        _planSchema(
+          PlanToolNames.create,
+          'Create the initial execution plan for the user request. This is the first action in Plan Mode.',
+        ),
+        ...management,
+      ];
+    }
+    return management;
+  }
+
+  static String instructionFor(ConversationPlan plan) {
+    final items = plan.items
+        .map(
+          (item) =>
+              '- ${item.id} [${planItemStatusToString(item.status)}] ${item.title}: ${item.description}',
+        )
+        .join('\n');
+
+    if (!plan.hasPlan) {
+      return '''
+<cuplivo_plan_mode>
+Plan Mode is active. Before doing anything else for the user's task, you MUST call the hidden create_plan tool. Do not answer with normal text and do not call any other tool before create_plan. Make a practical ordered plan with concise task titles and one or two sentence descriptions. The user will approve or reject it before execution.
+</cuplivo_plan_mode>''';
+    }
+
+    final phaseText = switch (plan.phase) {
+      PlanPhase.planning =>
+        'The plan is not approved. You may discuss, research, or locally revise it, but MUST NOT execute the plan as a task. When the revised plan is ready, call request_plan_approval.',
+      PlanPhase.awaitingApproval =>
+        'The plan is awaiting user approval. Do not execute it until the approval tool result says approved.',
+      PlanPhase.executing =>
+        'The plan is approved. Execute it in order. Before working on an item call set_plan_item_status(in_progress); after success mark completed; after failure mark error. Keep at most one item in_progress. Change only plan items that genuinely need changing. When all planned work is finished, provide the final answer.',
+      PlanPhase.completed =>
+        'The current plan is completed. You may answer normally. If the user extends the task, add or revise only the necessary plan items and continue using Plan Mode.',
+    };
+
+    return '''
+<cuplivo_plan_mode>
+Plan Mode is active.
+$phaseText
+Current plan title: ${plan.title}
+Current plan items:
+$items
+</cuplivo_plan_mode>''';
+  }
+
+  static bool handles(String name) => PlanToolNames.all.contains(name);
+
+  static List<({String title, String description})> _parseItems(dynamic raw) {
+    if (raw is! List) return const [];
+    final out = <({String title, String description})>[];
+    for (final value in raw) {
+      if (value is! Map) continue;
+      final title = (value['title'] ?? '').toString().trim();
+      final description = (value['description'] ?? '').toString().trim();
+      if (title.isEmpty) continue;
+      out.add((title: title, description: description));
+      if (out.length >= 20) break;
+    }
+    return out;
+  }
+
+  static String _snapshot(ConversationPlan? plan, {String? decision}) {
+    return jsonEncode({
+      'ok': plan != null,
+      if (decision != null) 'decision': decision,
+      if (decision == 'approved')
+        'instruction': 'The user approved the plan. Execute it in order now. Before each item call set_plan_item_status with in_progress, then mark completed after success or error after failure. Keep at most one item in_progress. When the plan is finished, provide the final answer.',
+      if (decision == 'rejected')
+        'instruction': 'The user rejected this plan. Stop this turn now; do not execute tasks or emit an additional answer.',
+      if (plan != null) ...{
+        'title': plan.title,
+        'phase': planPhaseToString(plan.phase),
+        'items': [
+          for (final item in plan.items)
+            {
+              'id': item.id,
+              'title': item.title,
+              'description': item.description,
+              'status': planItemStatusToString(item.status),
+            },
+        ],
+      },
+    });
+  }
+
+  static Future<String> handle({
+    required BuildContext context,
+    required String conversationId,
+    required String name,
+    required Map<String, dynamic> arguments,
+  }) async {
+    final store = context.read<PlanModeProvider>();
+    await store.initialize();
+    final current = store.planFor(conversationId);
+    if (current == null || !current.active) {
+      return jsonEncode({'ok': false, 'error': 'plan_mode_inactive'});
+    }
+
+    switch (name) {
+      case PlanToolNames.create:
+      case PlanToolNames.replace:
+        final items = _parseItems(arguments['items']);
+        if (items.isEmpty) {
+          return jsonEncode({'ok': false, 'error': 'plan_items_required'});
+        }
+        final plan = await store.createOrReplacePlan(
+          conversationId: conversationId,
+          title: (arguments['title'] ?? '').toString(),
+          items: items,
+          awaitingApproval: true,
+        );
+        final decision = await store.waitForApproval(conversationId);
+        return _snapshot(
+          store.planFor(conversationId) ?? plan,
+          decision: decision == PlanApprovalDecision.approved
+              ? 'approved'
+              : 'rejected',
+        );
+
+      case PlanToolNames.requestApproval:
+        if (current.items.isEmpty) {
+          return jsonEncode({'ok': false, 'error': 'plan_is_empty'});
+        }
+        await store.markAwaitingApproval(conversationId);
+        final decision = await store.waitForApproval(conversationId);
+        return _snapshot(
+          store.planFor(conversationId),
+          decision: decision == PlanApprovalDecision.approved
+              ? 'approved'
+              : 'rejected',
+        );
+
+      case PlanToolNames.updateItem:
+        final updated = await store.updateItem(
+          conversationId: conversationId,
+          itemId: (arguments['item_id'] ?? '').toString(),
+          title: arguments['title']?.toString(),
+          description: arguments['description']?.toString(),
+          requireApproval: current.phase != PlanPhase.executing,
+        );
+        return _snapshot(updated);
+
+      case PlanToolNames.setItemStatus:
+        if (current.phase != PlanPhase.executing &&
+            current.phase != PlanPhase.completed) {
+          return jsonEncode({'ok': false, 'error': 'plan_not_approved'});
+        }
+        final status = planItemStatusFromString(
+          arguments['status']?.toString(),
+        );
+        final updated = await store.setItemStatus(
+          conversationId: conversationId,
+          itemId: (arguments['item_id'] ?? '').toString(),
+          status: status,
+        );
+        return _snapshot(updated);
+
+      case PlanToolNames.addItem:
+        final rawAfter = arguments['after_index'];
+        final updated = await store.addItem(
+          conversationId: conversationId,
+          title: (arguments['title'] ?? '').toString(),
+          description: (arguments['description'] ?? '').toString(),
+          afterIndex: rawAfter is num ? rawAfter.toInt() : null,
+          requireApproval: current.phase != PlanPhase.executing,
+        );
+        return _snapshot(updated);
+
+      case PlanToolNames.removeItem:
+        final updated = await store.removeItem(
+          conversationId: conversationId,
+          itemId: (arguments['item_id'] ?? '').toString(),
+          requireApproval: current.phase != PlanPhase.executing,
+        );
+        return _snapshot(updated);
+    }
+
+    return jsonEncode({'ok': false, 'error': 'unknown_plan_tool'});
+  }
+
+  static ToolCallHandler wrapHandler({
+    required BuildContext context,
+    required String conversationId,
+    ToolCallHandler? fallback,
+  }) {
+    return (name, arguments, {String? toolCallId}) async {
+      if (handles(name)) {
+        return handle(
+          context: context,
+          conversationId: conversationId,
+          name: name,
+          arguments: arguments,
+        );
+      }
+      if (fallback != null) {
+        return fallback(name, arguments, toolCallId: toolCallId);
+      }
+      return jsonEncode({'ok': false, 'error': 'unknown_tool', 'tool': name});
+    };
+  }
+}

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -126,6 +126,9 @@ class ChatInputBar extends StatefulWidget {
     this.multiAIModelCount,
     this.onMultiSelectModel,
     this.mode = ChatInputMode.normal,
+    this.supportsPlanMode = false,
+    this.planModeActive = false,
+    this.onPlanModeChanged,
   });
 
   /// When [ChatInputMode.groupChat], hide model/search/reasoning/MCP/multi-AI.
@@ -182,6 +185,9 @@ class ChatInputBar extends StatefulWidget {
   final bool backgroundImageActive;
   final double inputBackgroundOpacityLight;
   final double inputBackgroundOpacityDark;
+  final bool supportsPlanMode;
+  final bool planModeActive;
+  final ValueChanged<bool>? onPlanModeChanged;
 
   @override
   State<ChatInputBar> createState() => _ChatInputBarState();
@@ -224,6 +230,7 @@ class _ChatInputBarState extends State<ChatInputBar>
   bool _oneClickCompressing = false;
   bool _oneClickCompressDone = false;
   bool _oneClickConfirming = false;
+  bool _showPlanCommand = false;
   Timer? _confirmTimer;
   String? _lastImageDefaultsSignature;
   final _imageGenController = ImageGenerationOptionsController();
@@ -421,14 +428,28 @@ class _ChatInputBarState extends State<ChatInputBar>
   bool get _hasDraftMedia => _images.isNotEmpty || _docs.isNotEmpty;
 
   // Instance method for onChanged to avoid recreating the callback on every build
-  void _onTextChanged(String _) {
+  void _onTextChanged(String value) {
     // User typing = a NEW input: the restored queued input's "must not route"
     // flag no longer applies to unrelated later sends.
     _inputStatus.clearRestoredUnsupportedImagesApiRouting(
       widget.conversationId,
     );
-    setState(() {});
+    final showPlanCommand =
+        widget.mode == ChatInputMode.normal &&
+        widget.supportsPlanMode &&
+        !widget.planModeActive &&
+        value == '/';
+    setState(() => _showPlanCommand = showPlanCommand);
     _scheduleDraftSave();
+  }
+
+  void _activatePlanMode() {
+    if (!widget.supportsPlanMode || widget.onPlanModeChanged == null) return;
+    _controller.clear();
+    setState(() => _showPlanCommand = false);
+    widget.onPlanModeChanged!(true);
+    _scheduleDraftSave();
+    widget.focusNode?.requestFocus();
   }
 
   /// Restores the cold-start draft into the input bar. Runs synchronously in
@@ -894,6 +915,10 @@ class _ChatInputBarState extends State<ChatInputBar>
       }
       widget.asrProvider?.addListener(_handleAsrChanged);
     }
+    if ((!widget.supportsPlanMode || widget.planModeActive) &&
+        _showPlanCommand) {
+      _showPlanCommand = false;
+    }
   }
 
   String _hint(BuildContext context) {
@@ -1207,6 +1232,10 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   Future<void> _handleSend() async {
+    if (_showPlanCommand) {
+      _activatePlanMode();
+      return;
+    }
     if (_isSubmitting) return;
     if (_oneClickCompressing) return;
     if (_ownsVoiceSession || _finishingVoice) return;
@@ -2881,6 +2910,16 @@ class _ChatInputBarState extends State<ChatInputBar>
               ),
               const SizedBox(height: AppSpacing.xs),
             ],
+            if (_showPlanCommand) ...[
+              _PlanSlashCommandPopup(
+                onTap: _activatePlanMode,
+                label: AppLocalizations.of(context)!.planModeLabel,
+                description: AppLocalizations.of(
+                  context,
+                )!.planModeCommandDescription,
+              ),
+              const SizedBox(height: AppSpacing.xs),
+            ],
             Stack(
               clipBehavior: Clip.none,
               children: [
@@ -3211,6 +3250,79 @@ class _ChatInputBarState extends State<ChatInputBar>
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanSlashCommandPopup extends StatelessWidget {
+  const _PlanSlashCommandPopup({
+    required this.onTap,
+    required this.label,
+    required this.description,
+  });
+
+  final VoidCallback onTap;
+  final String label;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 300),
+        child: IosCardPress(
+          borderRadius: BorderRadius.circular(14),
+          baseColor: cs.surface,
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 30,
+                  height: 30,
+                  decoration: BoxDecoration(
+                    color: cs.primary.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(9),
+                  ),
+                  child: Icon(Lucide.ListChecks, size: 17, color: cs.primary),
+                ),
+                const SizedBox(width: 10),
+                Flexible(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        label,
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: cs.onSurface,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        description,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: cs.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/home/widgets/chat_input_section.dart
+++ b/lib/features/home/widgets/chat_input_section.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -7,6 +9,7 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/asr_provider.dart';
 import '../../../core/providers/mcp_provider.dart';
+import '../../../core/providers/plan_mode_provider.dart';
 import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
@@ -129,8 +132,17 @@ class ChatInputSection extends StatelessWidget {
     final pk = modelIds.providerKey;
     final mid = modelIds.modelId;
 
-    // Enforce model capabilities: disable MCP selection if model doesn't support tools
+    // Enforce model capabilities: disable MCP/Plan when the model cannot use tools.
     _enforceModelCapabilities(context, settings, ap, a, pk, mid);
+    final modelResolved = pk != null && mid != null;
+    final supportsPlanMode = modelResolved && isToolModel(pk, mid);
+    final planStore = context.watch<PlanModeProvider>();
+    final planActive = planStore.isActive(conversationId);
+    if (modelResolved && !supportsPlanMode && planActive && conversationId != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        unawaited(planStore.setActive(conversationId!, false));
+      });
+    }
 
     final isDesktop = _isDesktopPlatform(context);
     final hasWorldBooks =
@@ -225,6 +237,11 @@ class ChatInputSection extends StatelessWidget {
       inputBackgroundOpacityDark: settings.chatInputBackgroundOpacityDark,
       multiAIModelCount: multiAIModelCount,
       onMultiSelectModel: onMultiSelectModel,
+      supportsPlanMode: supportsPlanMode,
+      planModeActive: planActive && supportsPlanMode,
+      onPlanModeChanged: conversationId == null
+          ? null
+          : (active) => unawaited(planStore.setActive(conversationId!, active)),
     );
   }
 

--- a/lib/features/home/widgets/live_panel.dart
+++ b/lib/features/home/widgets/live_panel.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/providers/download_progress_store.dart';
+import '../../../core/models/plan_mode.dart';
 import '../../../core/providers/input_status_provider.dart';
+import '../../../core/providers/plan_mode_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -37,6 +39,7 @@ class _LivePanelState extends State<LivePanel> {
   Timer? _ticker;
   final _expandedJobIds = <String>{};
   final _expandedDownloadIds = <String>{};
+  bool _planExpanded = true;
 
   @override
   void initState() {
@@ -131,8 +134,13 @@ class _LivePanelState extends State<LivePanel> {
     final jobs = _activeJobs();
     final downloads = _activeDownloads();
     final inputStatus = context.watch<InputStatusProvider>();
+    final chatService = context.watch<ChatService>();
+    final conversationId = chatService.currentConversationId;
+    final planStore = context.watch<PlanModeProvider>();
+    final plan = planStore.planFor(conversationId);
+    final hasPlan = plan?.active == true;
     final hasPills =
-        inputStatus.imageModeActive || inputStatus.imageWarningActive;
+        inputStatus.imageModeActive || inputStatus.imageWarningActive || hasPlan;
     if (jobs.isEmpty && downloads.isEmpty && !hasPills) {
       return const SizedBox.shrink();
     }
@@ -147,6 +155,27 @@ class _LivePanelState extends State<LivePanel> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (hasPlan && plan != null && conversationId != null) ...[
+            if (plan.hasPlan)
+              _buildPlanCard(
+                plan: plan,
+                conversationId: conversationId,
+                store: planStore,
+                base: base,
+                cs: cs,
+                l10n: l10n,
+              )
+            else
+              _buildPlanModePill(
+                label: l10n.planModeLabel,
+                closeTooltip: l10n.planModeDisableTooltip,
+                onClose: () => unawaited(
+                  planStore.setActive(conversationId, false),
+                ),
+                cs: cs,
+              ),
+            const SizedBox(height: 6),
+          ],
           if (inputStatus.imageModeActive) ...[
             _buildPill(
               icon: Lucide.Brush,
@@ -181,6 +210,245 @@ class _LivePanelState extends State<LivePanel> {
           ],
         ],
       ),
+    );
+  }
+
+  Widget _buildPlanModePill({
+    required String label,
+    required String closeTooltip,
+    required VoidCallback onClose,
+    required ColorScheme cs,
+  }) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.11),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: cs.primary.withValues(alpha: 0.22)),
+        ),
+        padding: const EdgeInsets.fromLTRB(10, 6, 4, 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Lucide.ListChecks, size: 14, color: cs.primary),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w600,
+                color: cs.primary,
+              ),
+            ),
+            const SizedBox(width: 3),
+            IosIconButton(
+              icon: Icons.close,
+              size: 14,
+              color: cs.primary,
+              semanticLabel: closeTooltip,
+              onTap: onClose,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlanCard({
+    required ConversationPlan plan,
+    required String conversationId,
+    required PlanModeProvider store,
+    required Color base,
+    required ColorScheme cs,
+    required AppLocalizations l10n,
+  }) {
+    final awaiting = plan.phase == PlanPhase.awaitingApproval;
+    final showBody = awaiting || _planExpanded;
+    final completed = plan.items
+        .where((item) => item.status == PlanItemStatus.completed)
+        .length;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: base,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: cs.primary.withValues(alpha: 0.16)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IosCardPress(
+            borderRadius: BorderRadius.circular(14),
+            baseColor: Colors.transparent,
+            pressedScale: 0.995,
+            onTap: awaiting
+                ? null
+                : () => setState(() => _planExpanded = !_planExpanded),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+              child: Row(
+                children: [
+                  Icon(Lucide.ListChecks, size: 15, color: cs.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          plan.title.trim().isEmpty
+                              ? l10n.planModeLabel
+                              : plan.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: cs.onSurface,
+                          ),
+                        ),
+                        Text(
+                          awaiting
+                              ? l10n.planModeAwaitingApproval
+                              : '$completed/${plan.items.length}',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: cs.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (!awaiting)
+                    Icon(
+                      showBody ? Lucide.ChevronUp : Lucide.ChevronDown,
+                      size: 16,
+                      color: cs.onSurfaceVariant,
+                    ),
+                  const SizedBox(width: 4),
+                  IosIconButton(
+                    icon: Icons.close,
+                    size: 16,
+                    color: cs.onSurfaceVariant,
+                    semanticLabel: l10n.planModeDisableTooltip,
+                    onTap: () => unawaited(
+                      store.setActive(conversationId, false),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (showBody) ...[
+            Divider(height: 1, color: cs.outlineVariant.withValues(alpha: 0.45)),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+              child: Column(
+                children: [
+                  for (var i = 0; i < plan.items.length; i++) ...[
+                    _buildPlanItem(plan.items[i], cs, l10n),
+                    if (i != plan.items.length - 1) const SizedBox(height: 9),
+                  ],
+                  if (awaiting && store.hasPendingApproval(conversationId)) ...[
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        TextButton(
+                          onPressed: () => unawaited(store.reject(conversationId)),
+                          child: Text(l10n.planModeReject),
+                        ),
+                        const SizedBox(width: 8),
+                        FilledButton(
+                          onPressed: () => unawaited(store.approve(conversationId)),
+                          child: Text(l10n.planModeApprove),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlanItem(
+    PlanItem item,
+    ColorScheme cs,
+    AppLocalizations l10n,
+  ) {
+    final (icon, color, statusLabel) = switch (item.status) {
+      PlanItemStatus.pending => (
+          Icons.circle_outlined,
+          cs.onSurfaceVariant,
+          l10n.planModeStatusPending,
+        ),
+      PlanItemStatus.inProgress => (
+          Lucide.Loader,
+          cs.primary,
+          l10n.planModeStatusInProgress,
+        ),
+      PlanItemStatus.completed => (
+          Lucide.CheckCircle,
+          cs.primary,
+          l10n.planModeStatusCompleted,
+        ),
+      PlanItemStatus.error => (
+          Lucide.TriangleAlert,
+          cs.error,
+          l10n.planModeStatusError,
+        ),
+    };
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: Icon(icon, size: 15, color: color),
+        ),
+        const SizedBox(width: 9),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      item.title,
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        fontWeight: FontWeight.w600,
+                        color: cs.onSurface,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    statusLabel,
+                    style: TextStyle(fontSize: 10, color: color),
+                  ),
+                ],
+              ),
+              if (item.description.trim().isNotEmpty) ...[
+                const SizedBox(height: 2),
+                Text(
+                  item.description,
+                  style: TextStyle(
+                    fontSize: 11,
+                    height: 1.35,
+                    color: cs.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1317,22 +1317,50 @@
   "sideDrawerBatchExportSuccess": "{exported} conversations exported",
   "@sideDrawerBatchExportSuccess": {
     "description": "Batch export completed successfully",
-    "placeholders": {"exported": {"type": "int"}}
+    "placeholders": {
+      "exported": {
+        "type": "int"
+      }
+    }
   },
   "sideDrawerBatchExportSuccessSkipped": "{exported} conversations exported, {skipped} empty skipped",
   "@sideDrawerBatchExportSuccessSkipped": {
     "description": "Batch export completed successfully with empty conversations skipped",
-    "placeholders": {"exported": {"type": "int"}, "skipped": {"type": "int"}}
+    "placeholders": {
+      "exported": {
+        "type": "int"
+      },
+      "skipped": {
+        "type": "int"
+      }
+    }
   },
   "sideDrawerBatchExportPartialFailure": "{exported} exported, {failed} failed",
   "@sideDrawerBatchExportPartialFailure": {
     "description": "Batch export partially failed",
-    "placeholders": {"exported": {"type": "int"}, "failed": {"type": "int"}}
+    "placeholders": {
+      "exported": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
   },
   "sideDrawerBatchExportPartialFailureSkipped": "{exported} exported, {failed} failed, {skipped} empty skipped",
   "@sideDrawerBatchExportPartialFailureSkipped": {
     "description": "Batch export partially failed with empty conversations skipped",
-    "placeholders": {"exported": {"type": "int"}, "failed": {"type": "int"}, "skipped": {"type": "int"}}
+    "placeholders": {
+      "exported": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      },
+      "skipped": {
+        "type": "int"
+      }
+    }
   },
   "@sideDrawerBatchPartialFailure": {
     "placeholders": {
@@ -3720,5 +3748,15 @@
   "workspaceToolUnzipUserDesc": "Extract zip archives",
   "workspaceToolDownloadTitle": "Download",
   "workspaceToolDownloadUserDesc": "Download a URL into the workspace",
-  "assistantEditLocalToolWorkspaceTitle": "Workspace"
+  "assistantEditLocalToolWorkspaceTitle": "Workspace",
+  "planModeLabel": "Plan",
+  "planModeCommandDescription": "Plan and execute a multi-step task",
+  "planModeDisableTooltip": "Exit Plan mode",
+  "planModeAwaitingApproval": "Review the plan before execution",
+  "planModeApprove": "Approve and execute",
+  "planModeReject": "Reject",
+  "planModeStatusPending": "Pending",
+  "planModeStatusInProgress": "In progress",
+  "planModeStatusCompleted": "Completed",
+  "planModeStatusError": "Error"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -14987,6 +14987,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Workspace'**
   String get assistantEditLocalToolWorkspaceTitle;
+
+  /// No description provided for @planModeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Plan'**
+  String get planModeLabel;
+
+  /// No description provided for @planModeCommandDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Plan and execute a multi-step task'**
+  String get planModeCommandDescription;
+
+  /// No description provided for @planModeDisableTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Exit Plan mode'**
+  String get planModeDisableTooltip;
+
+  /// No description provided for @planModeAwaitingApproval.
+  ///
+  /// In en, this message translates to:
+  /// **'Review the plan before execution'**
+  String get planModeAwaitingApproval;
+
+  /// No description provided for @planModeApprove.
+  ///
+  /// In en, this message translates to:
+  /// **'Approve and execute'**
+  String get planModeApprove;
+
+  /// No description provided for @planModeReject.
+  ///
+  /// In en, this message translates to:
+  /// **'Reject'**
+  String get planModeReject;
+
+  /// No description provided for @planModeStatusPending.
+  ///
+  /// In en, this message translates to:
+  /// **'Pending'**
+  String get planModeStatusPending;
+
+  /// No description provided for @planModeStatusInProgress.
+  ///
+  /// In en, this message translates to:
+  /// **'In progress'**
+  String get planModeStatusInProgress;
+
+  /// No description provided for @planModeStatusCompleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed'**
+  String get planModeStatusCompleted;
+
+  /// No description provided for @planModeStatusError.
+  ///
+  /// In en, this message translates to:
+  /// **'Error'**
+  String get planModeStatusError;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8283,4 +8283,34 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => 'Workspace';
+
+  @override
+  String get planModeLabel => 'Plan';
+
+  @override
+  String get planModeCommandDescription => 'Plan and execute a multi-step task';
+
+  @override
+  String get planModeDisableTooltip => 'Exit Plan mode';
+
+  @override
+  String get planModeAwaitingApproval => 'Review the plan before execution';
+
+  @override
+  String get planModeApprove => 'Approve and execute';
+
+  @override
+  String get planModeReject => 'Reject';
+
+  @override
+  String get planModeStatusPending => 'Pending';
+
+  @override
+  String get planModeStatusInProgress => 'In progress';
+
+  @override
+  String get planModeStatusCompleted => 'Completed';
+
+  @override
+  String get planModeStatusError => 'Error';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7917,6 +7917,36 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get planModeLabel => 'Plan';
+
+  @override
+  String get planModeCommandDescription => '规划并逐步执行复杂任务';
+
+  @override
+  String get planModeDisableTooltip => '退出 Plan 模式';
+
+  @override
+  String get planModeAwaitingApproval => '请确认计划后再执行';
+
+  @override
+  String get planModeApprove => '批准并执行';
+
+  @override
+  String get planModeReject => '拒绝';
+
+  @override
+  String get planModeStatusPending => '待完成';
+
+  @override
+  String get planModeStatusInProgress => '正在执行';
+
+  @override
+  String get planModeStatusCompleted => '已完成';
+
+  @override
+  String get planModeStatusError => '出错';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -15832,6 +15862,36 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get planModeLabel => 'Plan';
+
+  @override
+  String get planModeCommandDescription => '规划并逐步执行复杂任务';
+
+  @override
+  String get planModeDisableTooltip => '退出 Plan 模式';
+
+  @override
+  String get planModeAwaitingApproval => '请确认计划后再执行';
+
+  @override
+  String get planModeApprove => '批准并执行';
+
+  @override
+  String get planModeReject => '拒绝';
+
+  @override
+  String get planModeStatusPending => '待完成';
+
+  @override
+  String get planModeStatusInProgress => '正在执行';
+
+  @override
+  String get planModeStatusCompleted => '已完成';
+
+  @override
+  String get planModeStatusError => '出错';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -23747,4 +23807,34 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作區';
+
+  @override
+  String get planModeLabel => 'Plan';
+
+  @override
+  String get planModeCommandDescription => '規劃並逐步執行複雜任務';
+
+  @override
+  String get planModeDisableTooltip => '退出 Plan 模式';
+
+  @override
+  String get planModeAwaitingApproval => '請確認計劃後再執行';
+
+  @override
+  String get planModeApprove => '批准並執行';
+
+  @override
+  String get planModeReject => '拒絕';
+
+  @override
+  String get planModeStatusPending => '待完成';
+
+  @override
+  String get planModeStatusInProgress => '正在執行';
+
+  @override
+  String get planModeStatusCompleted => '已完成';
+
+  @override
+  String get planModeStatusError => '出錯';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3136,5 +3136,15 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "planModeLabel": "Plan",
+  "planModeCommandDescription": "规划并逐步执行复杂任务",
+  "planModeDisableTooltip": "退出 Plan 模式",
+  "planModeAwaitingApproval": "请确认计划后再执行",
+  "planModeApprove": "批准并执行",
+  "planModeReject": "拒绝",
+  "planModeStatusPending": "待完成",
+  "planModeStatusInProgress": "正在执行",
+  "planModeStatusCompleted": "已完成",
+  "planModeStatusError": "出错"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3137,5 +3137,15 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "planModeLabel": "Plan",
+  "planModeCommandDescription": "规划并逐步执行复杂任务",
+  "planModeDisableTooltip": "退出 Plan 模式",
+  "planModeAwaitingApproval": "请确认计划后再执行",
+  "planModeApprove": "批准并执行",
+  "planModeReject": "拒绝",
+  "planModeStatusPending": "待完成",
+  "planModeStatusInProgress": "正在执行",
+  "planModeStatusCompleted": "已完成",
+  "planModeStatusError": "出错"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3137,5 +3137,15 @@
   "workspaceToolUnzipUserDesc": "解壓 zip 壓縮檔",
   "workspaceToolDownloadTitle": "下載",
   "workspaceToolDownloadUserDesc": "將 URL 下載到工作區",
-  "assistantEditLocalToolWorkspaceTitle": "工作區"
+  "assistantEditLocalToolWorkspaceTitle": "工作區",
+  "planModeLabel": "Plan",
+  "planModeCommandDescription": "規劃並逐步執行複雜任務",
+  "planModeDisableTooltip": "退出 Plan 模式",
+  "planModeAwaitingApproval": "請確認計劃後再執行",
+  "planModeApprove": "批准並執行",
+  "planModeReject": "拒絕",
+  "planModeStatusPending": "待完成",
+  "planModeStatusInProgress": "正在執行",
+  "planModeStatusCompleted": "已完成",
+  "planModeStatusError": "出錯"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'core/providers/backup_reminder_provider.dart';
 import 'core/providers/hotkey_provider.dart';
 import 'core/providers/download_progress_store.dart';
 import 'core/providers/input_status_provider.dart';
+import 'core/providers/plan_mode_provider.dart';
 import 'core/services/chat/chat_service.dart';
 import 'core/services/trash_restore_coordinator.dart';
 import 'core/services/mcp/mcp_tool_service.dart';
@@ -226,6 +227,9 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
         ChangeNotifierProvider(create: (_) => DownloadProgressStore()),
         ChangeNotifierProvider(create: (_) => InputStatusProvider()),
+        ChangeNotifierProvider(
+          create: (_) => PlanModeProvider()..initialize(),
+        ),
         ChangeNotifierProvider(
           create: (ctx) => GenerationEngine(
             chatService: ctx.read<ChatService>(),

--- a/test/core/services/generation_engine_test.dart
+++ b/test/core/services/generation_engine_test.dart
@@ -209,6 +209,7 @@ void main() {
             onToolCall,
             extraHeaders,
             extraBody,
+            String? forcedFirstToolName,
             required stream,
             requestId,
             required allowImagesApiRouting,

--- a/test/features/group_chat/group_chat_slot_runner_test.dart
+++ b/test/features/group_chat/group_chat_slot_runner_test.dart
@@ -192,6 +192,7 @@ void main() {
       ToolCallHandler? onToolCall,
       Map<String, String>? extraHeaders,
       Map<String, dynamic>? extraBody,
+      String? forcedFirstToolName,
       bool stream = true,
       String? requestId,
       bool allowImagesApiRouting = true,

--- a/test/features/home/services/handoff_tool_service_test.dart
+++ b/test/features/home/services/handoff_tool_service_test.dart
@@ -322,6 +322,7 @@ void main() {
               maxTokens,
               extraHeaders,
               extraBody,
+              String? forcedFirstToolName,
               required stream,
               String? requestId,
               required allowImagesApiRouting,

--- a/test/features/home/widgets/live_panel_test.dart
+++ b/test/features/home/widgets/live_panel_test.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import 'package:Cuplivo/core/providers/download_progress_store.dart';
 import 'package:Cuplivo/core/providers/input_status_provider.dart';
+import 'package:Cuplivo/core/providers/plan_mode_provider.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/core/services/generation_engine.dart';
@@ -53,6 +54,9 @@ void main() {
             ),
             ChangeNotifierProvider<InputStatusProvider>.value(
               value: inputStatus,
+            ),
+            ChangeNotifierProvider<PlanModeProvider>(
+              create: (_) => PlanModeProvider(),
             ),
           ],
           child: Scaffold(body: LivePanel(onOpenChild: onOpenChild)),


### PR DESCRIPTION
## Plan Mode

Plan mode lets the user toggle a planning workflow: the assistant builds a step-by-step plan, awaits explicit approval, then executes the approved steps with tool calls.

- `plan_mode` model + `PlanModeProvider` store (pending/in-progress/completed/error states, approvals)
- `PlanModeToolsService`: plan-mode tool definitions and prompt injection
- `GenerationEngine` / `openai_common`: `forcedFirstToolName` support via `tool_choice`
- Chat UI: plan mode toggle, approve/reject actions, status chip
- l10n: 10 new `planMode` keys in all 4 ARBs + regenerated files