### PR TITLE
fix(background): prevent background shift on keyboard open

### DIFF
--- a/lib/features/home/pages/home_mobile_layout.dart
+++ b/lib/features/home/pages/home_mobile_layout.dart
@@ -119,13 +119,13 @@ class HomeMobileScaffold extends StatelessWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          // Keep the chat artwork at the full window size while Scaffold
-          // resizes only its body around the keyboard. Transparent IMEs can
-          // then reveal the artwork instead of Scaffold's surface color.
+          // Keep the chat artwork at the full window size. Scaffold uses
+          // resizeToAvoidBottomInset: false so its body is never shrunk by
+          // the keyboard; ChatInputOverlayLayout handles the inset itself.
           const MobileBackgroundLayer(),
           Scaffold(
             key: scaffoldKey,
-            resizeToAvoidBottomInset: true,
+            resizeToAvoidBottomInset: false,
             extendBodyBehindAppBar: true,
             backgroundColor: Colors.transparent,
             appBar: appBarOverride ?? _buildAppBar(context, cs),

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -890,6 +890,7 @@ class _HomePageState extends State<HomePage>
     final backgroundImageActive = _assistantBackgroundActive(context);
 
     return ChatInputOverlayLayout(
+      keyboardInset: MediaQuery.viewInsetsOf(context).bottom,
       topInset: _chatTopOverlayInset(context),
       background: backgroundImageActive
           ? _buildChatBackground(context, cs)

--- a/lib/features/home/widgets/chat_input_overlay_layout.dart
+++ b/lib/features/home/widgets/chat_input_overlay_layout.dart
@@ -10,6 +10,7 @@ class ChatInputOverlayLayout extends StatelessWidget {
     this.topBackground,
     this.foreground,
     this.backgroundImageActive = false,
+    this.keyboardInset = 0,
   });
 
   static const double _topOverlayTailHeight = 16;
@@ -23,67 +24,77 @@ class ChatInputOverlayLayout extends StatelessWidget {
   final Widget? foreground;
   final bool backgroundImageActive;
 
+  /// Keyboard height passed in from the parent so that only the foreground
+  /// content and input bar avoid the keyboard while the background stays at
+  /// full screen height.
+  final double keyboardInset;
+
   @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
         if (background != null) Positioned.fill(child: background!),
         Positioned.fill(
-          child: Stack(
-            children: [
-              Positioned.fill(child: content),
-              if (backgroundImageActive && topBackground != null)
-                Positioned.fill(
-                  child: ClipRect(
-                    clipper: _TopOverlayClipper(
-                      topInset + _topOverlayTailHeight,
-                    ),
-                    child: _TopBackgroundFade(
-                      height: topInset + _topOverlayTailHeight,
-                      child: IgnorePointer(
-                        key: const Key('chat-input-overlay-top-background'),
-                        child: topBackground!,
+          child: Padding(
+            padding: EdgeInsets.only(bottom: keyboardInset),
+            child: Stack(
+              children: [
+                Positioned.fill(child: content),
+                if (backgroundImageActive && topBackground != null)
+                  Positioned.fill(
+                    child: ClipRect(
+                      clipper: _TopOverlayClipper(
+                        topInset + _topOverlayTailHeight,
+                      ),
+                      child: _TopBackgroundFade(
+                        height: topInset + _topOverlayTailHeight,
+                        child: IgnorePointer(
+                          key: const Key('chat-input-overlay-top-background'),
+                          child: topBackground!,
+                        ),
                       ),
                     ),
+                  )
+                else if (!backgroundImageActive)
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    top: 0,
+                    height: topInset + _topOverlayTailHeight,
+                    child: const _TopOverlayFade(),
                   ),
-                )
-              else if (!backgroundImageActive)
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  top: 0,
-                  height: topInset + _topOverlayTailHeight,
-                  child: const _TopOverlayFade(),
-                ),
-              if (backgroundImageActive && topBackground != null)
-                Positioned.fill(
-                  child: ClipRect(
-                    clipper: const _BottomOverlayClipper(
-                      _bottomOverlayFadeHeight,
-                    ),
-                    child: _BottomBackgroundFade(
-                      height: _bottomOverlayFadeHeight,
-                      child: IgnorePointer(
-                        key: const Key('chat-input-overlay-bottom-background'),
-                        child: topBackground!,
+                if (backgroundImageActive && topBackground != null)
+                  Positioned.fill(
+                    child: ClipRect(
+                      clipper: const _BottomOverlayClipper(
+                        _bottomOverlayFadeHeight,
+                      ),
+                      child: _BottomBackgroundFade(
+                        height: _bottomOverlayFadeHeight,
+                        child: IgnorePointer(
+                          key: const Key('chat-input-overlay-bottom-background'),
+                          child: topBackground!,
+                        ),
                       ),
                     ),
+                  )
+                else if (!backgroundImageActive)
+                  const Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    height: _bottomOverlayFadeHeight,
+                    child: _BottomOverlayFade(),
                   ),
-                )
-              else if (!backgroundImageActive)
-                const Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  height: _bottomOverlayFadeHeight,
-                  child: _BottomOverlayFade(),
-                ),
-              if (foreground != null) Positioned.fill(child: foreground!),
-            ],
+                if (foreground != null) Positioned.fill(child: foreground!),
+              ],
+            ),
           ),
         ),
-        Align(
-          alignment: Alignment.bottomCenter,
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: keyboardInset,
           child: UnconstrainedBox(
             constrainedAxis: Axis.horizontal,
             alignment: Alignment.bottomCenter,


### PR DESCRIPTION
## Problem

When the keyboard opens, the chat background image visually shifts/jumps. This is because `Scaffold(resizeToAvoidBottomInset: true)` shrinks its body, and the background inside `ChatInputOverlayLayout` (using `Positioned.fill` + `BoxFit.cover`) re-crops to the smaller area.

Previous attempts (#430, #432, #436, #444) tried various approaches but didn't address the root cause. PR #450 v1 correctly identified the root cause but placed the `viewInsets.bottom` padding on the **entire body**, which still compressed the background.

## Root Cause Analysis

```
Scaffold(resizeToAvoidBottomInset: true)
  └── body (shrinks when keyboard opens)
        └── ChatInputOverlayLayout
              ├── background: Positioned.fill  ← Re-crops on resize ✗
              ├── content: Positioned.fill     ← Also shrinks
              └── bottomOverlay: Align(bottom) ← Also shrinks
```

The key insight: **the keyboard avoidance must be applied selectively** — only to the content layer and input bar, not to the background.

## Fix

**3 files changed, 1 commit:**

### 1. `home_mobile_layout.dart` (+4/-4)
- `resizeToAvoidBottomInset: false` — Scaffold body no longer shrinks
- Updated comments to reflect the new approach

### 2. `home_page.dart` (+1/-0)
- Pass `keyboardInset: MediaQuery.viewInsetsOf(context).bottom` to `ChatInputOverlayLayout`

### 3. `chat_input_overlay_layout.dart` (+58/-47, mostly re-indentation)
- New `keyboardInset` parameter (default `0`, backward compatible)
- **Background layer**: unchanged — `Positioned.fill` stays full screen ✓
- **Content layer**: wrapped in `Padding(bottom: keyboardInset)` — pushes chat messages above keyboard ✓
- **Bottom overlay (input bar)**: changed from `Align(bottomCenter)` to `Positioned(bottom: keyboardInset)` — moves input above keyboard ✓

### Result

```
Stack (full screen)
├── background: Positioned.fill = 800px  ← Full screen, no re-crop ✓
├── content: Padding(bottom: 300)
│     └── Stack height = 500px           ← Content avoids keyboard ✓
└── input: Positioned(bottom: 300)       ← Input above keyboard ✓
```

Works correctly with and without background images. When `keyboardInset` is `0` (keyboard closed), behavior is identical to the original code.