### PR TITLE
fix(chat): theme details/summary block with elevated surfaces (black block in dark mode)

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -5612,10 +5612,11 @@ class _DetailsHtmlBlockState extends State<_DetailsHtmlBlock> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final surface = Color.alphaBlend(
-      cs.onSurface.withValues(alpha: isDark ? 0.05 : 0.025),
-      cs.surface,
-    );
+    // Issue #298: use the same elevated surfaces as code blocks instead of
+    // blending with cs.surface — the blend resolves to a near-black block in
+    // dark themes (and pure-black backgrounds), clashing with the theme.
+    final blockColor = cs.surfaceContainer;
+    final headerColor = cs.surfaceContainerHighest;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.18 : 0.30,
     );
@@ -5629,10 +5630,11 @@ class _DetailsHtmlBlockState extends State<_DetailsHtmlBlock> {
     final bodyConfig = widget.config.copyWith(style: bodyStyle);
 
     return Container(
+      key: const ValueKey('details-block'),
       width: double.infinity,
       margin: const EdgeInsets.symmetric(vertical: 4),
       decoration: BoxDecoration(
-        color: surface,
+        color: blockColor,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: borderColor, width: 0.8),
       ),
@@ -5641,33 +5643,37 @@ class _DetailsHtmlBlockState extends State<_DetailsHtmlBlock> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: [
-          IosCardPress(
-            onTap: () => setState(() => _expanded = !_expanded),
-            baseColor: Colors.transparent,
-            borderRadius: BorderRadius.circular(8),
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-            haptics: false,
-            child: Row(
-              children: [
-                AnimatedRotation(
-                  turns: _expanded ? 0.25 : 0.0,
-                  duration: const Duration(milliseconds: 160),
-                  curve: Curves.easeOutCubic,
-                  child: Icon(
-                    Lucide.ChevronRight,
-                    size: 15,
-                    color: cs.onSurfaceVariant.withValues(alpha: 0.78),
+          // Header row: slightly elevated header (mirrors code-block header).
+          Container(
+            color: headerColor,
+            child: IosCardPress(
+              onTap: () => setState(() => _expanded = !_expanded),
+              baseColor: Colors.transparent,
+              borderRadius: BorderRadius.circular(8),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              haptics: false,
+              child: Row(
+                children: [
+                  AnimatedRotation(
+                    turns: _expanded ? 0.25 : 0.0,
+                    duration: const Duration(milliseconds: 160),
+                    curve: Curves.easeOutCubic,
+                    child: Icon(
+                      Lucide.ChevronRight,
+                      size: 15,
+                      color: cs.onSurfaceVariant.withValues(alpha: 0.78),
+                    ),
                   ),
-                ),
-                const SizedBox(width: 7),
-                Expanded(
-                  child: Text(
-                    widget.summary,
-                    style: summaryStyle,
-                    softWrap: true,
+                  const SizedBox(width: 7),
+                  Expanded(
+                    child: Text(
+                      widget.summary,
+                      style: summaryStyle,
+                      softWrap: true,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           AnimatedSwitcher(

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3682,6 +3682,86 @@ void main() {
   );
 
   testWidgets(
+    'MarkdownWithCodeHighlight themes details block with elevated surfaces '
+    '(issue #298: no black block in dark mode)',
+    (tester) async {
+      const markdown = '<details><summary>更多信息</summary>隐藏内容</details>';
+
+      // Dark mode: the block must use the theme's elevated surface (same as
+      // code blocks) instead of a near-black blend of cs.surface.
+      final darkTheme = ThemeData(
+        brightness: Brightness.dark,
+        useMaterial3: true,
+      );
+      await tester.pumpWidget(
+        _markdownHarness(
+          markdown,
+          theme: darkTheme,
+          darkTheme: darkTheme,
+          themeMode: ThemeMode.dark,
+        ),
+      );
+      await tester.pump();
+
+      final block = tester.widget<Container>(
+        find.byKey(const ValueKey('details-block')),
+      );
+      expect(
+        (block.decoration! as BoxDecoration).color,
+        darkTheme.colorScheme.surfaceContainer,
+      );
+
+      // The summary header gets the code-block-style header surface.
+      // (Container(color:) stores the color in `color`, not `decoration`.)
+      final headerColor = darkTheme.colorScheme.surfaceContainerHighest;
+      final headerContainers = tester
+          .widgetList<Container>(
+            find.descendant(
+              of: find.byKey(const ValueKey('details-block')),
+              matching: find.byType(Container),
+            ),
+          )
+          .where(
+            (c) =>
+                c.color == headerColor ||
+                (c.decoration is BoxDecoration &&
+                    (c.decoration! as BoxDecoration).color == headerColor),
+          );
+      expect(headerContainers, isNotEmpty);
+
+      // Sanity: the block still collapses/expands in dark mode.
+      expect(find.text('隐藏内容', findRichText: true), findsNothing);
+      await tester.tap(find.text('更多信息'));
+      await tester.pumpAndSettle();
+      expect(find.text('隐藏内容', findRichText: true), findsOneWidget);
+
+      // Light mode: the block follows the light elevated surface too.
+      final lightTheme = ThemeData(
+        brightness: Brightness.light,
+        useMaterial3: true,
+      );
+      await tester.pumpWidget(
+        _markdownHarness(
+          markdown,
+          theme: lightTheme,
+          darkTheme: lightTheme,
+          themeMode: ThemeMode.light,
+        ),
+      );
+      // MaterialApp animates theme changes (AnimatedTheme), so settle it.
+      await tester.pumpAndSettle();
+
+      final lightBlock = tester.widget<Container>(
+        find.byKey(const ValueKey('details-block')),
+      );
+      expect(
+        (lightBlock.decoration! as BoxDecoration).color,
+        lightTheme.colorScheme.surfaceContainer,
+      );
+    },
+  );
+
+  testWidgets(
     'MarkdownWithCodeHighlight opens math export menu on long press',
     (tester) async {
       markdownMathTargetPlatformOverride = TargetPlatform.android;


### PR DESCRIPTION
## 修复内容（Issue #298）

### 问题根因

`<details>/<summary>` 折叠块在聊天中渲染成"黑色块"，与主题不协调。

根因在 `lib/shared/widgets/markdown_with_highlight.dart` 的 `_DetailsHtmlBlockState.build`：折叠块背景色通过 `Color.alphaBlend(cs.onSurface @ 5%, cs.surface)` 推导。在**深色模式下该混色结果接近黑色**——尤其应用启用"纯黑背景"（OLED/桌面端默认开启，此时 `cs.surface = #000000`）时，折叠块就是一个纯黑方块，边框也几乎不可见。

对比同一聊天中代码块的表现：代码块使用 M3 升高面 `cs.surfaceContainer` / `cs.surfaceContainerHighest`，深色下清晰可见、与主题协调。

### 修复方案

让折叠块复用与代码块一致的 M3 升高面：

- 折叠块背景：`cs.surfaceContainer`（浅色 = #F3EDF7，深色 = #211F26，跟随主题）
- summary 头部行：`cs.surfaceContainerHighest`（与代码块头部一致，强化可折叠提示）
- 文字/边框颜色保持主题推导（`cs.onSurface` / `cs.outlineVariant`），深/浅色模式均协调

### 测试

新增 widget 测试（`test/shared/widgets/markdown_with_highlight_test.dart`）：
- 深色模式下折叠块背景 == `ThemeData.dark().colorScheme.surfaceContainer`（非近黑色）
- summary 头部使用 `surfaceContainerHighest`
- 深色下折叠/展开行为正常
- 浅色模式同样跟随 `surfaceContainer`
