### PR TITLE
fix: re-arm proactive care alarms after assistants load and log the trigger path

### DIFF
--- a/docs/adr/0031-proactive-care-startup-reschedule-and-logging.md
+++ b/docs/adr/0031-proactive-care-startup-reschedule-and-logging.md
@@ -1,0 +1,63 @@
+# ADR-0031: Proactive Care Startup Re-arm and Always-On Trigger-Path Logging
+
+Ta的来信 (Proactive Care) is an Android-only exact-alarm feature that wakes the app
+(`android_alarm_manager_plus`, one-shot, `exact: true, wakeup: true,
+allowWhileIdle: true`) and asks the LLM for a scheduled care reply. A user reported
+that the scheduled time arrived with the app in the foreground and no reply was
+generated. The trigger path was effectively silent: the only always-on log was the
+background-isolate `Alarm fired` line, everything else went through `FlutterLogger`
+which is off by default (`flutter_log_enabled_v1`).
+
+## Context
+
+Three suspects could each explain "foreground, time arrived, no reply":
+
+- **Startup re-arm race (fixed here)**: `main.dart` scheduled a post-frame callback
+  that captured `AssistantProvider.assistants` before Drift was open and assistants
+  had loaded, then called `rescheduleAll([])` — a silent no-op wrapped in `catch (_) {}`.
+  After an Android force-stop (which clears all alarms) the next launch never re-armed
+  the alarms, so the feature was dead until the user re-saved assistant settings.
+- **Exact-alarm permission silently denied** (Android 12+ `SCHEDULE_EXACT_ALARM`):
+  `oneShotAt` failures were only logged to the off-by-default `FlutterLogger`.
+- **Startup-window trigger drop**: the main-isolate port is registered synchronously
+  while assistants still load; `handleProactiveCareTrigger` silently early-returned
+  when the assistant was not found yet, consuming the one-shot alarm.
+
+No root cause was confirmed at session time; the agreed strategy was debug-first:
+make the whole trigger path observable in logcat with always-on `debugPrint`, fix the
+demonstrable startup race in the same change, and let the next user reproduction
+produce evidence (`Alarm fired` present/absent, permission state) that pins the
+remaining suspect.
+
+## Decisions
+
+- **Re-arm after assistants load, not at first frame**: `rescheduleAll` moved to
+  `HomePageController.initChat`, right after `AssistantProvider.ensureDefaults`
+  completes (where `ProactiveCareAlarmService.isSupported` guards non-Android). The
+  first-frame block in `main.dart` now only persists the l10n snapshot.
+- **Always-on trigger-path logging**: every silent step of the app-alive chain now
+  `debugPrint`s with the `[ProactiveCare]` prefix — port receipt, handler entry and
+  each early return, `newTime == null` decision outcome, schedule result, and all
+  catch blocks. Existing `FlutterLogger.log` calls are kept alongside (file capture
+  when the user enables it) but are no longer the only trace.
+- **Schedule failure carries the permission state**: when `oneShotAt` returns false,
+  the log includes `Permission.scheduleExactAlarm.status`, so a denied exact-alarm
+  permission is identifiable in logcat without behavior changes.
+- **Pure filter extracted**: `pendingForReschedule(List<Assistant>, {DateTime? now})`
+  (enabled + future `proactiveCareNextMessageAt`) is the single source of truth for
+  the re-arm filter, shared by `rescheduleAll` and unit tests.
+- **No behavior change beyond re-arming**: the silent-drop path only logs for now;
+  the permission-denied path still does not auto-degrade (AGENTS.md 3.6) and the
+  recurring-cycle decision failure is out of scope until evidence points at it.
+
+## Consequences
+
+- `main.dart` no longer re-arms alarms at first frame; `initChat` is the single re-arm
+  point (idempotent — `sync` replaces the pending alarm).
+- A force-stop → relaunch now logs `rescheduleAll: N/M assistants need re-arming`
+  plus one `Alarm scheduled`/`Alarm schedule FAILED` line per assistant, closing the
+  evidence gap for the next user reproduction.
+- New unit test `test/core/services/proactive_care_alarm_service_test.dart` pins the
+  re-arm filter contract (disabled / null / past / exactly-now skipped, future kept).
+- Remaining suspects (permission denial, decision-model loop death) stay unresolved by
+  design; the next reproduction's logcat decides.

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -181,7 +181,17 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
             await ProactiveCareAlarmService.sync(
               assistant.copyWith(proactiveCareNextMessageAt: newTime),
             );
+          } else {
+            debugPrint(
+              '[ProactiveCare] Failed to persist next care time for '
+              '${assistant.id}',
+            );
           }
+        } else {
+          debugPrint(
+            '[ProactiveCare] Headless decision returned no next time for '
+            '${assistant.id}',
+          );
         }
       }
     } catch (e) {
@@ -321,12 +331,14 @@ class ProactiveCareAlarmService {
     try {
       final ok = await AndroidAlarmManager.initialize();
       if (!ok) {
+        debugPrint('[ProactiveCare] AndroidAlarmManager.initialize false');
         FlutterLogger.log(
           'AndroidAlarmManager.initialize returned false',
           tag: _logTag,
         );
       }
     } catch (e) {
+      debugPrint('[ProactiveCare] AlarmManager initialize failed: $e');
       FlutterLogger.log('AlarmManager initialize failed: $e', tag: _logTag);
     }
   }
@@ -342,6 +354,23 @@ class ProactiveCareAlarmService {
       hash = (hash * fnvPrime) & 0xFFFFFFFF;
     }
     return hash & 0x7FFFFFFF;
+  }
+
+  /// Returns the assistants whose proactive care alarm should be armed:
+  /// proactive care enabled with a future [Assistant.proactiveCareNextMessageAt].
+  @visibleForTesting
+  static List<Assistant> pendingForReschedule(
+    List<Assistant> assistants, {
+    DateTime? now,
+  }) {
+    final current = now ?? DateTime.now();
+    return <Assistant>[
+      for (final a in assistants)
+        if (a.enableProactiveCare &&
+            a.proactiveCareNextMessageAt != null &&
+            a.proactiveCareNextMessageAt!.isAfter(current))
+          a,
+    ];
   }
 
   /// Schedules or cancels the exact alarm so it matches the assistant's
@@ -367,12 +396,32 @@ class ProactiveCareAlarmService {
         rescheduleOnReboot: true,
         params: <String, dynamic>{'assistantId': assistant.id},
       );
+      if (ok) {
+        debugPrint(
+          '[ProactiveCare] Alarm scheduled for ${assistant.id} at '
+          '${at.toIso8601String()} (id=$id)',
+        );
+      } else {
+        String exactAlarmPermission = 'unknown';
+        try {
+          exactAlarmPermission = (await Permission.scheduleExactAlarm.status)
+              .toString();
+        } catch (e) {
+          exactAlarmPermission = 'check failed: $e';
+        }
+        debugPrint(
+          '[ProactiveCare] Alarm schedule FAILED for ${assistant.id} at '
+          '${at.toIso8601String()} (id=$id, '
+          'exactAlarmPermission=$exactAlarmPermission)',
+        );
+      }
       FlutterLogger.log(
         'Alarm ${ok ? 'scheduled' : 'schedule FAILED'} for assistant '
         '${assistant.id} at ${at.toIso8601String()} (id=$id)',
         tag: _logTag,
       );
     } catch (e) {
+      debugPrint('[ProactiveCare] Alarm sync failed for ${assistant.id}: $e');
       FlutterLogger.log(
         'Alarm sync failed for assistant ${assistant.id}: $e',
         tag: _logTag,
@@ -386,6 +435,7 @@ class ProactiveCareAlarmService {
     try {
       await AndroidAlarmManager.cancel(alarmIdFor(assistantId));
     } catch (e) {
+      debugPrint('[ProactiveCare] Alarm cancel failed for $assistantId: $e');
       FlutterLogger.log(
         'Alarm cancel failed for assistant $assistantId: $e',
         tag: _logTag,
@@ -398,15 +448,15 @@ class ProactiveCareAlarmService {
   /// recover alarms lost after force-stop or process death.
   static Future<void> rescheduleAll(List<Assistant> assistants) async {
     if (!_isAndroid) return;
-    for (final a in assistants) {
-      if (!a.enableProactiveCare) continue;
-      final at = a.proactiveCareNextMessageAt;
-      if (at == null || !at.isAfter(DateTime.now())) continue;
-      try {
-        await sync(a);
-      } catch (e) {
-        FlutterLogger.log('rescheduleAll failed for ${a.id}: $e', tag: _logTag);
-      }
+    final pending = pendingForReschedule(assistants);
+    debugPrint(
+      '[ProactiveCare] rescheduleAll: ${pending.length}/${assistants.length} '
+      'assistants need re-arming',
+    );
+    // sync() never throws (all failures are caught and logged inside), so no
+    // per-assistant try/catch is needed here.
+    for (final a in pending) {
+      await sync(a);
     }
   }
 
@@ -425,6 +475,7 @@ class ProactiveCareAlarmService {
       }
       exactAlarm = status.isGranted;
     } catch (e) {
+      debugPrint('[ProactiveCare] Exact alarm permission request failed: $e');
       FlutterLogger.log(
         'Exact alarm permission request failed: $e',
         tag: _logTag,

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -230,7 +230,11 @@ class ProactiveCareMessageFlow {
               cfg = ProviderConfig.fromJson(entry.cast<String, dynamic>());
             }
           }
-        } catch (_) {}
+        } catch (e) {
+          debugPrint(
+            '[ProactiveCare] Decision provider config decode failed: $e',
+          );
+        }
         cfg ??= ProviderConfig.defaultsFor(provKey);
         return ProactiveCareModelConfig(
           config: cfg,
@@ -250,7 +254,9 @@ class ProactiveCareMessageFlow {
       final prefs = await SharedPreferences.getInstance();
       final n = prefs.getString(_userNamePrefsKey);
       if (n != null && n.isNotEmpty) return n;
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[ProactiveCare] User nickname load failed: $e');
+    }
     return 'User';
   }
 
@@ -260,7 +266,9 @@ class ProactiveCareMessageFlow {
     try {
       final prefs = await SharedPreferences.getInstance();
       return prefs.getInt('thinking_budget_v1');
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[ProactiveCare] Thinking budget load failed: $e');
+    }
     return null;
   }
 

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -355,6 +355,7 @@ class HomePageController extends ChangeNotifier {
       );
       if (!registered) {
         port.close();
+        debugPrint('[ProactiveCare] Port registration failed');
         FlutterLogger.log(
           'Proactive care port registration failed',
           tag: 'HomePageController',
@@ -364,10 +365,14 @@ class HomePageController extends ChangeNotifier {
       _proactiveCarePort = port;
       port.listen((dynamic data) {
         final assistantId = data?.toString() ?? '';
+        debugPrint(
+          '[ProactiveCare] Main isolate received trigger for $assistantId',
+        );
         if (assistantId.isEmpty) return;
         unawaited(_viewModel.handleProactiveCareTrigger(assistantId));
       });
     } catch (e) {
+      debugPrint('[ProactiveCare] Port setup failed: $e');
       FlutterLogger.log(
         'Proactive care port setup failed: $e',
         tag: 'HomePageController',
@@ -667,6 +672,23 @@ class HomePageController extends ChangeNotifier {
     await _chatService.init();
     if (!ctx.mounted) return;
     await assistantProvider.ensureDefaults(ctx);
+    // Re-arm proactive care exact alarms lost after force-stop or process
+    // death. This must run after assistants have finished loading (the
+    // first-frame callback in main.dart captured an empty list) — see
+    // docs/adr/0031-proactive-care-startup-reschedule-and-logging.md.
+    if (ProactiveCareAlarmService.isSupported) {
+      try {
+        await ProactiveCareAlarmService.rescheduleAll(
+          assistantProvider.assistants,
+        );
+      } catch (e) {
+        debugPrint('[ProactiveCare] Startup rescheduleAll failed: $e');
+        FlutterLogger.log(
+          'Proactive care startup rescheduleAll failed: $e',
+          tag: 'HomePageController',
+        );
+      }
+    }
     if (prefs.newChatOnLaunch) {
       await _createNewConversation();
     } else {

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1758,7 +1758,13 @@ class HomeViewModel extends ChangeNotifier {
         decisionPrompt: decisionPrompt,
         fallbackThinkingBudget: settings.thinkingBudget,
       );
-      if (newTime == null) return;
+      if (newTime == null) {
+        debugPrint(
+          '[ProactiveCare] Decision returned no next time for '
+          '${assistant.id}',
+        );
+        return;
+      }
 
       final latest = assistantProvider.getById(assistant.id);
       if (latest == null || !latest.enableProactiveCare) return;
@@ -1770,6 +1776,9 @@ class HomeViewModel extends ChangeNotifier {
         latest.copyWith(proactiveCareNextMessageAt: newTime),
       );
     } catch (e) {
+      debugPrint(
+        '[ProactiveCare] Decision request failed for ${assistant.id}: $e',
+      );
       FlutterLogger.log(
         '[ProactiveCare] Decision request failed: $e',
         tag: 'HomeViewModel',
@@ -1781,9 +1790,22 @@ class HomeViewModel extends ChangeNotifier {
   /// Builds the care prompt, streams a reply, persists it, notifies the user,
   /// and re-decides the next care time.
   Future<void> handleProactiveCareTrigger(String assistantId) async {
+    debugPrint('[ProactiveCare] Trigger received for $assistantId');
     final assistantProvider = _contextProvider.read<AssistantProvider>();
     final assistant = assistantProvider.getById(assistantId);
-    if (assistant == null || !assistant.enableProactiveCare) return;
+    if (assistant == null) {
+      debugPrint(
+        '[ProactiveCare] Assistant $assistantId not found, dropping trigger',
+      );
+      return;
+    }
+    if (!assistant.enableProactiveCare) {
+      debugPrint(
+        '[ProactiveCare] Proactive care disabled for $assistantId, '
+        'dropping trigger',
+      );
+      return;
+    }
 
     final settings = _contextProvider.read<SettingsProvider>();
     final provKey =
@@ -1791,6 +1813,7 @@ class HomeViewModel extends ChangeNotifier {
     final mdlId = assistant.chatModelId ?? settings.currentModelId;
     final l10n = AppLocalizations.of(_contextProvider);
     if (provKey == null || mdlId == null) {
+      debugPrint('[ProactiveCare] No chat model configured for $assistantId');
       FlutterLogger.log(
         '[ProactiveCare] No chat model configured for $assistantId',
         tag: 'HomeViewModel',
@@ -1858,6 +1881,9 @@ class HomeViewModel extends ChangeNotifier {
       await _showProactiveCareNotification(assistant, reply);
       await _maybeUpdateProactiveCareFor(convo.id);
     } catch (e) {
+      debugPrint(
+        '[ProactiveCare] Foreground care flow failed for $assistantId: $e',
+      );
       FlutterLogger.log(
         '[ProactiveCare] Foreground care flow failed: $e',
         tag: 'HomeViewModel',
@@ -1882,6 +1908,9 @@ class HomeViewModel extends ChangeNotifier {
         body: body,
       );
     } catch (e) {
+      debugPrint(
+        '[ProactiveCare] Failed to show notification for ${assistant.id}: $e',
+      );
       FlutterLogger.log(
         '[ProactiveCare] Failed to show notification: $e',
         tag: 'HomeViewModel',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -388,11 +388,6 @@ class MyApp extends StatelessWidget {
                     final mode = settings.androidBackgroundChatMode;
                     final l10n = AppLocalizations.of(context);
                     if (l10n == null) return;
-                    // Capture before any async gap to satisfy
-                    // use_build_context_synchronously.
-                    final allAssistants = context
-                        .read<AssistantProvider>()
-                        .assistants;
                     if (mode != AndroidBackgroundChatMode.off) {
                       // Enable only if currently disabled to avoid duplicate ROM prompts
                       try {
@@ -413,14 +408,14 @@ class MyApp extends StatelessWidget {
                         await NotificationService.ensureAndroidNotificationsPermission();
                       }
                     }
-                    // Initialize proactive care alarms (reschedule any pending).
-                    // This runs regardless of background chat mode, because
-                    // proactive care uses its own exact-alarm mechanism
-                    // independent of the background chat service.
+                    // Persist l10n strings so the background isolate can use
+                    // localized text instead of English fallbacks. Alarm
+                    // recovery (rescheduleAll) runs in HomePageController
+                    // initChat after assistants finish loading — the
+                    // assistant list is not available at first frame, see
+                    // docs/adr/0031-proactive-care-startup-reschedule-and-logging.md.
                     try {
                       if (ProactiveCareAlarmService.isSupported) {
-                        // Persist l10n strings so the background isolate can
-                        // use localized text instead of English fallbacks.
                         await ProactiveCareL10nSnapshot.save(
                           defaultConversationTitle:
                               l10n.chatServiceDefaultConversationTitle,
@@ -431,15 +426,16 @@ class MyApp extends StatelessWidget {
                           failureNotificationBody:
                               l10n.proactiveCareFailedNotificationBody,
                         );
-                        // Recover alarms lost after force-stop or process
-                        // death by re-scheduling all enabled assistants.
-                        await ProactiveCareAlarmService.rescheduleAll(
-                          allAssistants,
-                        );
                       }
-                    } catch (_) {}
+                    } catch (e) {
+                      debugPrint(
+                        '[ProactiveCare] L10n snapshot save failed: $e',
+                      );
+                    }
                   }
-                } catch (_) {}
+                } catch (e) {
+                  debugPrint('[main] Android background setup failed: $e');
+                }
               });
 
               final useDyn = isAndroid && settings.useDynamicColor;

--- a/test/core/services/proactive_care_alarm_service_test.dart
+++ b/test/core/services/proactive_care_alarm_service_test.dart
@@ -1,0 +1,133 @@
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/services/proactive_care_alarm_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProactiveCareAlarmService.pendingForReschedule', () {
+    final now = DateTime(2026, 8, 14, 12, 0, 0);
+
+    Assistant assistant({
+      String id = 'a1',
+      bool enabled = true,
+      DateTime? nextAt,
+    }) => Assistant(
+      id: id,
+      name: 'Test',
+      enableProactiveCare: enabled,
+      proactiveCareNextMessageAt: nextAt,
+    );
+
+    test('empty list yields nothing to re-arm', () {
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule(
+          const <Assistant>[],
+          now: now,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('assistant with proactive care disabled is skipped', () {
+      final a = assistant(
+        enabled: false,
+        nextAt: now.add(const Duration(minutes: 5)),
+      );
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([a], now: now),
+        isEmpty,
+      );
+    });
+
+    test('assistant without a next time is skipped', () {
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([
+          assistant(nextAt: null),
+        ], now: now),
+        isEmpty,
+      );
+    });
+
+    test('assistant with a past next time is skipped', () {
+      final a = assistant(nextAt: now.subtract(const Duration(minutes: 1)));
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([a], now: now),
+        isEmpty,
+      );
+    });
+
+    test('next time exactly at now is skipped (must be strictly after)', () {
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([
+          assistant(nextAt: now),
+        ], now: now),
+        isEmpty,
+      );
+    });
+
+    test('assistant with a future next time is re-armed', () {
+      final a = assistant(nextAt: now.add(const Duration(minutes: 5)));
+      expect(ProactiveCareAlarmService.pendingForReschedule([a], now: now), [
+        a,
+      ]);
+    });
+
+    test('mixed list filters to only the pending assistants', () {
+      final pending = assistant(nextAt: now.add(const Duration(minutes: 5)));
+      final disabled = assistant(
+        id: 'a2',
+        enabled: false,
+        nextAt: now.add(const Duration(minutes: 5)),
+      );
+      final noTime = assistant(id: 'a3', nextAt: null);
+      final past = assistant(
+        id: 'a4',
+        nextAt: now.subtract(const Duration(minutes: 1)),
+      );
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([
+          pending,
+          disabled,
+          noTime,
+          past,
+        ], now: now),
+        [pending],
+      );
+    });
+
+    test('multiple pending assistants keep their original order', () {
+      final pending1 = assistant(
+        id: 'a1',
+        nextAt: now.add(const Duration(minutes: 3)),
+      );
+      final disabled = assistant(
+        id: 'a2',
+        enabled: false,
+        nextAt: now.add(const Duration(minutes: 5)),
+      );
+      final pending2 = assistant(
+        id: 'a3',
+        nextAt: now.add(const Duration(minutes: 9)),
+      );
+      final past = assistant(
+        id: 'a4',
+        nextAt: now.subtract(const Duration(minutes: 1)),
+      );
+      expect(
+        ProactiveCareAlarmService.pendingForReschedule([
+          pending1,
+          disabled,
+          pending2,
+          past,
+        ], now: now),
+        [pending1, pending2],
+      );
+    });
+
+    test('uses the wall clock when now is not provided', () {
+      final a = assistant(
+        nextAt: DateTime.now().add(const Duration(minutes: 5)),
+      );
+      expect(ProactiveCareAlarmService.pendingForReschedule([a]), [a]);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

Ta的来信（Proactive Care，仅 Android）使用系统精确闹钟（android_alarm_manager_plus，一次性 exact alarm）在设定时间触发 LLM 回复。用户反馈：**到点、应用在前台，但没有触发 LLM 回复**。

排查结论（详见 docs/adr/0031）：

- **根因（已修）**： 在首帧 post-frame 回调里调用 ，但此时  尚未加载（Drift 异步打开 + 读库），列表恒为空 → 静默 no-op。Android 强停后系统清空所有闹钟，下次启动永远不会重新武装，功能死寂直到用户再次编辑助手设置。
- **可观测性缺口（已补）**：前台触发链路全静默——port 转发、handler 入口与 early return、决策结果、调度结果只进默认关闭的 FlutterLogger；权限被拒（Android 14+ 默认拒绝 ）在 logcat 完全不可见。

## 改动

1. **B1 修复**： 移至 ，在  完成后执行（ 门控，非 Android no-op）； 只保留 l10n snapshot 保存，两处静默 catch 补日志。
2. **Always-on 日志**（ 前缀，logcat 可见）：port 收到触发、handler 入口与两类 early return、决策无下次时间、 失败时附 、各 catch 块；保留既有 FlutterLogger 并行。
3. **纯函数抽取**：（enabled + 未来时间）供  复用。
4. **测试**： 9 个用例（空/禁用/null/过去/恰好 now/未来/混合过滤/多 pending 顺序/默认时钟）。
5. **ADR**：。

## 验证

- Analyzing lib, test...
No issues found! → No issues
- 00:00 +0: loading /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart
00:00 +0: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule empty list yields nothing to re-arm
00:00 +1: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule assistant with proactive care disabled is skipped
00:00 +2: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule assistant without a next time is skipped
00:00 +3: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule assistant with a past next time is skipped
00:00 +4: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule next time exactly at now is skipped (must be strictly after)
00:00 +5: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule assistant with a future next time is re-armed
00:00 +6: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule mixed list filters to only the pending assistants
00:00 +7: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule multiple pending assistants keep their original order
00:00 +8: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_alarm_service_test.dart: ProactiveCareAlarmService.pendingForReschedule uses the wall clock when now is not provided
00:00 +9: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 1: valid future time via chunk toolCalls returns the exact time
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171644491
00:00 +10: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 2: decision via onToolCall handler returns the time neutrally
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171666746
00:00 +11: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 3: UTC input is converted to local time
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171675088
00:00 +12: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 4: past time is final (null, no retry)
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171678577
00:00 +13: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 5: malformed time arg is final (null, no retry)
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171683972
00:00 +14: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 6: missing or empty next_care_time is final (null, no retry)
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171689330
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171690168
00:00 +15: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 7: keep_care_time returns null and cancels without retry
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171694448
00:00 +16: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 8: free text on both attempts returns null and retry appends the tool-only directive
00:00 +17: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 9: first stream error retries and returns the retry time
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171702309-retry
00:00 +18: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 10: follow-up handler calls after a decision stay neutral
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171709977
00:00 +19: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 11: lenient tool-name matching accepts Update-Care-Time
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171714850
00:00 +20: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 12: empty history returns null without sending
00:00 +21: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 15: unknown tool name stays undecided, later valid call settles
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171725099
00:00 +22: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 16: both attempts error returns null after two sends
00:00 +23: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 17: handler and chunk double delivery decides once, first wins
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171733892
00:00 +24: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 18: first attempt timeout retries and second attempt decides
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171736668
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171736668-retry
00:00 +25: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 19: both attempts timing out returns null after two sends
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171765404
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171765404-retry
00:00 +26: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 20: timeout cancels the hung attempt subscription
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171814209
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171814209-retry
00:00 +27: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: decision flow 22: validation uses a fresh clock, not the request-level now
[CancelTrace] cancelRequest: token NOT FOUND for key=proactive-care-decision-a1-1786693171862584
00:01 +28: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: ProactiveCareService 21: empty decision prompt omits the system message
00:01 +29: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: ProactiveCareDecisionTools 13: parseUpdateTimeArgs keeps the old JSON-decision semantics
00:01 +30: /root/.paseo/worktrees/0rqsyz7h/glowing-meerkat/test/core/services/proactive_care_decision_test.dart: ProactiveCareDecisionTools 14: definitions() are OpenAI-shaped function tools
00:01 +31: All tests passed! → 31/31 通过
- 本环境无 Android SDK，真机验证未执行；用户将装新包复测，logcat 可凭新日志定位剩余嫌疑（权限被拒 / 决策循环失效——本次按日志先行策略不改行为）

## 手动测试计划

- 正常路径：设 2 分钟后触发 → 到点收到回复； 可见完整链路
- 边界：强停 → 重启 → logcat 见 `rescheduleAll: N/M assistants need re-arming` → 到点仍触发（B1 修复验证）
- 关闭 Ta的来信 → logcat 见 disabled drop 日志