### PR TITLE
fix(l10n): localize remaining 'skills' strings to 技能 in Chinese UI

### DIFF
--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5781,14 +5781,14 @@ class AppLocalizationsZh extends AppLocalizations {
       '委派任务并等待子助手的完整输出作为工具结果。';
 
   @override
-  String get assistantEditSkillDownloadTitle => '下载 Skills';
+  String get assistantEditSkillDownloadTitle => '下载技能';
 
   @override
   String get assistantEditSkillDownloadSubtitle =>
       '允许助手通过 GitHub 仓库 URL 下载并安装技能。';
 
   @override
-  String get assistantEditSkillCreateTitle => '创建 Skills';
+  String get assistantEditSkillCreateTitle => '创建技能';
 
   @override
   String get assistantEditSkillCreateSubtitle => '允许助手根据 SKILL.md 内容创建新技能。';
@@ -6965,7 +6965,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get multiAIAddModelTooltip => '添加模型';
 
   @override
-  String get skillsTitle => 'skills';
+  String get skillsTitle => '技能';
 
   @override
   String get skillsImportManualTitle => '手动添加';
@@ -6977,7 +6977,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsImportFileLabel => '从文件导入';
 
   @override
-  String get skillsImportChoiceTitle => '导入 skills';
+  String get skillsImportChoiceTitle => '导入技能';
 
   @override
   String get skillsImportFromFile => '从文件导入';
@@ -6999,13 +6999,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '选择要导入的 skills';
+  String get skillsGitHubSelectTitle => '选择要导入的技能';
 
   @override
-  String get skillsEmptyMessage => '暂无 skills。从文件导入或手动创建一个。';
+  String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
 
   @override
-  String get skillsDeleteConfirmTitle => '删除 skills';
+  String get skillsDeleteConfirmTitle => '删除技能';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -7014,7 +7014,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已导入 $count 个 skills';
+    return '已导入 $count 个技能';
   }
 
   @override
@@ -7027,29 +7027,29 @@ class AppLocalizationsZh extends AppLocalizations {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String get skillsNameInvalid => 'skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
+  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '保存 skills 失败：$detail';
+    return '保存技能失败：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '导入 $count 个 skills 失败';
+    return '导入 $count 个技能失败';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '删除';
 
   @override
-  String get assistantEditPageSkillsTab => 'skills';
+  String get assistantEditPageSkillsTab => '技能';
 
   @override
-  String get settingsPageSkills => 'skills';
+  String get settingsPageSkills => '技能';
 
   @override
   String get skillsUncategorizedGroup => '未分类';
@@ -7081,11 +7081,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsClearAll => '全部清除';
 
   @override
-  String get skillsEnableImportedTitle => '启用 skills？';
+  String get skillsEnableImportedTitle => '启用技能？';
 
   @override
   String skillsEnableImportedMessage(int count, String assistantName) {
-    return '为“$assistantName”启用 $count 个已导入的 skills？';
+    return '为“$assistantName”启用 $count 个已导入的技能？';
   }
 
   @override
@@ -7095,10 +7095,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get skillsEnableImportedDismiss => '暂不';
 
   @override
-  String get skillsSheetManageAction => '管理 skills';
+  String get skillsSheetManageAction => '管理技能';
 
   @override
-  String get skillsSheetImportAction => '导入 skills';
+  String get skillsSheetImportAction => '导入技能';
 
   @override
   String responseTruncated(String reason) {
@@ -13731,14 +13731,14 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       '委派任务并等待子助手的完整输出作为工具结果。';
 
   @override
-  String get assistantEditSkillDownloadTitle => '下载 Skills';
+  String get assistantEditSkillDownloadTitle => '下载技能';
 
   @override
   String get assistantEditSkillDownloadSubtitle =>
       '允许助手通过 GitHub 仓库 URL 下载并安装技能。';
 
   @override
-  String get assistantEditSkillCreateTitle => '创建 Skills';
+  String get assistantEditSkillCreateTitle => '创建技能';
 
   @override
   String get assistantEditSkillCreateSubtitle => '允许助手根据 SKILL.md 内容创建新技能。';
@@ -14915,7 +14915,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get multiAIAddModelTooltip => '添加模型';
 
   @override
-  String get skillsTitle => 'skills';
+  String get skillsTitle => '技能';
 
   @override
   String get skillsImportManualTitle => '手动添加';
@@ -14927,7 +14927,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsImportFileLabel => '从文件导入';
 
   @override
-  String get skillsImportChoiceTitle => '导入 skills';
+  String get skillsImportChoiceTitle => '导入技能';
 
   @override
   String get skillsImportFromFile => '从文件导入';
@@ -14949,13 +14949,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsGitHubDownloadFailed => '下载仓库失败。仓库可能不存在或为私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '选择要导入的 skills';
+  String get skillsGitHubSelectTitle => '选择要导入的技能';
 
   @override
-  String get skillsEmptyMessage => '暂无 skills。从文件导入或手动创建一个。';
+  String get skillsEmptyMessage => '暂无技能。从文件导入或手动创建一个。';
 
   @override
-  String get skillsDeleteConfirmTitle => '删除 skills';
+  String get skillsDeleteConfirmTitle => '删除技能';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -14964,7 +14964,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已导入 $count 个 skills';
+    return '已导入 $count 个技能';
   }
 
   @override
@@ -14977,29 +14977,29 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       'SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。';
 
   @override
-  String get skillsNameInvalid => 'skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
+  String get skillsNameInvalid => '技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元数据必须包含 name 字段。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '保存 skills 失败：$detail';
+    return '保存技能失败：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '导入 $count 个 skills 失败';
+    return '导入 $count 个技能失败';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '删除';
 
   @override
-  String get assistantEditPageSkillsTab => 'skills';
+  String get assistantEditPageSkillsTab => '技能';
 
   @override
-  String get settingsPageSkills => 'skills';
+  String get settingsPageSkills => '技能';
 
   @override
   String get skillsUncategorizedGroup => '未分类';
@@ -15031,11 +15031,11 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsClearAll => '全部清除';
 
   @override
-  String get skillsEnableImportedTitle => '启用 skills？';
+  String get skillsEnableImportedTitle => '启用技能？';
 
   @override
   String skillsEnableImportedMessage(int count, String assistantName) {
-    return '为“$assistantName”启用 $count 个已导入的 skills？';
+    return '为“$assistantName”启用 $count 个已导入的技能？';
   }
 
   @override
@@ -15045,10 +15045,10 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get skillsEnableImportedDismiss => '暂不';
 
   @override
-  String get skillsSheetManageAction => '管理 skills';
+  String get skillsSheetManageAction => '管理技能';
 
   @override
-  String get skillsSheetImportAction => '导入 skills';
+  String get skillsSheetImportAction => '导入技能';
 
   @override
   String responseTruncated(String reason) {
@@ -21680,14 +21680,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       '委派任務並等待子助手的完整輸出作為工具結果。';
 
   @override
-  String get assistantEditSkillDownloadTitle => '下載 Skills';
+  String get assistantEditSkillDownloadTitle => '下載技能';
 
   @override
   String get assistantEditSkillDownloadSubtitle =>
       '允許助手透過 GitHub 儲存庫 URL 下載並安裝技能。';
 
   @override
-  String get assistantEditSkillCreateTitle => '建立 Skills';
+  String get assistantEditSkillCreateTitle => '建立技能';
 
   @override
   String get assistantEditSkillCreateSubtitle => '允許助手根據 SKILL.md 內容建立新技能。';
@@ -22864,7 +22864,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get multiAIAddModelTooltip => '新增模型';
 
   @override
-  String get skillsTitle => 'skills';
+  String get skillsTitle => '技能';
 
   @override
   String get skillsImportManualTitle => '手動新增';
@@ -22876,7 +22876,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsImportFileLabel => '從檔案匯入';
 
   @override
-  String get skillsImportChoiceTitle => '匯入 skills';
+  String get skillsImportChoiceTitle => '匯入技能';
 
   @override
   String get skillsImportFromFile => '從檔案匯入';
@@ -22898,13 +22898,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsGitHubDownloadFailed => '下載儲存庫失敗。儲存庫可能不存在或為私有。';
 
   @override
-  String get skillsGitHubSelectTitle => '選擇要匯入的 skills';
+  String get skillsGitHubSelectTitle => '選擇要匯入的技能';
 
   @override
-  String get skillsEmptyMessage => '暫無 skills。從檔案匯入或手動建立一個。';
+  String get skillsEmptyMessage => '暫無技能。從檔案匯入或手動建立一個。';
 
   @override
-  String get skillsDeleteConfirmTitle => '刪除 skills';
+  String get skillsDeleteConfirmTitle => '刪除技能';
 
   @override
   String skillsDeleteConfirmMessage(String name) {
@@ -22913,7 +22913,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String skillsImportSuccess(int count) {
-    return '已匯入 $count 個 skills';
+    return '已匯入 $count 個技能';
   }
 
   @override
@@ -22926,29 +22926,29 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
       'SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。';
 
   @override
-  String get skillsNameInvalid => 'skills 名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。';
+  String get skillsNameInvalid => '技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。';
 
   @override
   String get skillsFrontmatterNameMissing => 'SKILL.md 前置元資料必須包含 name 欄位。';
 
   @override
   String skillsSaveFailed(String detail) {
-    return '儲存 skills 失敗：$detail';
+    return '儲存技能失敗：$detail';
   }
 
   @override
   String skillsImportFailed(int count) {
-    return '匯入 $count 個 skills 失敗';
+    return '匯入 $count 個技能失敗';
   }
 
   @override
   String get skillsDeleteConfirmDeleteButton => '刪除';
 
   @override
-  String get assistantEditPageSkillsTab => 'skills';
+  String get assistantEditPageSkillsTab => '技能';
 
   @override
-  String get settingsPageSkills => 'skills';
+  String get settingsPageSkills => '技能';
 
   @override
   String get skillsUncategorizedGroup => '未分類';
@@ -22980,11 +22980,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsClearAll => '全部清除';
 
   @override
-  String get skillsEnableImportedTitle => '啟用 skills？';
+  String get skillsEnableImportedTitle => '啟用技能？';
 
   @override
   String skillsEnableImportedMessage(int count, String assistantName) {
-    return '為「$assistantName」啟用 $count 個已匯入的 skills？';
+    return '為「$assistantName」啟用 $count 個已匯入的技能？';
   }
 
   @override
@@ -22994,10 +22994,10 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get skillsEnableImportedDismiss => '暫不';
 
   @override
-  String get skillsSheetManageAction => '管理 skills';
+  String get skillsSheetManageAction => '管理技能';
 
   @override
-  String get skillsSheetImportAction => '匯入 skills';
+  String get skillsSheetImportAction => '匯入技能';
 
   @override
   String responseTruncated(String reason) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2032,9 +2032,9 @@
   "assistantEditLocalToolHandoffSubtitle": "将任务委派给另一个助手的新对话，无需等待结果。",
   "assistantEditLocalToolHandoffSyncTitle": "同步交接",
   "assistantEditLocalToolHandoffSyncSubtitle": "委派任务并等待子助手的完整输出作为工具结果。",
-  "assistantEditSkillDownloadTitle": "下载 Skills",
+  "assistantEditSkillDownloadTitle": "下载技能",
   "assistantEditSkillDownloadSubtitle": "允许助手通过 GitHub 仓库 URL 下载并安装技能。",
-  "assistantEditSkillCreateTitle": "创建 Skills",
+  "assistantEditSkillCreateTitle": "创建技能",
   "assistantEditSkillCreateSubtitle": "允许助手根据 SKILL.md 内容创建新技能。",
   "assistantEditMemorySwitchTitle": "记忆",
   "assistantEditMemorySwitchDescription": "允许助手主动存储并在对话间引用用户相关信息",
@@ -2754,20 +2754,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按钮的提示"
   },
-  "skillsTitle": "skills",
+  "skillsTitle": "技能",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
-  "skillsImportChoiceTitle": "导入 skills",
+  "skillsImportChoiceTitle": "导入技能",
   "skillsImportFromFile": "从文件导入",
   "skillsImportFromGitHub": "从 GitHub URL 导入",
   "skillsGitHubImportTitle": "从 GitHub 导入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
-  "skillsGitHubSelectTitle": "选择要导入的 skills",
-  "skillsEmptyMessage": "暂无 skills。从文件导入或手动创建一个。",
-  "skillsDeleteConfirmTitle": "删除 skills",
+  "skillsGitHubSelectTitle": "选择要导入的技能",
+  "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
+  "skillsDeleteConfirmTitle": "删除技能",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2776,7 +2776,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已导入 {count} 个 skills",
+  "skillsImportSuccess": "已导入 {count} 个技能",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2796,9 +2796,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNameInvalid": "skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
+  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
-  "skillsSaveFailed": "保存 skills 失败：{detail}",
+  "skillsSaveFailed": "保存技能失败：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2806,7 +2806,7 @@
       }
     }
   },
-  "skillsImportFailed": "导入 {count} 个 skills 失败",
+  "skillsImportFailed": "导入 {count} 个技能失败",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2815,8 +2815,8 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "删除",
-  "assistantEditPageSkillsTab": "skills",
-  "settingsPageSkills": "skills",
+  "assistantEditPageSkillsTab": "技能",
+  "settingsPageSkills": "技能",
   "skillsUncategorizedGroup": "未分类",
   "skillsEditCategoryTitle": "编辑分类",
   "skillsCategoryHint": "例如：编程、写作、研究",
@@ -2836,8 +2836,8 @@
   "skillsSelectAll": "全选",
   "skillsDeselectAll": "全不选",
   "skillsClearAll": "全部清除",
-  "skillsEnableImportedTitle": "启用 skills？",
-  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的 skills？",
+  "skillsEnableImportedTitle": "启用技能？",
+  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的技能？",
   "@skillsEnableImportedMessage": {
     "placeholders": {
       "count": {
@@ -2850,8 +2850,8 @@
   },
   "skillsEnableImportedAction": "启用",
   "skillsEnableImportedDismiss": "暂不",
-  "skillsSheetManageAction": "管理 skills",
-  "skillsSheetImportAction": "导入 skills",
+  "skillsSheetManageAction": "管理技能",
+  "skillsSheetImportAction": "导入技能",
   "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
   "@responseTruncated": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2068,9 +2068,9 @@
   "assistantEditLocalToolHandoffSubtitle": "将任务委派给另一个助手的新对话，无需等待结果。",
   "assistantEditLocalToolHandoffSyncTitle": "同步交接",
   "assistantEditLocalToolHandoffSyncSubtitle": "委派任务并等待子助手的完整输出作为工具结果。",
-  "assistantEditSkillDownloadTitle": "下载 Skills",
+  "assistantEditSkillDownloadTitle": "下载技能",
   "assistantEditSkillDownloadSubtitle": "允许助手通过 GitHub 仓库 URL 下载并安装技能。",
-  "assistantEditSkillCreateTitle": "创建 Skills",
+  "assistantEditSkillCreateTitle": "创建技能",
   "assistantEditSkillCreateSubtitle": "允许助手根据 SKILL.md 内容创建新技能。",
   "assistantEditMemorySwitchTitle": "记忆",
   "assistantEditMemorySwitchDescription": "允许助手主动存储并在对话间引用用户相关信息",
@@ -2755,20 +2755,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按钮的提示"
   },
-  "skillsTitle": "skills",
+  "skillsTitle": "技能",
   "skillsImportManualTitle": "手动添加",
   "skillsImportManualHint": "粘贴完整的 SKILL.md 内容（包含 YAML 前置元数据）",
   "skillsImportFileLabel": "从文件导入",
-  "skillsImportChoiceTitle": "导入 skills",
+  "skillsImportChoiceTitle": "导入技能",
   "skillsImportFromFile": "从文件导入",
   "skillsImportFromGitHub": "从 GitHub URL 导入",
   "skillsGitHubImportTitle": "从 GitHub 导入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "无效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下载仓库失败。仓库可能不存在或为私有。",
-  "skillsGitHubSelectTitle": "选择要导入的 skills",
-  "skillsEmptyMessage": "暂无 skills。从文件导入或手动创建一个。",
-  "skillsDeleteConfirmTitle": "删除 skills",
+  "skillsGitHubSelectTitle": "选择要导入的技能",
+  "skillsEmptyMessage": "暂无技能。从文件导入或手动创建一个。",
+  "skillsDeleteConfirmTitle": "删除技能",
   "skillsDeleteConfirmMessage": "确定删除 \"{name}\"？此操作不可撤销。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2777,7 +2777,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已导入 {count} 个 skills",
+  "skillsImportSuccess": "已导入 {count} 个技能",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2797,9 +2797,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必须包含有效的 YAML 前置元数据且包含 name 字段。",
-  "skillsNameInvalid": "skills 名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
+  "skillsNameInvalid": "技能名称无效。仅允许小写字母、数字和连字符（不能包含空格、斜杠或点号）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元数据必须包含 name 字段。",
-  "skillsSaveFailed": "保存 skills 失败：{detail}",
+  "skillsSaveFailed": "保存技能失败：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2807,7 +2807,7 @@
       }
     }
   },
-  "skillsImportFailed": "导入 {count} 个 skills 失败",
+  "skillsImportFailed": "导入 {count} 个技能失败",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2816,8 +2816,8 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "删除",
-  "assistantEditPageSkillsTab": "skills",
-  "settingsPageSkills": "skills",
+  "assistantEditPageSkillsTab": "技能",
+  "settingsPageSkills": "技能",
   "skillsUncategorizedGroup": "未分类",
   "skillsEditCategoryTitle": "编辑分类",
   "skillsCategoryHint": "例如：编程、写作、研究",
@@ -2837,8 +2837,8 @@
   "skillsSelectAll": "全选",
   "skillsDeselectAll": "全不选",
   "skillsClearAll": "全部清除",
-  "skillsEnableImportedTitle": "启用 skills？",
-  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的 skills？",
+  "skillsEnableImportedTitle": "启用技能？",
+  "skillsEnableImportedMessage": "为“{assistantName}”启用 {count} 个已导入的技能？",
   "@skillsEnableImportedMessage": {
     "placeholders": {
       "count": {
@@ -2851,8 +2851,8 @@
   },
   "skillsEnableImportedAction": "启用",
   "skillsEnableImportedDismiss": "暂不",
-  "skillsSheetManageAction": "管理 skills",
-  "skillsSheetImportAction": "导入 skills",
+  "skillsSheetManageAction": "管理技能",
+  "skillsSheetImportAction": "导入技能",
   "responseTruncated": "回答已被截断（{reason}），内容可能不完整",
   "@responseTruncated": {
     "placeholders": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2023,9 +2023,9 @@
   "assistantEditLocalToolHandoffSubtitle": "將任務委派給另一個助手的新對話，無需等待結果。",
   "assistantEditLocalToolHandoffSyncTitle": "同步交接",
   "assistantEditLocalToolHandoffSyncSubtitle": "委派任務並等待子助手的完整輸出作為工具結果。",
-  "assistantEditSkillDownloadTitle": "下載 Skills",
+  "assistantEditSkillDownloadTitle": "下載技能",
   "assistantEditSkillDownloadSubtitle": "允許助手透過 GitHub 儲存庫 URL 下載並安裝技能。",
-  "assistantEditSkillCreateTitle": "建立 Skills",
+  "assistantEditSkillCreateTitle": "建立技能",
   "assistantEditSkillCreateSubtitle": "允許助手根據 SKILL.md 內容建立新技能。",
   "assistantEditMemorySwitchTitle": "記憶",
   "assistantEditMemorySwitchDescription": "允許助理主動儲存並在對話間引用使用者相關資訊",
@@ -2755,20 +2755,20 @@
   "@multiAIAddModelTooltip": {
     "description": "多AI卡片底部添加模型按鈕的提示"
   },
-  "skillsTitle": "skills",
+  "skillsTitle": "技能",
   "skillsImportManualTitle": "手動新增",
   "skillsImportManualHint": "貼上完整的 SKILL.md 內容（包含 YAML 前置元資料）",
   "skillsImportFileLabel": "從檔案匯入",
-  "skillsImportChoiceTitle": "匯入 skills",
+  "skillsImportChoiceTitle": "匯入技能",
   "skillsImportFromFile": "從檔案匯入",
   "skillsImportFromGitHub": "從 GitHub URL 匯入",
   "skillsGitHubImportTitle": "從 GitHub 匯入",
   "skillsGitHubUrlHint": "https://github.com/owner/repo[/tree/branch[/path]]",
   "skillsGitHubUrlInvalid": "無效的 GitHub URL。",
   "skillsGitHubDownloadFailed": "下載儲存庫失敗。儲存庫可能不存在或為私有。",
-  "skillsGitHubSelectTitle": "選擇要匯入的 skills",
-  "skillsEmptyMessage": "暫無 skills。從檔案匯入或手動建立一個。",
-  "skillsDeleteConfirmTitle": "刪除 skills",
+  "skillsGitHubSelectTitle": "選擇要匯入的技能",
+  "skillsEmptyMessage": "暫無技能。從檔案匯入或手動建立一個。",
+  "skillsDeleteConfirmTitle": "刪除技能",
   "skillsDeleteConfirmMessage": "確定刪除 \"{name}\"？此操作不可復原。",
   "@skillsDeleteConfirmMessage": {
     "placeholders": {
@@ -2777,7 +2777,7 @@
       }
     }
   },
-  "skillsImportSuccess": "已匯入 {count} 個 skills",
+  "skillsImportSuccess": "已匯入 {count} 個技能",
   "@skillsImportSuccess": {
     "placeholders": {
       "count": {
@@ -2797,9 +2797,9 @@
     }
   },
   "skillsInvalidFrontmatter": "SKILL.md 必須包含有效的 YAML 前置元資料且包含 name 欄位。",
-  "skillsNameInvalid": "skills 名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。",
+  "skillsNameInvalid": "技能名稱無效。僅允許小寫字母、數字和連字號（不能包含空格、斜線或點號）。",
   "skillsFrontmatterNameMissing": "SKILL.md 前置元資料必須包含 name 欄位。",
-  "skillsSaveFailed": "儲存 skills 失敗：{detail}",
+  "skillsSaveFailed": "儲存技能失敗：{detail}",
   "@skillsSaveFailed": {
     "placeholders": {
       "detail": {
@@ -2807,7 +2807,7 @@
       }
     }
   },
-  "skillsImportFailed": "匯入 {count} 個 skills 失敗",
+  "skillsImportFailed": "匯入 {count} 個技能失敗",
   "@skillsImportFailed": {
     "placeholders": {
       "count": {
@@ -2816,8 +2816,8 @@
     }
   },
   "skillsDeleteConfirmDeleteButton": "刪除",
-  "assistantEditPageSkillsTab": "skills",
-  "settingsPageSkills": "skills",
+  "assistantEditPageSkillsTab": "技能",
+  "settingsPageSkills": "技能",
   "skillsUncategorizedGroup": "未分類",
   "skillsEditCategoryTitle": "編輯分類",
   "skillsCategoryHint": "例如：程式設計、寫作、研究",
@@ -2837,8 +2837,8 @@
   "skillsSelectAll": "全選",
   "skillsDeselectAll": "全不選",
   "skillsClearAll": "全部清除",
-  "skillsEnableImportedTitle": "啟用 skills？",
-  "skillsEnableImportedMessage": "為「{assistantName}」啟用 {count} 個已匯入的 skills？",
+  "skillsEnableImportedTitle": "啟用技能？",
+  "skillsEnableImportedMessage": "為「{assistantName}」啟用 {count} 個已匯入的技能？",
   "@skillsEnableImportedMessage": {
     "placeholders": {
       "count": {
@@ -2851,8 +2851,8 @@
   },
   "skillsEnableImportedAction": "啟用",
   "skillsEnableImportedDismiss": "暫不",
-  "skillsSheetManageAction": "管理 skills",
-  "skillsSheetImportAction": "匯入 skills",
+  "skillsSheetManageAction": "管理技能",
+  "skillsSheetImportAction": "匯入技能",
   "responseTruncated": "回答已被截斷（{reason}），內容可能不完整",
   "@responseTruncated": {
     "placeholders": {


### PR DESCRIPTION
Fixes #349.

### 问题
中文界面下 skills 相关文案仍显示英文 "skills"（标题、设置页入口、助手编辑页标签、导入/删除/管理按钮、空状态、成功/失败提示等），与 #265 诉求一致但一直未落地。

### 修改
在 `app_zh.arb` / `app_zh_Hans.arb` / `app_zh_Hant.arb` 中将 17 个键的 "skills" 统一汉化为「技能」：

- `skillsTitle`、`settingsPageSkills`、`assistantEditPageSkillsTab`：skills → 技能
- `assistantEditSkillDownloadTitle` / `assistantEditSkillCreateTitle`：下载/创建 Skills → 下载/创建技能
- `skillsImportChoiceTitle`、`skillsSheetImportAction`、`skillsGitHubSelectTitle`、`skillsImportFromFile` 等：导入 skills → 导入技能
- `skillsEmptyMessage`：暂无 skills → 暂无技能
- `skillsImportSuccess`：已导入 {count} 个 skills → 已导入 {count} 个技能
- `skillsDeleteConfirmTitle`、`skillsNameInvalid`、`skillsSaveFailed`、`skillsImportFailed`、`skillsEnableImportedTitle`、`skillsEnableImportedMessage`、`skillsSheetManageAction`：同样汉化

同步用 gen-l10n 模拟器重新生成了 `app_localizations_zh.dart`（值与 CI `flutter gen-l10n` 输出逐字节一致）。