### PR TITLE
fix(background): remove duplicate body-internal background to prevent keyboard shift

### DIFF
--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -891,9 +891,10 @@ class _HomePageState extends State<HomePage>
 
     return ChatInputOverlayLayout(
       topInset: _chatTopOverlayInset(context),
-      background: backgroundImageActive
-          ? _buildChatBackground(context, cs)
-          : null,
+      // The full-bleed background is already rendered by MobileBackgroundLayer
+      // outside the Scaffold (home_mobile_layout.dart). Placing a duplicate
+      // inside the Scaffold body causes it to shrink with the body when the
+      // keyboard opens (adjustResize), which visually shifts the image upward.
       topBackground: backgroundImageActive
           ? _buildChatBackground(context, cs)
           : null,


### PR DESCRIPTION
**⚠️ 探索性改动，未经真机验证。不保证能完全修复键盘弹出时背景跳动的问题。**

Addresses the keyboard background shift issue reviewed in #432.

## Analysis

Per the review on #432, the outer `MobileBackgroundLayer` (home_mobile_layout.dart:125) is a sibling of the Scaffold and is **not** affected by keyboard resize. The layer that shifts is the body-internal copy: `_buildMobileBody` passes `background: _buildChatBackground(…)` to `ChatInputOverlayLayout`, which renders it via `Positioned.fill` (chat_input_overlay_layout.dart:30) inside the Scaffold body. When `adjustResize` shrinks the body for the keyboard, `BoxFit.cover` recalculates and the image visually jumps.

## Fix

Remove the redundant `background` parameter from `ChatInputOverlayLayout` in `_buildMobileBody`. The outer `MobileBackgroundLayer` continues to provide the full-bleed background. The `topBackground` parameter is preserved for the top/bottom gradient overlay effects.

## Caveat

This fix is based on code-level analysis only. It has **not been verified on a real device**. If the actual issue is the entire window shrinking under `adjustResize` (affecting `MobileBackgroundLayer` as well), a different approach would be needed (e.g. switching `windowSoftInputMode` to `adjustPan` or using `MediaQuery.removeViewInsets`).

## Changes

- `lib/features/home/pages/home_page.dart`: Remove `background:` argument (3 lines), add explanatory comment (4 lines)
- 1 file changed, net +4/-3 lines