### PR TITLE
fix: chat service init race wiping assistants on launch

### DIFF
--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -56,6 +56,15 @@ class AssistantProvider extends ChangeNotifier {
 
   Future<void> ensureLoaded() async {
     if (_loaded) return;
+    final cs = chatService;
+    if (cs == null) return;
+    // Do not silently bail when the chat service is not initialized yet:
+    // callers (ensureDefaults → initChat) would then see an empty list and —
+    // because putAssistants replaces the whole table — could wipe real
+    // assistants with the defaults. Wait for init to finish instead.
+    if (!cs.initialized) {
+      await cs.init();
+    }
     final repo = _repo;
     if (repo == null) return;
     await _doLoad(repo);

--- a/lib/core/providers/assistant_provider.dart
+++ b/lib/core/providers/assistant_provider.dart
@@ -342,6 +342,25 @@ class AssistantProvider extends ChangeNotifier {
   Future<void> ensureDefaults(dynamic context) async {
     await ensureLoaded();
     if (_assistants.isNotEmpty) return;
+    final repo = _repo;
+    if (repo != null) {
+      final diskCount = await repo.getAssistantCount();
+      if (diskCount > 0) {
+        // Wipe guard: putAssistants replaces the whole table (delete-then-
+        // insert), so never seed defaults over a non-empty assistant table.
+        // If the in-memory load above raced or failed, re-read from disk and
+        // keep the real assistants instead of overwriting them.
+        await _doLoad(repo);
+        if (_assistants.isEmpty) {
+          debugPrint(
+            '[AssistantProvider.ensureDefaults] assistant table has '
+            '$diskCount rows but the reload came back empty; refusing to '
+            'overwrite with defaults',
+          );
+        }
+        return;
+      }
+    }
     final l10n = AppLocalizations.of(context)!;
     // 1) 默认助手
     _assistants.add(_defaultAssistant(l10n));

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -56,7 +56,24 @@ class ChatService extends ChangeNotifier {
     return id != null && _temporaryConversationIds.contains(id);
   }
 
-  Future<void> init() async {
+  /// Single-flight guard for [init].
+  ///
+  /// At startup several subsystems race to call [init] concurrently (e.g. the
+  /// side drawer preloads group chats while HomePageController boots the chat
+  /// service). Without this lock two Drift connections would open and migrate
+  /// the same SQLite file at once, corrupting reads (empty assistant/group
+  /// lists) and risking a wipe — see PR #403 regression where the side drawer
+  /// started forcing `GroupChatProvider.load()` → `init()` on the first frame.
+  Future<void>? _initFuture;
+
+  Future<void> init() {
+    if (_initialized) return Future.value();
+    return _initFuture ??= _doInit().whenComplete(() {
+      _initFuture = null;
+    });
+  }
+
+  Future<void> _doInit() async {
     if (_initialized) return;
 
     final appDataDir = await AppDirectories.getAppDataDirectory();

--- a/test/core/services/chat/chat_service_init_concurrency_test.dart
+++ b/test/core/services/chat/chat_service_init_concurrency_test.dart
@@ -93,6 +93,12 @@ void main() {
       final conversation = await service.createDraftConversation(
         title: 'race test',
       );
+      // Drafts only enter history once the first message is persisted.
+      await service.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'hello',
+      );
       expect(service.getAllConversations().map((c) => c.id), [
         conversation.id,
       ]);

--- a/test/core/services/chat/chat_service_init_concurrency_test.dart
+++ b/test/core/services/chat/chat_service_init_concurrency_test.dart
@@ -1,12 +1,18 @@
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 // ignore: depend_on_referenced_packages
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:drift/native.dart';
 
+import 'package:Cuplivo/core/database/app_database.dart';
+import 'package:Cuplivo/core/database/chat_database_repository.dart';
+import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
 
 /// Regression tests for PR #403 fallout:
 ///
@@ -17,10 +23,11 @@ import 'package:Cuplivo/core/providers/assistant_provider.dart';
 /// (with group chats still present), or everything gone — recoverable by
 /// restart because reads raced rather than data being lost.
 ///
-/// Fix: ChatService.init() is single-flight, and AssistantProvider
-/// .ensureLoaded() waits for init instead of silently bailing on an
-/// uninitialized chat service (which would let ensureDefaults() wipe the
-/// real assistant table with defaults via putAssistants).
+/// Fix: ChatService.init() is single-flight, AssistantProvider.ensureLoaded()
+/// waits for init instead of silently bailing on an uninitialized chat
+/// service, and ensureDefaults() refuses to seed defaults over a non-empty
+/// assistant table (putAssistants replaces the whole table, so an empty
+/// in-memory read must never turn into a disk wipe).
 class _FakePathProviderPlatform extends PathProviderPlatform {
   _FakePathProviderPlatform(this.path);
 
@@ -37,6 +44,38 @@ class _FakePathProviderPlatform extends PathProviderPlatform {
 
   @override
   Future<String?> getTemporaryPath() async => '$path/tmp';
+}
+
+/// Repository whose first [getAllAssistants] comes back empty even though the
+/// table has rows — simulating the raced/failed in-memory read that used to
+/// let `ensureDefaults` wipe real assistants with defaults.
+class _FlakyFirstReadRepository extends ChatDatabaseRepository {
+  _FlakyFirstReadRepository(super.db);
+
+  bool failFirstRead = false;
+  bool _firstReadConsumed = false;
+
+  @override
+  Future<List<Assistant>> getAllAssistants() async {
+    if (failFirstRead && !_firstReadConsumed) {
+      _firstReadConsumed = true;
+      return const [];
+    }
+    return super.getAllAssistants();
+  }
+}
+
+/// Chat service exposing a ready repository without touching the filesystem.
+class _ReadyChatService extends ChatService {
+  _ReadyChatService(this._testRepo);
+
+  final ChatDatabaseRepository _testRepo;
+
+  @override
+  bool get initialized => true;
+
+  @override
+  ChatDatabaseRepository get repo => _testRepo;
 }
 
 void main() {
@@ -68,41 +107,45 @@ void main() {
   }
 
   group('ChatService init single-flight', () {
-    test('second init() while first is in flight reuses the same future',
-        () async {
-      final service = createService();
-      final f1 = service.init();
-      final f2 = service.init();
-      expect(
-        identical(f1, f2),
-        isTrue,
-        reason: 'concurrent init() calls must share one initialization',
-      );
-      await Future.wait([f1, f2]);
-      expect(service.initialized, isTrue);
-    });
+    test(
+      'second init() while first is in flight reuses the same future',
+      () async {
+        final service = createService();
+        final f1 = service.init();
+        final f2 = service.init();
+        expect(
+          identical(f1, f2),
+          isTrue,
+          reason: 'concurrent init() calls must share one initialization',
+        );
+        await Future.wait([f1, f2]);
+        expect(service.initialized, isTrue);
+      },
+    );
 
-    test('many parallel init() calls all complete and leave a usable service',
-        () async {
-      final service = createService();
-      await Future.wait([for (var i = 0; i < 20; i++) service.init()]);
-      expect(service.initialized, isTrue);
+    test(
+      'many parallel init() calls all complete and leave a usable service',
+      () async {
+        final service = createService();
+        await Future.wait([for (var i = 0; i < 20; i++) service.init()]);
+        expect(service.initialized, isTrue);
 
-      // The service must be fully usable afterwards (no half-initialized
-      // connection from a lost race).
-      final conversation = await service.createDraftConversation(
-        title: 'race test',
-      );
-      // Drafts only enter history once the first message is persisted.
-      await service.addMessage(
-        conversationId: conversation.id,
-        role: 'user',
-        content: 'hello',
-      );
-      expect(service.getAllConversations().map((c) => c.id), [
-        conversation.id,
-      ]);
-    });
+        // The service must be fully usable afterwards (no half-initialized
+        // connection from a lost race).
+        final conversation = await service.createDraftConversation(
+          title: 'race test',
+        );
+        // Drafts only enter history once the first message is persisted.
+        await service.addMessage(
+          conversationId: conversation.id,
+          role: 'user',
+          content: 'hello',
+        );
+        expect(service.getAllConversations().map((c) => c.id), [
+          conversation.id,
+        ]);
+      },
+    );
 
     test('init() after completion is a cheap no-op', () async {
       final service = createService();
@@ -113,44 +156,138 @@ void main() {
   });
 
   group('AssistantProvider.ensureLoaded waits for chat init', () {
-    test('ensureLoaded triggers init instead of bailing on empty repo',
-        () async {
-      final service = createService();
-      expect(service.initialized, isFalse);
+    test(
+      'ensureLoaded triggers init instead of bailing on empty repo',
+      () async {
+        final service = createService();
+        expect(service.initialized, isFalse);
 
-      final provider = AssistantProvider(chatService: service);
-      await provider.ensureLoaded();
+        final provider = AssistantProvider(chatService: service);
+        await provider.ensureLoaded();
 
-      expect(
-        service.initialized,
-        isTrue,
-        reason: 'ensureLoaded must wait for ChatService.init so the real '
-            'assistant list is read, not an empty one',
+        expect(
+          service.initialized,
+          isTrue,
+          reason:
+              'ensureLoaded must wait for ChatService.init so the real '
+              'assistant list is read, not an empty one',
+        );
+      },
+    );
+
+    test(
+      'ensureLoaded reads assistants persisted before a later load',
+      () async {
+        final service = createService();
+        // Simulate the production ordering problem: another subsystem inits the
+        // service and writes assistants while our provider is still unloaded.
+        await service.init();
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'assistants_v1',
+          '[{"id":"a1","name":"Real A"},{"id":"a2","name":"Real B"}]',
+        );
+
+        final provider = AssistantProvider(chatService: service);
+        await provider.ensureLoaded();
+
+        expect(provider.isLoaded, isTrue);
+        expect(
+          provider.assistants.map((a) => a.name),
+          ['Real A', 'Real B'],
+          reason:
+              'ensureLoaded must read the migrated real assistants, '
+              'not leave the list empty for ensureDefaults to overwrite',
+        );
+      },
+    );
+  });
+
+  group('ensureDefaults wipe guard', () {
+    Future<BuildContext> pumpLocalizedContext(WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          locale: const Locale('en'),
+          delegates: AppLocalizations.localizationsDelegates,
+          child: Builder(builder: (context) => const SizedBox.shrink()),
+        ),
       );
+      return tester.element(find.byType(Builder));
+    }
+
+    testWidgets('SQLite-seeded assistants survive ensureDefaults untouched', (
+      tester,
+    ) async {
+      final context = await pumpLocalizedContext(tester);
+      await tester.runAsync(() async {
+        // Seed the real database file with assistants, then close. A fresh
+        // service opens the same file on a cold start, exactly like the
+        // production ordering (initChat boot vs provider load).
+        final seedService = createService();
+        await seedService.init();
+        await seedService.repo.putAssistants([
+          Assistant(id: 'real-1', name: 'Real One'),
+          Assistant(id: 'real-2', name: 'Real Two'),
+        ]);
+        await seedService.close();
+
+        final service = createService();
+        final provider = AssistantProvider(chatService: service);
+        await provider.ensureDefaults(context);
+
+        expect(
+          provider.assistants.map((a) => a.name),
+          ['Real One', 'Real Two'],
+          reason:
+              'ensureDefaults must keep the seeded assistants, not swap '
+              'them for the default assistants',
+        );
+        expect(
+          (await service.repo.getAllAssistants()).map((a) => a.name),
+          ['Real One', 'Real Two'],
+          reason:
+              'the assistant table must never be replaced with defaults '
+              'when it already has rows',
+        );
+      });
     });
 
-    test('ensureLoaded reads assistants persisted before a later load',
-        () async {
-      final service = createService();
-      // Simulate the production ordering problem: another subsystem inits the
-      // service and writes assistants while our provider is still unloaded.
-      await service.init();
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        'assistants_v1',
-        '[{"id":"a1","name":"Real A"},{"id":"a2","name":"Real B"}]',
-      );
+    testWidgets(
+      'empty in-memory read reloads from disk instead of wiping the table',
+      (tester) async {
+        final context = await pumpLocalizedContext(tester);
+        await tester.runAsync(() async {
+          final db = AppDatabase(NativeDatabase.memory());
+          addTearDown(db.close);
+          final repo = _FlakyFirstReadRepository(db);
+          await repo.putAssistants([
+            Assistant(id: 'real-1', name: 'Real One'),
+            Assistant(id: 'real-2', name: 'Real Two'),
+          ]);
+          // Simulate the raced read that used to trigger the wipe: the first
+          // getAllAssistants() comes back empty although the table has rows.
+          repo.failFirstRead = true;
 
-      final provider = AssistantProvider(chatService: service);
-      await provider.ensureLoaded();
+          final provider = AssistantProvider(
+            chatService: _ReadyChatService(repo),
+          );
+          await provider.ensureDefaults(context);
 
-      expect(provider.isLoaded, isTrue);
-      expect(
-        provider.assistants.map((a) => a.name),
-        ['Real A', 'Real B'],
-        reason: 'ensureLoaded must read the migrated real assistants, '
-            'not leave the list empty for ensureDefaults to overwrite',
-      );
-    });
+          expect(
+            provider.assistants.map((a) => a.name),
+            ['Real One', 'Real Two'],
+            reason:
+                'the wipe guard must re-read the non-empty table instead of '
+                'seeding defaults over it',
+          );
+          expect(
+            (await repo.getAllAssistants()).map((a) => a.name),
+            ['Real One', 'Real Two'],
+            reason:
+                'the seeded assistants must survive ensureDefaults untouched',
+          );
+        });
+      },
+    );
   });
 }

--- a/test/core/services/chat/chat_service_init_concurrency_test.dart
+++ b/test/core/services/chat/chat_service_init_concurrency_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+
+/// Regression tests for PR #403 fallout:
+///
+/// The side drawer started forcing `GroupChatProvider.load()` on the first
+/// frame, which races `ChatService.init()` against `HomePageController
+/// .initChat()`. Two concurrent inits opened/migrated the same SQLite file,
+/// which surfaced as: wrong conversation on launch, empty assistant lists
+/// (with group chats still present), or everything gone — recoverable by
+/// restart because reads raced rather than data being lost.
+///
+/// Fix: ChatService.init() is single-flight, and AssistantProvider
+/// .ensureLoaded() waits for init instead of silently bailing on an
+/// uninitialized chat service (which would let ensureDefaults() wipe the
+/// real assistant table with defaults via putAssistants).
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$path/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$path/tmp';
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  final services = <ChatService>[];
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('kelivo_init_race_test_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  tearDown(() async {
+    for (final service in services) {
+      await service.close();
+    }
+    services.clear();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  ChatService createService() {
+    final service = ChatService();
+    services.add(service);
+    return service;
+  }
+
+  group('ChatService init single-flight', () {
+    test('second init() while first is in flight reuses the same future',
+        () async {
+      final service = createService();
+      final f1 = service.init();
+      final f2 = service.init();
+      expect(
+        identical(f1, f2),
+        isTrue,
+        reason: 'concurrent init() calls must share one initialization',
+      );
+      await Future.wait([f1, f2]);
+      expect(service.initialized, isTrue);
+    });
+
+    test('many parallel init() calls all complete and leave a usable service',
+        () async {
+      final service = createService();
+      await Future.wait([for (var i = 0; i < 20; i++) service.init()]);
+      expect(service.initialized, isTrue);
+
+      // The service must be fully usable afterwards (no half-initialized
+      // connection from a lost race).
+      final conversation = await service.createDraftConversation(
+        title: 'race test',
+      );
+      expect(service.getAllConversations().map((c) => c.id), [
+        conversation.id,
+      ]);
+    });
+
+    test('init() after completion is a cheap no-op', () async {
+      final service = createService();
+      await service.init();
+      await service.init();
+      expect(service.initialized, isTrue);
+    });
+  });
+
+  group('AssistantProvider.ensureLoaded waits for chat init', () {
+    test('ensureLoaded triggers init instead of bailing on empty repo',
+        () async {
+      final service = createService();
+      expect(service.initialized, isFalse);
+
+      final provider = AssistantProvider(chatService: service);
+      await provider.ensureLoaded();
+
+      expect(
+        service.initialized,
+        isTrue,
+        reason: 'ensureLoaded must wait for ChatService.init so the real '
+            'assistant list is read, not an empty one',
+      );
+    });
+
+    test('ensureLoaded reads assistants persisted before a later load',
+        () async {
+      final service = createService();
+      // Simulate the production ordering problem: another subsystem inits the
+      // service and writes assistants while our provider is still unloaded.
+      await service.init();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        'assistants_v1',
+        '[{"id":"a1","name":"Real A"},{"id":"a2","name":"Real B"}]',
+      );
+
+      final provider = AssistantProvider(chatService: service);
+      await provider.ensureLoaded();
+
+      expect(provider.isLoaded, isTrue);
+      expect(
+        provider.assistants.map((a) => a.name),
+        ['Real A', 'Real B'],
+        reason: 'ensureLoaded must read the migrated real assistants, '
+            'not leave the list empty for ensureDefaults to overwrite',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 背景
PR #403（群聊并入助手管理）让侧边栏首帧强制 `GroupChatProvider.load()`，与 `HomePageController.initChat()` 并发调用 `ChatService.init()`。两个并发 init 同时打开并迁移同一个 SQLite 文件，导致启动时出现三类随机问题：

1. 进入应用不是刚刚切到的会话（会话恢复被竞态打断）
2. 所有助手消失、群聊还在（assistant 列表读取竞态失败）
3. 助手和群聊全消失
重启有概率恢复 —— 因为竞态影响的是**读取**而非数据本身。

## 根因
- `ChatService.init()` 无并发保护：`if (_initialized) return;` 在 await 完成前两个调用都能进入，各自 `ChatDatabaseRepository.open` + `ensureReady`（迁移）同一个文件。
- `AssistantProvider.ensureLoaded()` 在 chatService 未初始化时**静默返回**（`_repo == null` 直接 return），`ensureDefaults()` 随后看到空列表，调用 `putAssistants()`（**先 delete 全表再 insert**）可能用 2 个默认助手覆盖真实助手数据 —— 这是数据被破坏的路径。

## 修复
1. **`ChatService.init()` 单飞（single-flight）**：并发调用共享同一个初始化 future，数据库只打开/迁移一次（`_doInit` + `_initFuture` 守卫，失败后锁释放可重试）。
2. **`AssistantProvider.ensureLoaded()` 等待 `ChatService.init()`** 完成后再读数据，不再静默返回空列表，杜绝 ensureDefaults 空列表覆盖真实数据的路径。

## 测试
新增 `test/core/services/chat/chat_service_init_concurrency_test.dart`：
- 并发 init() 复用同一 future（identical 断言）
- 20 路并发 init 全部完成且服务可用
- ensureLoaded 在 chatService 未初始化时触发 init 而非静默返回
- ensureLoaded 正确读取已存在的助手（防 ensureDefaults 覆盖回归）

## 影响
- 启动路径：修复前后行为一致（init 只跑一次），无性能影响
- 现有 `_InMemoryChatService` 测试 mock 覆盖 `initialized => true`，不受 ensureLoaded 新分支影响