### PR TITLE
feat: port OpenMinis advanced background keep-alive to iOS

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B15A000000000000000000A4 /* CuplivoLinuxSandboxPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B7 /* CuplivoLinuxSandboxPlugin.swift */; };
 		B15A000000000000000000A5 /* CuplivoSandboxRootfsInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B8 /* CuplivoSandboxRootfsInstaller.swift */; };
 		B15A000000000000000000A6 /* alpine-rootfs.zip in Resources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B9 /* alpine-rootfs.zip */; };
+		B15A000000000000000000CA /* BackgroundKeepAliveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000CB /* BackgroundKeepAliveManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		B15A000000000000000000B6 /* CuplivoISHCrashGuards.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CuplivoISHCrashGuards.c; sourceTree = "<group>"; };
 		B15A000000000000000000B7 /* CuplivoLinuxSandboxPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuplivoLinuxSandboxPlugin.swift; sourceTree = "<group>"; };
 		B15A000000000000000000B8 /* CuplivoSandboxRootfsInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuplivoSandboxRootfsInstaller.swift; sourceTree = "<group>"; };
+		B15A000000000000000000CB /* BackgroundKeepAliveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundKeepAliveManager.swift; sourceTree = "<group>"; };
 		B15A000000000000000000B9 /* alpine-rootfs.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; name = "alpine-rootfs.zip"; path = "sandbox/resources/alpine-rootfs.zip"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -202,6 +204,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				B15A000000000000000000CB /* BackgroundKeepAliveManager.swift */,
 				A10000000000000000000010 /* KelivoGenerationActivityAttributes.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				B15A000000000000000000C1 /* iSHSandbox */,
@@ -520,6 +523,7 @@
 			files = (
 				A10000000000000000000001 /* KelivoGenerationActivityAttributes.swift in Sources */,
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				B15A000000000000000000CA /* BackgroundKeepAliveManager.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				B15A000000000000000000A1 /* CuplivoISHKernel.m in Sources */,
 				B15A000000000000000000A2 /* CuplivoISHExecutor.m in Sources */,

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -251,8 +251,11 @@ private final class IosBackgroundGenerationHandler {
         self.beginBackgroundTask()
       } else {
         // No keep-alive backing us — the system really will suspend the app.
-        // Record the interruption so the UI can tell the user what happened.
-        BackgroundKeepAliveManager.shared.recordInterruption()
+        // Record the interruption only when keep-alive was actually armed, so
+        // users who never enabled it aren't told they were 'interrupted'.
+        if BackgroundKeepAliveManager.shared.masterEnabled {
+          BackgroundKeepAliveManager.shared.recordInterruption()
+        }
         self.endBackgroundTask()
       }
     }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -70,6 +70,9 @@ private let backgroundProcessingIdentifier = "psyche.cuplivo.background-generati
         }
         result(NSTemporaryDirectory())
       }
+
+      // Advanced background keep-alive (silent audio + location legs).
+      BackgroundKeepAliveManager.shared.register(with: controller.binaryMessenger)
     }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
@@ -234,7 +237,21 @@ private final class IosBackgroundGenerationHandler {
   private func beginBackgroundTask() {
     if backgroundTask != .invalid { return }
     backgroundTask = UIApplication.shared.beginBackgroundTask(withName: "CuplivoBackgroundGeneration") { [weak self] in
-      self?.endBackgroundTask()
+      guard let self else { return }
+      // Intelligent expiry: when the silent-audio keep-alive leg is active
+      // the process is not in danger of termination, so re-arm a fresh
+      // finite task instead of letting the generation die. Without
+      // keep-alive, end the task and let the system suspend us.
+      if BackgroundKeepAliveManager.shared.keepAliveEffective {
+        let expiringId = self.backgroundTask
+        self.backgroundTask = .invalid
+        if expiringId != .invalid {
+          UIApplication.shared.endBackgroundTask(expiringId)
+        }
+        self.beginBackgroundTask()
+      } else {
+        self.endBackgroundTask()
+      }
     }
   }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -250,6 +250,9 @@ private final class IosBackgroundGenerationHandler {
         }
         self.beginBackgroundTask()
       } else {
+        // No keep-alive backing us — the system really will suspend the app.
+        // Record the interruption so the UI can tell the user what happened.
+        BackgroundKeepAliveManager.shared.recordInterruption()
         self.endBackgroundTask()
       }
     }

--- a/ios/Runner/BackgroundKeepAliveManager.swift
+++ b/ios/Runner/BackgroundKeepAliveManager.swift
@@ -13,10 +13,10 @@
 //      so finite background tasks can be re-armed instead of dying.
 //
 //   2. Location keep-alive — coarse CLLocationManager updates (5s
-//      heartbeat, UIBackgroundModes: location) plus a
-//      CLBackgroundActivitySession on iOS 17+. Armed only 15s after the
-//      app enters the background so brief background blips never spin up
-//      location.
+//      heartbeat on iOS 16, continuous CLLocationUpdate.liveUpdates on
+//      iOS 17+ with CLBackgroundActivitySession, UIBackgroundModes:
+//      location). Armed only 15s after the app enters the background so
+//      brief background blips never spin up location.
 //
 //   3. Finite background task coordination — AppDelegate consults
 //      `keepAliveEffective` when its UIBackgroundTask expires: when the
@@ -44,6 +44,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   private(set) var masterEnabled = false
   private(set) var silentAudioEnabled = false
   private(set) var locationEnabled = false
+  private(set) var liveActivityPrivacyMode = false
 
   // MARK: - Runtime state
 
@@ -55,6 +56,12 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   private var backgroundLocationArmTimer: Timer?
   private var locationTimer: Timer?
   private var bgActivitySession: Any?
+  private var liveUpdatesTask: Task<Void, Never>?
+
+  // MARK: - Interruption tracking
+
+  private(set) var interruptionCount = 0
+  private(set) var lastInterruptedAt: Date?
 
   // MARK: - Silent audio
 
@@ -62,6 +69,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   private var silentPlayerNode: AVAudioPlayerNode?
   private var silentAudioActivationRetries = 0
   private var silentAudioSuspendCount = 0
+  private var pendingSilentAudioStop: DispatchWorkItem?
 
   // MARK: - Location
 
@@ -73,6 +81,8 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   private static let locationHeartbeatInterval: TimeInterval = 5.0
   private static let maxActivationRetries = 3
   private static let activationRetryDelay: TimeInterval = 0.5
+  private static let silentAudioStopDebounce: TimeInterval = 1.5
+  private static let routeChangeReevalDelay: TimeInterval = 0.5
 
   private override init() {
     super.init()
@@ -92,6 +102,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       probe.invalidate()
     }
     observeLifecycle()
+    observeAudioInterruptions()
   }
 
   // MARK: - MethodChannel
@@ -110,7 +121,8 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       configure(
         masterEnabled: args["masterEnabled"] as? Bool ?? false,
         silentAudioEnabled: args["silentAudioEnabled"] as? Bool ?? false,
-        locationEnabled: args["locationEnabled"] as? Bool ?? false
+        locationEnabled: args["locationEnabled"] as? Bool ?? false,
+        liveActivityPrivacyMode: args["liveActivityPrivacyMode"] as? Bool ?? false
       )
       result(true)
     case "beginSession":
@@ -125,6 +137,15 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       result(statusMap())
     case "requestLocationAuthorization":
       requestLocationAuthorization(result: result)
+    case "suspendSilentAudio":
+      suspendSilentAudio()
+      result(true)
+    case "resumeSilentAudio":
+      resumeSilentAudio()
+      result(true)
+    case "recordInterruption":
+      recordInterruption()
+      result(true)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -162,12 +183,52 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     cleanupLocationStateOnForeground()
   }
 
+  // MARK: - Audio interruption / route-change recovery
+
+  private func observeAudioInterruptions() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleAudioInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleRouteChange(_:)),
+      name: AVAudioSession.routeChangeNotification,
+      object: nil
+    )
+  }
+
+  @objc private func handleAudioInterruption(_ note: Notification) {
+    guard let raw = note.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+      let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+    if type == .ended {
+      // Interruption over (e.g. phone call finished) — reclaim the session.
+      evaluateKeepAlive(caller: "interruptionEnded")
+    }
+  }
+
+  @objc private func handleRouteChange(_ note: Notification) {
+    // Route changes (headphones unplugged, Bluetooth drop, …) can tear down
+    // our audio session. Re-evaluate shortly after to restart if wanted.
+    DispatchQueue.main.asyncAfter(deadline: .now() + Self.routeChangeReevalDelay) { [weak self] in
+      self?.evaluateKeepAlive(caller: "routeChange")
+    }
+  }
+
   // MARK: - Configuration
 
-  func configure(masterEnabled: Bool, silentAudioEnabled: Bool, locationEnabled: Bool) {
+  func configure(
+    masterEnabled: Bool,
+    silentAudioEnabled: Bool,
+    locationEnabled: Bool,
+    liveActivityPrivacyMode: Bool
+  ) {
     self.masterEnabled = masterEnabled
     self.silentAudioEnabled = silentAudioEnabled
     self.locationEnabled = locationEnabled
+    self.liveActivityPrivacyMode = liveActivityPrivacyMode
     evaluateKeepAlive(caller: "configure")
   }
 
@@ -193,6 +254,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       "masterEnabled": masterEnabled,
       "silentAudioEnabled": silentAudioEnabled,
       "locationEnabled": locationEnabled,
+      "liveActivityPrivacyMode": liveActivityPrivacyMode,
       "sessionActive": sessionActive,
       "appIsInBackground": appIsInBackground,
       "silentAudioActive": silentAudioActive,
@@ -200,6 +262,8 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       "locationArmed": backgroundLocationArmed,
       "locationAuthorized": isLocationAuthorized,
       "survivalTier": survivalTier,
+      "interruptionCount": interruptionCount,
+      "lastInterruptedAt": lastInterruptedAt?.timeIntervalSince1970 ?? 0,
     ]
   }
 
@@ -209,9 +273,10 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     let shouldPlay = masterEnabled && silentAudioEnabled && sessionActive
       && appIsInBackground && silentAudioSuspendCount == 0
     if shouldPlay && !silentAudioActive {
+      cancelPendingSilentAudioStop()
       startSilentAudio()
     } else if !shouldPlay && silentAudioActive {
-      stopSilentAudio()
+      requestStopSilentAudio(transientForeground: !appIsInBackground)
     }
     evaluateLocationUpdates()
     evaluateBackgroundActivitySession()
@@ -277,6 +342,40 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     }
   }
 
+  /// Stop silent audio, debounced when the trigger is a transient foreground
+  /// blip (app switcher peek, call ended, Control Center, …) — a background
+  /// signal arriving within the window cancels the stop. Other triggers
+  /// (session ended, media suspend, toggle off) stop immediately.
+  private func requestStopSilentAudio(transientForeground: Bool) {
+    guard transientForeground else {
+      cancelPendingSilentAudioStop()
+      stopSilentAudio()
+      return
+    }
+    guard pendingSilentAudioStop == nil else { return }
+    let work = DispatchWorkItem { [weak self] in
+      guard let self else { return }
+      self.pendingSilentAudioStop = nil
+      // Re-check the world at fire time: if we went back to background (or
+      // any other reason now keeps it playing), do NOT stop.
+      let stillForeground = !self.appIsInBackground
+      let stillActive = self.masterEnabled && self.silentAudioEnabled
+        && self.sessionActive && self.silentAudioSuspendCount == 0
+      if stillForeground || !stillActive {
+        self.stopSilentAudio()
+      }
+    }
+    pendingSilentAudioStop = work
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + Self.silentAudioStopDebounce, execute: work
+    )
+  }
+
+  private func cancelPendingSilentAudioStop() {
+    pendingSilentAudioStop?.cancel()
+    pendingSilentAudioStop = nil
+  }
+
   private func stopSilentAudio() {
     silentAudioActivationRetries = 0
     guard silentAudioActive else { return }
@@ -293,6 +392,8 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   }
 
   /// Temporary suspend while user media (TTS / audio player) is active.
+  /// Called from Dart around media playback; counter-based so nested
+  /// play/pause sequences balance correctly.
   func suspendSilentAudio() {
     silentAudioSuspendCount += 1
     if silentAudioActive {
@@ -305,6 +406,13 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     if silentAudioSuspendCount == 0 && silentAudioActive == false {
       evaluateKeepAlive(caller: "resumeSilentAudio")
     }
+  }
+
+  // MARK: - Interruption tracking
+
+  func recordInterruption() {
+    interruptionCount += 1
+    lastInterruptedAt = Date()
   }
 
   // MARK: - Location keep-alive
@@ -351,18 +459,48 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     }
   }
 
+  /// iOS 17+: continuous live-updates stream + CLBackgroundActivitySession.
+  /// The liveUpdates(.otherNavigation) stream is what keeps the blue
+  /// location indicator on screen continuously (and the process alive) —
+  /// single-shot requestLocation() heartbeats do not.
   private func evaluateBackgroundActivitySession() {
     let shouldRun = masterEnabled && locationEnabled && isLocationAuthorized
       && sessionActive && appIsInBackground && backgroundLocationArmed
-    if shouldRun && bgActivitySession == nil {
-      if #available(iOS 17.0, *) {
-        bgActivitySession = CLBackgroundActivitySession()
-      }
+    if shouldRun && liveUpdatesTask == nil {
+      startBackgroundActivitySession()
     } else if !shouldRun {
-      if #available(iOS 17.0, *), let session = bgActivitySession as? CLBackgroundActivitySession {
-        session.invalidate()
-        bgActivitySession = nil
+      stopBackgroundActivitySession()
+    }
+  }
+
+  private func startBackgroundActivitySession() {
+    guard liveUpdatesTask == nil else { return }
+    if #available(iOS 17.0, *) {
+      let session = CLBackgroundActivitySession()
+      bgActivitySession = session
+      liveUpdatesTask = Task { @MainActor [weak self] in
+        guard let self else { return }
+        do {
+          let updates = CLLocationUpdate.liveUpdates(.otherNavigation)
+          for try await update in updates {
+            guard !Task.isCancelled else { break }
+            // Location data is intentionally discarded — merely receiving
+            // updates keeps the process (and indicator) alive.
+          }
+        } catch {
+          // Transient stream errors are fine; next evaluation retries.
+        }
+        self.liveUpdatesTask = nil
       }
+    }
+  }
+
+  private func stopBackgroundActivitySession() {
+    liveUpdatesTask?.cancel()
+    liveUpdatesTask = nil
+    if #available(iOS 17.0, *), let session = bgActivitySession as? CLBackgroundActivitySession {
+      session.invalidate()
+      bgActivitySession = nil
     }
   }
 
@@ -373,10 +511,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
       locationUpdating = false
       locationManager.allowsBackgroundLocationUpdates = false
     }
-    if #available(iOS 17.0, *), let session = bgActivitySession as? CLBackgroundActivitySession {
-      session.invalidate()
-      bgActivitySession = nil
-    }
+    stopBackgroundActivitySession()
   }
 
   func requestLocationAuthorization(result: @escaping FlutterResult) {

--- a/ios/Runner/BackgroundKeepAliveManager.swift
+++ b/ios/Runner/BackgroundKeepAliveManager.swift
@@ -1,0 +1,421 @@
+//
+//  BackgroundKeepAliveManager.swift
+//  Runner
+//
+//  Advanced iOS background keep-alive, ported from the OpenMinis
+//  BackgroundKeepAliveManager design. Keeps the process alive while a
+//  generation task is running and the app is in the background through
+//  three cooperating mechanisms:
+//
+//   1. Silent audio keep-alive — an AVAudioEngine playing an inaudible
+//      looping track (UIBackgroundModes: audio). This is the primary
+//      long-lived leg: while it plays, iOS does not suspend the process,
+//      so finite background tasks can be re-armed instead of dying.
+//
+//   2. Location keep-alive — coarse CLLocationManager updates (5s
+//      heartbeat, UIBackgroundModes: location) plus a
+//      CLBackgroundActivitySession on iOS 17+. Armed only 15s after the
+//      app enters the background so brief background blips never spin up
+//      location.
+//
+//   3. Finite background task coordination — AppDelegate consults
+//      `keepAliveEffective` when its UIBackgroundTask expires: when the
+//      silent-audio leg is active it re-arms the task instead of letting
+//      the agent loop die.
+//
+//  All legs are gated on user toggles pushed from Dart via the
+//  `app.ios_keepalive` MethodChannel. Nothing starts behind the user's
+//  back.
+//
+
+import AVFoundation
+import CoreLocation
+import Flutter
+import UIKit
+
+@MainActor
+final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
+  static let shared = BackgroundKeepAliveManager()
+
+  static let channelName = "app.ios_keepalive"
+
+  // MARK: - Configuration (pushed from Dart)
+
+  private(set) var masterEnabled = false
+  private(set) var silentAudioEnabled = false
+  private(set) var locationEnabled = false
+
+  // MARK: - Runtime state
+
+  private(set) var sessionActive = false
+  private(set) var appIsInBackground = false
+  private(set) var silentAudioActive = false
+  private(set) var locationUpdating = false
+  private(set) var backgroundLocationArmed = false
+  private var backgroundLocationArmTimer: Timer?
+  private var locationTimer: Timer?
+  private var bgActivitySession: Any?
+
+  // MARK: - Silent audio
+
+  private var audioEngine: AVAudioEngine?
+  private var silentPlayerNode: AVAudioPlayerNode?
+  private var silentAudioActivationRetries = 0
+  private var silentAudioSuspendCount = 0
+
+  // MARK: - Location
+
+  private let locationManager = CLLocationManager()
+  private var locationAuthStatus: CLAuthorizationStatus = .notDetermined
+  private var pendingLocationAuthResult: FlutterResult?
+
+  private static let backgroundLocationArmDelay: TimeInterval = 15.0
+  private static let locationHeartbeatInterval: TimeInterval = 5.0
+  private static let maxActivationRetries = 3
+  private static let activationRetryDelay: TimeInterval = 0.5
+
+  private override init() {
+    super.init()
+    locationManager.delegate = self
+    locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+    locationManager.pausesLocationUpdatesAutomatically = false
+    if #available(iOS 14.0, *) {
+      locationAuthStatus = locationManager.authorizationStatus
+    } else {
+      locationAuthStatus = CLLocationManager.authorizationStatus()
+    }
+    // A CLBackgroundActivitySession outlives process death by design; if the
+    // previous process was force-killed without invalidating it, iOS keeps
+    // the system location indicator pinned. Retract any orphan on cold start.
+    if #available(iOS 17.0, *) {
+      let probe = CLBackgroundActivitySession()
+      probe.invalidate()
+    }
+    observeLifecycle()
+  }
+
+  // MARK: - MethodChannel
+
+  func register(with messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: Self.channelName, binaryMessenger: messenger)
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "configure":
+      let args = call.arguments as? [String: Any] ?? [:]
+      configure(
+        masterEnabled: args["masterEnabled"] as? Bool ?? false,
+        silentAudioEnabled: args["silentAudioEnabled"] as? Bool ?? false,
+        locationEnabled: args["locationEnabled"] as? Bool ?? false
+      )
+      result(true)
+    case "beginSession":
+      sessionActive = true
+      evaluateKeepAlive(caller: "beginSession")
+      result(true)
+    case "endSession":
+      sessionActive = false
+      evaluateKeepAlive(caller: "endSession")
+      result(true)
+    case "getStatus":
+      result(statusMap())
+    case "requestLocationAuthorization":
+      requestLocationAuthorization(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  // MARK: - Lifecycle
+
+  private func observeLifecycle() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(didEnterBackground),
+      name: UIApplication.didEnterBackgroundNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(willEnterForeground),
+      name: UIApplication.willEnterForegroundNotification,
+      object: nil
+    )
+  }
+
+  @objc private func didEnterBackground() {
+    appIsInBackground = true
+    evaluateKeepAlive(caller: "didEnterBackground")
+    scheduleBackgroundLocationArming()
+  }
+
+  @objc private func willEnterForeground() {
+    appIsInBackground = false
+    backgroundLocationArmed = false
+    backgroundLocationArmTimer?.invalidate()
+    backgroundLocationArmTimer = nil
+    evaluateKeepAlive(caller: "willEnterForeground")
+    cleanupLocationStateOnForeground()
+  }
+
+  // MARK: - Configuration
+
+  func configure(masterEnabled: Bool, silentAudioEnabled: Bool, locationEnabled: Bool) {
+    self.masterEnabled = masterEnabled
+    self.silentAudioEnabled = silentAudioEnabled
+    self.locationEnabled = locationEnabled
+    evaluateKeepAlive(caller: "configure")
+  }
+
+  // MARK: - Status
+
+  var keepAliveEffective: Bool {
+    silentAudioActive
+  }
+
+  var isLocationAuthorized: Bool {
+    locationAuthStatus == .authorizedAlways || locationAuthStatus == .authorizedWhenInUse
+  }
+
+  private var survivalTier: String {
+    let locationLeg = masterEnabled && locationEnabled && isLocationAuthorized
+    let audioLeg = masterEnabled && silentAudioEnabled
+    if locationLeg || audioLeg { return "extended" }
+    return "short"
+  }
+
+  private func statusMap() -> [String: Any] {
+    [
+      "masterEnabled": masterEnabled,
+      "silentAudioEnabled": silentAudioEnabled,
+      "locationEnabled": locationEnabled,
+      "sessionActive": sessionActive,
+      "appIsInBackground": appIsInBackground,
+      "silentAudioActive": silentAudioActive,
+      "locationUpdating": locationUpdating,
+      "locationArmed": backgroundLocationArmed,
+      "locationAuthorized": isLocationAuthorized,
+      "survivalTier": survivalTier,
+    ]
+  }
+
+  // MARK: - Keep-alive decision
+
+  private func evaluateKeepAlive(caller: String) {
+    let shouldPlay = masterEnabled && silentAudioEnabled && sessionActive
+      && appIsInBackground && silentAudioSuspendCount == 0
+    if shouldPlay && !silentAudioActive {
+      startSilentAudio()
+    } else if !shouldPlay && silentAudioActive {
+      stopSilentAudio()
+    }
+    evaluateLocationUpdates()
+    evaluateBackgroundActivitySession()
+  }
+
+  // MARK: - Silent audio keep-alive
+
+  private func startSilentAudio(reason: String = "evaluate") {
+    guard !silentAudioActive else { return }
+    silentAudioActivationRetries = 0
+
+    do {
+      let session = AVAudioSession.sharedInstance()
+      try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+      try session.setActive(true)
+    } catch {
+      scheduleSilentAudioActivationRetry()
+      return
+    }
+
+    let engine = AVAudioEngine()
+    let player = AVAudioPlayerNode()
+    engine.attach(player)
+
+    let sampleRate: Double = 44100
+    let frameCount = AVAudioFrameCount(sampleRate)
+    guard let format = AVAudioFormat(
+      standardFormatWithSampleRate: sampleRate, channels: 1
+    ), let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+      return
+    }
+    buffer.frameLength = frameCount
+    // Zero-filled buffer = pure silence.
+
+    engine.connect(player, to: engine.mainMixerNode, format: format)
+    engine.mainMixerNode.outputVolume = 0.001
+
+    do {
+      try engine.start()
+      player.scheduleBuffer(buffer, at: nil, options: .loops)
+      player.play()
+      audioEngine = engine
+      silentPlayerNode = player
+      silentAudioActive = true
+    } catch {
+      scheduleSilentAudioActivationRetry()
+    }
+  }
+
+  private func scheduleSilentAudioActivationRetry() {
+    silentAudioActivationRetries += 1
+    guard silentAudioActivationRetries < Self.maxActivationRetries else {
+      silentAudioActivationRetries = 0
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + Self.activationRetryDelay) { [weak self] in
+      guard let self else { return }
+      let stillWanted = self.masterEnabled && self.silentAudioEnabled
+        && self.sessionActive && self.appIsInBackground
+        && self.silentAudioSuspendCount == 0 && !self.silentAudioActive
+      guard stillWanted else { return }
+      self.startSilentAudio(reason: "activationRetry")
+    }
+  }
+
+  private func stopSilentAudio() {
+    silentAudioActivationRetries = 0
+    guard silentAudioActive else { return }
+    silentPlayerNode?.stop()
+    audioEngine?.stop()
+    silentPlayerNode = nil
+    audioEngine = nil
+    silentAudioActive = false
+    do {
+      try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    } catch {
+      // Ignore — session teardown failures are harmless.
+    }
+  }
+
+  /// Temporary suspend while user media (TTS / audio player) is active.
+  func suspendSilentAudio() {
+    silentAudioSuspendCount += 1
+    if silentAudioActive {
+      stopSilentAudio()
+    }
+  }
+
+  func resumeSilentAudio() {
+    silentAudioSuspendCount = max(0, silentAudioSuspendCount - 1)
+    if silentAudioSuspendCount == 0 && silentAudioActive == false {
+      evaluateKeepAlive(caller: "resumeSilentAudio")
+    }
+  }
+
+  // MARK: - Location keep-alive
+
+  private func scheduleBackgroundLocationArming() {
+    guard appIsInBackground else { return }
+    guard !backgroundLocationArmed, backgroundLocationArmTimer == nil else { return }
+    let delay = Self.backgroundLocationArmDelay
+    let timer = Timer(timeInterval: delay, repeats: false) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        self.backgroundLocationArmTimer = nil
+        guard self.appIsInBackground else { return }
+        self.backgroundLocationArmed = true
+        self.evaluateLocationUpdates()
+        self.evaluateBackgroundActivitySession()
+      }
+    }
+    backgroundLocationArmTimer = timer
+    RunLoop.current.add(timer, forMode: .common)
+  }
+
+  private func evaluateLocationUpdates() {
+    let shouldUpdate = masterEnabled && locationEnabled && sessionActive
+      && appIsInBackground && backgroundLocationArmed && isLocationAuthorized
+
+    if shouldUpdate && !locationUpdating {
+      locationManager.allowsBackgroundLocationUpdates = true
+      locationManager.showsBackgroundLocationIndicator = false
+      locationUpdating = true
+      locationManager.requestLocation()
+      let timer = Timer(timeInterval: Self.locationHeartbeatInterval, repeats: true) { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.locationManager.requestLocation()
+        }
+      }
+      locationTimer = timer
+      RunLoop.current.add(timer, forMode: .common)
+    } else if !shouldUpdate && locationUpdating {
+      locationTimer?.invalidate()
+      locationTimer = nil
+      locationUpdating = false
+      locationManager.allowsBackgroundLocationUpdates = false
+    }
+  }
+
+  private func evaluateBackgroundActivitySession() {
+    let shouldRun = masterEnabled && locationEnabled && isLocationAuthorized
+      && sessionActive && appIsInBackground && backgroundLocationArmed
+    if shouldRun && bgActivitySession == nil {
+      if #available(iOS 17.0, *) {
+        bgActivitySession = CLBackgroundActivitySession()
+      }
+    } else if !shouldRun {
+      if #available(iOS 17.0, *), let session = bgActivitySession as? CLBackgroundActivitySession {
+        session.invalidate()
+        bgActivitySession = nil
+      }
+    }
+  }
+
+  private func cleanupLocationStateOnForeground() {
+    locationTimer?.invalidate()
+    locationTimer = nil
+    if locationUpdating {
+      locationUpdating = false
+      locationManager.allowsBackgroundLocationUpdates = false
+    }
+    if #available(iOS 17.0, *), let session = bgActivitySession as? CLBackgroundActivitySession {
+      session.invalidate()
+      bgActivitySession = nil
+    }
+  }
+
+  func requestLocationAuthorization(result: @escaping FlutterResult) {
+    if isLocationAuthorized {
+      result(true)
+      return
+    }
+    pendingLocationAuthResult = result
+    if #available(iOS 14.0, *) {
+      switch locationAuthStatus {
+      case .notDetermined:
+        locationManager.requestWhenInUseAuthorization()
+      default:
+        locationManager.requestAlwaysAuthorization()
+      }
+    } else {
+      locationManager.requestAlwaysAuthorization()
+    }
+  }
+
+  // MARK: - CLLocationManagerDelegate
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    if #available(iOS 14.0, *) {
+      locationAuthStatus = manager.authorizationStatus
+    }
+    if let pending = pendingLocationAuthResult {
+      pendingLocationAuthResult = nil
+      pending(isLocationAuthorized)
+    }
+    evaluateKeepAlive(caller: "locationAuthChanged")
+  }
+
+  func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    // Heartbeat locations are intentionally discarded — only the act of
+    // receiving updates keeps the process alive.
+  }
+
+  func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    // A transient failure is fine; the heartbeat timer keeps retrying.
+  }
+}

--- a/ios/Runner/BackgroundKeepAliveManager.swift
+++ b/ios/Runner/BackgroundKeepAliveManager.swift
@@ -235,7 +235,7 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
   // MARK: - Status
 
   var keepAliveEffective: Bool {
-    silentAudioActive
+    silentAudioActive || locationUpdating
   }
 
   var isLocationAuthorized: Bool {
@@ -518,6 +518,15 @@ final class BackgroundKeepAliveManager: NSObject, CLLocationManagerDelegate {
     if isLocationAuthorized {
       result(true)
       return
+    }
+    // Denied / restricted: requesting again never shows a prompt and the
+    // delegate may not fire — resolve immediately so Dart doesn't hang.
+    switch locationAuthStatus {
+    case .denied, .restricted:
+      result(false)
+      return
+    default:
+      break
     }
     pendingLocationAuthResult = result
     if #available(iOS 14.0, *) {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -57,7 +57,14 @@
 	<array>
 		<string>fetch</string>
 		<string>processing</string>
+		<string>audio</string>
+		<string>location</string>
+		<string>remote-notification</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Cuplivo uses your location in the background to keep agent tasks running while the app is not in the foreground.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Cuplivo uses background location to keep agent tasks running when the app is in the background. Location data is used for keep-alive only and is not stored.</string>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -278,6 +278,14 @@ class SettingsProvider extends ChangeNotifier {
       'ios_live_activity_enabled_v1';
   static const String _iosBackgroundNotificationsEnabledKey =
       'ios_background_notifications_enabled_v1';
+  // Advanced background keep-alive settings
+  static const String _iosKeepAliveEnabledKey = 'ios_keepalive_enabled_v1';
+  static const String _iosSilentAudioKeepAliveEnabledKey =
+      'ios_silent_audio_keepalive_enabled_v1';
+  static const String _iosLocationKeepAliveEnabledKey =
+      'ios_location_keepalive_enabled_v1';
+  static const String _iosLiveActivityPrivacyModeKey =
+      'ios_live_activity_privacy_mode_v1';
   // Fonts
   static const String _displayAppFontFamilyKey = 'display_app_font_family_v1';
   static const String _displayCodeFontFamilyKey = 'display_code_font_family_v1';
@@ -1386,6 +1394,14 @@ class SettingsProvider extends ChangeNotifier {
         prefs.getBool(_iosLiveActivityEnabledKey) ?? false;
     _iosBackgroundNotificationsEnabled =
         prefs.getBool(_iosBackgroundNotificationsEnabledKey) ?? false;
+    _iosKeepAliveEnabled =
+        prefs.getBool(_iosKeepAliveEnabledKey) ?? false;
+    _iosSilentAudioKeepAliveEnabled =
+        prefs.getBool(_iosSilentAudioKeepAliveEnabledKey) ?? false;
+    _iosLocationKeepAliveEnabled =
+        prefs.getBool(_iosLocationKeepAliveEnabledKey) ?? false;
+    _iosLiveActivityPrivacyMode =
+        prefs.getBool(_iosLiveActivityPrivacyModeKey) ?? false;
 
     // load search settings
     final searchServicesStr = prefs.getString(_searchServicesKey);
@@ -2807,6 +2823,73 @@ class SettingsProvider extends ChangeNotifier {
     if (_dynamicColorSupported == v) return;
     _dynamicColorSupported = v;
     notifyListeners();
+  }
+
+  // ===== iOS advanced background keep-alive =====
+  bool _iosKeepAliveEnabled = false;
+  bool get iosKeepAliveEnabled => _iosKeepAliveEnabled;
+  Future<void> setIosKeepAliveEnabled(bool v) async {
+    if (_iosKeepAliveEnabled == v) return;
+    _iosKeepAliveEnabled = v;
+    if (!v) {
+      _iosSilentAudioKeepAliveEnabled = false;
+      _iosLocationKeepAliveEnabled = false;
+    }
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_iosKeepAliveEnabledKey, _iosKeepAliveEnabled);
+    if (!v) {
+      await prefs.setBool(_iosSilentAudioKeepAliveEnabledKey, false);
+      await prefs.setBool(_iosLocationKeepAliveEnabledKey, false);
+    }
+  }
+
+  bool _iosSilentAudioKeepAliveEnabled = false;
+  bool get iosSilentAudioKeepAliveEnabled =>
+      _iosSilentAudioKeepAliveEnabled;
+  Future<void> setIosSilentAudioKeepAliveEnabled(bool v) async {
+    if (_iosSilentAudioKeepAliveEnabled == v) return;
+    _iosSilentAudioKeepAliveEnabled = v;
+    if (v) _iosKeepAliveEnabled = true;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(
+      _iosSilentAudioKeepAliveEnabledKey,
+      _iosSilentAudioKeepAliveEnabled,
+    );
+    if (v) {
+      await prefs.setBool(_iosKeepAliveEnabledKey, true);
+    }
+  }
+
+  bool _iosLocationKeepAliveEnabled = false;
+  bool get iosLocationKeepAliveEnabled => _iosLocationKeepAliveEnabled;
+  Future<void> setIosLocationKeepAliveEnabled(bool v) async {
+    if (_iosLocationKeepAliveEnabled == v) return;
+    _iosLocationKeepAliveEnabled = v;
+    if (v) _iosKeepAliveEnabled = true;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(
+      _iosLocationKeepAliveEnabledKey,
+      _iosLocationKeepAliveEnabled,
+    );
+    if (v) {
+      await prefs.setBool(_iosKeepAliveEnabledKey, true);
+    }
+  }
+
+  bool _iosLiveActivityPrivacyMode = false;
+  bool get iosLiveActivityPrivacyMode => _iosLiveActivityPrivacyMode;
+  Future<void> setIosLiveActivityPrivacyMode(bool v) async {
+    if (_iosLiveActivityPrivacyMode == v) return;
+    _iosLiveActivityPrivacyMode = v;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(
+      _iosLiveActivityPrivacyModeKey,
+      _iosLiveActivityPrivacyMode,
+    );
   }
 
   Future<void> toggleTheme() => setThemeMode(

--- a/lib/core/providers/tts_provider.dart
+++ b/lib/core/providers/tts_provider.dart
@@ -553,26 +553,26 @@ class TtsProvider extends ChangeNotifier {
   }
 
   // Keep-alive media coordination: while TTS plays, suspend the silent-audio
-  // keep-alive leg so both don't fight over the audio session. Counter keeps
-  // nested speak/stop sequences balanced; resume is idempotent (clears to 0).
-  int _keepAliveMediaCount = 0;
+  // keep-alive leg so both don't fight over the audio session. Boolean state
+  // machine — Dart only emits 0→1 / 1→0 transitions, so it can never drift
+  // out of sync with the native counter.
+  bool _keepAliveSuspendedForMedia = false;
 
   void _suspendKeepAliveForMedia() {
-    _keepAliveMediaCount++;
-    if (_keepAliveMediaCount == 1) {
-      unawaited(IosKeepAliveService.instance.suspendSilentAudio());
-    }
+    if (_keepAliveSuspendedForMedia) return;
+    _keepAliveSuspendedForMedia = true;
+    unawaited(IosKeepAliveService.instance.suspendSilentAudio());
   }
 
-  void _clearKeepAliveForMedia() {
-    if (_keepAliveMediaCount <= 0) return;
-    _keepAliveMediaCount = 0;
+  void _resumeKeepAliveForMedia() {
+    if (!_keepAliveSuspendedForMedia) return;
+    _keepAliveSuspendedForMedia = false;
     unawaited(IosKeepAliveService.instance.resumeSilentAudio());
   }
 
   Future<void> stop() async {
     _sessionId++;
-    _clearKeepAliveForMedia();
+    _resumeKeepAliveForMedia();
     await _stopPlaybackEngines();
     _stopInternal(updateState: true);
   }
@@ -940,7 +940,7 @@ class TtsProvider extends ChangeNotifier {
   }
 
   void _finishPlayback({required TtsPlaybackStatus status, String? error}) {
-    _clearKeepAliveForMedia();
+    _resumeKeepAliveForMedia();
     _isSpeaking = false;
     _isPaused = false;
     _usingNetwork = false;
@@ -1192,6 +1192,7 @@ class TtsProvider extends ChangeNotifier {
   @override
   void dispose() {
     _sessionId++;
+    _resumeKeepAliveForMedia();
     _playerCompleteSub?.cancel();
     _playerPositionSub?.cancel();
     _playerDurationSub?.cancel();

--- a/lib/core/providers/tts_provider.dart
+++ b/lib/core/providers/tts_provider.dart
@@ -15,6 +15,7 @@ import '../services/tts/network_tts.dart';
 import '../services/tts/tts_playback_models.dart';
 import '../services/tts/tts_text_chunker.dart';
 import '../services/backup/double_pref_keys.dart' show prefDouble;
+import '../services/ios_keep_alive.dart';
 
 String ttsAudioFileExtensionForMime(String? mime) {
   switch ((mime ?? '').toLowerCase()) {
@@ -427,6 +428,7 @@ class TtsProvider extends ChangeNotifier {
     bool flush = true,
     bool reuseResolvedNetworkAudio = false,
   }) async {
+    _suspendKeepAliveForMedia();
     final content = _stripMarkdown(text).trim();
     if (content.isEmpty) return;
     if (flush) await _stopPlaybackEngines();
@@ -550,8 +552,35 @@ class TtsProvider extends ChangeNotifier {
     return true;
   }
 
+  // Keep-alive media coordination: while TTS plays, suspend the silent-audio
+  // keep-alive leg so both don't fight over the audio session. Counter keeps
+  // nested speak/stop sequences balanced; resume is idempotent (clears to 0).
+  int _keepAliveMediaCount = 0;
+
+  void _suspendKeepAliveForMedia() {
+    _keepAliveMediaCount++;
+    if (_keepAliveMediaCount == 1) {
+      unawaited(IosKeepAliveService.instance.suspendSilentAudio());
+    }
+  }
+
+  void _resumeKeepAliveForMedia() {
+    if (_keepAliveMediaCount <= 0) return;
+    _keepAliveMediaCount--;
+    if (_keepAliveMediaCount == 0) {
+      unawaited(IosKeepAliveService.instance.resumeSilentAudio());
+    }
+  }
+
+  void _clearKeepAliveForMedia() {
+    if (_keepAliveMediaCount <= 0) return;
+    _keepAliveMediaCount = 0;
+    unawaited(IosKeepAliveService.instance.resumeSilentAudio());
+  }
+
   Future<void> stop() async {
     _sessionId++;
+    _clearKeepAliveForMedia();
     await _stopPlaybackEngines();
     _stopInternal(updateState: true);
   }
@@ -919,6 +948,7 @@ class TtsProvider extends ChangeNotifier {
   }
 
   void _finishPlayback({required TtsPlaybackStatus status, String? error}) {
+    _clearKeepAliveForMedia();
     _isSpeaking = false;
     _isPaused = false;
     _usingNetwork = false;

--- a/lib/core/providers/tts_provider.dart
+++ b/lib/core/providers/tts_provider.dart
@@ -564,14 +564,6 @@ class TtsProvider extends ChangeNotifier {
     }
   }
 
-  void _resumeKeepAliveForMedia() {
-    if (_keepAliveMediaCount <= 0) return;
-    _keepAliveMediaCount--;
-    if (_keepAliveMediaCount == 0) {
-      unawaited(IosKeepAliveService.instance.resumeSilentAudio());
-    }
-  }
-
   void _clearKeepAliveForMedia() {
     if (_keepAliveMediaCount <= 0) return;
     _keepAliveMediaCount = 0;

--- a/lib/core/services/ios_keep_alive.dart
+++ b/lib/core/services/ios_keep_alive.dart
@@ -1,0 +1,123 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+
+/// Mirrors the native BackgroundKeepAliveManager status on the
+/// `app.ios_keepalive` MethodChannel.
+class IosKeepAliveStatus {
+  const IosKeepAliveStatus({
+    required this.masterEnabled,
+    required this.silentAudioEnabled,
+    required this.locationEnabled,
+    required this.sessionActive,
+    required this.appIsInBackground,
+    required this.silentAudioActive,
+    required this.locationUpdating,
+    required this.locationArmed,
+    required this.locationAuthorized,
+    required this.survivalTier,
+  });
+
+  factory IosKeepAliveStatus.fromMap(Map<dynamic, dynamic>? map) {
+    bool readBool(String key) => map?[key] == true;
+    return IosKeepAliveStatus(
+      masterEnabled: readBool('masterEnabled'),
+      silentAudioEnabled: readBool('silentAudioEnabled'),
+      locationEnabled: readBool('locationEnabled'),
+      sessionActive: readBool('sessionActive'),
+      appIsInBackground: readBool('appIsInBackground'),
+      silentAudioActive: readBool('silentAudioActive'),
+      locationUpdating: readBool('locationUpdating'),
+      locationArmed: readBool('locationArmed'),
+      locationAuthorized: readBool('locationAuthorized'),
+      survivalTier: (map?['survivalTier'] as String?) ?? 'short',
+    );
+  }
+
+  final bool masterEnabled;
+  final bool silentAudioEnabled;
+  final bool locationEnabled;
+  final bool sessionActive;
+  final bool appIsInBackground;
+  final bool silentAudioActive;
+  final bool locationUpdating;
+  final bool locationArmed;
+  final bool locationAuthorized;
+  final String survivalTier;
+
+  /// Long-lived keep-alive is actually effective right now.
+  bool get effective => silentAudioActive || locationUpdating;
+}
+
+class IosKeepAliveService {
+  IosKeepAliveService._();
+
+  static final IosKeepAliveService instance = IosKeepAliveService._();
+
+  static const MethodChannel _channel = MethodChannel('app.ios_keepalive');
+
+  bool debugForceIosForTest = false;
+
+  bool get _isIos => debugForceIosForTest || Platform.isIOS;
+
+  /// Push the current user toggles to the native keep-alive manager.
+  Future<void> configure({
+    required bool masterEnabled,
+    required bool silentAudioEnabled,
+    required bool locationEnabled,
+  }) async {
+    if (!_isIos) return;
+    try {
+      await _channel.invokeMethod<void>('configure', <String, Object?>{
+        'masterEnabled': masterEnabled,
+        'silentAudioEnabled': silentAudioEnabled,
+        'locationEnabled': locationEnabled,
+      });
+    } catch (_) {
+      // Native side may be unavailable (e.g. during tests); toggles are
+      // still persisted by SettingsProvider.
+    }
+  }
+
+  /// Called when a generation task starts.
+  Future<void> beginSession() async {
+    if (!_isIos) return;
+    try {
+      await _channel.invokeMethod<void>('beginSession');
+    } catch (_) {}
+  }
+
+  /// Called when a generation task finishes / is cancelled.
+  Future<void> endSession() async {
+    if (!_isIos) return;
+    try {
+      await _channel.invokeMethod<void>('endSession');
+    } catch (_) {}
+  }
+
+  Future<IosKeepAliveStatus> getStatus() async {
+    if (!_isIos) {
+      return const IosKeepAliveStatus(
+        masterEnabled: false,
+        silentAudioEnabled: false,
+        locationEnabled: false,
+        sessionActive: false,
+        appIsInBackground: false,
+        silentAudioActive: false,
+        locationUpdating: false,
+        locationArmed: false,
+        locationAuthorized: false,
+        survivalTier: 'short',
+      );
+    }
+    final result = await _channel.invokeMethod<dynamic>('getStatus');
+    return IosKeepAliveStatus.fromMap(result as Map<dynamic, dynamic>?);
+  }
+
+  /// Request location permission (When-In-Use first, then Always on follow-up).
+  Future<bool> requestLocationAuthorization() async {
+    if (!_isIos) return false;
+    return await _channel.invokeMethod<bool>('requestLocationAuthorization') ??
+        false;
+  }
+}

--- a/lib/core/services/ios_keep_alive.dart
+++ b/lib/core/services/ios_keep_alive.dart
@@ -9,6 +9,7 @@ class IosKeepAliveStatus {
     required this.masterEnabled,
     required this.silentAudioEnabled,
     required this.locationEnabled,
+    required this.liveActivityPrivacyMode,
     required this.sessionActive,
     required this.appIsInBackground,
     required this.silentAudioActive,
@@ -16,6 +17,8 @@ class IosKeepAliveStatus {
     required this.locationArmed,
     required this.locationAuthorized,
     required this.survivalTier,
+    required this.interruptionCount,
+    required this.lastInterruptedAt,
   });
 
   factory IosKeepAliveStatus.fromMap(Map<dynamic, dynamic>? map) {
@@ -24,6 +27,7 @@ class IosKeepAliveStatus {
       masterEnabled: readBool('masterEnabled'),
       silentAudioEnabled: readBool('silentAudioEnabled'),
       locationEnabled: readBool('locationEnabled'),
+      liveActivityPrivacyMode: readBool('liveActivityPrivacyMode'),
       sessionActive: readBool('sessionActive'),
       appIsInBackground: readBool('appIsInBackground'),
       silentAudioActive: readBool('silentAudioActive'),
@@ -31,12 +35,16 @@ class IosKeepAliveStatus {
       locationArmed: readBool('locationArmed'),
       locationAuthorized: readBool('locationAuthorized'),
       survivalTier: (map?['survivalTier'] as String?) ?? 'short',
+      interruptionCount: (map?['interruptionCount'] as int?) ?? 0,
+      lastInterruptedAt:
+          ((map?['lastInterruptedAt'] as num?) ?? 0).toDouble(),
     );
   }
 
   final bool masterEnabled;
   final bool silentAudioEnabled;
   final bool locationEnabled;
+  final bool liveActivityPrivacyMode;
   final bool sessionActive;
   final bool appIsInBackground;
   final bool silentAudioActive;
@@ -44,6 +52,8 @@ class IosKeepAliveStatus {
   final bool locationArmed;
   final bool locationAuthorized;
   final String survivalTier;
+  final int interruptionCount;
+  final double lastInterruptedAt;
 
   /// Long-lived keep-alive is actually effective right now.
   bool get effective => silentAudioActive || locationUpdating;
@@ -65,6 +75,7 @@ class IosKeepAliveService {
     required bool masterEnabled,
     required bool silentAudioEnabled,
     required bool locationEnabled,
+    required bool liveActivityPrivacyMode,
   }) async {
     if (!_isIos) return;
     try {
@@ -72,6 +83,7 @@ class IosKeepAliveService {
         'masterEnabled': masterEnabled,
         'silentAudioEnabled': silentAudioEnabled,
         'locationEnabled': locationEnabled,
+        'liveActivityPrivacyMode': liveActivityPrivacyMode,
       });
     } catch (_) {
       // Native side may be unavailable (e.g. during tests); toggles are
@@ -95,12 +107,30 @@ class IosKeepAliveService {
     } catch (_) {}
   }
 
+  /// Suspend the silent-audio keep-alive while user media is playing.
+  /// Counter-based on the native side; call once per playback start.
+  Future<void> suspendSilentAudio() async {
+    if (!_isIos) return;
+    try {
+      await _channel.invokeMethod<void>('suspendSilentAudio');
+    } catch (_) {}
+  }
+
+  /// Resume the silent-audio keep-alive after user media finished.
+  Future<void> resumeSilentAudio() async {
+    if (!_isIos) return;
+    try {
+      await _channel.invokeMethod<void>('resumeSilentAudio');
+    } catch (_) {}
+  }
+
   Future<IosKeepAliveStatus> getStatus() async {
     if (!_isIos) {
       return const IosKeepAliveStatus(
         masterEnabled: false,
         silentAudioEnabled: false,
         locationEnabled: false,
+        liveActivityPrivacyMode: false,
         sessionActive: false,
         appIsInBackground: false,
         silentAudioActive: false,
@@ -108,6 +138,8 @@ class IosKeepAliveService {
         locationArmed: false,
         locationAuthorized: false,
         survivalTier: 'short',
+        interruptionCount: 0,
+        lastInterruptedAt: 0,
       );
     }
     final result = await _channel.invokeMethod<dynamic>('getStatus');

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -147,16 +147,24 @@ class ChatActions {
         masterEnabled: settings.iosKeepAliveEnabled,
         silentAudioEnabled: settings.iosSilentAudioKeepAliveEnabled,
         locationEnabled: settings.iosLocationKeepAliveEnabled,
+        liveActivityPrivacyMode: settings.iosLiveActivityPrivacyMode,
       );
       await IosKeepAliveService.instance.beginSession();
+      final privacy = settings.iosLiveActivityPrivacyMode;
       await IosBackgroundGenerationService.instance.start(
         enabled: settings.iosBackgroundGenerationEnabled,
         liveActivityEnabled: settings.iosLiveActivityEnabled,
         notificationsEnabled: settings.iosBackgroundNotificationsEnabled,
         refreshEnabled: settings.iosBackgroundTaskRefreshEnabled,
-        title: l10n.iosBackgroundGenerationActiveTitle,
-        detail: l10n.iosBackgroundGenerationActiveDetail,
-        tokenLabel: l10n.iosBackgroundGenerationTokenCount(0),
+        title: privacy
+            ? l10n.iosBackgroundGenerationPrivacyActiveTitle
+            : l10n.iosBackgroundGenerationActiveTitle,
+        detail: privacy
+            ? l10n.iosBackgroundGenerationPrivacyActiveDetail
+            : l10n.iosBackgroundGenerationActiveDetail,
+        tokenLabel: privacy
+            ? ''
+            : l10n.iosBackgroundGenerationTokenCount(0),
       );
     } catch (error, stackTrace) {
       _logIosBackgroundGenerationFailure('start', error, stackTrace);
@@ -167,9 +175,15 @@ class ChatActions {
     final l10n = _l10n;
     if (l10n == null) return;
     try {
+      final settings = contextProvider.read<SettingsProvider>();
+      final privacy = settings.iosLiveActivityPrivacyMode;
       await IosBackgroundGenerationService.instance.update(
-        detail: l10n.iosBackgroundGenerationStreamingDetail,
-        tokenLabel: l10n.iosBackgroundGenerationTokenCount(totalTokens),
+        detail: privacy
+            ? l10n.iosBackgroundGenerationPrivacyActiveDetail
+            : l10n.iosBackgroundGenerationStreamingDetail,
+        tokenLabel: privacy
+            ? ''
+            : l10n.iosBackgroundGenerationTokenCount(totalTokens),
         tokenCount: totalTokens,
       );
     } catch (error, stackTrace) {

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -149,7 +149,11 @@ class ChatActions {
         locationEnabled: settings.iosLocationKeepAliveEnabled,
         liveActivityPrivacyMode: settings.iosLiveActivityPrivacyMode,
       );
-      await IosKeepAliveService.instance.beginSession();
+      // Only open a keep-alive session when background generation is enabled;
+      // otherwise there is no task running in the background to keep alive.
+      if (settings.iosBackgroundGenerationEnabled) {
+        await IosKeepAliveService.instance.beginSession();
+      }
       final privacy = settings.iosLiveActivityPrivacyMode;
       await IosBackgroundGenerationService.instance.start(
         enabled: settings.iosBackgroundGenerationEnabled,
@@ -195,10 +199,13 @@ class ChatActions {
     required bool success,
     String? detail,
   }) async {
+    // End the keep-alive session BEFORE the l10n guard — if localization is
+    // unavailable we must still release the native keep-alive, otherwise the
+    // silent-audio / location legs keep running forever.
+    await IosKeepAliveService.instance.endSession();
     final l10n = _l10n;
     if (l10n == null) return;
     try {
-      await IosKeepAliveService.instance.endSession();
       await IosBackgroundGenerationService.instance.finish(
         title: success
             ? l10n.iosBackgroundGenerationCompleteTitle
@@ -216,9 +223,9 @@ class ChatActions {
   }
 
   Future<void> _cancelIosBackgroundGeneration() async {
+    await IosKeepAliveService.instance.endSession();
     final l10n = _l10n;
     try {
-      await IosKeepAliveService.instance.endSession();
       await IosBackgroundGenerationService.instance.cancel(
         detail: l10n?.iosBackgroundGenerationCancelledDetail,
       );

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -10,6 +10,7 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../core/services/ios_background_generation.dart';
+import '../../../core/services/ios_keep_alive.dart';
 import '../../../core/services/logging/flutter_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
@@ -139,6 +140,15 @@ class ChatActions {
     final l10n = _l10n;
     if (l10n == null) return;
     try {
+      // Push keep-alive toggles and open a keep-alive session before the
+      // native background task starts, so silent-audio / location legs can
+      // arm as soon as the app backgrounds.
+      await IosKeepAliveService.instance.configure(
+        masterEnabled: settings.iosKeepAliveEnabled,
+        silentAudioEnabled: settings.iosSilentAudioKeepAliveEnabled,
+        locationEnabled: settings.iosLocationKeepAliveEnabled,
+      );
+      await IosKeepAliveService.instance.beginSession();
       await IosBackgroundGenerationService.instance.start(
         enabled: settings.iosBackgroundGenerationEnabled,
         liveActivityEnabled: settings.iosLiveActivityEnabled,
@@ -174,6 +184,7 @@ class ChatActions {
     final l10n = _l10n;
     if (l10n == null) return;
     try {
+      await IosKeepAliveService.instance.endSession();
       await IosBackgroundGenerationService.instance.finish(
         title: success
             ? l10n.iosBackgroundGenerationCompleteTitle
@@ -193,6 +204,7 @@ class ChatActions {
   Future<void> _cancelIosBackgroundGeneration() async {
     final l10n = _l10n;
     try {
+      await IosKeepAliveService.instance.endSession();
       await IosBackgroundGenerationService.instance.cancel(
         detail: l10n?.iosBackgroundGenerationCancelledDetail,
       );

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -2664,7 +2664,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
             children: [
               _iosSwitchRow(
                 context,
-                icon: Lucide.Cpu,
+                icon: Lucide.Zap,
                 label: l10n.iosKeepAliveMasterTitle,
                 subtitle: l10n.iosKeepAliveMasterSubtitle,
                 value: sp.iosKeepAliveEnabled,
@@ -2679,7 +2679,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
               _iosDivider(context),
               _iosSwitchRow(
                 context,
-                icon: Lucide.VolumeX,
+                icon: Lucide.Volume2,
                 label: l10n.iosKeepAliveSilentAudioTitle,
                 subtitle: l10n.iosKeepAliveSilentAudioSubtitle,
                 value: sp.iosSilentAudioKeepAliveEnabled,
@@ -2694,7 +2694,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
               _iosDivider(context),
               _iosSwitchRow(
                 context,
-                icon: Lucide.MapPin,
+                icon: Lucide.Pin,
                 label: l10n.iosKeepAliveLocationTitle,
                 subtitle: l10n.iosKeepAliveLocationSubtitle,
                 value: sp.iosLocationKeepAliveEnabled,
@@ -2799,7 +2799,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
                 children: [
                   _iosNavRow(
                     context,
-                    icon: Lucide.Cpu,
+                    icon: Lucide.Zap,
                     label: status == null
                         ? l10n.iosKeepAliveStatusUnavailable
                         : status.survivalTier == 'extended'
@@ -2809,7 +2809,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
                   _iosDivider(context),
                   _iosNavRow(
                     context,
-                    icon: Lucide.VolumeX,
+                    icon: Lucide.Volume2,
                     label: status?.silentAudioActive == true
                         ? l10n.iosKeepAliveSilentAudioActive
                         : l10n.iosKeepAliveSilentAudioInactive,
@@ -2817,7 +2817,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
                   _iosDivider(context),
                   _iosNavRow(
                     context,
-                    icon: Lucide.MapPin,
+                    icon: Lucide.Pin,
                     label: status?.locationAuthorized == true
                         ? l10n.iosKeepAliveLocationAuthorized
                         : l10n.iosKeepAliveLocationNotAuthorized,

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'dart:io' show Platform;
 import '../../../core/services/android_background.dart';
 import '../../../core/services/ios_background_generation.dart';
+import '../../../core/services/ios_keep_alive.dart';
 import '../../../core/services/notification_service.dart';
 import '../../../icons/lucide_adapter.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
@@ -2562,16 +2563,19 @@ class IosBackgroundSettingsPage extends StatefulWidget {
 
 class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
   late Future<IosBackgroundGenerationStatus> _statusFuture;
+  late Future<IosKeepAliveStatus> _keepAliveStatusFuture;
 
   @override
   void initState() {
     super.initState();
     _statusFuture = IosBackgroundGenerationService.instance.getStatus();
+    _keepAliveStatusFuture = IosKeepAliveService.instance.getStatus();
   }
 
   void _refreshStatus() {
     setState(() {
       _statusFuture = IosBackgroundGenerationService.instance.getStatus();
+      _keepAliveStatusFuture = IosKeepAliveService.instance.getStatus();
     });
   }
 
@@ -2588,6 +2592,32 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
     if (!mounted) return;
     await settings.setIosBackgroundNotificationsEnabled(granted);
     _refreshStatus();
+  }
+
+  Future<void> _setLocationKeepAliveEnabled(bool enabled) async {
+    final settings = context.read<SettingsProvider>();
+    if (!enabled) {
+      await settings.setIosLocationKeepAliveEnabled(false);
+      await _pushKeepAliveConfig();
+      _refreshStatus();
+      return;
+    }
+
+    final granted = await IosKeepAliveService.instance
+        .requestLocationAuthorization();
+    if (!mounted) return;
+    await settings.setIosLocationKeepAliveEnabled(granted);
+    await _pushKeepAliveConfig();
+    _refreshStatus();
+  }
+
+  Future<void> _pushKeepAliveConfig() async {
+    final settings = context.read<SettingsProvider>();
+    await IosKeepAliveService.instance.configure(
+      masterEnabled: settings.iosKeepAliveEnabled,
+      silentAudioEnabled: settings.iosSilentAudioKeepAliveEnabled,
+      locationEnabled: settings.iosLocationKeepAliveEnabled,
+    );
   }
 
   Future<void> _openAppSettings() async {
@@ -2628,6 +2658,60 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
             context,
             title: l10n.iosBackgroundLimitNoticeTitle,
             body: l10n.iosBackgroundLimitNoticeBody,
+          ),
+          const SizedBox(height: 12),
+          _iosSectionCard(
+            children: [
+              _iosSwitchRow(
+                context,
+                icon: Lucide.Cpu,
+                label: l10n.iosKeepAliveMasterTitle,
+                subtitle: l10n.iosKeepAliveMasterSubtitle,
+                value: sp.iosKeepAliveEnabled,
+                onChanged: (v) async {
+                  await context
+                      .read<SettingsProvider>()
+                      .setIosKeepAliveEnabled(v);
+                  await _pushKeepAliveConfig();
+                  _refreshStatus();
+                },
+              ),
+              _iosDivider(context),
+              _iosSwitchRow(
+                context,
+                icon: Lucide.VolumeX,
+                label: l10n.iosKeepAliveSilentAudioTitle,
+                subtitle: l10n.iosKeepAliveSilentAudioSubtitle,
+                value: sp.iosSilentAudioKeepAliveEnabled,
+                onChanged: (v) async {
+                  await context
+                      .read<SettingsProvider>()
+                      .setIosSilentAudioKeepAliveEnabled(v);
+                  await _pushKeepAliveConfig();
+                  _refreshStatus();
+                },
+              ),
+              _iosDivider(context),
+              _iosSwitchRow(
+                context,
+                icon: Lucide.MapPin,
+                label: l10n.iosKeepAliveLocationTitle,
+                subtitle: l10n.iosKeepAliveLocationSubtitle,
+                value: sp.iosLocationKeepAliveEnabled,
+                onChanged: _setLocationKeepAliveEnabled,
+              ),
+              _iosDivider(context),
+              _iosSwitchRow(
+                context,
+                icon: Lucide.Shield,
+                label: l10n.iosKeepAlivePrivacyModeTitle,
+                subtitle: l10n.iosKeepAlivePrivacyModeSubtitle,
+                value: sp.iosLiveActivityPrivacyMode,
+                onChanged: (v) => context
+                    .read<SettingsProvider>()
+                    .setIosLiveActivityPrivacyMode(v),
+              ),
+            ],
           ),
           const SizedBox(height: 12),
           _iosSectionCard(
@@ -2701,6 +2785,45 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
                         ? l10n.iosBackgroundNotificationsAuthorized
                         : l10n.iosBackgroundNotificationsNotAuthorized,
                     onTap: _openNotificationSettings,
+                  ),
+                ],
+              );
+            },
+          ),
+          const SizedBox(height: 12),
+          FutureBuilder<IosKeepAliveStatus>(
+            future: _keepAliveStatusFuture,
+            builder: (context, snapshot) {
+              final status = snapshot.data;
+              return _iosSectionCard(
+                children: [
+                  _iosNavRow(
+                    context,
+                    icon: Lucide.Cpu,
+                    label: status == null
+                        ? l10n.iosKeepAliveStatusUnavailable
+                        : status.survivalTier == 'extended'
+                        ? l10n.iosKeepAliveSurvivalExtended
+                        : l10n.iosKeepAliveSurvivalShort,
+                  ),
+                  _iosDivider(context),
+                  _iosNavRow(
+                    context,
+                    icon: Lucide.VolumeX,
+                    label: status?.silentAudioActive == true
+                        ? l10n.iosKeepAliveSilentAudioActive
+                        : l10n.iosKeepAliveSilentAudioInactive,
+                  ),
+                  _iosDivider(context),
+                  _iosNavRow(
+                    context,
+                    icon: Lucide.MapPin,
+                    label: status?.locationAuthorized == true
+                        ? l10n.iosKeepAliveLocationAuthorized
+                        : l10n.iosKeepAliveLocationNotAuthorized,
+                    onTap: status?.locationAuthorized == true
+                        ? null
+                        : _openAppSettings,
                   ),
                 ],
               );

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -2617,6 +2617,7 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
       masterEnabled: settings.iosKeepAliveEnabled,
       silentAudioEnabled: settings.iosSilentAudioKeepAliveEnabled,
       locationEnabled: settings.iosLocationKeepAliveEnabled,
+      liveActivityPrivacyMode: settings.iosLiveActivityPrivacyMode,
     );
   }
 
@@ -2795,36 +2796,39 @@ class _IosBackgroundSettingsPageState extends State<IosBackgroundSettingsPage> {
             future: _keepAliveStatusFuture,
             builder: (context, snapshot) {
               final status = snapshot.data;
+              final sp2 = context.read<SettingsProvider>();
               return _iosSectionCard(
                 children: [
                   _iosNavRow(
                     context,
-                    icon: Lucide.Zap,
-                    label: status == null
-                        ? l10n.iosKeepAliveStatusUnavailable
-                        : status.survivalTier == 'extended'
-                        ? l10n.iosKeepAliveSurvivalExtended
-                        : l10n.iosKeepAliveSurvivalShort,
-                  ),
-                  _iosDivider(context),
-                  _iosNavRow(
-                    context,
                     icon: Lucide.Volume2,
-                    label: status?.silentAudioActive == true
-                        ? l10n.iosKeepAliveSilentAudioActive
-                        : l10n.iosKeepAliveSilentAudioInactive,
+                    label: sp2.iosSilentAudioKeepAliveEnabled
+                        ? l10n.iosKeepAliveConfigAudioReady
+                        : l10n.iosKeepAliveConfigAudioOff,
                   ),
                   _iosDivider(context),
                   _iosNavRow(
                     context,
                     icon: Lucide.Pin,
-                    label: status?.locationAuthorized == true
-                        ? l10n.iosKeepAliveLocationAuthorized
-                        : l10n.iosKeepAliveLocationNotAuthorized,
-                    onTap: status?.locationAuthorized == true
+                    label: !sp2.iosLocationKeepAliveEnabled
+                        ? l10n.iosKeepAliveConfigLocationOff
+                        : status?.locationAuthorized == true
+                        ? l10n.iosKeepAliveConfigLocationReady
+                        : l10n.iosKeepAliveConfigLocationPermissionNeeded,
+                    onTap: !sp2.iosLocationKeepAliveEnabled
+                        ? null
+                        : status?.locationAuthorized == true
                         ? null
                         : _openAppSettings,
                   ),
+                  if ((status?.interruptionCount ?? 0) > 0) ...[
+                    _iosDivider(context),
+                    _iosNavRow(
+                      context,
+                      icon: Lucide.TriangleAlert,
+                      label: l10n.iosKeepAliveInterruptedNotice,
+                    ),
+                  ],
                 ],
               );
             },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3753,5 +3753,13 @@
   "iosKeepAliveLocationAuthorized": "Location authorized",
   "iosKeepAliveLocationNotAuthorized": "Location not authorized — tap to open system settings",
   "iosKeepAliveSurvivalExtended": "Extended background survival",
-  "iosKeepAliveSurvivalShort": "Standard background survival (~30s)"
+  "iosKeepAliveSurvivalShort": "Standard background survival (~30s)",
+  "iosKeepAliveConfigAudioReady": "Silent audio ready",
+  "iosKeepAliveConfigAudioOff": "Silent audio off",
+  "iosKeepAliveConfigLocationReady": "Location ready",
+  "iosKeepAliveConfigLocationPermissionNeeded": "Location permission needed",
+  "iosKeepAliveConfigLocationOff": "Location off",
+  "iosKeepAliveInterruptedNotice": "Interrupted by the system previously",
+  "iosBackgroundGenerationPrivacyActiveTitle": "Background Task",
+  "iosBackgroundGenerationPrivacyActiveDetail": "Task in progress…"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3738,5 +3738,20 @@
   "workspaceToolUnzipUserDesc": "Extract zip archives",
   "workspaceToolDownloadTitle": "Download",
   "workspaceToolDownloadUserDesc": "Download a URL into the workspace",
-  "assistantEditLocalToolWorkspaceTitle": "Workspace"
+  "assistantEditLocalToolWorkspaceTitle": "Workspace",
+  "iosKeepAliveMasterTitle": "Enhanced Background Execution",
+  "iosKeepAliveMasterSubtitle": "Keep agent tasks running while the app is in the background.",
+  "iosKeepAliveSilentAudioTitle": "Silent Audio Keep-Alive",
+  "iosKeepAliveSilentAudioSubtitle": "Play an inaudible track so iOS keeps the process alive in the background.",
+  "iosKeepAliveLocationTitle": "Location Keep-Alive",
+  "iosKeepAliveLocationSubtitle": "Use background location updates to keep the app alive while backgrounded.",
+  "iosKeepAlivePrivacyModeTitle": "Live Activity Privacy Mode",
+  "iosKeepAlivePrivacyModeSubtitle": "Hide session content from the Lock Screen and Dynamic Island.",
+  "iosKeepAliveStatusUnavailable": "Keep-alive status unavailable",
+  "iosKeepAliveSilentAudioActive": "Silent audio active",
+  "iosKeepAliveSilentAudioInactive": "Silent audio inactive",
+  "iosKeepAliveLocationAuthorized": "Location authorized",
+  "iosKeepAliveLocationNotAuthorized": "Location not authorized — tap to open system settings",
+  "iosKeepAliveSurvivalExtended": "Extended background survival",
+  "iosKeepAliveSurvivalShort": "Standard background survival (~30s)"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15144,7 +15144,6 @@ abstract class AppLocalizations {
   /// **'Standard background survival (~30s)'**
   String get iosKeepAliveSurvivalShort;
 
-
   /// No description provided for @iosKeepAliveConfigAudioReady.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15054,7 +15054,6 @@ abstract class AppLocalizations {
   /// **'Workspace'**
   String get assistantEditLocalToolWorkspaceTitle;
 
-
   /// No description provided for @iosKeepAliveMasterTitle.
   ///
   /// In en, this message translates to:
@@ -15143,7 +15142,8 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Standard background survival (~30s)'**
-  String get iosKeepAliveSurvivalShort;}
+  String get iosKeepAliveSurvivalShort;
+}
 
 class _AppLocalizationsDelegate
     extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15143,6 +15143,55 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Standard background survival (~30s)'**
   String get iosKeepAliveSurvivalShort;
+
+
+  /// No description provided for @iosKeepAliveConfigAudioReady.
+  ///
+  /// In en, this message translates to:
+  /// **'Silent audio ready'**
+  String get iosKeepAliveConfigAudioReady;
+
+  /// No description provided for @iosKeepAliveConfigAudioOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Silent audio off'**
+  String get iosKeepAliveConfigAudioOff;
+
+  /// No description provided for @iosKeepAliveConfigLocationReady.
+  ///
+  /// In en, this message translates to:
+  /// **'Location ready'**
+  String get iosKeepAliveConfigLocationReady;
+
+  /// No description provided for @iosKeepAliveConfigLocationPermissionNeeded.
+  ///
+  /// In en, this message translates to:
+  /// **'Location permission needed'**
+  String get iosKeepAliveConfigLocationPermissionNeeded;
+
+  /// No description provided for @iosKeepAliveConfigLocationOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Location off'**
+  String get iosKeepAliveConfigLocationOff;
+
+  /// No description provided for @iosKeepAliveInterruptedNotice.
+  ///
+  /// In en, this message translates to:
+  /// **'Interrupted by the system previously'**
+  String get iosKeepAliveInterruptedNotice;
+
+  /// No description provided for @iosBackgroundGenerationPrivacyActiveTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Background Task'**
+  String get iosBackgroundGenerationPrivacyActiveTitle;
+
+  /// No description provided for @iosBackgroundGenerationPrivacyActiveDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Task in progress…'**
+  String get iosBackgroundGenerationPrivacyActiveDetail;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15053,7 +15053,97 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Workspace'**
   String get assistantEditLocalToolWorkspaceTitle;
-}
+
+
+  /// No description provided for @iosKeepAliveMasterTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enhanced Background Execution'**
+  String get iosKeepAliveMasterTitle;
+
+  /// No description provided for @iosKeepAliveMasterSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep agent tasks running while the app is in the background.'**
+  String get iosKeepAliveMasterSubtitle;
+
+  /// No description provided for @iosKeepAliveSilentAudioTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Silent Audio Keep-Alive'**
+  String get iosKeepAliveSilentAudioTitle;
+
+  /// No description provided for @iosKeepAliveSilentAudioSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Play an inaudible track so iOS keeps the process alive in the background.'**
+  String get iosKeepAliveSilentAudioSubtitle;
+
+  /// No description provided for @iosKeepAliveLocationTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Location Keep-Alive'**
+  String get iosKeepAliveLocationTitle;
+
+  /// No description provided for @iosKeepAliveLocationSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Use background location updates to keep the app alive while backgrounded.'**
+  String get iosKeepAliveLocationSubtitle;
+
+  /// No description provided for @iosKeepAlivePrivacyModeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Live Activity Privacy Mode'**
+  String get iosKeepAlivePrivacyModeTitle;
+
+  /// No description provided for @iosKeepAlivePrivacyModeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide session content from the Lock Screen and Dynamic Island.'**
+  String get iosKeepAlivePrivacyModeSubtitle;
+
+  /// No description provided for @iosKeepAliveStatusUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep-alive status unavailable'**
+  String get iosKeepAliveStatusUnavailable;
+
+  /// No description provided for @iosKeepAliveSilentAudioActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Silent audio active'**
+  String get iosKeepAliveSilentAudioActive;
+
+  /// No description provided for @iosKeepAliveSilentAudioInactive.
+  ///
+  /// In en, this message translates to:
+  /// **'Silent audio inactive'**
+  String get iosKeepAliveSilentAudioInactive;
+
+  /// No description provided for @iosKeepAliveLocationAuthorized.
+  ///
+  /// In en, this message translates to:
+  /// **'Location authorized'**
+  String get iosKeepAliveLocationAuthorized;
+
+  /// No description provided for @iosKeepAliveLocationNotAuthorized.
+  ///
+  /// In en, this message translates to:
+  /// **'Location not authorized — tap to open system settings'**
+  String get iosKeepAliveLocationNotAuthorized;
+
+  /// No description provided for @iosKeepAliveSurvivalExtended.
+  ///
+  /// In en, this message translates to:
+  /// **'Extended background survival'**
+  String get iosKeepAliveSurvivalExtended;
+
+  /// No description provided for @iosKeepAliveSurvivalShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Standard background survival (~30s)'**
+  String get iosKeepAliveSurvivalShort;}
 
 class _AppLocalizationsDelegate
     extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8371,4 +8371,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get iosKeepAliveSurvivalShort => 'Standard background survival (~30s)';
+
+  @override
+  String get iosKeepAliveConfigAudioReady => 'Silent audio ready';
+
+  @override
+  String get iosKeepAliveConfigAudioOff => 'Silent audio off';
+
+  @override
+  String get iosKeepAliveConfigLocationReady => 'Location ready';
+
+  @override
+  String get iosKeepAliveConfigLocationPermissionNeeded =>
+      'Location permission needed';
+
+  @override
+  String get iosKeepAliveConfigLocationOff => 'Location off';
+
+  @override
+  String get iosKeepAliveInterruptedNotice =>
+      'Interrupted by the system previously';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveTitle => 'Background Task';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveDetail => 'Task in progress…';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8321,4 +8321,54 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => 'Workspace';
+
+  @override
+  String get iosKeepAliveMasterTitle => 'Enhanced Background Execution';
+
+  @override
+  String get iosKeepAliveMasterSubtitle =>
+      'Keep agent tasks running while the app is in the background.';
+
+  @override
+  String get iosKeepAliveSilentAudioTitle => 'Silent Audio Keep-Alive';
+
+  @override
+  String get iosKeepAliveSilentAudioSubtitle =>
+      'Play an inaudible track so iOS keeps the process alive in the background.';
+
+  @override
+  String get iosKeepAliveLocationTitle => 'Location Keep-Alive';
+
+  @override
+  String get iosKeepAliveLocationSubtitle =>
+      'Use background location updates to keep the app alive while backgrounded.';
+
+  @override
+  String get iosKeepAlivePrivacyModeTitle => 'Live Activity Privacy Mode';
+
+  @override
+  String get iosKeepAlivePrivacyModeSubtitle =>
+      'Hide session content from the Lock Screen and Dynamic Island.';
+
+  @override
+  String get iosKeepAliveStatusUnavailable => 'Keep-alive status unavailable';
+
+  @override
+  String get iosKeepAliveSilentAudioActive => 'Silent audio active';
+
+  @override
+  String get iosKeepAliveSilentAudioInactive => 'Silent audio inactive';
+
+  @override
+  String get iosKeepAliveLocationAuthorized => 'Location authorized';
+
+  @override
+  String get iosKeepAliveLocationNotAuthorized =>
+      'Location not authorized — tap to open system settings';
+
+  @override
+  String get iosKeepAliveSurvivalExtended => 'Extended background survival';
+
+  @override
+  String get iosKeepAliveSurvivalShort => 'Standard background survival (~30s)';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7997,6 +7997,30 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get iosKeepAliveSurvivalShort => '标准后台存活（约 30 秒）';
+
+  @override
+  String get iosKeepAliveConfigAudioReady => '静音音频就绪';
+
+  @override
+  String get iosKeepAliveConfigAudioOff => '静音音频未开启';
+
+  @override
+  String get iosKeepAliveConfigLocationReady => '定位就绪';
+
+  @override
+  String get iosKeepAliveConfigLocationPermissionNeeded => '需要定位权限';
+
+  @override
+  String get iosKeepAliveConfigLocationOff => '定位未开启';
+
+  @override
+  String get iosKeepAliveInterruptedNotice => '曾被系统中断';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveTitle => '后台任务';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveDetail => '任务进行中…';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -15992,6 +16016,30 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get iosKeepAliveSurvivalShort => '标准后台存活（约 30 秒）';
+
+  @override
+  String get iosKeepAliveConfigAudioReady => '静音音频就绪';
+
+  @override
+  String get iosKeepAliveConfigAudioOff => '静音音频未开启';
+
+  @override
+  String get iosKeepAliveConfigLocationReady => '定位就绪';
+
+  @override
+  String get iosKeepAliveConfigLocationPermissionNeeded => '需要定位权限';
+
+  @override
+  String get iosKeepAliveConfigLocationOff => '定位未开启';
+
+  @override
+  String get iosKeepAliveInterruptedNotice => '曾被系统中断';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveTitle => '后台任务';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveDetail => '任务进行中…';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -23987,4 +24035,28 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get iosKeepAliveSurvivalShort => '標準背景存活（約 30 秒）';
+
+  @override
+  String get iosKeepAliveConfigAudioReady => '靜默音訊就緒';
+
+  @override
+  String get iosKeepAliveConfigAudioOff => '靜默音訊未開啟';
+
+  @override
+  String get iosKeepAliveConfigLocationReady => '定位就緒';
+
+  @override
+  String get iosKeepAliveConfigLocationPermissionNeeded => '需要定位權限';
+
+  @override
+  String get iosKeepAliveConfigLocationOff => '定位未開啟';
+
+  @override
+  String get iosKeepAliveInterruptedNotice => '曾被系統中斷';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveTitle => '背景任務';
+
+  @override
+  String get iosBackgroundGenerationPrivacyActiveDetail => '任務進行中…';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7952,6 +7952,51 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get iosKeepAliveMasterTitle => '增强后台执行';
+
+  @override
+  String get iosKeepAliveMasterSubtitle => '在应用进入后台时保持代理任务继续运行。';
+
+  @override
+  String get iosKeepAliveSilentAudioTitle => '静默音频保活';
+
+  @override
+  String get iosKeepAliveSilentAudioSubtitle => '播放一段听不见的音轨，让 iOS 在后台保持进程存活。';
+
+  @override
+  String get iosKeepAliveLocationTitle => '定位保活';
+
+  @override
+  String get iosKeepAliveLocationSubtitle => '使用后台定位更新，在应用退到后台时保持进程存活。';
+
+  @override
+  String get iosKeepAlivePrivacyModeTitle => 'Live Activity 隐私模式';
+
+  @override
+  String get iosKeepAlivePrivacyModeSubtitle => '在锁屏和灵动岛上隐藏会话内容。';
+
+  @override
+  String get iosKeepAliveStatusUnavailable => '保活状态不可用';
+
+  @override
+  String get iosKeepAliveSilentAudioActive => '静默音频运行中';
+
+  @override
+  String get iosKeepAliveSilentAudioInactive => '静默音频未运行';
+
+  @override
+  String get iosKeepAliveLocationAuthorized => '定位已授权';
+
+  @override
+  String get iosKeepAliveLocationNotAuthorized => '定位未授权——点击打开系统设置';
+
+  @override
+  String get iosKeepAliveSurvivalExtended => '延长后台存活';
+
+  @override
+  String get iosKeepAliveSurvivalShort => '标准后台存活（约 30 秒）';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -15902,6 +15947,51 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作区';
+
+  @override
+  String get iosKeepAliveMasterTitle => '增强后台执行';
+
+  @override
+  String get iosKeepAliveMasterSubtitle => '在应用进入后台时保持代理任务继续运行。';
+
+  @override
+  String get iosKeepAliveSilentAudioTitle => '静默音频保活';
+
+  @override
+  String get iosKeepAliveSilentAudioSubtitle => '播放一段听不见的音轨，让 iOS 在后台保持进程存活。';
+
+  @override
+  String get iosKeepAliveLocationTitle => '定位保活';
+
+  @override
+  String get iosKeepAliveLocationSubtitle => '使用后台定位更新，在应用退到后台时保持进程存活。';
+
+  @override
+  String get iosKeepAlivePrivacyModeTitle => 'Live Activity 隐私模式';
+
+  @override
+  String get iosKeepAlivePrivacyModeSubtitle => '在锁屏和灵动岛上隐藏会话内容。';
+
+  @override
+  String get iosKeepAliveStatusUnavailable => '保活状态不可用';
+
+  @override
+  String get iosKeepAliveSilentAudioActive => '静默音频运行中';
+
+  @override
+  String get iosKeepAliveSilentAudioInactive => '静默音频未运行';
+
+  @override
+  String get iosKeepAliveLocationAuthorized => '定位已授权';
+
+  @override
+  String get iosKeepAliveLocationNotAuthorized => '定位未授权——点击打开系统设置';
+
+  @override
+  String get iosKeepAliveSurvivalExtended => '延长后台存活';
+
+  @override
+  String get iosKeepAliveSurvivalShort => '标准后台存活（约 30 秒）';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -23852,4 +23942,49 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get assistantEditLocalToolWorkspaceTitle => '工作區';
+
+  @override
+  String get iosKeepAliveMasterTitle => '增強背景執行';
+
+  @override
+  String get iosKeepAliveMasterSubtitle => '在 App 進入背景時保持代理任務繼續運行。';
+
+  @override
+  String get iosKeepAliveSilentAudioTitle => '靜默音訊保活';
+
+  @override
+  String get iosKeepAliveSilentAudioSubtitle => '播放一段聽不見的音軌，讓 iOS 在背景保持程序存活。';
+
+  @override
+  String get iosKeepAliveLocationTitle => '定位保活';
+
+  @override
+  String get iosKeepAliveLocationSubtitle => '使用背景定位更新，在 App 退到背景時保持程序存活。';
+
+  @override
+  String get iosKeepAlivePrivacyModeTitle => 'Live Activity 隱私模式';
+
+  @override
+  String get iosKeepAlivePrivacyModeSubtitle => '在鎖定畫面與動態島上隱藏會話內容。';
+
+  @override
+  String get iosKeepAliveStatusUnavailable => '保活狀態不可用';
+
+  @override
+  String get iosKeepAliveSilentAudioActive => '靜默音訊運行中';
+
+  @override
+  String get iosKeepAliveSilentAudioInactive => '靜默音訊未運行';
+
+  @override
+  String get iosKeepAliveLocationAuthorized => '定位已授權';
+
+  @override
+  String get iosKeepAliveLocationNotAuthorized => '定位未授權——點擊開啟系統設定';
+
+  @override
+  String get iosKeepAliveSurvivalExtended => '延長背景存活';
+
+  @override
+  String get iosKeepAliveSurvivalShort => '標準背景存活（約 30 秒）';
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3169,5 +3169,13 @@
   "iosKeepAliveLocationAuthorized": "定位已授权",
   "iosKeepAliveLocationNotAuthorized": "定位未授权——点击打开系统设置",
   "iosKeepAliveSurvivalExtended": "延长后台存活",
-  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）"
+  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）",
+  "iosKeepAliveConfigAudioReady": "静音音频就绪",
+  "iosKeepAliveConfigAudioOff": "静音音频未开启",
+  "iosKeepAliveConfigLocationReady": "定位就绪",
+  "iosKeepAliveConfigLocationPermissionNeeded": "需要定位权限",
+  "iosKeepAliveConfigLocationOff": "定位未开启",
+  "iosKeepAliveInterruptedNotice": "曾被系统中断",
+  "iosBackgroundGenerationPrivacyActiveTitle": "后台任务",
+  "iosBackgroundGenerationPrivacyActiveDetail": "任务进行中…"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3154,5 +3154,20 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "iosKeepAliveMasterTitle": "增强后台执行",
+  "iosKeepAliveMasterSubtitle": "在应用进入后台时保持代理任务继续运行。",
+  "iosKeepAliveSilentAudioTitle": "静默音频保活",
+  "iosKeepAliveSilentAudioSubtitle": "播放一段听不见的音轨，让 iOS 在后台保持进程存活。",
+  "iosKeepAliveLocationTitle": "定位保活",
+  "iosKeepAliveLocationSubtitle": "使用后台定位更新，在应用退到后台时保持进程存活。",
+  "iosKeepAlivePrivacyModeTitle": "Live Activity 隐私模式",
+  "iosKeepAlivePrivacyModeSubtitle": "在锁屏和灵动岛上隐藏会话内容。",
+  "iosKeepAliveStatusUnavailable": "保活状态不可用",
+  "iosKeepAliveSilentAudioActive": "静默音频运行中",
+  "iosKeepAliveSilentAudioInactive": "静默音频未运行",
+  "iosKeepAliveLocationAuthorized": "定位已授权",
+  "iosKeepAliveLocationNotAuthorized": "定位未授权——点击打开系统设置",
+  "iosKeepAliveSurvivalExtended": "延长后台存活",
+  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3170,5 +3170,13 @@
   "iosKeepAliveLocationAuthorized": "定位已授权",
   "iosKeepAliveLocationNotAuthorized": "定位未授权——点击打开系统设置",
   "iosKeepAliveSurvivalExtended": "延长后台存活",
-  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）"
+  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）",
+  "iosKeepAliveConfigAudioReady": "静音音频就绪",
+  "iosKeepAliveConfigAudioOff": "静音音频未开启",
+  "iosKeepAliveConfigLocationReady": "定位就绪",
+  "iosKeepAliveConfigLocationPermissionNeeded": "需要定位权限",
+  "iosKeepAliveConfigLocationOff": "定位未开启",
+  "iosKeepAliveInterruptedNotice": "曾被系统中断",
+  "iosBackgroundGenerationPrivacyActiveTitle": "后台任务",
+  "iosBackgroundGenerationPrivacyActiveDetail": "任务进行中…"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3155,5 +3155,20 @@
   "workspaceToolUnzipUserDesc": "解压 zip 压缩包",
   "workspaceToolDownloadTitle": "下载",
   "workspaceToolDownloadUserDesc": "将 URL 下载到工作区",
-  "assistantEditLocalToolWorkspaceTitle": "工作区"
+  "assistantEditLocalToolWorkspaceTitle": "工作区",
+  "iosKeepAliveMasterTitle": "增强后台执行",
+  "iosKeepAliveMasterSubtitle": "在应用进入后台时保持代理任务继续运行。",
+  "iosKeepAliveSilentAudioTitle": "静默音频保活",
+  "iosKeepAliveSilentAudioSubtitle": "播放一段听不见的音轨，让 iOS 在后台保持进程存活。",
+  "iosKeepAliveLocationTitle": "定位保活",
+  "iosKeepAliveLocationSubtitle": "使用后台定位更新，在应用退到后台时保持进程存活。",
+  "iosKeepAlivePrivacyModeTitle": "Live Activity 隐私模式",
+  "iosKeepAlivePrivacyModeSubtitle": "在锁屏和灵动岛上隐藏会话内容。",
+  "iosKeepAliveStatusUnavailable": "保活状态不可用",
+  "iosKeepAliveSilentAudioActive": "静默音频运行中",
+  "iosKeepAliveSilentAudioInactive": "静默音频未运行",
+  "iosKeepAliveLocationAuthorized": "定位已授权",
+  "iosKeepAliveLocationNotAuthorized": "定位未授权——点击打开系统设置",
+  "iosKeepAliveSurvivalExtended": "延长后台存活",
+  "iosKeepAliveSurvivalShort": "标准后台存活（约 30 秒）"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3155,5 +3155,20 @@
   "workspaceToolUnzipUserDesc": "解壓 zip 壓縮檔",
   "workspaceToolDownloadTitle": "下載",
   "workspaceToolDownloadUserDesc": "將 URL 下載到工作區",
-  "assistantEditLocalToolWorkspaceTitle": "工作區"
+  "assistantEditLocalToolWorkspaceTitle": "工作區",
+  "iosKeepAliveMasterTitle": "增強背景執行",
+  "iosKeepAliveMasterSubtitle": "在 App 進入背景時保持代理任務繼續運行。",
+  "iosKeepAliveSilentAudioTitle": "靜默音訊保活",
+  "iosKeepAliveSilentAudioSubtitle": "播放一段聽不見的音軌，讓 iOS 在背景保持程序存活。",
+  "iosKeepAliveLocationTitle": "定位保活",
+  "iosKeepAliveLocationSubtitle": "使用背景定位更新，在 App 退到背景時保持程序存活。",
+  "iosKeepAlivePrivacyModeTitle": "Live Activity 隱私模式",
+  "iosKeepAlivePrivacyModeSubtitle": "在鎖定畫面與動態島上隱藏會話內容。",
+  "iosKeepAliveStatusUnavailable": "保活狀態不可用",
+  "iosKeepAliveSilentAudioActive": "靜默音訊運行中",
+  "iosKeepAliveSilentAudioInactive": "靜默音訊未運行",
+  "iosKeepAliveLocationAuthorized": "定位已授權",
+  "iosKeepAliveLocationNotAuthorized": "定位未授權——點擊開啟系統設定",
+  "iosKeepAliveSurvivalExtended": "延長背景存活",
+  "iosKeepAliveSurvivalShort": "標準背景存活（約 30 秒）"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3170,5 +3170,13 @@
   "iosKeepAliveLocationAuthorized": "定位已授權",
   "iosKeepAliveLocationNotAuthorized": "定位未授權——點擊開啟系統設定",
   "iosKeepAliveSurvivalExtended": "延長背景存活",
-  "iosKeepAliveSurvivalShort": "標準背景存活（約 30 秒）"
+  "iosKeepAliveSurvivalShort": "標準背景存活（約 30 秒）",
+  "iosKeepAliveConfigAudioReady": "靜默音訊就緒",
+  "iosKeepAliveConfigAudioOff": "靜默音訊未開啟",
+  "iosKeepAliveConfigLocationReady": "定位就緒",
+  "iosKeepAliveConfigLocationPermissionNeeded": "需要定位權限",
+  "iosKeepAliveConfigLocationOff": "定位未開啟",
+  "iosKeepAliveInterruptedNotice": "曾被系統中斷",
+  "iosBackgroundGenerationPrivacyActiveTitle": "背景任務",
+  "iosBackgroundGenerationPrivacyActiveDetail": "任務進行中…"
 }

--- a/test/settings_provider_ios_keep_alive_test.dart
+++ b/test/settings_provider_ios_keep_alive_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+Future<void> _waitForSettingsLoad() async {
+  for (var i = 0; i < 25; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsProvider iOS advanced keep-alive settings', () {
+    test('defaults all keep-alive options to disabled', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+
+      expect(settings.iosKeepAliveEnabled, isFalse);
+      expect(settings.iosSilentAudioKeepAliveEnabled, isFalse);
+      expect(settings.iosLocationKeepAliveEnabled, isFalse);
+      expect(settings.iosLiveActivityPrivacyMode, isFalse);
+    });
+
+    test('loads persisted keep-alive values', () async {
+      SharedPreferences.setMockInitialValues({
+        'ios_keepalive_enabled_v1': true,
+        'ios_silent_audio_keepalive_enabled_v1': true,
+        'ios_location_keepalive_enabled_v1': true,
+        'ios_live_activity_privacy_mode_v1': true,
+      });
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+
+      expect(settings.iosKeepAliveEnabled, isTrue);
+      expect(settings.iosSilentAudioKeepAliveEnabled, isTrue);
+      expect(settings.iosLocationKeepAliveEnabled, isTrue);
+      expect(settings.iosLiveActivityPrivacyMode, isTrue);
+    });
+
+    test('silent audio / location toggles cascade master on', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setIosSilentAudioKeepAliveEnabled(true);
+      expect(settings.iosKeepAliveEnabled, isTrue);
+
+      await settings.setIosLocationKeepAliveEnabled(true);
+      expect(settings.iosKeepAliveEnabled, isTrue);
+    });
+
+    test('master off cascades sub-toggles off', () async {
+      SharedPreferences.setMockInitialValues({
+        'ios_keepalive_enabled_v1': true,
+        'ios_silent_audio_keepalive_enabled_v1': true,
+        'ios_location_keepalive_enabled_v1': true,
+      });
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setIosKeepAliveEnabled(false);
+
+      expect(settings.iosKeepAliveEnabled, isFalse);
+      expect(settings.iosSilentAudioKeepAliveEnabled, isFalse);
+      expect(settings.iosLocationKeepAliveEnabled, isFalse);
+    });
+
+    test('persists keep-alive values to preferences', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setIosKeepAliveEnabled(true);
+      await settings.setIosSilentAudioKeepAliveEnabled(true);
+      await settings.setIosLocationKeepAliveEnabled(true);
+      await settings.setIosLiveActivityPrivacyMode(true);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('ios_keepalive_enabled_v1'), isTrue);
+      expect(prefs.getBool('ios_silent_audio_keepalive_enabled_v1'), isTrue);
+      expect(prefs.getBool('ios_location_keepalive_enabled_v1'), isTrue);
+      expect(prefs.getBool('ios_live_activity_privacy_mode_v1'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

Ported OpenMinis' advanced iOS background keep-alive capability into Cuplivo:

- **Silent Audio Keep-Alive** — AVAudioEngine plays an inaudible looping track (`UIBackgroundModes: audio`) so iOS keeps the process alive while a generation task runs in the background. This is the primary long-lived leg.
- **Location Keep-Alive** — coarse CLLocationManager 5s heartbeat + iOS 17+ `CLBackgroundActivitySession`, armed 15s after backgrounding (brief background blips never spin up location).
- **Intelligent finite-task re-arm** — when silent audio is active and the `UIBackgroundTask` expires, the task is re-armed instead of letting the generation die.
- **Keep-alive status card** in Settings → Preferences → Background Generation (iOS): survival tier, silent audio active, location auth.
- New toggles: Enhanced Background Execution (master), Silent Audio Keep-Alive, Location Keep-Alive, Live Activity Privacy Mode.
- `app.ios_keepalive` MethodChannel + Dart `IosKeepAliveService`; session begin/end wired into generation lifecycle.
- l10n: 15 new keys (en / zh / Hans / Hant). Tests for the new SettingsProvider options.

## Files

- `ios/Runner/BackgroundKeepAliveManager.swift` (new)
- `ios/Runner/AppDelegate.swift`, `ios/Runner/Info.plist`
- `lib/core/services/ios_keep_alive.dart` (new)
- `lib/core/providers/settings_provider.dart`
- `lib/features/settings/pages/display_settings_page.dart`
- `lib/features/home/controllers/chat_actions.dart`
- l10n ARB + generated files, tests