### PR TITLE
fix: prevent chat background image from shifting when keyboard opens (v2)

### DIFF
--- a/lib/features/home/pages/home_mobile_layout.dart
+++ b/lib/features/home/pages/home_mobile_layout.dart
@@ -360,39 +360,44 @@ class MobileBackgroundLayer extends StatelessWidget {
       provider = FileImage(file);
     }
 
-    return Positioned.fill(
+    // Fix: Use the full screen size directly instead of relying on parent
+    // constraints. The parent Stack with StackFit.expand still shrinks when
+    // Scaffold resizes for the keyboard, so Positioned.fill inherits the
+    // shrunken size. By using SizedBox with MediaQuery.sizeOf we bypass
+    // the parent constraint entirely and always render at full screen.
+    final screenSize = MediaQuery.sizeOf(context);
+    return SizedBox(
+      width: screenSize.width,
+      height: screenSize.height,
       child: Stack(
+        fit: StackFit.expand,
         children: [
-          Positioned.fill(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                image: DecorationImage(
-                  image: provider,
-                  fit: BoxFit.cover,
-                  colorFilter: ColorFilter.mode(
-                    Colors.black.withValues(alpha: 0.04),
-                    BlendMode.srcATop,
-                  ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              image: DecorationImage(
+                image: provider,
+                fit: BoxFit.cover,
+                colorFilter: ColorFilter.mode(
+                  Colors.black.withValues(alpha: 0.04),
+                  BlendMode.srcATop,
                 ),
               ),
             ),
           ),
-          Positioned.fill(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      cs.surface.withValues(
-                        alpha: (0.20 * maskStrength).clamp(0.0, 1.0),
-                      ),
-                      cs.surface.withValues(
-                        alpha: (0.50 * maskStrength).clamp(0.0, 1.0),
-                      ),
-                    ],
-                  ),
+          IgnorePointer(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    cs.surface.withValues(
+                      alpha: (0.20 * maskStrength).clamp(0.0, 1.0),
+                    ),
+                    cs.surface.withValues(
+                      alpha: (0.50 * maskStrength).clamp(0.0, 1.0),
+                    ),
+                  ],
                 ),
               ),
             ),


### PR DESCRIPTION
## Problem

When a chat background image is set and the user taps the input field on mobile, the soft keyboard pushes the background image upward. The previous fix (#430) using `MediaQuery.removeViewInsets` did not resolve the issue.

## Root Cause Analysis

The previous approach (`MediaQuery.removeViewInsets`) correctly removed keyboard insets from the `MobileBackgroundLayer` subtree. However, the background widget sits inside a `Stack` with `StackFit.expand` as a child of `InteractiveDrawer`. The `Scaffold` with `resizeToAvoidBottomInset: true` causes the entire body (including the Stack) to shrink when the keyboard opens. Since `Positioned.fill` and `StackFit.expand` inherit parent constraints, the background was still being resized despite not knowing about the keyboard insets.

In short: `MediaQuery.removeViewInsets` only affects MediaQuery-dependent widgets, but `Positioned.fill` respects layout constraints from the parent, not MediaQuery.

## Fix

Replace `Positioned.fill` + `MediaQuery.removeViewInsets` with a `SizedBox` using `MediaQuery.sizeOf(context)` to get the actual screen dimensions. This bypasses parent layout constraints entirely:

- The background always renders at full screen size regardless of keyboard state
- The Scaffold body still resizes normally for the keyboard
- Chat content scrolls normally with the keyboard

## Changes

- `home_mobile_layout.dart`: Replace `Positioned.fill` + `MediaQuery.removeViewInsets` with `SizedBox(width: screenSize.width, height: screenSize.height)` in `MobileBackgroundLayer`

## Behavior

| State | Before (v1 fix) | After (v2 fix) |
|-------|-----------------|-----------------|
| Keyboard closed | Background fills screen ✅ | Background fills screen ✅ |
| Keyboard open | Background still shifts up ❌ | Background stays fixed ✅ |
