### PR TITLE
fix(mcp): auto-reconnect MCP servers on network change / app restart

### DIFF
--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -436,6 +436,10 @@ class McpProvider extends ChangeNotifier {
   final Set<String> _reconnecting = <String>{};
   // Heartbeat timers for live-connection health checks
   final Map<String, Timer> _heartbeats = <String, Timer>{};
+  // Transport-disconnect listeners: trigger an automatic reconnect when the
+  // connection drops (network switch / restore), unless we disconnected
+  // intentionally.
+  final _disconnectSubs = <String, StreamSubscription<mcp.DisconnectReason>>{};
   Duration _requestTimeout = const Duration(seconds: 30);
 
   final McpStdioCommandResolver _stdioCommandResolver =
@@ -1263,22 +1267,47 @@ class McpProvider extends ChangeNotifier {
       // debugPrint('[MCP/Connected] id=$id (${server.name})');
       notifyListeners();
 
+      // React to transport drops (network switch, server restart, session
+      // expiry) by marking the server errored and scheduling an automatic
+      // reconnect. Intentional disconnects emit
+      // [mcp.DisconnectReason.clientDisconnected] and are ignored.
+      _disconnectSubs[id]?.cancel();
+      _disconnectSubs[id] = client.onDisconnect.listen((reason) {
+        if (reason == mcp.DisconnectReason.clientDisconnected) return;
+        if (!_servers.any((s) => s.id == id && s.enabled)) return;
+        // debugPrint('[MCP/Disconnect] transport dropped id=$id reason=$reason');
+        _status[id] = McpStatus.error;
+        _errors[id] = 'MCP connection lost: $reason';
+        notifyListeners();
+        unawaited(_reconnectWithBackoff(id, maxAttempts: 3));
+      });
+
       // Try to refresh tools once connected
       // debugPrint('[MCP/Tools] refreshing tools for id=$id ...');
       await refreshTools(id);
       // debugPrint('[MCP/Tools] refresh done for id=$id');
-
-      // Start/refresh heartbeat for this connection
-      _startHeartbeat(
-        id,
-        interval: Duration(seconds: server.heartbeatIntervalSeconds ?? 12),
-      );
     } catch (e) {
       // debugPrint('[MCP/Error] connect failed for id=$id (${server.name})');
       // _logMcpException('connect', serverId: id, error: e, stack: st);
       _status[id] = McpStatus.error;
       _errors[id] = e.toString();
       notifyListeners();
+    } finally {
+      // Keep a supervisor heartbeat for every enabled server — including when
+      // connect() failed (e.g. the network was down at startup). Later ticks
+      // retry the connection, so the server reconnects automatically once the
+      // network is back instead of staying in the error state forever.
+      // OAuth servers that are still awaiting authorization are excluded —
+      // they connect right after the OAuth flow completes.
+      final cfg = getById(id);
+      final needsOAuth =
+          cfg != null && cfg.oauth != null && cfg.oauthToken == null;
+      if (cfg != null && cfg.enabled && !needsOAuth) {
+        _startHeartbeat(
+          id,
+          interval: Duration(seconds: server.heartbeatIntervalSeconds ?? 12),
+        );
+      }
     }
   }
 
@@ -1310,6 +1339,7 @@ class McpProvider extends ChangeNotifier {
       // debugPrint('[MCP/Error] disconnect failed for id=$id');
       // _logMcpException('disconnect', serverId: id, error: e, stack: st);
     }
+    _disconnectSubs.remove(id)?.cancel();
     _status[id] = McpStatus.idle;
     _errors.remove(id);
     _stopHeartbeat(id);
@@ -1343,30 +1373,45 @@ class McpProvider extends ChangeNotifier {
   }) {
     _stopHeartbeat(id);
     _heartbeats[id] = Timer.periodic(interval, (t) async {
-      // Heartbeat only when we think we're connected
-      if (!isConnected(id)) return;
-      final client = _clients[id];
-      if (client == null) return;
-      try {
-        // A lightweight call to verify liveness
-        // listTools is relatively cheap and available
-        final fut = client.listTools(logTags: {'reason': 'heartbeat'});
-        // Add a soft timeout to avoid piling up
-        await fut.timeout(const Duration(seconds: 6));
-      } catch (e) {
-        // Rate-limited? Server is alive — skip this tick, don't reconnect.
-        if (_isRateLimitError(e)) return;
-        // debugPrint('[MCP/Heartbeat] liveness check failed id=$id');
-        // Consider connection lost; mark error and try auto-reconnect
-        _status[id] = McpStatus.error;
-        _errors[id] = e.toString();
-        notifyListeners();
-        await _reconnectWithBackoff(id, maxAttempts: 3);
-        // If reconnected, restart heartbeat (connect() also starts it)
-        if (!isConnected(id)) {
-          // keep error state; next heartbeat tick will be a no-op
+      // Supervisor heartbeat: only run for enabled servers and skip while a
+      // connect/retry is already in flight.
+      final server = getById(id);
+      if (server == null || !server.enabled) return;
+      if (_status[id] == McpStatus.connecting) return;
+      if (_reconnecting.contains(id)) return;
+
+      if (isConnected(id)) {
+        final client = _clients[id];
+        if (client == null) return;
+        try {
+          // A lightweight call to verify liveness
+          // listTools is relatively cheap and available
+          final fut = client.listTools(logTags: {'reason': 'heartbeat'});
+          // Add a soft timeout to avoid piling up
+          await fut.timeout(const Duration(seconds: 6));
+        } catch (e) {
+          // Rate-limited? Server is alive — skip this tick, don't reconnect.
+          if (_isRateLimitError(e)) return;
+          // debugPrint('[MCP/Heartbeat] liveness check failed id=$id');
+          // Consider connection lost; mark error and try auto-reconnect
+          _status[id] = McpStatus.error;
+          _errors[id] = e.toString();
+          notifyListeners();
+          await _reconnectWithBackoff(id, maxAttempts: 3);
+          // If reconnected, restart heartbeat (connect() also starts it);
+          // otherwise keep the error state and retry on a later tick.
         }
+        return;
       }
+
+      // Not connected (initial connect failed, or a previous reconnect gave
+      // up while the network was still down). Retry so the server reconnects
+      // automatically once the network is back. Skip OAuth servers that are
+      // still awaiting authorization — they connect after the OAuth flow.
+      final needsOAuth = server.oauth != null && server.oauthToken == null;
+      if (needsOAuth) return;
+      // debugPrint('[MCP/Heartbeat] auto-retrying connection id=$id');
+      await _reconnectWithBackoff(id, maxAttempts: 2);
     });
   }
 
@@ -1841,6 +1886,11 @@ class McpProvider extends ChangeNotifier {
       t.cancel();
     }
     _heartbeats.clear();
+    // Clean up transport-disconnect listeners
+    for (final sub in _disconnectSubs.values) {
+      sub.cancel();
+    }
+    _disconnectSubs.clear();
     super.dispose();
   }
 

--- a/test/core/providers/mcp_auto_reconnect_test.dart
+++ b/test/core/providers/mcp_auto_reconnect_test.dart
@@ -10,8 +10,23 @@ import 'package:Cuplivo/core/providers/mcp_provider.dart';
 /// `notifications/initialized` and `tools/list` so mcp_client can complete
 /// a real connect handshake. No `MCP-Session-Id` header is sent, so the
 /// transport stays in pure request/response mode (no SSE GET stream).
+///
+/// Binds to [port], retrying briefly in case another concurrently-running
+/// test grabbed the port between probe and bind.
 Future<HttpServer> _startMcpServer(int port) async {
-  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+  for (var attempt = 0; attempt < 5; attempt++) {
+    try {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+      _attachMcpHandler(server);
+      return server;
+    } on SocketException {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+  }
+  throw StateError('could not bind MCP test server to port $port');
+}
+
+void _attachMcpHandler(HttpServer server) {
   server.listen((request) async {
     if (request.method != 'POST') {
       request.response.statusCode = 405;
@@ -33,7 +48,9 @@ Future<HttpServer> _startMcpServer(int port) async {
           'result': {
             'protocolVersion': (msg['params'] as Map)['protocolVersion'],
             'serverInfo': {'name': 'Test MCP', 'version': '1.0.0'},
-            'capabilities': {'tools': true},
+            // mcp_client's ServerCapabilities.fromJson requires `tools` to
+            // be an object, not the spec's boolean `true`.
+            'capabilities': {'tools': <String, Object>{}},
           },
         }),
       );
@@ -54,7 +71,6 @@ Future<HttpServer> _startMcpServer(int port) async {
     }
     await response.close();
   });
-  return server;
 }
 
 /// Returns a port that is free right now (bound then released).

--- a/test/core/providers/mcp_auto_reconnect_test.dart
+++ b/test/core/providers/mcp_auto_reconnect_test.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/providers/mcp_provider.dart';
+
+/// Minimal MCP streamable-HTTP server. Answers `initialize`,
+/// `notifications/initialized` and `tools/list` so mcp_client can complete
+/// a real connect handshake. No `MCP-Session-Id` header is sent, so the
+/// transport stays in pure request/response mode (no SSE GET stream).
+Future<HttpServer> _startMcpServer(int port) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+  server.listen((request) async {
+    if (request.method != 'POST') {
+      request.response.statusCode = 405;
+      await request.response.close();
+      return;
+    }
+    final body = await utf8.decoder.bind(request).join();
+    final msg = jsonDecode(body) as Map<String, dynamic>;
+    final method = msg['method'];
+    final id = msg['id'];
+    final response = request.response;
+    response.headers.contentType = ContentType.json;
+    if (method == 'initialize') {
+      response.statusCode = 200;
+      response.write(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': id,
+          'result': {
+            'protocolVersion': (msg['params'] as Map)['protocolVersion'],
+            'serverInfo': {'name': 'Test MCP', 'version': '1.0.0'},
+            'capabilities': {'tools': true},
+          },
+        }),
+      );
+    } else if (method == 'notifications/initialized') {
+      response.statusCode = 202;
+    } else {
+      // tools/list and anything else: an empty result.
+      response.statusCode = 200;
+      response.write(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': id,
+          'result': {
+            'tools': <Object>[],
+          },
+        }),
+      );
+    }
+    await response.close();
+  });
+  return server;
+}
+
+/// Returns a port that is free right now (bound then released).
+Future<int> _freePort() async {
+  final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = probe.port;
+  await probe.close();
+  return port;
+}
+
+void main() {
+  test(
+    'an enabled server whose initial connect failed auto-reconnects once it '
+    'becomes reachable (network restore after app start)',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final port = await _freePort();
+
+      final provider = McpProvider(
+        contextProvider: () => throw UnimplementedError(),
+      );
+      final id = await provider.addServer(
+        enabled: true,
+        name: 'Auto Reconnect',
+        transport: McpTransportType.http,
+        url: 'http://127.0.0.1:$port/mcp',
+        // 1s supervisor heartbeat so the test does not wait 12s.
+        heartbeatIntervalSeconds: 1,
+      );
+      await pumpEventQueue();
+
+      // Phase 1: server is down — connect fails and the provider reports
+      // the error state (no tools available to the main agent).
+      expect(provider.isConnected(id), isFalse);
+      expect(provider.statusFor(id), McpStatus.error);
+
+      // Phase 2: server comes up (e.g. the network is restored). The
+      // supervisor heartbeat must reconnect automatically without any
+      // user action.
+      final server = await _startMcpServer(port);
+      try {
+        final deadline = DateTime.now().add(const Duration(seconds: 10));
+        while (DateTime.now().isBefore(deadline)) {
+          if (provider.isConnected(id)) break;
+          await Future<void>.delayed(const Duration(milliseconds: 250));
+        }
+        expect(
+          provider.isConnected(id),
+          isTrue,
+          reason: 'supervisor heartbeat should auto-reconnect the server',
+        );
+        expect(provider.statusFor(id), McpStatus.connected);
+        expect(provider.errorFor(id), isNull);
+      } finally {
+        // Cancel the supervisor heartbeat and the disconnect listener.
+        await provider.disconnect(id);
+        await server.close(force: true);
+      }
+    },
+  );
+}

--- a/test/core/providers/mcp_auto_reconnect_test.dart
+++ b/test/core/providers/mcp_auto_reconnect_test.dart
@@ -65,6 +65,19 @@ Future<int> _freePort() async {
   return port;
 }
 
+/// Polls [predicate] until it returns true or [timeout] elapses.
+Future<bool> _waitUntil(
+  Future<bool> Function() predicate,
+  Duration timeout,
+) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (await predicate()) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+  return predicate();
+}
+
 void main() {
   test(
     'an enabled server whose initial connect failed auto-reconnects once it '
@@ -76,6 +89,10 @@ void main() {
       final provider = McpProvider(
         contextProvider: () => throw UnimplementedError(),
       );
+      // Fail fast: mcp_client swallows transport errors, so a dead endpoint
+      // only surfaces after the request timeout (default 30s would make this
+      // test too slow). Each failed connect also retries 3x with 2s delays.
+      await provider.updateRequestTimeout(const Duration(milliseconds: 800));
       final id = await provider.addServer(
         enabled: true,
         name: 'Auto Reconnect',
@@ -86,23 +103,30 @@ void main() {
       );
       await pumpEventQueue();
 
-      // Phase 1: server is down — connect fails and the provider reports
-      // the error state (no tools available to the main agent).
+      // Phase 1: server is down — the initial connect fails and the provider
+      // lands in the error state (tools unavailable to the main agent).
+      final reachedError = await _waitUntil(
+        () async => provider.statusFor(id) == McpStatus.error,
+        const Duration(seconds: 12),
+      );
+      expect(
+        reachedError,
+        isTrue,
+        reason: 'connect to a dead endpoint should end in the error state',
+      );
       expect(provider.isConnected(id), isFalse);
-      expect(provider.statusFor(id), McpStatus.error);
 
       // Phase 2: server comes up (e.g. the network is restored). The
       // supervisor heartbeat must reconnect automatically without any
       // user action.
       final server = await _startMcpServer(port);
       try {
-        final deadline = DateTime.now().add(const Duration(seconds: 10));
-        while (DateTime.now().isBefore(deadline)) {
-          if (provider.isConnected(id)) break;
-          await Future<void>.delayed(const Duration(milliseconds: 250));
-        }
+        final reconnected = await _waitUntil(
+          () async => provider.isConnected(id),
+          const Duration(seconds: 15),
+        );
         expect(
-          provider.isConnected(id),
+          reconnected,
           isTrue,
           reason: 'supervisor heartbeat should auto-reconnect the server',
         );

--- a/test/core/providers/mcp_auto_reconnect_test.dart
+++ b/test/core/providers/mcp_auto_reconnect_test.dart
@@ -11,22 +11,20 @@ import 'package:Cuplivo/core/providers/mcp_provider.dart';
 /// a real connect handshake. No `MCP-Session-Id` header is sent, so the
 /// transport stays in pure request/response mode (no SSE GET stream).
 ///
-/// Binds to [port], retrying briefly in case another concurrently-running
-/// test grabbed the port between probe and bind.
-Future<HttpServer> _startMcpServer(int port) async {
-  for (var attempt = 0; attempt < 5; attempt++) {
-    try {
-      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
-      _attachMcpHandler(server);
-      return server;
-    } on SocketException {
-      await Future<void>.delayed(const Duration(milliseconds: 200));
-    }
-  }
-  throw StateError('could not bind MCP test server to port $port');
+/// While [authRequired] returns true every request is answered with a
+/// plain HTTP 401. mcp_client treats that as a JSON-RPC error message
+/// (not a transport stream error), so failed connects stay quiet — no
+/// unhandled stream errors in the test zone.
+Future<HttpServer> _startMcpServer(
+  int port, {
+  required bool Function() authRequired,
+}) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
+  _attachMcpHandler(server, authRequired);
+  return server;
 }
 
-void _attachMcpHandler(HttpServer server) {
+void _attachMcpHandler(HttpServer server, bool Function() authRequired) {
   server.listen((request) async {
     if (request.method != 'POST') {
       request.response.statusCode = 405;
@@ -39,6 +37,14 @@ void _attachMcpHandler(HttpServer server) {
     final id = msg['id'];
     final response = request.response;
     response.headers.contentType = ContentType.json;
+    if (authRequired()) {
+      // No OAuth is configured, so the client surfaces this as an
+      // McpError from initialize() and retries; it never emits an
+      // unhandled transport stream error.
+      response.statusCode = 401;
+      await response.close();
+      return;
+    }
     if (method == 'initialize') {
       response.statusCode = 200;
       response.write(
@@ -73,14 +79,6 @@ void _attachMcpHandler(HttpServer server) {
   });
 }
 
-/// Returns a port that is free right now (bound then released).
-Future<int> _freePort() async {
-  final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  final port = probe.port;
-  await probe.close();
-  return port;
-}
-
 /// Polls [predicate] until it returns true or [timeout] elapses.
 Future<bool> _waitUntil(
   Future<bool> Function() predicate,
@@ -96,19 +94,23 @@ Future<bool> _waitUntil(
 
 void main() {
   test(
-    'an enabled server whose initial connect failed auto-reconnects once it '
-    'becomes reachable (network restore after app start)',
+    'an enabled server whose initial connect failed auto-reconnects once the '
+    'server accepts connections again (network restore after app start)',
     () async {
       SharedPreferences.setMockInitialValues({});
-      final port = await _freePort();
+      // The server runs for the whole test: first rejecting every request
+      // (simulates the network being down / server unreachable), then
+      // accepting. Binding port 0 gives a real free port — no probe race.
+      var authRequired = true;
+      final server = await _startMcpServer(
+        0,
+        authRequired: () => authRequired,
+      );
+      final port = server.port;
 
       final provider = McpProvider(
         contextProvider: () => throw UnimplementedError(),
       );
-      // Fail fast: mcp_client swallows transport errors, so a dead endpoint
-      // only surfaces after the request timeout (default 30s would make this
-      // test too slow). Each failed connect also retries 3x with 2s delays.
-      await provider.updateRequestTimeout(const Duration(milliseconds: 800));
       final id = await provider.addServer(
         enabled: true,
         name: 'Auto Reconnect',
@@ -119,24 +121,25 @@ void main() {
       );
       await pumpEventQueue();
 
-      // Phase 1: server is down — the initial connect fails and the provider
-      // lands in the error state (tools unavailable to the main agent).
-      final reachedError = await _waitUntil(
-        () async => provider.statusFor(id) == McpStatus.error,
-        const Duration(seconds: 12),
-      );
-      expect(
-        reachedError,
-        isTrue,
-        reason: 'connect to a dead endpoint should end in the error state',
-      );
-      expect(provider.isConnected(id), isFalse);
-
-      // Phase 2: server comes up (e.g. the network is restored). The
-      // supervisor heartbeat must reconnect automatically without any
-      // user action.
-      final server = await _startMcpServer(port);
       try {
+        // Phase 1: server rejects requests — the initial connect fails and
+        // the provider lands in the error state (tools unavailable to the
+        // main agent).
+        final reachedError = await _waitUntil(
+          () async => provider.statusFor(id) == McpStatus.error,
+          const Duration(seconds: 12),
+        );
+        expect(
+          reachedError,
+          isTrue,
+          reason: 'a rejected connect should end in the error state',
+        );
+        expect(provider.isConnected(id), isFalse);
+
+        // Phase 2: server starts accepting (e.g. the network is restored).
+        // The supervisor heartbeat must reconnect automatically without any
+        // user action.
+        authRequired = false;
         final reconnected = await _waitUntil(
           () async => provider.isConnected(id),
           const Duration(seconds: 15),


### PR DESCRIPTION
## 问题

MCP 服务器在切换网络（Wi-Fi ↔ 4G/5G）或断网后重新打开 App 时不会自动重连，工具列表为空，主代理拿不到工具，只能手动重连（fixes #285）。

## 根因

`lib/core/providers/mcp_provider.dart` 的重连机制存在两个缺口：

1. **心跳只在连接成功后才启动，且失败后不再重试**：`_startHeartbeat` 只在 `connect()` 成功路径调用；tick 里 `if (!isConnected(id)) return;` 直接跳过。因此初始连接失败（如启动时断网）或一次重连失败（如切换网络瞬间）后，服务器永久停在 error 状态，即使网络恢复也不会再自动重连。
2. **对 transport 断开无反应**：连接意外断开（网络切换导致 SSE/HTTP 连接关闭）时没有任何事件驱动重连。

## 修复

- **`connect()` 订阅 `client.onDisconnect`**：transport 意外断开（网络切换、服务器重启、会话过期）时立即标记 error 并调度自动重连（`_reconnectWithBackoff`）；主动断开（`clientDisconnected`）忽略。
- **心跳升级为 supervisor**：`connect()` 的 `finally` 块为每个 enabled 服务器启动心跳（连接失败也启动）；每个 tick 在未连接时自动重试连接（`maxAttempts: 2`，受 `_reconnecting` 保护），因此断网恢复后服务器在下一个心跳周期内自动重连。待授权的 OAuth 服务器跳过。
- **`disconnect()` / `dispose()` 清理监听**。

## 测试

新增 `test/core/providers/mcp_auto_reconnect_test.dart`：启动真实本地 MCP HTTP 服务器，验证"初始连接失败的 enabled 服务器在服务器可达后自动重连"（旧代码下该测试会失败）。