### PR TITLE
feat: directed conversation tree with parent-linked messages

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -378,7 +378,7 @@ class AppDatabase extends _$AppDatabase {
   // self-heal below repairs such gaps on every open; without it the gap is
   // permanent because later upgrades skip the failed step's `from < N` block.
   // See docs/adr/0019-schema-self-heal.md.
-  int get schemaVersion => 19;
+  int get schemaVersion => 20;
 
   /// Whether [table] has a physical column named [column] (sqlite name).
   Future<bool> _hasColumn(String table, String column) async {
@@ -558,6 +558,20 @@ class AppDatabase extends _$AppDatabase {
       'request_extra_body_json',
       'ALTER TABLE message_rows ADD COLUMN request_extra_body_json TEXT NULL',
     );
+    // Schema v20: the generated Drift row remains intentionally unchanged
+    // until build_runner is available, so these two additive columns are
+    // accessed through ChatDatabaseRepository's parameterized raw queries.
+    // This keeps an upgrade safe even in release builds that do not regenerate
+    // app_database.g.dart during installation.
+    await _ensureColumn(
+      'message_rows',
+      'parent_message_id',
+      'ALTER TABLE message_rows ADD COLUMN parent_message_id TEXT NULL',
+    );
+    await customStatement(
+      'CREATE INDEX IF NOT EXISTS idx_messages_parent_message_id '
+      'ON message_rows(conversation_id, parent_message_id)',
+    );
 
     // --- conversation_rows ---
     await _ensureColumn(
@@ -569,6 +583,11 @@ class AppDatabase extends _$AppDatabase {
       'conversation_rows',
       'conversation_kind',
       "ALTER TABLE conversation_rows ADD COLUMN conversation_kind TEXT NOT NULL DEFAULT 'normal'",
+    );
+    await _ensureColumn(
+      'conversation_rows',
+      'active_message_id',
+      'ALTER TABLE conversation_rows ADD COLUMN active_message_id TEXT NULL',
     );
     await customStatement(
       "UPDATE conversation_rows SET conversation_kind = 'normal' "
@@ -826,6 +845,26 @@ class AppDatabase extends _$AppDatabase {
         try {
           await migrator.addColumn(assistantRows, assistantRows.workspaceId);
         } catch (_) {}
+      }
+      if (from < 20) {
+        // Directed conversation-tree metadata is deliberately added with raw
+        // SQL because the current generated Drift companion has no fields for
+        // these additive columns. _healSchemaIfNeeded mirrors this for a
+        // partially completed upgrade.
+        await _ensureColumn(
+          'message_rows',
+          'parent_message_id',
+          'ALTER TABLE message_rows ADD COLUMN parent_message_id TEXT NULL',
+        );
+        await _ensureColumn(
+          'conversation_rows',
+          'active_message_id',
+          'ALTER TABLE conversation_rows ADD COLUMN active_message_id TEXT NULL',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS idx_messages_parent_message_id '
+          'ON message_rows(conversation_id, parent_message_id)',
+        );
       }
       // Final pass: heal any column/table that still did not land.
       await _healSchemaIfNeeded();

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -309,7 +309,7 @@ class ChatDatabaseRepository {
     final row = await (_db.select(
       _db.messageRows,
     )..where((t) => t.id.equals(messageId))).getSingleOrNull();
-    return row == null ? null : _messageFromRow(row);
+    return row == null ? null : _withParentMessageId(_messageFromRow(row));
   }
 
   ChatMessage? getMessageSync(String messageId) {
@@ -334,7 +334,9 @@ class ChatDatabaseRepository {
               ..orderBy([(t) => OrderingTerm.asc(t.messageOrder)])
               ..limit(limit, offset: safeStart))
             .get();
-    return rows.map(_messageFromRow).toList(growable: false);
+    return _withParentMessageIds(
+      rows.map(_messageFromRow).toList(growable: false),
+    );
   }
 
   List<ChatMessage> getMessagesRangeSync(
@@ -358,8 +360,11 @@ class ChatDatabaseRepository {
     final rows = await (_db.select(
       _db.messageRows,
     )..where((t) => t.id.isIn(ids))).get();
+    final mapped = await _withParentMessageIds(
+      rows.map(_messageFromRow).toList(growable: false),
+    );
     final byId = <String, ChatMessage>{
-      for (final row in rows) row.id: _messageFromRow(row),
+      for (final message in mapped) message.id: message,
     };
     return [
       for (final id in ids)
@@ -431,7 +436,9 @@ class ChatDatabaseRepository {
               )
               ..orderBy([(t) => OrderingTerm.asc(t.messageOrder)]))
             .get();
-    return rows.map(_messageFromRow).toList(growable: false);
+    return _withParentMessageIds(
+      rows.map(_messageFromRow).toList(growable: false),
+    );
   }
 
   List<ChatMessage> getMessagesForGroupsSync(
@@ -579,6 +586,7 @@ class ChatDatabaseRepository {
       await _db
           .into(_db.conversationRows)
           .insertOnConflictUpdate(_conversationCompanion(conversation));
+      await _writeActiveMessageId(conversation);
       await _replaceMcpServers(conversation.id, conversation.mcpServerIds);
     });
   }
@@ -586,9 +594,12 @@ class ChatDatabaseRepository {
   Future<void> putMessage(ChatMessage message, {int? messageOrder}) async {
     final order =
         messageOrder ?? await _nextMessageOrder(message.conversationId);
-    await _db
-        .into(_db.messageRows)
-        .insertOnConflictUpdate(_messageCompanion(message, order));
+    await _db.transaction(() async {
+      await _db
+          .into(_db.messageRows)
+          .insertOnConflictUpdate(_messageCompanion(message, order));
+      await _writeParentMessageId(message);
+    });
   }
 
   Future<void> putMigrationBatch({
@@ -652,6 +663,12 @@ class ChatDatabaseRepository {
           );
         }
       });
+      for (final conversation in conversations) {
+        await _writeActiveMessageId(conversation);
+      }
+      for (final entry in messages) {
+        await _writeParentMessageId(entry.message);
+      }
     });
   }
 
@@ -719,6 +736,105 @@ class ChatDatabaseRepository {
           );
         }
       });
+      for (final conversation in conversations) {
+        await _writeActiveMessageId(conversation);
+      }
+      for (final messages in messagesByConversation.values) {
+        for (final message in messages) {
+          await _writeParentMessageId(message);
+        }
+      }
+    });
+  }
+
+  /// Restores one directed branch and its conversation cursor atomically.
+  ///
+  /// A branch cannot be restored one row at a time: a child may refer to a
+  /// parent restored in the same operation, and a partially written branch
+  /// would otherwise become an orphan in the active tree.
+  Future<void> restoreDirectedTreeSubtree({
+    required Conversation conversation,
+    required List<ChatMessage> messages,
+    required Map<String, List<Map<String, dynamic>>> toolEventsByMessageId,
+    required Map<String, String> geminiSignaturesByMessageId,
+  }) async {
+    if (messages.isEmpty) return;
+
+    final messageOrder = <String, int>{
+      for (var i = 0; i < conversation.messageIds.length; i++)
+        conversation.messageIds[i]: i,
+    };
+
+    await _db.transaction(() async {
+      await _db
+          .into(_db.conversationRows)
+          .insertOnConflictUpdate(_conversationCompanion(conversation));
+      await _writeActiveMessageId(conversation);
+      await _replaceMcpServers(conversation.id, conversation.mcpServerIds);
+
+      for (final message in messages) {
+        await _db
+            .into(_db.messageRows)
+            .insertOnConflictUpdate(
+              _messageCompanion(message, messageOrder[message.id] ?? 0),
+            );
+        await _writeParentMessageId(message);
+      }
+
+      for (final entry in toolEventsByMessageId.entries) {
+        await _db
+            .into(_db.toolEventRows)
+            .insertOnConflictUpdate(
+              ToolEventRowsCompanion.insert(
+                messageId: entry.key,
+                eventsJson: jsonEncode(entry.value),
+              ),
+            );
+      }
+      for (final entry in geminiSignaturesByMessageId.entries) {
+        await _db
+            .into(_db.geminiThoughtSignatureRows)
+            .insertOnConflictUpdate(
+              GeminiThoughtSignatureRowsCompanion.insert(
+                messageId: entry.key,
+                signature: entry.value,
+              ),
+            );
+      }
+
+      for (var i = 0; i < conversation.messageIds.length; i++) {
+        await (_db.update(_db.messageRows)
+              ..where((t) => t.id.equals(conversation.messageIds[i])))
+            .write(MessageRowsCompanion(messageOrder: Value(i)));
+      }
+    });
+  }
+
+  /// Deletes a directed subtree as a single database operation.
+  ///
+  /// The caller has already chosen a complete parent-safe subtree. Keeping
+  /// the physical delete atomic ensures an interruption cannot leave only part
+  /// of that subtree in SQLite (and therefore cannot create a dangling parent
+  /// reference on the next launch).
+  Future<void> deleteDirectedTreeSubtree(Iterable<String> messageIds) async {
+    final ids = messageIds.where((id) => id.isNotEmpty).toSet();
+    if (ids.isEmpty) return;
+
+    await _db.transaction(() async {
+      for (final id in ids) {
+        await _db.customStatement(
+          'UPDATE conversation_rows SET active_message_id = NULL '
+          'WHERE active_message_id = ?',
+          [id],
+        );
+        await (_db.delete(_db.toolEventRows)
+              ..where((t) => t.messageId.equals(id)))
+            .go();
+        await (_db.delete(_db.geminiThoughtSignatureRows)
+              ..where((t) => t.messageId.equals(id)))
+            .go();
+        await (_db.delete(_db.messageRows)..where((t) => t.id.equals(id))).go();
+      }
     });
   }
 
@@ -727,11 +843,14 @@ class ChatDatabaseRepository {
       _db.messageRows,
     )..where((t) => t.id.equals(message.id))).getSingleOrNull();
     if (existing == null) return;
-    await _db
-        .into(_db.messageRows)
-        .insertOnConflictUpdate(
-          _messageCompanion(message, existing.messageOrder),
-        );
+    await _db.transaction(() async {
+      await _db
+          .into(_db.messageRows)
+          .insertOnConflictUpdate(
+            _messageCompanion(message, existing.messageOrder),
+          );
+      await _writeParentMessageId(message);
+    });
   }
 
   Future<void> updateConversationMessages({
@@ -746,6 +865,7 @@ class ChatDatabaseRepository {
               conversation.copyWith(messageIds: List<String>.of(messageIds)),
             ),
           );
+      await _writeActiveMessageId(conversation);
       await _replaceMcpServers(conversation.id, conversation.mcpServerIds);
       for (var i = 0; i < messageIds.length; i++) {
         await (_db.update(_db.messageRows)
@@ -766,6 +886,11 @@ class ChatDatabaseRepository {
       _db.messageRows,
     )..where((t) => t.id.equals(messageId))).getSingleOrNull();
     if (row == null) return;
+    await _db.customStatement(
+      'UPDATE conversation_rows SET active_message_id = NULL '
+      'WHERE active_message_id = ?',
+      [messageId],
+    );
     await (_db.delete(
       _db.messageRows,
     )..where((t) => t.id.equals(messageId))).go();
@@ -1124,6 +1249,7 @@ class ChatDatabaseRepository {
       assistantId: row.assistantId,
       truncateIndex: row.truncateIndex,
       versionSelections: _decodeStringIntMap(row.versionSelectionsJson),
+      activeMessageId: await _readActiveMessageId(row.id),
       summary: row.summary,
       lastSummarizedMessageCount: row.lastSummarizedMessageCount,
       chatSuggestions: _decodeStringList(row.chatSuggestionsJson),
@@ -1165,6 +1291,7 @@ class ChatDatabaseRepository {
       versionSelections: _decodeStringIntMap(
         row['version_selections_json'] as String? ?? '{}',
       ),
+      activeMessageId: _readOptionalString(row, 'active_message_id'),
       summary: row['summary'] as String?,
       lastSummarizedMessageCount:
           row['last_summarized_message_count'] as int? ?? 0,
@@ -1202,6 +1329,65 @@ class ChatDatabaseRepository {
     }
   }
 
+  /// [parent_message_id] and [active_message_id] are v20 physical columns.
+  /// They are intentionally queried here rather than referenced through Drift
+  /// companions until generated source can be regenerated in the build
+  /// environment. Keeping the SQL parameterized protects imports/restores
+  /// from malformed ids and preserves compatibility with the checked-in
+  /// generated classes.
+  Future<String?> _readActiveMessageId(String conversationId) async {
+    final rows = await _db.customSelect(
+      'SELECT active_message_id FROM conversation_rows WHERE id = ? LIMIT 1',
+      variables: [Variable.withString(conversationId)],
+    ).get();
+    if (rows.isEmpty) return null;
+    return rows.single.readNullable<String>('active_message_id');
+  }
+
+  Future<ChatMessage> _withParentMessageId(ChatMessage message) async {
+    final messages = await _withParentMessageIds([message]);
+    return messages.isEmpty ? message : messages.single;
+  }
+
+  Future<List<ChatMessage>> _withParentMessageIds(
+    List<ChatMessage> messages,
+  ) async {
+    if (messages.isEmpty) return const <ChatMessage>[];
+    final placeholders = List<String>.filled(messages.length, '?').join(',');
+    final rows = await _db.customSelect(
+      'SELECT id, parent_message_id FROM message_rows '
+      'WHERE id IN ($placeholders)',
+      variables: [
+        for (final message in messages) Variable.withString(message.id),
+      ],
+    ).get();
+    final parentById = <String, String?>{};
+    for (final row in rows) {
+      final id = row.readNullable<String>('id');
+      if (id != null) {
+        parentById[id] = row.readNullable<String>('parent_message_id');
+      }
+    }
+    return [
+      for (final message in messages)
+        message.copyWith(parentMessageId: parentById[message.id]),
+    ];
+  }
+
+  Future<void> _writeParentMessageId(ChatMessage message) {
+    return _db.customStatement(
+      'UPDATE message_rows SET parent_message_id = ? WHERE id = ?',
+      [message.parentMessageId, message.id],
+    );
+  }
+
+  Future<void> _writeActiveMessageId(Conversation conversation) {
+    return _db.customStatement(
+      'UPDATE conversation_rows SET active_message_id = ? WHERE id = ?',
+      [conversation.activeMessageId, conversation.id],
+    );
+  }
+
   ConversationRowsCompanion _conversationCompanion(Conversation conversation) {
     return ConversationRowsCompanion.insert(
       id: conversation.id,
@@ -1233,6 +1419,7 @@ class ChatDatabaseRepository {
       totalTokens: row.totalTokens,
       contextTokens: row.contextTokens,
       conversationId: row.conversationId,
+      parentMessageId: null,
       isStreaming: row.isStreaming,
       reasoningText: row.reasoningText,
       reasoningStartAt: row.reasoningStartAt,
@@ -1269,6 +1456,7 @@ class ChatDatabaseRepository {
       totalTokens: row['total_tokens'] as int?,
       contextTokens: row['context_tokens'] as int?,
       conversationId: row['conversation_id'] as String,
+      parentMessageId: _readOptionalString(row, 'parent_message_id'),
       isStreaming: row['is_streaming'] == 1,
       reasoningText: row['reasoning_text'] as String?,
       reasoningStartAt: nullableDate('reasoning_start_at'),

--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -25,6 +25,15 @@ class ChatMessage {
 
   final String conversationId;
 
+  /// The exact message this message continues from.
+  ///
+  /// New one-to-one conversations use this to form a directed conversation
+  /// tree: retries become sibling children of the same parent instead of
+  /// independent entries in a flat version list. Null is valid for the first
+  /// message in a conversation and for legacy messages created before the
+  /// tree model existed.
+  final String? parentMessageId;
+
   final bool isStreaming;
 
   // Optional reasoning fields for assistant messages
@@ -100,6 +109,7 @@ class ChatMessage {
     int? totalTokens,
     int? contextTokens,
     required String conversationId,
+    String? parentMessageId,
     bool isStreaming = false,
     String? reasoningText,
     DateTime? reasoningStartAt,
@@ -129,6 +139,7 @@ class ChatMessage {
       totalTokens: totalTokens,
       contextTokens: contextTokens,
       conversationId: conversationId,
+      parentMessageId: parentMessageId,
       isStreaming: isStreaming,
       reasoningText: reasoningText,
       reasoningStartAt: reasoningStartAt,
@@ -159,6 +170,7 @@ class ChatMessage {
     this.totalTokens,
     this.contextTokens,
     required this.conversationId,
+    this.parentMessageId,
     this.isStreaming = false,
     this.reasoningText,
     this.reasoningStartAt,
@@ -191,6 +203,7 @@ class ChatMessage {
     Object? totalTokens = sentinel,
     Object? contextTokens = sentinel,
     Object? conversationId = sentinel,
+    Object? parentMessageId = sentinel,
     Object? isStreaming = sentinel,
     Object? reasoningText = sentinel,
     Object? reasoningStartAt = sentinel,
@@ -229,6 +242,9 @@ class ChatMessage {
       conversationId: identical(conversationId, sentinel)
           ? this.conversationId
           : conversationId as String,
+      parentMessageId: identical(parentMessageId, sentinel)
+          ? this.parentMessageId
+          : parentMessageId as String?,
       isStreaming: identical(isStreaming, sentinel)
           ? this.isStreaming
           : isStreaming as bool,
@@ -291,6 +307,7 @@ class ChatMessage {
       'totalTokens': totalTokens,
       'contextTokens': contextTokens,
       'conversationId': conversationId,
+      'parentMessageId': parentMessageId,
       'isStreaming': isStreaming,
       'reasoningText': reasoningText,
       'reasoningStartAt': reasoningStartAt?.toIso8601String(),
@@ -322,6 +339,7 @@ class ChatMessage {
       totalTokens: json['totalTokens'] as int?,
       contextTokens: json['contextTokens'] as int?,
       conversationId: json['conversationId'] as String,
+      parentMessageId: json['parentMessageId'] as String?,
       isStreaming: json['isStreaming'] as bool? ?? false,
       reasoningText: json['reasoningText'] as String?,
       reasoningStartAt: json['reasoningStartAt'] != null

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -22,11 +22,17 @@ class Conversation {
   // Parent conversation that spawned this one via handoff; null for normal
   String? parentConversationId;
 
-  // Truncate context starting at this index (-1 means no truncation)
+  // Truncate context starting at this index (-1 means no truncation). In a
+  // directed conversation this index is relative to the active root-to-leaf
+  // path, not the full chronological row set.
   int truncateIndex;
 
   // Selected version per message group (groupId -> selected version index)
   Map<String, int> versionSelections;
+
+  /// Current leaf of the directed message tree. Null keeps a legacy
+  /// conversation on its original linear/versioned behavior.
+  String? activeMessageId;
 
   // LLM-generated conversation summary
   String? summary;
@@ -57,6 +63,7 @@ class Conversation {
     this.parentConversationId,
     int? truncateIndex,
     Map<String, int>? versionSelections,
+    this.activeMessageId,
     this.summary,
     int? lastSummarizedMessageCount,
     List<String>? chatSuggestions,
@@ -83,6 +90,8 @@ class Conversation {
     String? parentConversationId,
     int? truncateIndex,
     Map<String, int>? versionSelections,
+    String? activeMessageId,
+    bool clearActiveMessageId = false,
     String? summary,
     int? lastSummarizedMessageCount,
     List<String>? chatSuggestions,
@@ -101,6 +110,9 @@ class Conversation {
       parentConversationId: parentConversationId ?? this.parentConversationId,
       truncateIndex: truncateIndex ?? this.truncateIndex,
       versionSelections: versionSelections ?? this.versionSelections,
+      activeMessageId: clearActiveMessageId
+          ? null
+          : (activeMessageId ?? this.activeMessageId),
       summary: clearSummary ? null : (summary ?? this.summary),
       lastSummarizedMessageCount:
           lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
@@ -122,6 +134,7 @@ class Conversation {
       'parentConversationId': parentConversationId,
       'truncateIndex': truncateIndex,
       'versionSelections': versionSelections,
+      'activeMessageId': activeMessageId,
       'summary': summary,
       'lastSummarizedMessageCount': lastSummarizedMessageCount,
       'chatSuggestions': chatSuggestions,
@@ -147,6 +160,7 @@ class Conversation {
             (k, v) => MapEntry(k.toString(), (v as num).toInt()),
           ) ??
           <String, int>{},
+      activeMessageId: json['activeMessageId'] as String?,
       summary: json['summary'] as String?,
       lastSummarizedMessageCount:
           json['lastSummarizedMessageCount'] as int? ?? 0,

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1909,7 +1909,6 @@ class ChatService extends ChangeNotifier {
 
     final currentOriginal = original;
     final currentConversation = convo;
-    if (currentOriginal == null || currentConversation == null) return null;
 
     final isDirectedTree = currentConversation.activeMessageId != null;
     final directedPlacement = isDirectedTree

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -10,6 +10,7 @@ import '../../models/assistant.dart';
 import '../../models/chat_message.dart';
 import '../../models/conversation.dart';
 import '../../models/file_reference.dart';
+import '../../utils/conversation_tree.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
 import '../../../utils/path_canon.dart';
@@ -655,6 +656,65 @@ class ChatService extends ChangeNotifier {
     }
   }
 
+  /// Stores one complete directed subtree as a single recoverable unit.
+  ///
+  /// Recording every child as an independent trash item makes it possible to
+  /// restore an answer before its parent question. That produces a dangling
+  /// edge which the tree UI cannot safely display. A branch therefore has one
+  /// root recovery record and is restored atomically in parent-safe order.
+  Future<void> _recordDirectedTreeDeletion({
+    required ChatMessage root,
+    required List<ChatMessage> allMessages,
+    required Set<String> deletedIds,
+    required Conversation? conversation,
+  }) async {
+    final store = _deletedRecordsStore;
+    if (store == null) {
+      debugPrint(
+        '_recordDirectedTreeDeletion: deletedRecordsStore is null, skipping trash',
+      );
+      return;
+    }
+
+    try {
+      final branchMessages = allMessages
+          .where((message) => deletedIds.contains(message.id))
+          .toList(growable: false);
+      final toolEvents = <String, List<Map<String, dynamic>>>{};
+      final geminiSigs = <String, String?>{};
+      for (final message in branchMessages) {
+        if (message.role != 'assistant') continue;
+        toolEvents[message.id] = getToolEvents(message.id);
+        geminiSigs[message.id] = getGeminiThoughtSignature(message.id);
+      }
+
+      final recoveryJson = jsonEncode({
+        'treeSubtree': true,
+        // Keep the legacy preview shape understood by the trash UI.
+        'message': root.toJson(),
+        'messages': branchMessages.map((message) => message.toJson()).toList(),
+        'toolEvents': toolEvents,
+        'geminiSigs': geminiSigs,
+        'conversationId': root.conversationId,
+        'treeState': {
+          'activeMessageId': conversation?.activeMessageId,
+          'versionSelections': conversation?.versionSelections ??
+              const <String, int>{},
+          'messageIds': allMessages.map((message) => message.id).toList(),
+        },
+      });
+      await store.recordDeletion(
+        id: root.id,
+        type: DeletionEntityType.message,
+        recoveryJson: recoveryJson,
+        batchId: const Uuid().v4(),
+        deletedAt: DateTime.now(),
+      );
+    } catch (e) {
+      debugPrint('_recordDirectedTreeDeletion: failed to write trash: $e');
+    }
+  }
+
   Future<void> deleteConversationsForAssistant(String assistantId) async {
     if (!_initialized) await init();
 
@@ -1175,6 +1235,7 @@ class ChatService extends ChangeNotifier {
     String? groupId,
     String? subgroupId,
     int? version,
+    String? parentMessageId,
     bool isPreset = false,
     String? speakerAssistantId,
   }) async {
@@ -1206,6 +1267,44 @@ class ChatService extends ChangeNotifier {
       }
     }
 
+    // Keep every newly created ordinary conversation on the directed model
+    // from its first row onward. More importantly, a feature that adds a
+    // message outside ChatActions (preset injection, proactive care, handoff,
+    // etc.) must not create an invisible root beside the active branch.
+    //
+    // Existing non-empty legacy conversations intentionally remain untouched:
+    // their parent links cannot be reconstructed safely from flat versions.
+    final useDirectedTree =
+        !conversation.isGroup &&
+        (conversation.activeMessageId != null || conversation.messageIds.isEmpty);
+    final resolvedParentMessageId = useDirectedTree
+        ? (parentMessageId ?? conversation.activeMessageId)
+        : parentMessageId;
+    if (useDirectedTree && resolvedParentMessageId != null) {
+      if (resolvedParentMessageId.isEmpty) {
+        throw ArgumentError.value(
+          parentMessageId,
+          'parentMessageId',
+          'A directed message parent cannot be empty.',
+        );
+      }
+      final parentExists = getMessages(conversationId).any(
+        (candidate) => candidate.id == resolvedParentMessageId,
+      );
+      if (!parentExists) {
+        throw StateError(
+          'Cannot add a directed message under a missing parent '
+          '$resolvedParentMessageId in conversation $conversationId.',
+        );
+      }
+    }
+    final directedPlacement = useDirectedTree
+        ? nextDirectedTreeChild(
+            conversationId: conversationId,
+            parentMessageId: resolvedParentMessageId,
+          )
+        : null;
+
     final message = ChatMessage(
       role: role,
       content: content,
@@ -1217,9 +1316,13 @@ class ChatService extends ChangeNotifier {
       reasoningText: reasoningText,
       reasoningStartAt: reasoningStartAt,
       reasoningFinishedAt: reasoningFinishedAt,
-      groupId: groupId,
+      // A tree's group/version are derived from its exact parent. Callers may
+      // supply the same values for clarity, but cannot accidentally create a
+      // group that spans two parents.
+      groupId: directedPlacement?.groupId ?? groupId,
       subgroupId: subgroupId,
-      version: version,
+      version: directedPlacement?.version ?? version,
+      parentMessageId: resolvedParentMessageId,
       isPreset: isPreset,
       speakerAssistantId: speakerAssistantId,
     );
@@ -1247,6 +1350,15 @@ class ChatService extends ChangeNotifier {
     // Update cache
     if (_messagesCache.containsKey(conversationId)) {
       _messagesCache[conversationId]!.add(message);
+    }
+
+    // Move the cursor after the row has entered the cache/storage so every
+    // subsequent generic append continues from this exact message.
+    if (useDirectedTree) {
+      await activateDirectedTreeMessage(
+        conversationId: conversationId,
+        messageId: message.id,
+      );
     }
 
     notifyListeners();
@@ -1553,6 +1665,7 @@ class ChatService extends ChangeNotifier {
     );
     final ids = <String>[];
     final clones = <ChatMessage>[];
+    String? clonedParentId;
     for (final src in sourceMessages) {
       final clone = ChatMessage(
         role: src.role,
@@ -1562,6 +1675,7 @@ class ChatService extends ChangeNotifier {
         providerId: src.providerId,
         totalTokens: src.totalTokens,
         conversationId: convo.id,
+        parentMessageId: clonedParentId,
         isStreaming: false,
         reasoningText: src.reasoningText,
         reasoningStartAt: src.reasoningStartAt,
@@ -1571,10 +1685,16 @@ class ChatService extends ChangeNotifier {
         isPreset: src.isPreset,
         requestAllowImagesApiRouting: src.requestAllowImagesApiRouting,
         requestExtraBodyJson: src.requestExtraBodyJson,
+        groupId: ConversationTree.siblingGroupId(
+          conversationId: convo.id,
+          parentMessageId: clonedParentId,
+        ),
+        version: 0,
       );
       await _repo.putMessage(clone, messageOrder: ids.length);
       ids.add(clone.id);
       clones.add(clone);
+      clonedParentId = clone.id;
     }
     // Attach to conversation in storage
     final c = _conversationsCache[convo.id];
@@ -1583,6 +1703,7 @@ class ChatService extends ChangeNotifier {
         ..clear()
         ..addAll(ids);
       c.versionSelections = <String, int>{};
+      c.activeMessageId = clones.isEmpty ? null : clones.last.id;
       c.updatedAt = DateTime.now();
       await _saveConversation(c);
     }
@@ -1592,44 +1713,244 @@ class ChatService extends ChangeNotifier {
     return _conversationsCache[convo.id]!;
   }
 
+  /// Whether this conversation has opted into the directed message-tree
+  /// model. Legacy rows intentionally remain on their pre-v20 linear logic.
+  bool isDirectedTreeConversation(String conversationId) {
+    final conversation =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    return conversation?.activeMessageId != null;
+  }
+
+  /// Allocation for the next child of [parentMessageId]. All direct children
+  /// share one group id, so the existing version switcher can represent the
+  /// local fork without ever selecting a node from another parent.
+  ({String groupId, int version}) nextDirectedTreeChild({
+    required String conversationId,
+    required String? parentMessageId,
+  }) {
+    final messages = getMessages(conversationId);
+    return (
+      groupId: ConversationTree.siblingGroupId(
+        conversationId: conversationId,
+        parentMessageId: parentMessageId,
+      ),
+      version: ConversationTree.nextSiblingVersion(
+        messages: messages,
+        conversationId: conversationId,
+        parentMessageId: parentMessageId,
+      ),
+    );
+  }
+
+  /// Move the active cursor to [messageId] and persist the version selection
+  /// of every node on its root-to-leaf path.
+  Future<void> activateDirectedTreeMessage({
+    required String conversationId,
+    required String messageId,
+  }) async {
+    final conversation =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    if (conversation == null) return;
+
+    final messages = getMessages(conversationId);
+    final path = ConversationTree.pathToRoot(messages, messageId);
+    if (path.isEmpty || path.last.id != messageId) return;
+
+    final previousActiveId = conversation.activeMessageId;
+    final previousPath = previousActiveId == null
+        ? const <ChatMessage>[]
+        : ConversationTree.pathToRoot(messages, previousActiveId);
+    final continuesPreviousPath = previousActiveId == null ||
+        (previousPath.isNotEmpty &&
+            previousPath.length <= path.length &&
+            previousPath
+                .asMap()
+                .entries
+                .every((entry) => entry.value.id == path[entry.key].id));
+
+    for (final message in path) {
+      final groupId = message.groupId ??
+          ConversationTree.siblingGroupId(
+            conversationId: conversationId,
+            parentMessageId: message.parentMessageId,
+          );
+      final index = ConversationTree.siblingIndex(messages, message);
+      if (index >= 0) conversation.versionSelections[groupId] = index;
+    }
+    // A summary represents one branch. Keeping it after a retry, edit, or
+    // sibling switch would inject facts from the old branch into other chats.
+    // Extending the current leaf is safe; normal summary cadence can update it.
+    if (!continuesPreviousPath) {
+      conversation.summary = null;
+      conversation.lastSummarizedMessageCount = 0;
+    }
+    conversation.activeMessageId = messageId;
+    conversation.updatedAt = DateTime.now();
+    await _saveConversation(conversation);
+    notifyListeners();
+  }
+
+  /// Select a sibling version and then follow that branch's remembered child
+  /// selections. This is the critical guard that prevents, for example, an
+  /// edited user message from displaying an answer belonging to the old input.
+  Future<void> selectDirectedTreeVersion({
+    required String conversationId,
+    required String groupId,
+    required int version,
+  }) async {
+    final conversation =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    if (conversation == null) return;
+
+    final messages = getMessages(conversationId);
+    final candidates = messages
+        .where((message) => (message.groupId ?? message.id) == groupId)
+        .toList(growable: false);
+    if (candidates.isEmpty) return;
+
+    final siblings = ConversationTree.sortedSiblings(messages, candidates.last);
+    if (version < 0 || version >= siblings.length) return;
+
+    conversation.versionSelections[groupId] = version;
+    final leaf = ConversationTree.selectLeafForBranch(
+      messages: messages,
+      branchStart: siblings[version],
+      versionSelections: conversation.versionSelections,
+    );
+    await activateDirectedTreeMessage(
+      conversationId: conversationId,
+      messageId: leaf.id,
+    );
+  }
+
+  /// Safely upgrades a previously linear conversation when it has no existing
+  /// alternatives: the chronological order is then an unambiguous single
+  /// path. Conversations that already have version/subgroup branches are left
+  /// untouched rather than inventing parent edges for historical data.
+  Future<bool> adoptLinearConversationAsDirectedTree(
+    String conversationId,
+  ) async {
+    final conversation =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    if (conversation == null ||
+        conversation.activeMessageId != null ||
+        conversation.isGroup) {
+      return false;
+    }
+
+    final messages = getMessages(conversationId);
+    if (messages.isEmpty || messages.any((message) => message.subgroupId != null)) {
+      return false;
+    }
+    final seenGroups = <String>{};
+    for (final message in messages) {
+      final groupId = message.groupId ?? message.id;
+      if (message.version != 0 || !seenGroups.add(groupId)) return false;
+    }
+
+    String? parentMessageId;
+    final converted = <ChatMessage>[];
+    for (final message in messages) {
+      converted.add(
+        message.copyWith(
+          parentMessageId: parentMessageId,
+          groupId: ConversationTree.siblingGroupId(
+            conversationId: conversationId,
+            parentMessageId: parentMessageId,
+          ),
+          version: 0,
+        ),
+      );
+      parentMessageId = message.id;
+    }
+
+    if (isTemporaryConversation(conversationId)) {
+      _messagesCache[conversationId] = converted;
+    } else {
+      for (final message in converted) {
+        await _repo.updateMessage(message);
+      }
+      _messagesCache[conversationId] = converted;
+    }
+
+    conversation.versionSelections = <String, int>{
+      for (final message in converted) message.groupId!: 0,
+    };
+    conversation.activeMessageId = converted.last.id;
+    conversation.updatedAt = DateTime.now();
+    await _saveConversation(conversation);
+    notifyListeners();
+    return true;
+  }
+
   Future<ChatMessage?> appendMessageVersion({
     required String messageId,
     required String content,
   }) async {
     if (!_initialized) await init();
-    final original =
+    var original =
         _repo.getMessageSync(messageId) ?? _cachedTemporaryMessage(messageId);
     if (original == null) return null;
 
     final cid = original.conversationId;
-    final convo = _conversationsCache[cid] ?? _draftConversations[cid];
+    var convo = _conversationsCache[cid] ?? _draftConversations[cid];
     if (convo == null) return null;
 
-    final gid = (original.groupId ?? original.id);
-    // Find current max version within this group in this conversation
-    int maxVersion = -1;
-    final groupMessages = getMessagesForGroups(cid, [gid]);
-    for (final m in groupMessages) {
-      final mg = (m.groupId ?? m.id);
-      if (mg == gid) {
-        if (m.version > maxVersion) maxVersion = m.version;
-      }
+    if (convo.activeMessageId == null) {
+      await adoptLinearConversationAsDirectedTree(cid);
+      original = _repo.getMessageSync(messageId) ?? _cachedTemporaryMessage(messageId);
+      convo = _conversationsCache[cid] ?? _draftConversations[cid];
+      if (original == null || convo == null) return null;
     }
-    final nextVersion = maxVersion + 1;
+
+    final currentOriginal = original;
+    final currentConversation = convo;
+    if (currentOriginal == null || currentConversation == null) return null;
+
+    final isDirectedTree = currentConversation.activeMessageId != null;
+    final directedPlacement = isDirectedTree
+        ? nextDirectedTreeChild(
+            conversationId: cid,
+            parentMessageId: currentOriginal.parentMessageId,
+          )
+        : null;
+    final gid =
+        directedPlacement?.groupId ??
+        (currentOriginal.groupId ?? currentOriginal.id);
+    int nextVersion = directedPlacement?.version ?? 0;
+    if (directedPlacement == null) {
+      // Legacy messages retain their flat version behavior unchanged.
+      int maxVersion = -1;
+      final groupMessages = getMessagesForGroups(cid, [gid]);
+      for (final message in groupMessages) {
+        final messageGroupId = message.groupId ?? message.id;
+        if (messageGroupId == gid && message.version > maxVersion) {
+          maxVersion = message.version;
+        }
+      }
+      nextVersion = maxVersion + 1;
+    }
 
     final newMsg = ChatMessage(
-      role: original.role,
+      role: currentOriginal.role,
       content: content,
       conversationId: cid,
-      modelId: original.modelId,
-      providerId: original.providerId,
+      modelId: currentOriginal.modelId,
+      providerId: currentOriginal.providerId,
       totalTokens: null,
       isStreaming: false,
       groupId: gid,
       version: nextVersion,
-      speakerAssistantId: original.speakerAssistantId,
-      requestAllowImagesApiRouting: original.requestAllowImagesApiRouting,
-      requestExtraBodyJson: original.requestExtraBodyJson,
+      parentMessageId:
+          isDirectedTree ? currentOriginal.parentMessageId : null,
+      speakerAssistantId: currentOriginal.speakerAssistantId,
+      requestAllowImagesApiRouting:
+          currentOriginal.requestAllowImagesApiRouting,
+      requestExtraBodyJson: currentOriginal.requestExtraBodyJson,
     );
     // Append to conversation order at the end (we'll group when rendering)
     if (_draftConversations.containsKey(cid)) {
@@ -1651,6 +1972,12 @@ class ChatService extends ChangeNotifier {
     // Update caches
     final arr = _messagesCache[cid];
     if (arr != null) arr.add(newMsg);
+    if (isDirectedTree) {
+      await activateDirectedTreeMessage(
+        conversationId: cid,
+        messageId: newMsg.id,
+      );
+    }
     notifyListeners();
     return newMsg;
   }
@@ -1709,7 +2036,12 @@ class ChatService extends ChangeNotifier {
     // Draft case
     if (_draftConversations.containsKey(conversationId)) {
       final draft = _draftConversations[conversationId]!;
-      final lastIndexPlusOne = draft.messageIds.length; // last index + 1
+      final lastIndexPlusOne = draft.activeMessageId == null
+          ? draft.messageIds.length
+          : ConversationTree.pathToRoot(
+              getMessages(conversationId),
+              draft.activeMessageId,
+            ).length;
       final newValue = (draft.truncateIndex == lastIndexPlusOne)
           ? -1
           : lastIndexPlusOne;
@@ -1722,7 +2054,12 @@ class ChatService extends ChangeNotifier {
     // Persisted case
     final c = _conversationsCache[conversationId];
     if (c == null) return null;
-    final lastIndexPlusOne = getMessageCount(conversationId);
+    final lastIndexPlusOne = c.activeMessageId == null
+        ? getMessageCount(conversationId)
+        : ConversationTree.pathToRoot(
+            getMessages(conversationId),
+            c.activeMessageId,
+          ).length;
     final newValue = (c.truncateIndex == lastIndexPlusOne)
         ? -1
         : lastIndexPlusOne;
@@ -1767,6 +2104,11 @@ class ChatService extends ChangeNotifier {
     final message =
         _repo.getMessageSync(messageId) ?? _cachedTemporaryMessage(messageId);
     if (message == null) return;
+
+    if (isDirectedTreeConversation(message.conversationId)) {
+      await _deleteDirectedTreeSubtree(message);
+      return;
+    }
 
     if (isTemporaryConversation(message.conversationId)) {
       final conversation = _draftConversations[message.conversationId];
@@ -1847,6 +2189,114 @@ class ChatService extends ChangeNotifier {
     // Clean up orphaned upload files that are no longer referenced by any message
     await _cleanupOrphanUploads();
 
+    notifyListeners();
+  }
+
+  /// Removes an entire directed subtree so no remaining message can retain a
+  /// dangling parent edge. The legacy delete behavior above intentionally
+  /// stays untouched for pre-tree conversations.
+  Future<void> _deleteDirectedTreeSubtree(ChatMessage root) async {
+    final conversationId = root.conversationId;
+    final messages = getMessages(conversationId);
+    final byParentId = <String, List<ChatMessage>>{};
+    for (final message in messages) {
+      final parentId = message.parentMessageId;
+      if (parentId == null || parentId.isEmpty) continue;
+      byParentId.putIfAbsent(parentId, () => <ChatMessage>[]).add(message);
+    }
+
+    final orderedForDelete = <ChatMessage>[];
+    final deletedIds = <String>{};
+    void collect(ChatMessage message) {
+      if (!deletedIds.add(message.id)) return;
+      for (final child in byParentId[message.id] ?? const <ChatMessage>[]) {
+        collect(child);
+      }
+      orderedForDelete.add(message);
+    }
+
+    collect(root);
+    if (orderedForDelete.isEmpty) return;
+
+    final conversation =
+        _conversationsCache[conversationId] ??
+        _draftConversations[conversationId];
+    final previousActiveId = conversation?.activeMessageId;
+    String? fallbackId;
+    if (previousActiveId != null && deletedIds.contains(previousActiveId)) {
+      fallbackId = root.parentMessageId;
+      if (fallbackId == null || fallbackId.isEmpty) {
+        final siblings = ConversationTree.sortedSiblings(messages, root)
+            .where((candidate) => !deletedIds.contains(candidate.id))
+            .toList(growable: false);
+        if (siblings.isNotEmpty) fallbackId = siblings.last.id;
+      }
+    }
+
+    if (isTemporaryConversation(conversationId)) {
+      final cached = _messagesCache[conversationId];
+      cached?.removeWhere((message) => deletedIds.contains(message.id));
+      conversation?.messageIds.removeWhere(
+        (messageId) => deletedIds.contains(messageId),
+      );
+      for (final message in orderedForDelete) {
+        _temporaryToolEvents.remove(message.id);
+        _temporaryGeminiThoughtSigs.remove(message.id);
+      }
+    } else {
+      await _recordDirectedTreeDeletion(
+        root: root,
+        allMessages: messages,
+        deletedIds: deletedIds,
+        conversation: conversation,
+      );
+      await _repo.deleteDirectedTreeSubtree(
+        orderedForDelete.map((message) => message.id),
+      );
+      await _refreshConversation(conversationId);
+      _messagesCache.remove(conversationId);
+    }
+
+    final remaining = getMessages(conversationId);
+    if (fallbackId != null &&
+        remaining.any((message) => message.id == fallbackId)) {
+      final fallback = remaining.firstWhere(
+        (message) => message.id == fallbackId,
+      );
+      final selectedLeaf = ConversationTree.selectLeafForBranch(
+        messages: remaining,
+        branchStart: fallback,
+        versionSelections:
+            (_conversationsCache[conversationId] ??
+                    _draftConversations[conversationId])
+                ?.versionSelections ??
+            const <String, int>{},
+      );
+      await activateDirectedTreeMessage(
+        conversationId: conversationId,
+        messageId: selectedLeaf.id,
+      );
+    } else if (previousActiveId != null &&
+        remaining.any((message) => message.id == previousActiveId)) {
+      // A sibling before the active one may have been removed, changing its
+      // index in the version switcher. Re-activating normalizes those indexes.
+      await activateDirectedTreeMessage(
+        conversationId: conversationId,
+        messageId: previousActiveId,
+      );
+    } else if (previousActiveId != null && deletedIds.contains(previousActiveId)) {
+      final updated =
+          _conversationsCache[conversationId] ??
+          _draftConversations[conversationId];
+      if (updated != null) {
+        updated.activeMessageId = null;
+        updated.versionSelections.clear();
+        updated.updatedAt = DateTime.now();
+        await _saveConversation(updated);
+      }
+    }
+
+    await _cleanupOrphanUploads();
     notifyListeners();
   }
 
@@ -2066,6 +2516,207 @@ class ChatService extends ChangeNotifier {
     }
   }
 
+  /// Restores a complete directed subtree as one atomic branch.
+  ///
+  /// Tree deletes are intentionally stored as one record. Restoring each row
+  /// individually would allow children to reappear before their parent and
+  /// would break the parent-to-child invariant that keeps version selectors
+  /// scoped to the correct input.
+  Future<String?> _restoreDirectedTreeSubtree({
+    required String trashMessageId,
+    required Map<String, dynamic> bundle,
+  }) async {
+    final store = _deletedRecordsStore;
+    if (store == null) return 'deletedRecordsStore not initialized';
+
+    final rawMessages = bundle['messages'];
+    if (rawMessages is! List) {
+      return 'The deleted branch is missing its messages.';
+    }
+
+    final branchMessages = <ChatMessage>[];
+    for (final rawMessage in rawMessages) {
+      if (rawMessage is! Map) {
+        return 'The deleted branch contains invalid message data.';
+      }
+      final messageJson = <String, dynamic>{
+        for (final entry in rawMessage.entries)
+          entry.key.toString(): entry.value,
+      };
+      branchMessages.add(ChatMessage.fromJson(messageJson));
+    }
+    if (branchMessages.isEmpty) {
+      return 'The deleted branch is empty.';
+    }
+
+    final conversationId = branchMessages.first.conversationId;
+    if (branchMessages.any(
+      (message) => message.conversationId != conversationId,
+    )) {
+      return 'The deleted branch belongs to more than one conversation.';
+    }
+    if (!_conversationsCache.containsKey(conversationId)) {
+      return 'This branch belongs to a deleted conversation. Restore the conversation first.';
+    }
+
+    final restoredIds = branchMessages.map((message) => message.id).toSet();
+    if (restoredIds.length != branchMessages.length) {
+      return 'The deleted branch contains duplicate message ids.';
+    }
+    for (final restoredId in restoredIds) {
+      if (_repo.getMessageSync(restoredId) != null) {
+        return 'A message with this id already exists';
+      }
+    }
+
+    // Every parent must either arrive in this transaction or already be live
+    // in the same conversation. This check makes a corrupt/partial backup
+    // fail closed instead of writing a branch that cannot be traversed.
+    for (final message in branchMessages) {
+      final parentId = message.parentMessageId;
+      if (parentId == null || parentId.isEmpty || restoredIds.contains(parentId)) {
+        continue;
+      }
+      final parent = _repo.getMessageSync(parentId);
+      if (parent == null || parent.conversationId != conversationId) {
+        return 'This branch needs its parent branch restored first.';
+      }
+    }
+
+    final conversation = getCompleteConversation(conversationId);
+    if (conversation == null) {
+      return 'Parent conversation not found in cache';
+    }
+    final liveMessages = List<ChatMessage>.of(getMessages(conversationId));
+    final allMessages = <ChatMessage>[...liveMessages, ...branchMessages];
+    for (final message in branchMessages) {
+      if (ConversationTree.pathToRoot(allMessages, message.id).isEmpty) {
+        return 'The deleted branch has an invalid parent chain.';
+      }
+    }
+
+    final treeState = bundle['treeState'];
+    final rawOrder = treeState is Map ? treeState['messageIds'] : null;
+    final originalOrder = rawOrder is List
+        ? rawOrder.map((id) => id.toString()).toList(growable: false)
+        : const <String>[];
+    final availableIds = allMessages.map((message) => message.id).toSet();
+    final rebuiltOrder = <String>[];
+    final seenIds = <String>{};
+    void addToOrder(String id) {
+      if (availableIds.contains(id) && seenIds.add(id)) rebuiltOrder.add(id);
+    }
+
+    for (final id in originalOrder) {
+      addToOrder(id);
+    }
+    for (final message in liveMessages) {
+      addToOrder(message.id);
+    }
+    for (final message in branchMessages) {
+      addToOrder(message.id);
+    }
+    conversation.messageIds
+      ..clear()
+      ..addAll(rebuiltOrder);
+
+    final rawSelections = treeState is Map
+        ? treeState['versionSelections']
+        : null;
+    if (rawSelections is Map) {
+      final restoredSelections = <String, int>{};
+      for (final entry in rawSelections.entries) {
+        final rawVersion = entry.value;
+        final version = rawVersion is num
+            ? rawVersion.toInt()
+            : int.tryParse(rawVersion?.toString() ?? '');
+        if (version != null && version >= 0) {
+          restoredSelections[entry.key.toString()] = version;
+        }
+      }
+      conversation.versionSelections = restoredSelections;
+    }
+
+    final rawSavedActiveId = treeState is Map
+        ? treeState['activeMessageId']
+        : null;
+    final savedActiveId = rawSavedActiveId is String && rawSavedActiveId.isNotEmpty
+        ? rawSavedActiveId
+        : null;
+    final existingActiveId = conversation.activeMessageId;
+    final String activeMessageId;
+    if (savedActiveId != null && availableIds.contains(savedActiveId)) {
+      activeMessageId = savedActiveId;
+    } else if (existingActiveId != null &&
+        availableIds.contains(existingActiveId)) {
+      activeMessageId = existingActiveId;
+    } else {
+      activeMessageId = branchMessages.last.id;
+    }
+    if (ConversationTree.pathToRoot(allMessages, activeMessageId).isEmpty) {
+      return 'The deleted branch cannot be restored to a valid active path.';
+    }
+    conversation.activeMessageId = activeMessageId;
+    conversation.updatedAt = DateTime.now();
+
+    final toolEvents = <String, List<Map<String, dynamic>>>{};
+    final rawToolEvents = bundle['toolEvents'];
+    if (rawToolEvents is Map) {
+      for (final entry in rawToolEvents.entries) {
+        final restoredId = entry.key.toString();
+        if (!restoredIds.contains(restoredId) || entry.value is! List) continue;
+        final events = (entry.value as List)
+            .whereType<Map>()
+            .map((event) => <String, dynamic>{
+                  for (final item in event.entries)
+                    item.key.toString(): item.value,
+                })
+            .toList(growable: false);
+        if (events.isNotEmpty) toolEvents[restoredId] = events;
+      }
+    }
+
+    final geminiSigs = <String, String>{};
+    final rawGeminiSigs = bundle['geminiSigs'];
+    if (rawGeminiSigs is Map) {
+      for (final entry in rawGeminiSigs.entries) {
+        final restoredId = entry.key.toString();
+        if (restoredIds.contains(restoredId) && entry.value != null) {
+          geminiSigs[restoredId] = entry.value.toString();
+        }
+      }
+    }
+
+    try {
+      await _repo.restoreDirectedTreeSubtree(
+        conversation: conversation,
+        messages: branchMessages,
+        toolEventsByMessageId: toolEvents,
+        geminiSignaturesByMessageId: geminiSigs,
+      );
+
+      // Rebuild from the restored SQLite rows before normalizing the selected
+      // sibling indexes. Keep the complete order in cache even when the
+      // conversation had temporarily become empty after deletion.
+      _messagesCache.remove(conversationId);
+      _conversationsCache[conversationId] = conversation;
+      await activateDirectedTreeMessage(
+        conversationId: conversationId,
+        messageId: activeMessageId,
+      );
+
+      await store.purgeDeletedRecord(
+        trashMessageId,
+        DeletionEntityType.message,
+      );
+      notifyListeners();
+      return null;
+    } catch (e) {
+      debugPrint('_restoreDirectedTreeSubtree: failed: $e');
+      return 'Restore failed: $e';
+    }
+  }
+
   /// Restores a single message from trash by appending it to the end of its
   /// parent conversation.
   ///
@@ -2085,6 +2736,12 @@ class ChatService extends ChangeNotifier {
 
     try {
       final bundle = jsonDecode(record.recoveryJson) as Map<String, dynamic>;
+      if (bundle['treeSubtree'] == true) {
+        return await _restoreDirectedTreeSubtree(
+          trashMessageId: messageId,
+          bundle: bundle,
+        );
+      }
       final msgJson = bundle['message'] as Map<String, dynamic>;
       final message = ChatMessage.fromJson(msgJson);
       final conversationId = message.conversationId;
@@ -2098,6 +2755,16 @@ class ChatService extends ChangeNotifier {
       final existing = _repo.getMessageSync(messageId);
       if (existing != null) {
         return 'A message with this id already exists';
+      }
+
+      // Older recovery records may have been written before subtree deletes
+      // became atomic. Never restore such a child ahead of its parent.
+      final parentId = message.parentMessageId;
+      if (parentId != null && parentId.isNotEmpty) {
+        final parent = _repo.getMessageSync(parentId);
+        if (parent == null || parent.conversationId != conversationId) {
+          return 'This message needs its parent branch restored first.';
+        }
       }
 
       // Append to end of conversation.
@@ -2135,6 +2802,13 @@ class ChatService extends ChangeNotifier {
 
       // Clear cache so messages reload.
       _messagesCache.remove(conversationId);
+
+      if (conversation.activeMessageId != null) {
+        await activateDirectedTreeMessage(
+          conversationId: conversationId,
+          messageId: message.id,
+        );
+      }
 
       // Purge trash row.
       await store.purgeDeletedRecord(messageId, DeletionEntityType.message);

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -11,6 +11,7 @@ import '../models/assistant.dart';
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
 import '../providers/settings_provider.dart';
+import '../utils/conversation_tree.dart';
 import 'api/chat_api_service.dart';
 import 'api/plain_text_collector.dart';
 import 'chat/chat_service.dart';
@@ -315,6 +316,27 @@ class ProactiveCareMessageFlow {
     required Conversation conversation,
     required List<ChatMessage> messages,
   }) {
+    // A directed conversation must contribute only the cursor's exact path.
+    // A per-group collapse can otherwise splice a response from the old
+    // branch onto an edited user message.
+    if (conversation.activeMessageId != null) {
+      final path = ConversationTree.pathToRoot(
+        messages,
+        conversation.activeMessageId,
+      );
+      final tIndex = conversation.truncateIndex;
+      final effective = tIndex >= 0 && tIndex <= path.length
+          ? path.sublist(tIndex)
+          : path;
+      return <Map<String, dynamic>>[
+        for (final m in effective)
+          if ((m.role == 'user' || m.role == 'assistant') &&
+              !m.isStreaming &&
+              m.content.trim().isNotEmpty)
+            {'role': m.role, 'content': m.content},
+      ];
+    }
+
     final collapsed = collapseMessageVersions(
       messages,
       conversation.versionSelections,

--- a/lib/core/utils/conversation_tree.dart
+++ b/lib/core/utils/conversation_tree.dart
@@ -1,0 +1,151 @@
+import '../models/chat_message.dart';
+
+/// Pure helpers for the directed tree used by regular conversations.
+///
+/// A message has at most one parent. Siblings share a [ChatMessage.groupId]
+/// and use [ChatMessage.version] only as their stable display order. The
+/// parent link—not the chronological write order—is the authority for a
+/// conversation's active context.
+class ConversationTree {
+  const ConversationTree._();
+
+  static const String _rootGroupPrefix = '__conversation_tree_root__:';
+
+  /// A stable sibling-group key for children that have no message parent.
+  static String rootGroupId(String conversationId) =>
+      '$_rootGroupPrefix$conversationId';
+
+  /// Every direct child set gets one group. Existing UI controls can keep
+  /// using groupId/version, while path selection is controlled by parent ids.
+  static String siblingGroupId({
+    required String conversationId,
+    required String? parentMessageId,
+  }) {
+    return parentMessageId ?? rootGroupId(conversationId);
+  }
+
+  static List<ChatMessage> sortedSiblings(
+    Iterable<ChatMessage> messages,
+    ChatMessage message,
+  ) {
+    final siblings = messages
+        .where(
+          (candidate) =>
+              candidate.conversationId == message.conversationId &&
+              candidate.parentMessageId == message.parentMessageId &&
+              candidate.groupId == message.groupId,
+        )
+        .toList(growable: false)
+      ..sort(_compareVersions);
+    return siblings;
+  }
+
+  static int siblingIndex(
+    Iterable<ChatMessage> messages,
+    ChatMessage message,
+  ) {
+    return sortedSiblings(messages, message).indexWhere(
+      (candidate) => candidate.id == message.id,
+    );
+  }
+
+  /// Returns the root-to-leaf path for [leafMessageId]. Invalid parents and
+  /// cycles return no path: rendering even the surviving suffix would make an
+  /// orphan look like a valid conversation branch.
+  static List<ChatMessage> pathToRoot(
+    Iterable<ChatMessage> messages,
+    String? leafMessageId,
+  ) {
+    if (leafMessageId == null || leafMessageId.isEmpty) {
+      return const <ChatMessage>[];
+    }
+    final byId = <String, ChatMessage>{
+      for (final message in messages) message.id: message,
+    };
+    final reversed = <ChatMessage>[];
+    final visited = <String>{};
+    ChatMessage? current = byId[leafMessageId];
+    while (current != null) {
+      if (!visited.add(current.id)) return const <ChatMessage>[];
+      reversed.add(current);
+      final parentId = current.parentMessageId;
+      if (parentId == null || parentId.isEmpty) break;
+      final parent = byId[parentId];
+      if (parent == null || parent.conversationId != current.conversationId) {
+        return const <ChatMessage>[];
+      }
+      current = parent;
+    }
+    return reversed.reversed.toList(growable: false);
+  }
+
+  /// Follows the remembered selection at every later fork. If a selection is
+  /// absent or stale, the newest direct child is used as the deterministic
+  /// default. This makes switching back to a branch reveal its own continuation
+  /// instead of another branch's messages.
+  static ChatMessage selectLeafForBranch({
+    required Iterable<ChatMessage> messages,
+    required ChatMessage branchStart,
+    required Map<String, int> versionSelections,
+  }) {
+    final all = List<ChatMessage>.of(messages);
+    final visited = <String>{};
+    var current = branchStart;
+    while (visited.add(current.id)) {
+      final children = all
+          .where(
+            (candidate) =>
+                candidate.conversationId == current.conversationId &&
+                candidate.parentMessageId == current.id,
+          )
+          .toList(growable: false)
+        ..sort(_compareVersions);
+      if (children.isEmpty) return current;
+
+      // New tree messages deliberately give every direct child set one group.
+      // If damaged/imported data has multiple groups under a parent, prefer the
+      // latest group rather than silently combining incomparable choices.
+      final groupId = children.last.groupId ?? children.last.id;
+      final sameGroup = children
+          .where((candidate) => (candidate.groupId ?? candidate.id) == groupId)
+          .toList(growable: false)
+        ..sort(_compareVersions);
+      final selectedIndex = versionSelections[groupId];
+      final safeIndex = selectedIndex != null &&
+              selectedIndex >= 0 &&
+              selectedIndex < sameGroup.length
+          ? selectedIndex
+          : sameGroup.length - 1;
+      current = sameGroup[safeIndex];
+    }
+    return current;
+  }
+
+  static int nextSiblingVersion({
+    required Iterable<ChatMessage> messages,
+    required String conversationId,
+    required String? parentMessageId,
+  }) {
+    final groupId = siblingGroupId(
+      conversationId: conversationId,
+      parentMessageId: parentMessageId,
+    );
+    var maxVersion = -1;
+    for (final message in messages) {
+      if (message.conversationId == conversationId &&
+          message.parentMessageId == parentMessageId &&
+          (message.groupId ?? message.id) == groupId) {
+        if (message.version > maxVersion) maxVersion = message.version;
+      }
+    }
+    return maxVersion + 1;
+  }
+
+  static int _compareVersions(ChatMessage a, ChatMessage b) {
+    final byVersion = a.version.compareTo(b.version);
+    if (byVersion != 0) return byVersion;
+    final byTime = a.timestamp.compareTo(b.timestamp);
+    if (byTime != 0) return byTime;
+    return a.id.compareTo(b.id);
+  }
+}

--- a/lib/features/chat/widgets/message_export_sheet.dart
+++ b/lib/features/chat/widgets/message_export_sheet.dart
@@ -26,6 +26,7 @@ import '../../../core/providers/user_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../shared/widgets/markdown_with_highlight.dart';
 import '../../../shared/widgets/export_capture_scope.dart';
@@ -643,10 +644,16 @@ Future<bool> exportConversationsMarkdownBatch(
       final count = chatService.getMessageCount(id);
       final all = chatService.getMessagesRange(id, start: 0, limit: count);
       if (all.isEmpty) continue; // empty conversation → skipped
-      final collapsed = ChatController.collapseWithSelections(
-        all,
-        chatService.getVersionSelections(id),
-      );
+      // A directed conversation has one visible root-to-leaf branch. The
+      // legacy group collapse would independently pick a version from every
+      // group and could export an edited input beside an answer from the old
+      // input. Keep the export on the exact branch the user is viewing.
+      final collapsed = convo.activeMessageId == null
+          ? ChatController.collapseWithSelections(
+              all,
+              chatService.getVersionSelections(id),
+            )
+          : ConversationTree.pathToRoot(all, convo.activeMessageId);
       final body = await buildMarkdownExportBody(
         l10n: l10n,
         settings: settings,

--- a/lib/features/home/controllers/chat_actions.dart
+++ b/lib/features/home/controllers/chat_actions.dart
@@ -11,6 +11,7 @@ import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../core/services/ios_background_generation.dart';
 import '../../../core/services/logging/flutter_logger.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../services/ask_user_interaction_service.dart';
@@ -440,12 +441,39 @@ class ChatActions {
       return ChatActionResult.error('audio_attachment_unsupported');
     }
 
-    // Create user message
+    // New regular conversations start as directed trees. Existing legacy
+    // transcripts remain on their historical flat semantics until explicitly
+    // forked/edited, so old backups never need guessed parent links.
+    final latestConversation =
+        chatService.getConversation(conversation.id) ?? conversation;
+    final useDirectedTree =
+        !conversation.isGroup &&
+        (chatService.isDirectedTreeConversation(conversation.id) ||
+            chatService.getMessageCount(conversation.id) == 0);
+    final userParentMessageId =
+        useDirectedTree ? latestConversation.activeMessageId : null;
+    final userPlacement = useDirectedTree
+        ? chatService.nextDirectedTreeChild(
+            conversationId: conversation.id,
+            parentMessageId: userParentMessageId,
+          )
+        : null;
+
+    // Create user message.
     final userMessage = await messageGenerationService.createUserMessage(
       conversationId: conversation.id,
       input: input,
       assistant: assistant,
+      groupId: userPlacement?.groupId,
+      parentMessageId: userParentMessageId,
+      version: userPlacement?.version ?? 0,
     );
+    if (useDirectedTree) {
+      await chatService.activateDirectedTreeMessage(
+        conversationId: conversation.id,
+        messageId: userMessage.id,
+      );
+    }
     if (chatController.appendPersistedTailMessage(userMessage)) {
       viewModel.restoreMessageUiState();
     }
@@ -453,13 +481,29 @@ class ChatActions {
 
     _setConversationLoading(conversation.id, true);
 
-    // Create assistant message placeholder
+    final assistantPlacement = useDirectedTree
+        ? chatService.nextDirectedTreeChild(
+            conversationId: conversation.id,
+            parentMessageId: userMessage.id,
+          )
+        : null;
+
+    // Create assistant message placeholder.
     final assistantMessage = await messageGenerationService
         .createAssistantPlaceholder(
           conversationId: conversation.id,
           modelId: modelId,
           providerKey: providerKey,
+          groupId: assistantPlacement?.groupId,
+          parentMessageId: useDirectedTree ? userMessage.id : null,
+          version: assistantPlacement?.version ?? 0,
         );
+    if (useDirectedTree) {
+      await chatService.activateDirectedTreeMessage(
+        conversationId: conversation.id,
+        messageId: assistantMessage.id,
+      );
+    }
 
     // Pre-create streaming notifier BEFORE adding message to list
     // so that MessageListView can detect it's streaming on first render
@@ -579,6 +623,18 @@ class ChatActions {
         .getLoadedCurrentAssistant();
 
     await cancelStreaming(conversation);
+
+    if (!chatService.isDirectedTreeConversation(conversation.id)) {
+      await chatService.adoptLinearConversationAsDirectedTree(conversation.id);
+    }
+    if (chatService.isDirectedTreeConversation(conversation.id)) {
+      return _regenerateDirectedTreeAtMessage(
+        message: message,
+        conversation: conversation,
+        assistantAsNewReply: assistantAsNewReply,
+        allowImagesApiRouting: allowImagesApiRouting,
+      );
+    }
 
     final completeMessages = chatController.messagesForCompleteHistoryContext(
       conversation,
@@ -739,6 +795,170 @@ class ChatActions {
     );
 
     await _executeGeneration(ctx);
+    return ChatActionResult.success(assistantMessage);
+  }
+
+  /// Regenerate inside the currently selected directed path. Unlike the
+  /// legacy implementation this never removes later rows and never derives
+  /// context from chronological neighbors: the parent edge is the only source
+  /// of truth for the new answer's branch.
+  Future<ChatActionResult> _regenerateDirectedTreeAtMessage({
+    required ChatMessage message,
+    required Conversation conversation,
+    required bool assistantAsNewReply,
+    required bool allowImagesApiRouting,
+  }) async {
+    final rawMessages = chatService.getMessagesRange(
+      conversation.id,
+      start: 0,
+      limit: chatService.getMessageCount(conversation.id),
+    );
+    final targetIndex = rawMessages.indexWhere(
+      (candidate) => candidate.id == message.id,
+    );
+    if (targetIndex < 0) return ChatActionResult.error('message_not_found');
+
+    final target = rawMessages[targetIndex];
+    final String? assistantParentId;
+    if (target.role == 'assistant') {
+      assistantParentId = assistantAsNewReply
+          ? target.id
+          : target.parentMessageId;
+    } else if (target.role == 'user') {
+      assistantParentId = target.id;
+    } else {
+      return ChatActionResult.error('invalid_versioning');
+    }
+    if (assistantParentId == null || assistantParentId.isEmpty) {
+      return ChatActionResult.error('invalid_versioning');
+    }
+
+    final contextPath = ConversationTree.pathToRoot(
+      rawMessages,
+      assistantParentId,
+    );
+    if (contextPath.isEmpty || contextPath.last.id != assistantParentId) {
+      return ChatActionResult.error('invalid_versioning');
+    }
+
+    final settings = contextProvider.read<SettingsProvider>();
+    ToolApprovalService? approvalService;
+    AskUserInteractionService? askUserService;
+    try {
+      approvalService = contextProvider.read<ToolApprovalService>();
+    } catch (_) {}
+    try {
+      askUserService = contextProvider.read<AskUserInteractionService>();
+    } catch (_) {}
+    final shouldGenerateTitleOnRetry =
+        conversation.title == getTitleForLocale(contextProvider);
+    final assistant = await contextProvider
+        .read<AssistantProvider>()
+        .getLoadedCurrentAssistant();
+    final modelConfig = messageGenerationService.getModelConfig(
+      settings,
+      assistant,
+    );
+    if (modelConfig.providerKey == null || modelConfig.modelId == null) {
+      return ChatActionResult.noModel();
+    }
+    final providerKey = modelConfig.providerKey!;
+    final modelId = modelConfig.modelId!;
+
+    if (_hasUnsupportedAudioAttachments(
+      messages: contextPath,
+      conversation: conversation,
+      settings: settings,
+      providerKey: providerKey,
+      modelId: modelId,
+      maxRawTruncateIndex: null,
+    )) {
+      return ChatActionResult.error('audio_attachment_unsupported');
+    }
+
+    final placement = chatService.nextDirectedTreeChild(
+      conversationId: conversation.id,
+      parentMessageId: assistantParentId,
+    );
+    final assistantMessage = await messageGenerationService
+        .createAssistantPlaceholder(
+          conversationId: conversation.id,
+          modelId: modelId,
+          providerKey: providerKey,
+          groupId: placement.groupId,
+          version: placement.version,
+          parentMessageId: assistantParentId,
+        );
+    await chatService.activateDirectedTreeMessage(
+      conversationId: conversation.id,
+      messageId: assistantMessage.id,
+    );
+    streamController.markStreamingStarted(assistantMessage.id);
+
+    if (chatController.appendPersistedTailMessage(assistantMessage)) {
+      viewModel.restoreMessageUiState();
+    }
+    onMessagesChanged?.call();
+    _setConversationLoading(conversation.id, true);
+
+    final supportsReasoning = _isReasoningModel(providerKey, modelId);
+    final enableReasoning =
+        supportsReasoning &&
+        _isReasoningEnabled(
+          assistant?.thinkingBudget ?? settings.thinkingBudget,
+        );
+    await messageGenerationService.initializeReasoningState(
+      messageId: assistantMessage.id,
+      enableReasoning: enableReasoning,
+    );
+
+    final regenerationMessages = <ChatMessage>[
+      ...contextPath,
+      assistantMessage,
+    ];
+    final prepared = await messageGenerationService
+        .prepareApiMessagesWithInjections(
+          messages: regenerationMessages,
+          versionSelections: _versionSelections,
+          currentConversation: _conversationForMessageContext(
+            conversation,
+            regenerationMessages,
+          ),
+          settings: settings,
+          assistant: assistant,
+          assistantId: assistant?.id,
+          providerKey: providerKey,
+          modelId: modelId,
+          approvalService: approvalService,
+          askUserService: askUserService,
+        );
+    final userMediaPaths = messageGenerationService.buildUserMediaPaths(
+      input: null,
+      lastUserMediaPaths: prepared.lastUserImagePaths,
+      settings: settings,
+      providerKey: providerKey,
+      modelId: modelId,
+      assistant: assistant,
+    );
+    final requestOptions = _resolveRequestOptionsFromMessages(
+      regenerationMessages,
+      fallbackAllowImagesApiRouting: allowImagesApiRouting,
+    );
+    final context = messageGenerationService.buildGenerationContext(
+      assistantMessage: assistantMessage,
+      prepared: prepared,
+      userMediaPaths: userMediaPaths,
+      allowImagesApiRouting: requestOptions.allowImagesApiRouting,
+      providerKey: providerKey,
+      modelId: modelId,
+      assistant: assistant,
+      settings: settings,
+      supportsReasoning: supportsReasoning,
+      enableReasoning: enableReasoning,
+      generateTitleOnFinish: shouldGenerateTitleOnRetry,
+      requestExtraBody: requestOptions.requestExtraBody,
+    );
+    await _executeGeneration(context);
     return ChatActionResult.success(assistantMessage);
   }
 

--- a/lib/features/home/controllers/chat_controller.dart
+++ b/lib/features/home/controllers/chat_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/conversation.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/utils/conversation_tree.dart';
 
 /// Controller for managing conversation state in the home page.
 ///
@@ -43,8 +44,9 @@ class ChatController extends ChangeNotifier {
   int _totalMessageCount = 0;
   int get totalMessageCount => _totalMessageCount;
 
-  bool get hasMoreBefore => _loadedStartIndex > 0;
+  bool get hasMoreBefore => !_usesDirectedTree && _loadedStartIndex > 0;
   bool get hasMoreAfter =>
+      !_usesDirectedTree &&
       _loadedStartIndex + _messages.length < _totalMessageCount;
 
   /// Selected version per message group (groupId -> selected version index).
@@ -86,6 +88,24 @@ class ChatController extends ChangeNotifier {
 
   /// Get the ChatService instance.
   ChatService get chatService => _chatService;
+
+  bool get _usesDirectedTree {
+    final current = _currentConversation;
+    if (current == null) return false;
+    return (_chatService.getConversation(current.id)?.activeMessageId ??
+            current.activeMessageId) !=
+        null;
+  }
+
+  List<ChatMessage> _directedTreePath(Conversation conversation) {
+    final current = _chatService.getConversation(conversation.id) ?? conversation;
+    final raw = _chatService.getMessagesRange(
+      current.id,
+      start: 0,
+      limit: _chatService.getMessageCount(current.id),
+    );
+    return ConversationTree.pathToRoot(raw, current.activeMessageId);
+  }
 
   void _syncCurrentConversationWithService() {
     final conversation = _currentConversation;
@@ -188,6 +208,13 @@ class ChatController extends ChangeNotifier {
 
   void _loadInitialMessageWindow(String conversationId) {
     _totalMessageCount = _chatService.getMessageCount(conversationId);
+    final conversation = _currentConversation;
+    if (conversation != null && _usesDirectedTree) {
+      _messages = _directedTreePath(conversation);
+      _loadedStartIndex = 0;
+      invalidateCache();
+      return;
+    }
     _messages = List.of(_chatService.getRecentMessages(conversationId));
     _loadedStartIndex = (_totalMessageCount - _messages.length)
         .clamp(0, _totalMessageCount)
@@ -354,6 +381,7 @@ class ChatController extends ChangeNotifier {
   List<ChatMessage> allCollapsedMessagesForCurrentConversation() {
     final conversation = _currentConversation;
     if (conversation == null) return const <ChatMessage>[];
+    if (_usesDirectedTree) return _directedTreePath(conversation);
     return collapseVersions(
       _chatService.getMessagesRange(
         conversation.id,
@@ -372,6 +400,9 @@ class ChatController extends ChangeNotifier {
   List<ChatMessage> messagesForCompleteHistoryContext(
     Conversation conversation,
   ) {
+    if (_usesDirectedTree && _currentConversation?.id == conversation.id) {
+      return _directedTreePath(conversation);
+    }
     return _chatService.getMessagesRange(
       conversation.id,
       start: 0,
@@ -512,6 +543,17 @@ class ChatController extends ChangeNotifier {
       return false;
     }
 
+    if (_usesDirectedTree) {
+      _currentConversation =
+          _chatService.getConversation(conversation.id) ?? conversation;
+      _versionSelections = _chatService.getVersionSelections(conversation.id);
+      _totalMessageCount = _chatService.getMessageCount(conversation.id);
+      _messages = _directedTreePath(_currentConversation!);
+      _loadedStartIndex = 0;
+      notifyListeners();
+      return false;
+    }
+
     final wasAtTail =
         _loadedStartIndex + _messages.length >= _totalMessageCount;
     _totalMessageCount = _chatService.getMessageCount(conversation.id);
@@ -622,6 +664,16 @@ class ChatController extends ChangeNotifier {
   void reloadMessages() {
     if (_currentConversation == null) return;
     final conversationId = _currentConversation!.id;
+    if (_usesDirectedTree) {
+      _currentConversation =
+          _chatService.getConversation(conversationId) ?? _currentConversation;
+      _versionSelections = _chatService.getVersionSelections(conversationId);
+      _totalMessageCount = _chatService.getMessageCount(conversationId);
+      _messages = _directedTreePath(_currentConversation!);
+      _loadedStartIndex = 0;
+      notifyListeners();
+      return;
+    }
     final wasAtTail =
         _loadedStartIndex + _messages.length >= _totalMessageCount;
     _totalMessageCount = _chatService.getMessageCount(conversationId);
@@ -665,10 +717,24 @@ class ChatController extends ChangeNotifier {
 
   /// Set the selected version for a message group.
   Future<void> setSelectedVersion(String groupId, int version) async {
-    _versionSelections[groupId] = version;
-    if (_currentConversation != null) {
+    final conversation = _currentConversation;
+    if (conversation == null) return;
+    if (_usesDirectedTree) {
+      await _chatService.selectDirectedTreeVersion(
+        conversationId: conversation.id,
+        groupId: groupId,
+        version: version,
+      );
+      _currentConversation =
+          _chatService.getConversation(conversation.id) ?? conversation;
+      _versionSelections = _chatService.getVersionSelections(conversation.id);
+      _totalMessageCount = _chatService.getMessageCount(conversation.id);
+      _messages = _directedTreePath(_currentConversation!);
+      _loadedStartIndex = 0;
+    } else {
+      _versionSelections[groupId] = version;
       await _chatService.setSelectedVersion(
-        _currentConversation!.id,
+        conversation.id,
         groupId,
         version,
       );
@@ -821,6 +887,14 @@ class ChatController extends ChangeNotifier {
   /// Get messages collapsed by version (cached).
   List<ChatMessage> get collapsedMessages {
     if (_collapsedCache != null) return _collapsedCache!;
+    if (_usesDirectedTree) {
+      _collapsedCache = _directedTreePath(_currentConversation!);
+      _collapsedIdToIndex = <String, int>{
+        for (var i = 0; i < _collapsedCache!.length; i++)
+          _collapsedCache![i].id: i,
+      };
+      return _collapsedCache!;
+    }
     final raw = _messagesWithVisibleGroups();
     final active = subgroupActiveGroupIds;
     final filtered = active.isEmpty
@@ -977,9 +1051,20 @@ class ChatController extends ChangeNotifier {
   Map<String, List<ChatMessage>> groupMessagesByGroup() {
     final Map<String, List<ChatMessage>> byGroup =
         <String, List<ChatMessage>>{};
-    for (final m in _messagesWithVisibleGroups()) {
+    final conversation = _currentConversation;
+    final source = _usesDirectedTree && conversation != null
+        ? _chatService.getMessagesRange(
+            conversation.id,
+            start: 0,
+            limit: _chatService.getMessageCount(conversation.id),
+          )
+        : _messagesWithVisibleGroups();
+    for (final m in source) {
       final gid = (m.groupId ?? m.id);
       byGroup.putIfAbsent(gid, () => <ChatMessage>[]).add(m);
+    }
+    for (final messages in byGroup.values) {
+      messages.sort((a, b) => a.version.compareTo(b.version));
     }
     return byGroup;
   }

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -19,6 +19,7 @@ import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/memory_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../core/services/tts/tts_text_selection.dart';
 import '../../../core/services/haptics.dart';
@@ -761,11 +762,18 @@ class HomePageController extends ChangeNotifier {
       await _createNewConversation();
     }
 
+    // Multi-AI rounds still use their own flat subgroup representation. Keep
+    // a directed conversation on the regular send path instead of creating
+    // rows that lack parent edges.
+    final directedConversation = _chatService.isDirectedTreeConversation(
+      currentConversation!.id,
+    );
     ChatInputSubmissionResult result;
-    if (multiAIEngine.isActive &&
+    if (!directedConversation &&
+        multiAIEngine.isActive &&
         multiAIEngine.mode == MultiAIMode.synthesize) {
       result = await _sendSynthesize(input);
-    } else if (multiAIEngine.isActive) {
+    } else if (!directedConversation && multiAIEngine.isActive) {
       if (!_context.mounted) return ChatInputSubmissionResult.rejected;
       final settings = _context.read<SettingsProvider>();
       final assistant = await _context
@@ -1379,18 +1387,15 @@ class HomePageController extends ChangeNotifier {
       _viewModel.restoreMessageUiState();
     }
     final gid = (newMsg.groupId ?? newMsg.id);
-    versionSelections[gid] = newMsg.version;
-    notifyListeners();
-
     if (currentConversation != null) {
       try {
-        await _chatService.setSelectedVersion(
-          currentConversation!.id,
-          gid,
-          newMsg.version,
+        await _chatController.setSelectedVersion(gid, newMsg.version);
+        _viewModel.updateCurrentConversation(
+          _chatService.getConversation(currentConversation!.id),
         );
       } catch (_) {}
     }
+    notifyListeners();
 
     if (!result.shouldSend) return;
     if (message.role == 'assistant') {
@@ -1534,12 +1539,10 @@ class HomePageController extends ChangeNotifier {
       _viewModel.restoreMessageUiState();
     }
     final gid = newMsg.groupId ?? newMsg.id;
-    versionSelections[gid] = newMsg.version;
     try {
-      await _chatService.setSelectedVersion(
-        conversation.id,
-        gid,
-        newMsg.version,
+      await _chatController.setSelectedVersion(gid, newMsg.version);
+      _viewModel.updateCurrentConversation(
+        _chatService.getConversation(conversation.id),
       );
     } catch (_) {}
     notifyListeners();
@@ -1892,8 +1895,11 @@ class HomePageController extends ChangeNotifier {
       start: 0,
       limit: _chatService.getMessageCount(convo.id),
     );
+    final collapsedMessages = convo.activeMessageId == null
+        ? _chatController.collapseVersions(storedMessages)
+        : ConversationTree.pathToRoot(storedMessages, convo.activeMessageId);
     return ChatController.selectedCollapsedMessagesForExport(
-      collapsedMessages: _chatController.collapseVersions(storedMessages),
+      collapsedMessages: collapsedMessages,
       selectedIds: _selectedItems,
       storedMessages: storedMessages,
     );
@@ -2025,11 +2031,9 @@ class HomePageController extends ChangeNotifier {
   // ============================================================================
 
   Future<void> setSelectedVersion(String groupId, int version) async {
-    versionSelections[groupId] = version;
-    await _chatService.setSelectedVersion(
-      currentConversation!.id,
-      groupId,
-      version,
+    await _chatController.setSelectedVersion(groupId, version);
+    _viewModel.updateCurrentConversation(
+      _chatService.getConversation(currentConversation!.id),
     );
     notifyListeners();
   }
@@ -2066,7 +2070,8 @@ class HomePageController extends ChangeNotifier {
   bool get canStartMultiAIComparison =>
       multiAIEngine.isActive &&
       multiAIEngine.models.length >= 2 &&
-      _chatController.subgroupActiveGroupIds.isEmpty;
+      _chatController.subgroupActiveGroupIds.isEmpty &&
+      !_chatService.isDirectedTreeConversation(currentConversation?.id ?? '');
 
   /// Tag a trigger assistant message with its matching subgroupId from the
   /// engine's model list. If the trigger's model matches a pre-selected model,

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -15,6 +15,7 @@ import '../../../core/services/notification_service.dart';
 import '../../../core/services/proactive_care_alarm_service.dart';
 import '../../../core/services/proactive_care_message_flow.dart';
 import '../../../core/providers/user_provider.dart';
+import '../../../core/utils/conversation_tree.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../chat/widgets/chat_message_widget.dart' show ToolUIPart;
@@ -1438,13 +1439,18 @@ class HomeViewModel extends ChangeNotifier {
       assistant?.thinkingBudget,
     );
 
-    // Build content from messages (truncate to reasonable length)
-    final msgs = _chatService.getMessages(convo.id);
+    // Build content from the exact active branch when this is a directed
+    // conversation. Flat group collapse can otherwise combine two branches
+    // in an automatically generated title.
+    final rawMessages = _chatService.getMessages(convo.id);
+    final selectedMessages = convo.activeMessageId == null
+        ? collapseVersions(rawMessages)
+        : ConversationTree.pathToRoot(rawMessages, convo.activeMessageId);
     final tIndex = convo.truncateIndex;
-    final List<ChatMessage> sourceAll = (tIndex >= 0 && tIndex <= msgs.length)
-        ? msgs.sublist(tIndex)
-        : msgs;
-    final List<ChatMessage> source = collapseVersions(sourceAll);
+    final List<ChatMessage> source =
+        (tIndex >= 0 && tIndex <= selectedMessages.length)
+        ? selectedMessages.sublist(tIndex)
+        : selectedMessages;
     final joined = source
         .where((m) => m.content.isNotEmpty)
         .map(
@@ -1507,7 +1513,6 @@ class HomeViewModel extends ChangeNotifier {
     if (convo == null) return;
 
     final settings = _contextProvider.read<SettingsProvider>();
-    final msgCount = convo.messageIds.length;
     final assistantProvider = _contextProvider.read<AssistantProvider>();
 
     // Get assistant for this conversation
@@ -1523,6 +1528,13 @@ class HomeViewModel extends ChangeNotifier {
     final triggerMessageCount =
         assistant?.recentChatsSummaryMessageCount ??
         Assistant.defaultRecentChatsSummaryMessageCount;
+    // Summaries are branch-specific. Counting and summarizing raw rows would
+    // let a hidden retry/edit branch affect the active branch's memory.
+    final rawMessages = _chatService.getMessages(convo.id);
+    final msgs = convo.activeMessageId == null
+        ? rawMessages
+        : ConversationTree.pathToRoot(rawMessages, convo.activeMessageId);
+    final msgCount = msgs.length;
     if (msgCount == 0 ||
         msgCount - convo.lastSummarizedMessageCount < triggerMessageCount) {
       return;
@@ -1543,8 +1555,7 @@ class HomeViewModel extends ChangeNotifier {
 
     final cfg = settings.getProviderConfig(provKey);
 
-    // Get all messages and filter user messages
-    final msgs = _chatService.getMessages(convo.id);
+    // Get the active branch's user messages.
     final allUserMsgs = msgs
         .where((m) => m.role == 'user' && m.content.trim().isNotEmpty)
         .toList();
@@ -1633,12 +1644,18 @@ class HomeViewModel extends ChangeNotifier {
     if (provKey == null || mdlId == null) return;
 
     final rawMsgs = _chatService.getMessages(convo.id);
-    final msgs = collapseVersions(rawMsgs);
-    final collapsedTruncateIndex = ChatService.rawToCollapsedSkip(
-      rawMessages: rawMsgs,
-      collapsedMessages: msgs,
-      truncateIndex: convo.truncateIndex,
-    );
+    final msgs = convo.activeMessageId == null
+        ? collapseVersions(rawMsgs)
+        : ConversationTree.pathToRoot(rawMsgs, convo.activeMessageId);
+    final collapsedTruncateIndex = convo.activeMessageId == null
+        ? ChatService.rawToCollapsedSkip(
+            rawMessages: rawMsgs,
+            collapsedMessages: msgs,
+            truncateIndex: convo.truncateIndex,
+          )
+        : (convo.truncateIndex >= 0 && convo.truncateIndex <= msgs.length
+              ? convo.truncateIndex
+              : 0);
     final lastAssistant = msgs.cast<ChatMessage?>().lastWhere(
       (m) =>
           m != null &&

--- a/lib/features/home/services/handoff_tool_service.dart
+++ b/lib/features/home/services/handoff_tool_service.dart
@@ -11,6 +11,7 @@ import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../chat/utils/thinking_tag_parser.dart';
 import 'ask_user_interaction_service.dart';
 import 'local_tools_service.dart';
@@ -362,7 +363,14 @@ class HandoffToolService {
         assistant.thinkingBudget,
       );
 
-      final msgs = chatService.getMessages(conversationId);
+      final rawMessages = chatService.getMessages(conversationId);
+      final conversation = chatService.getConversation(conversationId);
+      final msgs = conversation?.activeMessageId == null
+          ? rawMessages
+          : ConversationTree.pathToRoot(
+              rawMessages,
+              conversation!.activeMessageId,
+            );
       final joined = msgs
           .where((m) => m.content.isNotEmpty)
           .map(

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -20,6 +20,7 @@ import '../../../core/services/world_book_store.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../../core/services/api/builtin_tools.dart';
 import '../../../core/models/assistant_regex.dart';
 import '../../../core/utils/multimodal_input_utils.dart';
@@ -129,11 +130,44 @@ class MessageBuilderService {
     required Conversation? currentConversation,
     bool includeToolMessages = false,
   }) {
+    // A tree already has exactly one authoritative root-to-leaf path. Do not
+    // re-collapse all chronological rows by group: that can pair an edited
+    // user input with an answer from the previous input. The caller may pass
+    // a temporary conversation copy to adjust truncation, so read only the
+    // live cursor from ChatService and retain the supplied truncateIndex.
+    final activeMessageId = currentConversation == null
+        ? null
+        : (chatService.getConversation(currentConversation.id)?.activeMessageId ??
+              currentConversation.activeMessageId);
+    final List<ChatMessage> selectedMessages;
+    if (activeMessageId == null) {
+      selectedMessages = List<ChatMessage>.of(messages);
+    } else {
+      final activePath = ConversationTree.pathToRoot(
+        messages,
+        activeMessageId,
+      );
+      if (activePath.isNotEmpty) {
+        selectedMessages = activePath;
+      } else if (messages.isNotEmpty &&
+          ConversationTree.pathToRoot(messages, messages.last.id).length ==
+              messages.length) {
+        // Regenerating an earlier turn deliberately supplies that earlier
+        // complete path while the live cursor still points at a later leaf.
+        // Respect this explicit, self-contained path; never fall back to a
+        // flat set of groups.
+        selectedMessages = List<ChatMessage>.of(messages);
+      } else {
+        // A corrupted or incomplete tree must not silently turn into a mixed
+        // flat context. Empty is safer than pairing unrelated branches.
+        selectedMessages = const <ChatMessage>[];
+      }
+    }
     final tIndex = currentConversation?.truncateIndex ?? -1;
     final List<ChatMessage> sourceAll =
-        (tIndex >= 0 && tIndex <= messages.length)
-        ? messages.sublist(tIndex)
-        : List.of(messages);
+        (tIndex >= 0 && tIndex <= selectedMessages.length)
+        ? selectedMessages.sublist(tIndex)
+        : selectedMessages;
     final List<ChatMessage> source = collapseVersions(
       sourceAll,
       versionSelections,

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -266,6 +266,8 @@ class MessageGenerationService {
     required ChatInputData input,
     required Assistant? assistant,
     String? groupId,
+    String? parentMessageId,
+    int version = 0,
   }) async {
     final message = await chatService.addMessage(
       conversationId: conversationId,
@@ -275,6 +277,8 @@ class MessageGenerationService {
         assistant: assistant,
       ),
       groupId: groupId,
+      parentMessageId: parentMessageId,
+      version: version,
     );
     // Persist per-message request metadata (routing decision + image options
     // body) so regenerate/continue can replay them. See
@@ -316,6 +320,7 @@ class MessageGenerationService {
     String? groupId,
     String? subgroupId,
     int version = 0,
+    String? parentMessageId,
     String? speakerAssistantId,
   }) async {
     return chatService.addMessage(
@@ -328,6 +333,7 @@ class MessageGenerationService {
       groupId: groupId,
       subgroupId: subgroupId,
       version: version,
+      parentMessageId: parentMessageId,
       speakerAssistantId: speakerAssistantId,
     );
   }

--- a/lib/features/home/widgets/side_drawer.dart
+++ b/lib/features/home/widgets/side_drawer.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import '../../../icons/lucide_adapter.dart';
 import 'package:provider/provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/utils/conversation_tree.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/logging/flutter_logger.dart';
 import '../../../core/providers/settings_provider.dart';
@@ -1149,8 +1150,15 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       assistant?.thinkingBudget,
     );
 
-    // Content
-    final msgs = chatService.getMessages(conversationId);
+    // Content from a directed conversation must be the active branch only.
+    final rawMessages = chatService.getMessages(conversationId);
+    final conversation = chatService.getConversation(conversationId);
+    final msgs = conversation?.activeMessageId == null
+        ? rawMessages
+        : ConversationTree.pathToRoot(
+            rawMessages,
+            conversation!.activeMessageId,
+          );
     final joined = msgs
         .where((m) => m.content.isNotEmpty)
         .map(

--- a/test/core/database/schema_heal_discoverable_test.dart
+++ b/test/core/database/schema_heal_discoverable_test.dart
@@ -235,6 +235,57 @@ void main() {
     },
   );
 
+  test('heal adds and round-trips directed-tree columns on an already-v20 DB',
+      () async {
+    // This deliberately has user_version=20 while both v20 physical columns
+    // are absent, mirroring a partially completed release upgrade. Only the
+    // beforeOpen self-heal can repair it.
+    _createLegacyDb(
+      dbFile,
+      userVersion: 20,
+      missingIsPreset: false,
+      missingHandoffColumns: false,
+      missingOcrMode: false,
+      missingContextTokens: false,
+    );
+
+    final repo = ChatDatabaseRepository.open(file: dbFile);
+    await repo.ensureReady();
+
+    final conversation = Conversation(
+      id: 'tree-conversation',
+      title: 'Tree',
+      activeMessageId: 'answer-2',
+    );
+    await repo.putConversation(conversation);
+    await repo.putMessage(
+      ChatMessage(
+        id: 'question-1',
+        role: 'user',
+        content: '1',
+        conversationId: conversation.id,
+        groupId: '__conversation_tree_root__:${conversation.id}',
+      ),
+    );
+    await repo.putMessage(
+      ChatMessage(
+        id: 'answer-2',
+        role: 'assistant',
+        content: '2',
+        conversationId: conversation.id,
+        parentMessageId: 'question-1',
+        groupId: 'question-1',
+      ),
+    );
+
+    final loadedConversation = await repo.getConversation(conversation.id);
+    final loadedMessage = await repo.getMessage('answer-2');
+    expect(loadedConversation?.activeMessageId, 'answer-2');
+    expect(loadedMessage?.parentMessageId, 'question-1');
+
+    await repo.close();
+  });
+
   test('heal adds inject_group_members column on group_chat_rows '
       '(v17 column shape)', () async {
     _createLegacyDb(

--- a/test/core/models/chat_message_request_metadata_test.dart
+++ b/test/core/models/chat_message_request_metadata_test.dart
@@ -50,5 +50,20 @@ void main() {
         'n': 2,
       });
     });
+
+    test('toJson/fromJson preserves directed-tree parent', () {
+      final message = ChatMessage(
+        id: 'answer-5',
+        role: 'assistant',
+        content: '5',
+        conversationId: 'conversation-1',
+        parentMessageId: 'question-4',
+      );
+
+      expect(
+        ChatMessage.fromJson(message.toJson()).parentMessageId,
+        'question-4',
+      );
+    });
   });
 }

--- a/test/core/models/conversation_test.dart
+++ b/test/core/models/conversation_test.dart
@@ -25,5 +25,31 @@ void main() {
 
       expect(conversation.toJson()['chatSuggestions'], ['继续', '举例']);
     });
+
+    test('toJson/fromJson preserves directed-tree active leaf', () {
+      final conversation = Conversation(
+        id: 'conversation-tree',
+        title: 'Chat',
+        activeMessageId: 'answer-5',
+      );
+
+      expect(
+        Conversation.fromJson(conversation.toJson()).activeMessageId,
+        'answer-5',
+      );
+    });
+
+    test('copyWith can explicitly clear the directed-tree active leaf', () {
+      final conversation = Conversation(
+        id: 'conversation-tree-clear',
+        title: 'Chat',
+        activeMessageId: 'answer-5',
+      );
+
+      expect(
+        conversation.copyWith(clearActiveMessageId: true).activeMessageId,
+        isNull,
+      );
+    });
   });
 }

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -209,7 +209,10 @@ void main() {
       expect(service.getMessages(conversation.id), hasLength(2));
       final convo = service.getConversation(conversation.id);
       expect(convo?.messageIds, contains(edited.id));
-      expect(service.getVersionSelections(conversation.id), {original.id: 1});
+      expect(
+        service.getVersionSelections(conversation.id),
+        {ConversationTree.rootGroupId(conversation.id): 1},
+      );
     });
 
     test(
@@ -240,7 +243,10 @@ void main() {
         expect(first?.version, 1);
         expect(second?.version, 2);
         expect(second?.groupId, ConversationTree.rootGroupId(conversation.id));
-        expect(service.getVersionSelections(conversation.id), {original.id: 2});
+        expect(
+        service.getVersionSelections(conversation.id),
+        {ConversationTree.rootGroupId(conversation.id): 2},
+      );
       },
     );
 

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/utils/conversation_tree.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   _FakePathProviderPlatform(this.path);
@@ -202,7 +203,7 @@ void main() {
       expect(edited!.role, 'user');
       expect(edited.content, 'hello, edited');
       expect(edited.conversationId, conversation.id);
-      expect(edited.groupId ?? edited.id, original.id);
+      expect(edited.groupId, ConversationTree.rootGroupId(conversation.id));
       expect(edited.version, 1);
 
       expect(service.getMessages(conversation.id), hasLength(2));
@@ -238,7 +239,7 @@ void main() {
 
         expect(first?.version, 1);
         expect(second?.version, 2);
-        expect(second?.groupId ?? second?.id, original.id);
+        expect(second?.groupId, ConversationTree.rootGroupId(conversation.id));
         expect(service.getVersionSelections(conversation.id), {original.id: 2});
       },
     );
@@ -294,8 +295,8 @@ void main() {
         expect(forkMessages.single.conversationId, fork.id);
         expect(forkMessages.single.content, 'edited answer');
         expect(
-          forkMessages.single.groupId ?? forkMessages.single.id,
-          forkMessages.single.id,
+          forkMessages.single.groupId,
+          ConversationTree.rootGroupId(fork.id),
         );
         expect(forkMessages.single.version, 0);
         expect(service.getVersionSelections(fork.id), isEmpty);

--- a/test/core/services/generation_engine_test.dart
+++ b/test/core/services/generation_engine_test.dart
@@ -39,6 +39,7 @@ class _FakeChatService extends ChatService {
     String? reasoningText,
     DateTime? reasoningStartAt,
     DateTime? reasoningFinishedAt,
+    String? parentMessageId,
     String? groupId,
     String? subgroupId,
     int? version,

--- a/test/core/services/proactive_care_decision_test.dart
+++ b/test/core/services/proactive_care_decision_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/api/chat_api_service.dart';
 import 'package:Cuplivo/core/services/proactive_care_decision_tools.dart';
@@ -96,6 +98,59 @@ void main() {
 
   tearDown(() async {
     await transport.closeAll();
+  });
+
+  group('directed history', () {
+    test('uses only the active root-to-leaf branch', () {
+      const conversationId = 'conversation-1';
+      final history = ProactiveCareMessageFlow.buildHistory(
+        conversation: Conversation(
+          id: conversationId,
+          title: 'test',
+          activeMessageId: 'a5',
+        ),
+        messages: [
+          ChatMessage(
+            id: 'u1',
+            role: 'user',
+            content: '1',
+            conversationId: conversationId,
+          ),
+          ChatMessage(
+            id: 'a2',
+            role: 'assistant',
+            content: '2',
+            conversationId: conversationId,
+            parentMessageId: 'u1',
+          ),
+          ChatMessage(
+            id: 'a3',
+            role: 'assistant',
+            content: '3',
+            conversationId: conversationId,
+            parentMessageId: 'u1',
+          ),
+          ChatMessage(
+            id: 'u4',
+            role: 'user',
+            content: '4',
+            conversationId: conversationId,
+          ),
+          ChatMessage(
+            id: 'a5',
+            role: 'assistant',
+            content: '5',
+            conversationId: conversationId,
+            parentMessageId: 'u4',
+          ),
+        ],
+      );
+
+      expect(history, [
+        {'role': 'user', 'content': '4'},
+        {'role': 'assistant', 'content': '5'},
+      ]);
+    });
   });
 
   Future<DateTime?> decide({

--- a/test/core/utils/conversation_tree_test.dart
+++ b/test/core/utils/conversation_tree_test.dart
@@ -1,0 +1,161 @@
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/utils/conversation_tree.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ChatMessage _message({
+  required String id,
+  required String content,
+  required String conversationId,
+  required String? parentMessageId,
+  required String groupId,
+  required int version,
+}) {
+  return ChatMessage(
+    id: id,
+    role: id.startsWith('u') ? 'user' : 'assistant',
+    content: content,
+    conversationId: conversationId,
+    parentMessageId: parentMessageId,
+    groupId: groupId,
+    version: version,
+  );
+}
+
+void main() {
+  group('ConversationTree', () {
+    const conversationId = 'conversation-1';
+    final rootGroup = ConversationTree.rootGroupId(conversationId);
+    final messages = <ChatMessage>[
+      _message(
+        id: 'u1',
+        content: '1',
+        conversationId: conversationId,
+        parentMessageId: null,
+        groupId: rootGroup,
+        version: 0,
+      ),
+      _message(
+        id: 'a2',
+        content: '2',
+        conversationId: conversationId,
+        parentMessageId: 'u1',
+        groupId: 'u1',
+        version: 0,
+      ),
+      _message(
+        id: 'a3',
+        content: '3',
+        conversationId: conversationId,
+        parentMessageId: 'u1',
+        groupId: 'u1',
+        version: 1,
+      ),
+      _message(
+        id: 'u4',
+        content: '4',
+        conversationId: conversationId,
+        parentMessageId: null,
+        groupId: rootGroup,
+        version: 1,
+      ),
+      _message(
+        id: 'a5',
+        content: '5',
+        conversationId: conversationId,
+        parentMessageId: 'u4',
+        groupId: 'u4',
+        version: 0,
+      ),
+    ];
+
+    test('edited input only resolves to descendants of that input', () {
+      final leaf = ConversationTree.selectLeafForBranch(
+        messages: messages,
+        branchStart: messages.singleWhere((message) => message.id == 'u4'),
+        versionSelections: {rootGroup: 1},
+      );
+
+      expect(leaf.id, 'a5');
+      expect(
+        ConversationTree.pathToRoot(messages, leaf.id)
+            .map((message) => message.id),
+        ['u4', 'a5'],
+      );
+    });
+
+    test('original input can switch only among its own regenerated answers', () {
+      final leaf = ConversationTree.selectLeafForBranch(
+        messages: messages,
+        branchStart: messages.singleWhere((message) => message.id == 'u1'),
+        versionSelections: {rootGroup: 0, 'u1': 1},
+      );
+
+      expect(leaf.id, 'a3');
+      expect(
+        ConversationTree.pathToRoot(messages, leaf.id)
+            .map((message) => message.id),
+        ['u1', 'a3'],
+      );
+    });
+
+    test('next version is scoped to the exact parent', () {
+      expect(
+        ConversationTree.nextSiblingVersion(
+          messages: messages,
+          conversationId: conversationId,
+          parentMessageId: 'u1',
+        ),
+        2,
+      );
+      expect(
+        ConversationTree.nextSiblingVersion(
+          messages: messages,
+          conversationId: conversationId,
+          parentMessageId: 'u4',
+        ),
+        1,
+      );
+    });
+
+    test('missing parent is not rendered as an orphan branch', () {
+      final damaged = _message(
+        id: 'a6',
+        content: 'damaged',
+        conversationId: conversationId,
+        parentMessageId: 'does-not-exist',
+        groupId: 'does-not-exist',
+        version: 0,
+      );
+
+      expect(
+        ConversationTree.pathToRoot([...messages, damaged], damaged.id)
+            .map((message) => message.id),
+        isEmpty,
+      );
+    });
+
+    test('cycle is rejected instead of producing a partial path', () {
+      final first = _message(
+        id: 'u6',
+        content: 'first',
+        conversationId: conversationId,
+        parentMessageId: 'a7',
+        groupId: 'a7',
+        version: 0,
+      );
+      final second = _message(
+        id: 'a7',
+        content: 'second',
+        conversationId: conversationId,
+        parentMessageId: 'u6',
+        groupId: 'u6',
+        version: 0,
+      );
+
+      expect(
+        ConversationTree.pathToRoot([...messages, first, second], first.id),
+        isEmpty,
+      );
+    });
+  });
+}

--- a/test/features/home/services/handoff_tool_service_test.dart
+++ b/test/features/home/services/handoff_tool_service_test.dart
@@ -88,6 +88,7 @@ class _FakeChatService extends ChatService {
     String? reasoningText,
     DateTime? reasoningStartAt,
     DateTime? reasoningFinishedAt,
+    String? parentMessageId,
     String? groupId,
     String? subgroupId,
     int? version,

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -167,6 +167,62 @@ void main() {
   });
 
   group('MessageBuilderService.buildApiMessages', () {
+    test('directed tree only sends the active input and its descendants', () {
+      final service = MessageBuilderService(
+        chatService: _FakeChatService(const {}),
+        contextProvider: _FakeBuildContext(),
+      );
+      final conversation = Conversation(
+        id: 'conversation-1',
+        title: 'test',
+        activeMessageId: 'a5',
+      );
+      final apiMessages = service.buildApiMessages(
+        messages: [
+          ChatMessage(
+            id: 'u1',
+            role: 'user',
+            content: '1',
+            conversationId: conversation.id,
+          ),
+          ChatMessage(
+            id: 'a2',
+            role: 'assistant',
+            content: '2',
+            conversationId: conversation.id,
+            parentMessageId: 'u1',
+          ),
+          ChatMessage(
+            id: 'a3',
+            role: 'assistant',
+            content: '3',
+            conversationId: conversation.id,
+            parentMessageId: 'u1',
+          ),
+          ChatMessage(
+            id: 'u4',
+            role: 'user',
+            content: '4',
+            conversationId: conversation.id,
+          ),
+          ChatMessage(
+            id: 'a5',
+            role: 'assistant',
+            content: '5',
+            conversationId: conversation.id,
+            parentMessageId: 'u4',
+          ),
+        ],
+        versionSelections: const <String, int>{},
+        currentConversation: conversation,
+      );
+
+      expect(
+        apiMessages.map((message) => message['content']).toList(),
+        ['4', '5'],
+      );
+    });
+
     test('有工具调用时会把 reasoning_content 回填到 assistant tool 消息', () {
       final service = MessageBuilderService(
         chatService: _FakeChatService({


### PR DESCRIPTION
## Directed Conversation Tree

Closes #751.

Linked to Chevey339/kelivo#864

普通对话改为有向树结构：每条消息记录 `parent_message_id`（续写自哪条消息），重试/分支成为同一父节点的兄弟子节点，而非扁平版本列表。父链（而非写入时间序）决定活跃上下文。

- `lib/core/utils/conversation_tree.dart`：纯函数树工具（兄弟分组/版本排序/根路径/分支叶子选择/环安全）
- `ChatMessage.parentMessageId` + `Conversation.activeMessageId`
- Schema v20：`message_rows.parent_message_id`（带索引）、`conversation_rows.active_message_id`，raw SQL + 自愈镜像（不依赖 build_runner）
- ChatService：父感知消息创建、重试分支、克隆到新会话保留父链
- 控制器/UI：活跃消息选择、导出路径、主动关怀镜像行
- 测试：conversation_tree_test + 仓库/模型/决策测试覆盖