### PR TITLE
feat(skills): collapsible category groups with animated chevron

### DIFF
--- a/lib/desktop/skills_popover.dart
+++ b/lib/desktop/skills_popover.dart
@@ -7,6 +7,7 @@ import '../core/providers/assistant_provider.dart';
 import '../features/skills/skill_manager.dart';
 import '../icons/lucide_adapter.dart';
 import '../l10n/app_localizations.dart';
+import '../shared/widgets/collapsible_group_header.dart';
 import '../theme/app_font_weights.dart';
 
 Future<void> showDesktopSkillsPopover(
@@ -210,7 +211,7 @@ class _GlassPanel extends StatelessWidget {
   }
 }
 
-class _SkillsPopoverContent extends StatelessWidget {
+class _SkillsPopoverContent extends StatefulWidget {
   const _SkillsPopoverContent({
     required this.skills,
     required this.assistantId,
@@ -224,10 +225,18 @@ class _SkillsPopoverContent extends StatelessWidget {
   final VoidCallback onClose;
 
   @override
+  State<_SkillsPopoverContent> createState() => _SkillsPopoverContentState();
+}
+
+class _SkillsPopoverContentState extends State<_SkillsPopoverContent>
+    with CollapsibleGroupsMixin<_SkillsPopoverContent> {
+  @override
   Widget build(BuildContext context) {
     final ap = context.watch<AssistantProvider>();
+    final skills = widget.skills;
+    final assistantId = widget.assistantId;
     final assistant = assistantId != null
-        ? ap.getById(assistantId!)
+        ? ap.getById(assistantId)
         : ap.currentAssistant;
     final allSelected =
         skills.isNotEmpty &&
@@ -242,11 +251,11 @@ class _SkillsPopoverContent extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             _SkillsPopoverHeader(
-              onManageSkills: onManageSkills == null
+              onManageSkills: widget.onManageSkills == null
                   ? null
                   : () {
-                      onClose();
-                      onManageSkills?.call();
+                      widget.onClose();
+                      widget.onManageSkills?.call();
                     },
               showSelectAll: skills.isNotEmpty && assistant != null,
               allSelected: allSelected,
@@ -267,27 +276,40 @@ class _SkillsPopoverContent extends StatelessWidget {
                     },
             ),
             if (skills.isEmpty)
-              _SkillsPopoverEmpty(onImport: onManageSkills, onClose: onClose)
+              _SkillsPopoverEmpty(
+                onImport: widget.onManageSkills,
+                onClose: widget.onClose,
+              )
             else
               for (final (group, groupSkills) in groupSkillsByCategory(
                 skills,
               )) ...[
-                Padding(
+                CollapsibleGroupHeader(
+                  groupName:
+                      group ??
+                      AppLocalizations.of(context)!.skillsUncategorizedGroup,
+                  skillCount: groupSkills.length,
+                  expanded: isGroupExpanded(group),
+                  onTap: () => toggleGroup(group),
+                  fontSize: 12.5,
+                  fontWeight: AppFontWeights.emphasis,
                   padding: const EdgeInsets.only(top: 6, bottom: 2),
-                  child: _GroupHeaderRow(
-                    title:
-                        group ??
-                        AppLocalizations.of(context)!.skillsUncategorizedGroup,
+                ),
+                CollapsibleGroupBody(
+                  expanded: isGroupExpanded(group),
+                  child: Column(
+                    children: [
+                      for (final skill in groupSkills)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 1),
+                          child: _SkillsRowItem(
+                            name: skill.name,
+                            assistantId: assistantId,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
-                for (final skill in groupSkills)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 1),
-                    child: _SkillsRowItem(
-                      name: skill.name,
-                      assistantId: assistantId,
-                    ),
-                  ),
               ],
           ],
         ),
@@ -467,38 +489,6 @@ class _SkillsPopoverEmpty extends StatelessWidget {
               label: Text(l10n.skillsSheetImportAction),
             ),
           ],
-        ],
-      ),
-    );
-  }
-}
-
-class _GroupHeaderRow extends StatelessWidget {
-  const _GroupHeaderRow({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return SizedBox(
-      height: 30,
-      child: Row(
-        children: [
-          const SizedBox(width: 6),
-          Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 12.5,
-                fontWeight: AppFontWeights.emphasis,
-                color: cs.onSurface.withValues(alpha: 0.75),
-                decoration: TextDecoration.none,
-              ),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -40,6 +40,7 @@ import '../../home/services/local_tools_service.dart';
 import '../../skills/skill_manager.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/collapsible_group_header.dart';
 import '../../../shared/widgets/emoji_picker_dialog.dart';
 import '../../../shared/widgets/emoji_text.dart';
 import '../../../shared/widgets/ios_switch.dart';

--- a/lib/features/assistant/pages/assistant_settings_edit_skills_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_skills_tab.dart
@@ -8,7 +8,8 @@ class _SkillsTab extends StatefulWidget {
   State<_SkillsTab> createState() => _SkillsTabState();
 }
 
-class _SkillsTabState extends State<_SkillsTab> {
+class _SkillsTabState extends State<_SkillsTab>
+    with CollapsibleGroupsMixin<_SkillsTab> {
   List<SkillMetadata> _skills = const [];
   bool _loading = true;
 
@@ -119,40 +120,41 @@ class _SkillsTabState extends State<_SkillsTab> {
               ),
               _iosDivider(context),
               for (final (group, skills) in groupSkillsByCategory(_skills)) ...[
-                Padding(
+                CollapsibleGroupHeader(
+                  groupName: group ?? l10n.skillsUncategorizedGroup,
+                  skillCount: skills.length,
+                  expanded: isGroupExpanded(group),
+                  onTap: () => toggleGroup(group),
                   padding: const EdgeInsets.fromLTRB(16, 10, 16, 2),
-                  child: Text(
-                    group ?? l10n.skillsUncategorizedGroup,
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: AppFontWeights.semibold,
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.5),
-                    ),
+                ),
+                CollapsibleGroupBody(
+                  expanded: isGroupExpanded(group),
+                  child: Column(
+                    children: [
+                      for (int i = 0; i < skills.length; i++) ...[
+                        if (i > 0) _iosDivider(context),
+                        _SkillRow(
+                          name: skills[i].name,
+                          description: skills[i].description,
+                          enabled: assistant.skillIds.contains(skills[i].name),
+                          onChanged: (value) {
+                            final ids = assistant.skillIds.toSet();
+                            if (value) {
+                              ids.add(skills[i].name);
+                            } else {
+                              ids.remove(skills[i].name);
+                            }
+                            context.read<AssistantProvider>().updateAssistant(
+                              assistant.copyWith(
+                                skillIds: ids.toList(growable: false),
+                              ),
+                            );
+                          },
+                        ),
+                      ],
+                    ],
                   ),
                 ),
-                for (int i = 0; i < skills.length; i++) ...[
-                  if (i > 0) _iosDivider(context),
-                  _SkillRow(
-                    name: skills[i].name,
-                    description: skills[i].description,
-                    enabled: assistant.skillIds.contains(skills[i].name),
-                    onChanged: (value) {
-                      final ids = assistant.skillIds.toSet();
-                      if (value) {
-                        ids.add(skills[i].name);
-                      } else {
-                        ids.remove(skills[i].name);
-                      }
-                      context.read<AssistantProvider>().updateAssistant(
-                        assistant.copyWith(
-                          skillIds: ids.toList(growable: false),
-                        ),
-                      );
-                    },
-                  ),
-                ],
               ],
             ],
           ],

--- a/lib/features/skills/pages/skills_page.dart
+++ b/lib/features/skills/pages/skills_page.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/collapsible_group_header.dart';
 import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
@@ -27,13 +28,10 @@ class SkillsPage extends StatefulWidget {
   State<SkillsPage> createState() => _SkillsPageState();
 }
 
-class _SkillsPageState extends State<SkillsPage> {
+class _SkillsPageState extends State<SkillsPage>
+    with CollapsibleGroupsMixin<SkillsPage> {
   List<SkillMetadata> _skills = const [];
   bool _loading = true;
-
-  /// Tracks which category groups are currently expanded.
-  /// All groups start expanded by default.
-  final Set<String> _collapsedGroups = {};
 
   @override
   void initState() {
@@ -565,23 +563,6 @@ class _SkillsPageState extends State<SkillsPage> {
     await _refresh();
   }
 
-  /// A stable key for a group, used to track collapsed state.
-  String _groupKey(String? group) => group ?? '__uncategorized__';
-
-  void _toggleGroup(String? group) {
-    setState(() {
-      final key = _groupKey(group);
-      if (_collapsedGroups.contains(key)) {
-        _collapsedGroups.remove(key);
-      } else {
-        _collapsedGroups.add(key);
-      }
-    });
-  }
-
-  bool _isGroupExpanded(String? group) =>
-      !_collapsedGroups.contains(_groupKey(group));
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -765,52 +746,64 @@ class _SkillsPageState extends State<SkillsPage> {
 
     return [
       for (final (group, skills) in groups) ...[
-        _CollapsibleGroupHeader(
+        CollapsibleGroupHeader(
           groupName: group ?? l10n.skillsUncategorizedGroup,
           skillCount: skills.length,
-          expanded: _isGroupExpanded(group),
-          onTap: () => _toggleGroup(group),
+          expanded: isGroupExpanded(group),
+          onTap: () => toggleGroup(group),
         ),
-        if (_isGroupExpanded(group))
-          for (final skill in skills)
-            desktop
-                ? _buildDesktopSkillCard(l10n, cs, skill)
-                : Card(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    child: ListTile(
-                      leading: Icon(Lucide.BookOpen, color: cs.primary),
-                      title: Text(
-                        skill.name,
-                        style: TextStyle(fontWeight: AppFontWeights.semibold),
-                      ),
-                      subtitle: skill.description.isNotEmpty
-                          ? Text(
-                              skill.description,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            )
-                          : null,
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 120),
-                            child: _CategoryTag(
-                              category: skill.category,
-                              label: skill.category ??
-                                  l10n.skillsUncategorizedGroup,
-                              onTap: () => _editCategory(skill),
+        CollapsibleGroupBody(
+          expanded: isGroupExpanded(group),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final skill in skills)
+                desktop
+                    ? _buildDesktopSkillCard(l10n, cs, skill)
+                    : Card(
+                        margin: const EdgeInsets.only(bottom: 8),
+                        child: ListTile(
+                          leading: Icon(Lucide.BookOpen, color: cs.primary),
+                          title: Text(
+                            skill.name,
+                            style: TextStyle(
+                              fontWeight: AppFontWeights.semibold,
                             ),
                           ),
-                          IconButton(
-                            icon: const Icon(Lucide.Trash2),
-                            color: cs.error,
-                            onPressed: () => _deleteSkill(skill.name),
+                          subtitle: skill.description.isNotEmpty
+                              ? Text(
+                                  skill.description,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                )
+                              : null,
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  maxWidth: 120,
+                                ),
+                                child: _CategoryTag(
+                                  category: skill.category,
+                                  label:
+                                      skill.category ??
+                                      l10n.skillsUncategorizedGroup,
+                                  onTap: () => _editCategory(skill),
+                                ),
+                              ),
+                              IconButton(
+                                icon: const Icon(Lucide.Trash2),
+                                color: cs.error,
+                                onPressed: () => _deleteSkill(skill.name),
+                              ),
+                            ],
                           ),
-                        ],
+                        ),
                       ),
-                    ),
-                  ),
+            ],
+          ),
+        ),
       ],
     ];
   }
@@ -980,63 +973,6 @@ class _SkillsPageState extends State<SkillsPage> {
       return;
     }
     await _refresh();
-  }
-}
-
-/// Collapsible group header with tap-to-expand/collapse and animated chevron.
-class _CollapsibleGroupHeader extends StatelessWidget {
-  const _CollapsibleGroupHeader({
-    required this.groupName,
-    required this.skillCount,
-    required this.expanded,
-    required this.onTap,
-  });
-
-  final String groupName;
-  final int skillCount;
-  final bool expanded;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(4, 12, 4, 6),
-        child: Row(
-          children: [
-            AnimatedRotation(
-              turns: expanded ? 0.25 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: Icon(
-                Lucide.ChevronRight,
-                size: 14,
-                color: cs.onSurface.withValues(alpha: 0.55),
-              ),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              groupName,
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: AppFontWeights.semibold,
-                color: cs.onSurface.withValues(alpha: 0.55),
-              ),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              '($skillCount)',
-              style: TextStyle(
-                fontSize: 11,
-                color: cs.onSurface.withValues(alpha: 0.38),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/features/skills/pages/skills_page.dart
+++ b/lib/features/skills/pages/skills_page.dart
@@ -31,6 +31,10 @@ class _SkillsPageState extends State<SkillsPage> {
   List<SkillMetadata> _skills = const [];
   bool _loading = true;
 
+  /// Tracks which category groups are currently expanded.
+  /// All groups start expanded by default.
+  final Set<String> _collapsedGroups = {};
+
   @override
   void initState() {
     super.initState();
@@ -561,6 +565,23 @@ class _SkillsPageState extends State<SkillsPage> {
     await _refresh();
   }
 
+  /// A stable key for a group, used to track collapsed state.
+  String _groupKey(String? group) => group ?? '__uncategorized__';
+
+  void _toggleGroup(String? group) {
+    setState(() {
+      final key = _groupKey(group);
+      if (_collapsedGroups.contains(key)) {
+        _collapsedGroups.remove(key);
+      } else {
+        _collapsedGroups.add(key);
+      }
+    });
+  }
+
+  bool _isGroupExpanded(String? group) =>
+      !_collapsedGroups.contains(_groupKey(group));
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -693,19 +714,13 @@ class _SkillsPageState extends State<SkillsPage> {
   List<Widget> _buildSkillGroups({bool desktop = false}) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    return [
-      for (final (group, skills) in groupSkillsByCategory(_skills)) ...[
-        Padding(
-          padding: const EdgeInsets.fromLTRB(4, 12, 4, 6),
-          child: Text(
-            group ?? l10n.skillsUncategorizedGroup,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: AppFontWeights.semibold,
-              color: cs.onSurface.withValues(alpha: 0.55),
-            ),
-          ),
-        ),
+    final groups = groupSkillsByCategory(_skills);
+
+    // When there is only one group, skip the collapsible header and render
+    // skills flat — the grouping chrome adds no value with a single category.
+    if (groups.length == 1) {
+      final (_, skills) = groups.first;
+      return [
         for (final skill in skills)
           desktop
               ? _buildDesktopSkillCard(l10n, cs, skill)
@@ -745,6 +760,57 @@ class _SkillsPageState extends State<SkillsPage> {
                     ),
                   ),
                 ),
+      ];
+    }
+
+    return [
+      for (final (group, skills) in groups) ...[
+        _CollapsibleGroupHeader(
+          groupName: group ?? l10n.skillsUncategorizedGroup,
+          skillCount: skills.length,
+          expanded: _isGroupExpanded(group),
+          onTap: () => _toggleGroup(group),
+        ),
+        if (_isGroupExpanded(group))
+          for (final skill in skills)
+            desktop
+                ? _buildDesktopSkillCard(l10n, cs, skill)
+                : Card(
+                    margin: const EdgeInsets.only(bottom: 8),
+                    child: ListTile(
+                      leading: Icon(Lucide.BookOpen, color: cs.primary),
+                      title: Text(
+                        skill.name,
+                        style: TextStyle(fontWeight: AppFontWeights.semibold),
+                      ),
+                      subtitle: skill.description.isNotEmpty
+                          ? Text(
+                              skill.description,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            )
+                          : null,
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 120),
+                            child: _CategoryTag(
+                              category: skill.category,
+                              label: skill.category ??
+                                  l10n.skillsUncategorizedGroup,
+                              onTap: () => _editCategory(skill),
+                            ),
+                          ),
+                          IconButton(
+                            icon: const Icon(Lucide.Trash2),
+                            color: cs.error,
+                            onPressed: () => _deleteSkill(skill.name),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
       ],
     ];
   }
@@ -914,6 +980,63 @@ class _SkillsPageState extends State<SkillsPage> {
       return;
     }
     await _refresh();
+  }
+}
+
+/// Collapsible group header with tap-to-expand/collapse and animated chevron.
+class _CollapsibleGroupHeader extends StatelessWidget {
+  const _CollapsibleGroupHeader({
+    required this.groupName,
+    required this.skillCount,
+    required this.expanded,
+    required this.onTap,
+  });
+
+  final String groupName;
+  final int skillCount;
+  final bool expanded;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(4, 12, 4, 6),
+        child: Row(
+          children: [
+            AnimatedRotation(
+              turns: expanded ? 0.25 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Icon(
+                Lucide.ChevronRight,
+                size: 14,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              groupName,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: AppFontWeights.semibold,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '($skillCount)',
+              style: TextStyle(
+                fontSize: 11,
+                color: cs.onSurface.withValues(alpha: 0.38),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/features/skills/widgets/skills_sheet.dart
+++ b/lib/features/skills/widgets/skills_sheet.dart
@@ -29,6 +29,10 @@ class _SkillsSheetState extends State<SkillsSheet> {
   List<SkillMetadata> _skills = const [];
   bool _loading = true;
 
+  /// Tracks which category groups are currently collapsed.
+  /// All groups start expanded by default.
+  final Set<String> _collapsedGroups = {};
+
   @override
   void initState() {
     super.initState();
@@ -80,6 +84,23 @@ class _SkillsSheetState extends State<SkillsSheet> {
     ).push(MaterialPageRoute(builder: (_) => const SkillsPage()));
   }
 
+  /// A stable key for a group, used to track collapsed state.
+  String _groupKey(String? group) => group ?? '__uncategorized__';
+
+  void _toggleGroup(String? group) {
+    setState(() {
+      final key = _groupKey(group);
+      if (_collapsedGroups.contains(key)) {
+        _collapsedGroups.remove(key);
+      } else {
+        _collapsedGroups.add(key);
+      }
+    });
+  }
+
+  bool _isGroupExpanded(String? group) =>
+      !_collapsedGroups.contains(_groupKey(group));
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -124,43 +145,122 @@ class _SkillsSheetState extends State<SkillsSheet> {
                           ),
                         ),
                       )
-                    : ListView(
-                        controller: controller,
-                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-                        children: [
-                          for (final (group, skills) in groupSkillsByCategory(
-                            _skills,
-                          )) ...[
-                            Padding(
-                              padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
-                              child: Text(
-                                group ?? l10n.skillsUncategorizedGroup,
-                                style: TextStyle(
-                                  fontSize: 12.5,
-                                  fontWeight: AppFontWeights.emphasis,
-                                  color: cs.onSurface.withValues(alpha: 0.55),
-                                ),
-                              ),
-                            ),
-                            for (final skill in skills)
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 10),
-                                child: _SkillSheetRow(
-                                  name: skill.name,
-                                  enabled: assistant.skillIds.contains(
-                                    skill.name,
-                                  ),
-                                  onChanged: (v) =>
-                                      _toggle(assistant, skill.name, v),
-                                ),
-                              ),
-                          ],
-                        ],
-                      ),
+                    : _buildGroupedList(controller, assistant, l10n, cs),
               ),
             ],
           );
         },
+      ),
+    );
+  }
+
+  Widget _buildGroupedList(
+    ScrollController controller,
+    Assistant assistant,
+    AppLocalizations l10n,
+    ColorScheme cs,
+  ) {
+    final groups = groupSkillsByCategory(_skills);
+
+    // When there is only one group, skip collapsible headers.
+    if (groups.length == 1) {
+      final (_, skills) = groups.first;
+      return ListView(
+        controller: controller,
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        children: [
+          for (final skill in skills)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: _SkillSheetRow(
+                name: skill.name,
+                enabled: assistant.skillIds.contains(skill.name),
+                onChanged: (v) => _toggle(assistant, skill.name, v),
+              ),
+            ),
+        ],
+      );
+    }
+
+    return ListView(
+      controller: controller,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      children: [
+        for (final (group, skills) in groups) ...[
+          _SheetCollapsibleGroupHeader(
+            groupName: group ?? l10n.skillsUncategorizedGroup,
+            skillCount: skills.length,
+            expanded: _isGroupExpanded(group),
+            onTap: () => _toggleGroup(group),
+          ),
+          if (_isGroupExpanded(group))
+            for (final skill in skills)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: _SkillSheetRow(
+                  name: skill.name,
+                  enabled: assistant.skillIds.contains(skill.name),
+                  onChanged: (v) => _toggle(assistant, skill.name, v),
+                ),
+              ),
+        ],
+      ],
+    );
+  }
+}
+
+/// Collapsible group header for the skills sheet.
+class _SheetCollapsibleGroupHeader extends StatelessWidget {
+  const _SheetCollapsibleGroupHeader({
+    required this.groupName,
+    required this.skillCount,
+    required this.expanded,
+    required this.onTap,
+  });
+
+  final String groupName;
+  final int skillCount;
+  final bool expanded;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
+        child: Row(
+          children: [
+            AnimatedRotation(
+              turns: expanded ? 0.25 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Icon(
+                Lucide.ChevronRight,
+                size: 14,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              groupName,
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: AppFontWeights.emphasis,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '($skillCount)',
+              style: TextStyle(
+                fontSize: 11,
+                color: cs.onSurface.withValues(alpha: 0.38),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/skills/widgets/skills_sheet.dart
+++ b/lib/features/skills/widgets/skills_sheet.dart
@@ -6,6 +6,7 @@ import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/haptics.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/collapsible_group_header.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../theme/app_font_weights.dart';
@@ -25,13 +26,10 @@ class SkillsSheet extends StatefulWidget {
   State<SkillsSheet> createState() => _SkillsSheetState();
 }
 
-class _SkillsSheetState extends State<SkillsSheet> {
+class _SkillsSheetState extends State<SkillsSheet>
+    with CollapsibleGroupsMixin<SkillsSheet> {
   List<SkillMetadata> _skills = const [];
   bool _loading = true;
-
-  /// Tracks which category groups are currently collapsed.
-  /// All groups start expanded by default.
-  final Set<String> _collapsedGroups = {};
 
   @override
   void initState() {
@@ -83,23 +81,6 @@ class _SkillsSheetState extends State<SkillsSheet> {
       context,
     ).push(MaterialPageRoute(builder: (_) => const SkillsPage()));
   }
-
-  /// A stable key for a group, used to track collapsed state.
-  String _groupKey(String? group) => group ?? '__uncategorized__';
-
-  void _toggleGroup(String? group) {
-    setState(() {
-      final key = _groupKey(group);
-      if (_collapsedGroups.contains(key)) {
-        _collapsedGroups.remove(key);
-      } else {
-        _collapsedGroups.add(key);
-      }
-    });
-  }
-
-  bool _isGroupExpanded(String? group) =>
-      !_collapsedGroups.contains(_groupKey(group));
 
   @override
   Widget build(BuildContext context) {
@@ -187,81 +168,33 @@ class _SkillsSheetState extends State<SkillsSheet> {
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
       children: [
         for (final (group, skills) in groups) ...[
-          _SheetCollapsibleGroupHeader(
+          CollapsibleGroupHeader(
             groupName: group ?? l10n.skillsUncategorizedGroup,
             skillCount: skills.length,
-            expanded: _isGroupExpanded(group),
-            onTap: () => _toggleGroup(group),
+            expanded: isGroupExpanded(group),
+            onTap: () => toggleGroup(group),
+            fontSize: 12.5,
+            fontWeight: AppFontWeights.emphasis,
+            padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
           ),
-          if (_isGroupExpanded(group))
-            for (final skill in skills)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: _SkillSheetRow(
-                  name: skill.name,
-                  enabled: assistant.skillIds.contains(skill.name),
-                  onChanged: (v) => _toggle(assistant, skill.name, v),
-                ),
-              ),
+          CollapsibleGroupBody(
+            expanded: isGroupExpanded(group),
+            child: Column(
+              children: [
+                for (final skill in skills)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _SkillSheetRow(
+                      name: skill.name,
+                      enabled: assistant.skillIds.contains(skill.name),
+                      onChanged: (v) => _toggle(assistant, skill.name, v),
+                    ),
+                  ),
+              ],
+            ),
+          ),
         ],
       ],
-    );
-  }
-}
-
-/// Collapsible group header for the skills sheet.
-class _SheetCollapsibleGroupHeader extends StatelessWidget {
-  const _SheetCollapsibleGroupHeader({
-    required this.groupName,
-    required this.skillCount,
-    required this.expanded,
-    required this.onTap,
-  });
-
-  final String groupName;
-  final int skillCount;
-  final bool expanded;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(4, 10, 4, 4),
-        child: Row(
-          children: [
-            AnimatedRotation(
-              turns: expanded ? 0.25 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: Icon(
-                Lucide.ChevronRight,
-                size: 14,
-                color: cs.onSurface.withValues(alpha: 0.55),
-              ),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              groupName,
-              style: TextStyle(
-                fontSize: 12.5,
-                fontWeight: AppFontWeights.emphasis,
-                color: cs.onSurface.withValues(alpha: 0.55),
-              ),
-            ),
-            const SizedBox(width: 6),
-            Text(
-              '($skillCount)',
-              style: TextStyle(
-                fontSize: 11,
-                color: cs.onSurface.withValues(alpha: 0.38),
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/shared/widgets/collapsible_group_header.dart
+++ b/lib/shared/widgets/collapsible_group_header.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+
+import '../../icons/lucide_adapter.dart';
+import '../../theme/app_font_weights.dart';
+
+/// Reusable collapsible group header with tap-to-expand/collapse and an
+/// animated chevron. Used by grouped lists (e.g. skills by category).
+class CollapsibleGroupHeader extends StatelessWidget {
+  const CollapsibleGroupHeader({
+    super.key,
+    required this.groupName,
+    required this.skillCount,
+    required this.expanded,
+    required this.onTap,
+    this.fontSize = 12,
+    this.fontWeight,
+    this.padding = const EdgeInsets.fromLTRB(4, 12, 4, 6),
+  });
+
+  final String groupName;
+  final int skillCount;
+  final bool expanded;
+  final VoidCallback onTap;
+  final double fontSize;
+  final FontWeight? fontWeight;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Padding(
+        padding: padding,
+        child: Row(
+          children: [
+            AnimatedRotation(
+              turns: expanded ? 0.25 : 0.0,
+              duration: const Duration(milliseconds: 200),
+              child: Icon(
+                Lucide.ChevronRight,
+                size: 14,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              groupName,
+              style: TextStyle(
+                fontSize: fontSize,
+                fontWeight: fontWeight ?? AppFontWeights.semibold,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '($skillCount)',
+              style: TextStyle(
+                fontSize: 11,
+                color: cs.onSurface.withValues(alpha: 0.38),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Animated body for a collapsible group: folds/unfolds with a
+/// [SizeTransition] height animation. Unlike `AnimatedSize`, the child is
+/// never re-laid-out per animation frame — only painted/clipped — so the
+/// collapse stays smooth regardless of content length.
+class CollapsibleGroupBody extends StatefulWidget {
+  const CollapsibleGroupBody({
+    super.key,
+    required this.expanded,
+    required this.child,
+  });
+
+  final bool expanded;
+  final Widget child;
+
+  @override
+  State<CollapsibleGroupBody> createState() => _CollapsibleGroupBodyState();
+}
+
+class _CollapsibleGroupBodyState extends State<CollapsibleGroupBody>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 240),
+    value: widget.expanded ? 1.0 : 0.0,
+  );
+  late final Animation<double> _curve = CurvedAnimation(
+    parent: _controller,
+    curve: Curves.easeInOutCubic,
+  );
+
+  @override
+  void didUpdateWidget(CollapsibleGroupBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.expanded == oldWidget.expanded) return;
+    if (widget.expanded) {
+      _controller.forward();
+    } else {
+      _controller.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizeTransition(
+      sizeFactor: _curve,
+      alignment: Alignment.topCenter,
+      child: widget.child,
+    );
+  }
+}
+
+/// Collapsible-group state shared by grouped list pages: tracks which category
+/// groups are collapsed and toggles them via [State.setState]. All groups
+/// start expanded by default.
+mixin CollapsibleGroupsMixin<T extends StatefulWidget> on State<T> {
+  final Set<String> _collapsedGroups = {};
+
+  /// A stable key for a group, used to track collapsed state.
+  String _groupKey(String? group) => group ?? '__uncategorized__';
+
+  void toggleGroup(String? group) {
+    setState(() {
+      final key = _groupKey(group);
+      if (_collapsedGroups.contains(key)) {
+        _collapsedGroups.remove(key);
+      } else {
+        _collapsedGroups.add(key);
+      }
+    });
+  }
+
+  bool isGroupExpanded(String? group) =>
+      !_collapsedGroups.contains(_groupKey(group));
+}


### PR DESCRIPTION
## Summary

Add collapsible/expandable category groups to the Skills management page and the Skills bottom sheet. When users have many skills organized into multiple categories, they can now tap on a category header to collapse or expand its group, keeping the UI clean and navigable.

## Changes

### `skills_page.dart`
- Added `_collapsedGroups` set to track which groups are collapsed
- Added `_toggleGroup()`, `_isGroupExpanded()`, `_groupKey()` helpers
- Modified `_buildSkillGroups()` to wrap each category in a `_CollapsibleGroupHeader`
- When only one group exists, skip collapsible headers (no value added)
- New `_CollapsibleGroupHeader` widget with animated rotating chevron icon and skill count badge

### `skills_sheet.dart` (bottom sheet)
- Same collapsible group logic added to the skill toggle sheet
- New `_SheetCollapsibleGroupHeader` widget matching the sheet's visual style
- Single-group case renders flat without headers

## Behavior

| State | Appearance |
|-------|-----------|
| Expanded (default) | `▸ 轩轩 (3)` with chevron rotated 90°, skills visible |
| Collapsed | `▸ 轩轩 (3)` with chevron at 0°, skills hidden |
| Single category | No group header shown, skills listed flat |

## Visual Details
- Animated chevron rotation (200ms) for expand/collapse feedback
- Group name + skill count displayed (e.g. "轩轩 (3)")
- All groups expanded by default
- Consistent styling between management page and bottom sheet

## Compatibility
- No breaking changes — data model and grouping logic (`groupSkillsByCategory`) unchanged
- No new dependencies
- Works on both mobile and desktop layouts
