### PR TITLE
fix(chat): preserve original timestamp when editing a message

### DIFF
--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1603,6 +1603,7 @@ class ChatService extends ChangeNotifier {
     final newMsg = ChatMessage(
       role: original.role,
       content: content,
+      timestamp: original.timestamp,
       conversationId: cid,
       modelId: original.modelId,
       providerId: original.providerId,


### PR DESCRIPTION
Fixes #446

## Problem

When editing a message (user or assistant), `appendMessageVersion` creates a new version but does not copy the original timestamp. The `ChatMessage` constructor defaults to `DateTime.now()`, so the displayed time changes to the edit time.

For example: an assistant replies at 10:30. The user edits the reply at 12:00. The timestamp now shows 12:00 instead of the original 10:30.

## Fix

Add `timestamp: original.timestamp` to the `ChatMessage` constructor call in `appendMessageVersion`, so the new version inherits the original send time.

## Changes

- `lib/core/services/chat/chat_service.dart`: Add one line (`timestamp: original.timestamp`) in `appendMessageVersion`
- 1 file changed, 1 insertion