### PR TITLE
feat: skip log analysis traffic via filename marker + token budget

### DIFF
--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -172,7 +172,16 @@ class DioHttpClient extends http.BaseClient {
     final reqHeaders = Map<String, String>.from(request.headers);
     reqHeaders.putIfAbsent('User-Agent', () => 'Cuplivo');
 
-    if (RequestLogger.llmEnabled) {
+    final bodyText = bodyBytes.isEmpty
+        ? ''
+        : RequestLogger.safeDecodeUtf8(bodyBytes);
+    // Requests carrying an attachment whose file name embeds the log-skip
+    // marker (e.g. the AI log-analysis export) are kept entirely out of the
+    // log files, so analysis traffic cannot inflate or poison the logs.
+    final skipLog = _hasLogSkipMarker(bodyText);
+    final logEnabled = RequestLogger.llmEnabled && !skipLog;
+
+    if (logEnabled) {
       RequestLogger.logLine('[REQ $reqId] $method $uri');
       if (reqHeaders.isNotEmpty) {
         RequestLogger.logLine(
@@ -181,12 +190,12 @@ class DioHttpClient extends http.BaseClient {
         );
       }
       if (bodyBytes.isNotEmpty) {
-        final decoded = RequestLogger.safeDecodeUtf8(bodyBytes);
-        final bodyText = decoded.isNotEmpty
+        final decoded = bodyText;
+        final logBody = decoded.isNotEmpty
             ? decoded
             : 'base64:${base64Encode(bodyBytes)}';
         RequestLogger.logLine(
-          '[REQ $reqId] body=${RequestLogger.escape(bodyText)}',
+          '[REQ $reqId] body=${RequestLogger.escape(logBody)}',
         );
       }
     }
@@ -213,7 +222,7 @@ class DioHttpClient extends http.BaseClient {
         headers[name] = values.join(',');
       });
 
-      if (RequestLogger.llmEnabled) {
+      if (logEnabled) {
         RequestLogger.logLine('[RES $reqId] status=$statusCode');
         if (headers.isNotEmpty) {
           RequestLogger.logLine(
@@ -232,7 +241,7 @@ class DioHttpClient extends http.BaseClient {
         body.stream.listen(
           (chunk) {
             controller.add(chunk);
-            if (RequestLogger.llmEnabled && RequestLogger.saveOutput) {
+            if (logEnabled && RequestLogger.saveOutput) {
               final s = RequestLogger.safeDecodeUtf8(chunk);
               if (s.isNotEmpty) {
                 RequestLogger.logLine(
@@ -242,7 +251,7 @@ class DioHttpClient extends http.BaseClient {
             }
           },
           onError: (e, st) {
-            if (RequestLogger.llmEnabled) {
+            if (logEnabled) {
               RequestLogger.logLine(
                 '[RES $reqId] error=${RequestLogger.escape(e.toString())}',
               );
@@ -251,7 +260,7 @@ class DioHttpClient extends http.BaseClient {
             controller.close();
           },
           onDone: () {
-            if (RequestLogger.llmEnabled) {
+            if (logEnabled) {
               RequestLogger.logLine('[RES $reqId] done');
             }
             controller.close();
@@ -282,19 +291,51 @@ class DioHttpClient extends http.BaseClient {
         reasonPhrase: resp.statusMessage,
       );
     } on DioException catch (e) {
-      if (RequestLogger.llmEnabled) {
+      if (logEnabled) {
         RequestLogger.logLine(
           '[RES $reqId] dio_error=${RequestLogger.escape(e.toString())}',
         );
       }
       throw http.ClientException(e.toString(), uri);
     } catch (e) {
-      if (RequestLogger.llmEnabled) {
+      if (logEnabled) {
         RequestLogger.logLine(
           '[RES $reqId] error=${RequestLogger.escape(e.toString())}',
         );
       }
       throw http.ClientException(e.toString(), uri);
     }
+  }
+
+  /// Returns true when [bodyText] carries an attachment whose file name
+  /// (or path) contains [RequestLogger.logSkipMarker]. Only attachment
+  /// fields are inspected, so a marker accidentally appearing in message
+  /// text does not suppress logging.
+  static bool _hasLogSkipMarker(String bodyText) {
+    if (bodyText.isEmpty) return false;
+    try {
+      return _nodeHasSkipMarker(jsonDecode(bodyText));
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static bool _nodeHasSkipMarker(Object? node) {
+    if (node is Map) {
+      for (final entry in node.entries) {
+        final name = entry.key.toString().toLowerCase();
+        if ((name == 'filename' || name == 'path' || name == 'name') &&
+            entry.value is String &&
+            (entry.value as String).contains(RequestLogger.logSkipMarker)) {
+          return true;
+        }
+        if (_nodeHasSkipMarker(entry.value)) return true;
+      }
+    } else if (node is List) {
+      for (final item in node) {
+        if (_nodeHasSkipMarker(item)) return true;
+      }
+    }
+    return false;
   }
 }

--- a/lib/core/services/network/dio_http_client.dart
+++ b/lib/core/services/network/dio_http_client.dart
@@ -172,14 +172,14 @@ class DioHttpClient extends http.BaseClient {
     final reqHeaders = Map<String, String>.from(request.headers);
     reqHeaders.putIfAbsent('User-Agent', () => 'Cuplivo');
 
-    final bodyText = bodyBytes.isEmpty
-        ? ''
-        : RequestLogger.safeDecodeUtf8(bodyBytes);
-    // Requests carrying an attachment whose file name embeds the log-skip
-    // marker (e.g. the AI log-analysis export) are kept entirely out of the
-    // log files, so analysis traffic cannot inflate or poison the logs.
-    final skipLog = _hasLogSkipMarker(bodyText);
-    final logEnabled = RequestLogger.llmEnabled && !skipLog;
+    // Decode only when logging is enabled; a request whose attachment file
+    // name embeds the log-skip marker (e.g. the AI log-analysis export) is
+    // kept entirely out of the log files, so analysis traffic cannot
+    // inflate or poison the logs.
+    final bodyText = RequestLogger.llmEnabled && bodyBytes.isNotEmpty
+        ? RequestLogger.safeDecodeUtf8(bodyBytes)
+        : '';
+    final logEnabled = RequestLogger.llmEnabled && !_hasLogSkipMarker(bodyText);
 
     if (logEnabled) {
       RequestLogger.logLine('[REQ $reqId] $method $uri');

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -14,6 +14,12 @@ class RequestLogger {
   static const String catTts = 'tts';
   static const String catSearch = 'search';
 
+  /// Filename marker that opts a request out of logging. When an attached
+  /// file's name contains this marker, the whole request/response exchange
+  /// is skipped (see DioHttpClient). The AI log-analysis export is named
+  /// with this marker so analysis traffic never grows the log files.
+  static const String logSkipMarker = 'cuplivo_n9x7';
+
   /// Header names whose values are masked in log output (case-insensitive).
   /// Credentials stay out of the plaintext log files: only the first 7
   /// characters plus the remaining length are written (e.g. `Bearer [45 more]`).

--- a/lib/features/settings/logs/request_log_ai_analysis.dart
+++ b/lib/features/settings/logs/request_log_ai_analysis.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../utils/app_directories.dart';
+import '../../../core/services/network/request_logger.dart';
 import 'request_log_parser.dart';
 
 /// Creates a privacy-scrubbed, AI-readable export of request-log entries.
@@ -69,7 +70,10 @@ class RequestLogAiAnalysisExporter {
         .replaceAll('.', '-');
     final prefix = _safeFileNamePrefix(fileNamePrefix);
     final file = File(
-      p.join(outputDirectory.path, '${prefix}_$timestamp.json'),
+      p.join(
+        outputDirectory.path,
+        '${RequestLogger.logSkipMarker}_${prefix}_$timestamp.json',
+      ),
     );
     final text = const JsonEncoder.withIndent('  ').convert(
       buildPayload(entries, generatedAt: now),
@@ -94,18 +98,61 @@ class RequestLogAiAnalysisExporter {
     } catch (_) {}
   }
 
+  /// Conservative token budget for the exported payload. Estimation uses a
+  /// 4x safety factor over raw character count (see [_estimateTokens]), so
+  /// the exported JSON never exceeds this budget under common tokenizers.
+  static const int _maxPayloadTokens = 100000;
+
   /// Produces the export payload without doing file I/O.
+  ///
+  /// Entries are consumed newest-first up to the token budget; any entry
+  /// that would exceed the budget (or that alone exceeds it) is skipped
+  /// entirely and reported via `omitted_count` / `omitted_hint` instead of
+  /// being truncated mid-entry.
   static Map<String, dynamic> buildPayload(
     List<RequestLogEntry> entries, {
     DateTime? generatedAt,
   }) {
     final timestamp = generatedAt ?? DateTime.now().toUtc();
+    final requests = <Map<String, dynamic>>[];
+    var budget = _maxPayloadTokens;
+    var omitted = 0;
+    for (final entry in entries) {
+      final payload = _entryToPayload(entry);
+      final estimate = _estimateTokens(payload);
+      if (estimate > _maxPayloadTokens) {
+        // A single entry alone exceeds the whole budget: skip it whole.
+        omitted++;
+        continue;
+      }
+      if (estimate > budget) {
+        // Budget exhausted; entries are newest-first, so the rest are older
+        // and omitted wholesale.
+        omitted += entries.length - requests.length - omitted;
+        break;
+      }
+      budget -= estimate;
+      requests.add(payload);
+    }
     return <String, dynamic>{
       'format': 'cuplivo.request-log-ai-analysis.v1',
       'generated_at': timestamp.toIso8601String(),
       'request_count': entries.length,
-      'requests': entries.map(_entryToPayload).toList(growable: false),
+      'omitted_count': omitted,
+      if (omitted > 0)
+        'omitted_hint':
+            '$omitted earlier log entries omitted due to token budget limit',
+      'requests': requests,
     };
+  }
+
+  /// Very conservative token estimate: 1 character counted as up to 4
+  /// tokens is a safe upper bound for common tokenizers (English text runs
+  /// ~3-4 chars/token, CJK ~1-3 tokens/char), guaranteeing the budget is
+  /// never exceeded in practice.
+  static int _estimateTokens(Map<String, dynamic> payload) {
+    final text = const JsonEncoder().convert(payload);
+    return text.length * 4;
   }
 
   static Map<String, dynamic> _entryToPayload(RequestLogEntry entry) {


### PR DESCRIPTION
## 日志分析流量防膨胀 + token 预算

### 问题
1. 点击日志页 AI 图标分析时，导出的日志 JSON（可达数 MB）作为附件发送，请求体被 RequestLogger **完整记录**进日志 → 日志自我膨胀（8MB → 30MB）→ 下次分析截取更大 → 恶性循环
2. 导出无 token 预算：30 条最新日志全量导出（请求体+流式响应体），可达 200 万 token，轻松超模型上下文

### 改动
1. **暗号跳过**：分析导出文件名改为 `cuplivo_n9x7_<prefix>_<ts>.json`；`DioHttpClient.send` 解析请求体，附件文件名（fileName/path/name 字段）含 `cuplivo_n9x7` → 整条 REQ+RES 不写日志。用户手动发的敏感文件也可用此文件名标记跳过
2. **token 预算**：`buildPayload` 按最新在前累计，估算 = 字符数 × 4（保守上界，绝不超限），预算 100k；放不下的条目整条省略（不截半），以 `omitted_count`/`omitted_hint` 告知 AI