### PR TITLE
fix(android): remove nonexistent KeyEvent.ACTION_CANCEL constant

### DIFF
--- a/android/app/src/main/kotlin/com/cup11/cuplivo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : FlutterActivity() {
                 KeyEvent.ACTION_DOWN -> {
                     if (event.repeatCount == 0) plugin.emitVolumeCtrl(true)
                 }
-                KeyEvent.ACTION_UP, KeyEvent.ACTION_CANCEL -> {
+                KeyEvent.ACTION_UP -> {
                     plugin.emitVolumeCtrl(false)
                 }
             }


### PR DESCRIPTION
## Problem
The release APK build on master fails with a Kotlin compile error:

```
MainActivity.kt:62:46 Unresolved reference 'ACTION_CANCEL'
```

`android.view.KeyEvent` has no `ACTION_CANCEL` constant (it belongs to `MotionEvent`); key cancel events surface as `ACTION_UP` with `FLAG_CANCELED`.

## Fix
Drop the invalid `KeyEvent.ACTION_CANCEL` case; `ACTION_UP` already covers key release and cancel delivery.

## Verification
- Triggered `Flutter Multi-Platform Build Stable 3.44` on this branch with `build_android=true`, `publish_release=false` — Android job succeeded, 3 split-per-ABI release APKs produced.