### PR TITLE
fix: export chats.json as version 1 for Kelivo backup compatibility

### DIFF
--- a/lib/core/providers/backup_provider.dart
+++ b/lib/core/providers/backup_provider.dart
@@ -115,9 +115,30 @@ class BackupProvider extends ChangeNotifier {
     return _dataSync.listBackupFiles(_cfg);
   }
 
-  Future<File> exportToFile() => _dataSync.exportToFile(_cfg);
-  Future<File> incrementalExportToFile(IncrementalBackupConfig config) =>
-      _dataSync.exportToFile(_cfg, incremental: config);
+  Future<File> exportToFile() async {
+    _busy = true;
+    _message = null;
+    notifyListeners();
+    try {
+      return await _dataSync.exportToFile(_cfg);
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
+  Future<File> incrementalExportToFile(IncrementalBackupConfig config) async {
+    _busy = true;
+    _message = null;
+    notifyListeners();
+    try {
+      return await _dataSync.exportToFile(_cfg, incremental: config);
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
   Future<void> restoreFromLocalFile(
     File file, {
     RestoreMode mode = RestoreMode.overwrite,

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -32,6 +32,13 @@ class DataSync {
   final Future<Set<String>> Function(String type)? _localIdResolver;
   DataSync({required this.chatService, this._localIdResolver});
 
+  // Upstream (Kelivo) legacy chats.json importer only accepts version 1 (or a
+  // missing field); anything else is rejected with FormatException. Cuplivo's
+  // own importer never reads this field, so exporting v1 keeps backups
+  // importable into Kelivo without affecting Cuplivo round-trips. Never bump
+  // this past 1 without relaxing Kelivo's _parseChatBackup constraint first.
+  static const int _chatsJsonVersion = 1;
+
   // ===== WebDAV helpers =====
   Uri _collectionUri(WebDavConfig cfg) {
     String base = cfg.url.trim();
@@ -992,11 +999,7 @@ class DataSync {
     final sink = file.openWrite();
 
     try {
-      // Upstream (Kelivo) legacy chats.json importer only accepts version 1
-      // (or a missing field); version 2 is rejected with FormatException.
-      // Cuplivo's own importer never reads this field, so exporting v1 keeps
-      // backups importable into Kelivo without affecting Cuplivo round-trips.
-      sink.write('{"version":1,');
+      sink.write('{"version":$_chatsJsonVersion,');
 
       // --- conversations ---
       sink.write('"conversations":[');
@@ -1050,7 +1053,7 @@ class DataSync {
       sink.write(jsonEncode(geminiThoughtSigs));
       sink.write(',');
 
-      // --- group chats (v2) ---
+      // --- group chats ---
       final groups = await chatService.repo.getAllGroupChats();
       final groupPayload = <Map<String, dynamic>>[];
       final memberPayload = <Map<String, dynamic>>[];
@@ -1537,7 +1540,9 @@ class DataSync {
             }
           }
 
-          // Restore group chat metadata (v2 keys; ignored on v1 backups).
+          // Restore group chat metadata. The groupChats/groupMembers keys are
+          // present on both v1 and v2 exports and are always restored when
+          // non-empty.
           final groupChatsRaw = obj['groupChats'] as List? ?? const [];
           final groupMembersRaw = obj['groupMembers'] as List? ?? const [];
           if (groupChatsRaw.isNotEmpty) {

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -992,7 +992,11 @@ class DataSync {
     final sink = file.openWrite();
 
     try {
-      sink.write('{"version":2,');
+      // Upstream (Kelivo) legacy chats.json importer only accepts version 1
+      // (or a missing field); version 2 is rejected with FormatException.
+      // Cuplivo's own importer never reads this field, so exporting v1 keeps
+      // backups importable into Kelivo without affecting Cuplivo round-trips.
+      sink.write('{"version":1,');
 
       // --- conversations ---
       sink.write('"conversations":[');

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -966,6 +966,40 @@ class DataSync {
     // prefs never hold a mirror copy (no dual truth, no staleness).
     map.addAll(KelivoImageSettingsMapper.translateToUpstream(map));
     _retainCloudAsrForExport(map);
+
+    // Kelivo's business router validates search_services_v1 entries and
+    // requires `apiKeys` to be a plain List<String> (round-robin pool).
+    // Cuplivo persists structured ApiKeyConfig objects there, so on export
+    // we split the payload: full objects move to `keyConfigs` (Cuplivo reads
+    // them back losslessly) and `apiKeys` becomes the string list Kelivo
+    // accepts. `apiKey` stays as the primary key string both sides read.
+    final searchServicesRaw = map['search_services_v1'];
+    if (searchServicesRaw is String && searchServicesRaw.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(searchServicesRaw) as List;
+        final converted = <Map<String, dynamic>>[];
+        for (final entry in decoded) {
+          final service = (entry as Map).cast<String, dynamic>();
+          final rawKeys = service['apiKeys'];
+          if (rawKeys is List &&
+              rawKeys.isNotEmpty &&
+              rawKeys.every((e) => e is Map)) {
+            service['keyConfigs'] = rawKeys;
+            service['apiKeys'] = [
+              for (final k in rawKeys.cast<Map<String, dynamic>>())
+                if ((k['key'] as String? ?? '').trim().isNotEmpty)
+                  (k['key'] as String).trim(),
+            ];
+          }
+          converted.add(service);
+        }
+        map['search_services_v1'] = jsonEncode(converted);
+      } catch (e) {
+        debugPrint(
+          'prepareBackupFile: search_services_v1 conversion failed: $e',
+        );
+      }
+    }
     return jsonEncode(map);
   }
 

--- a/lib/core/services/search/search_service.dart
+++ b/lib/core/services/search/search_service.dart
@@ -229,12 +229,30 @@ abstract class SearchServiceOptions {
 
   Map<String, dynamic> toJson();
 
-  /// Dual-read: prefers new `apiKeys` list, falls back to legacy `apiKey` string.
+  /// Dual-read: prefers the full `keyConfigs` objects written by Cuplivo
+  /// exports (lossless round-trip), then the `apiKeys` list, then the legacy
+  /// `apiKey` string. `apiKeys` may be either a list of ApiKeyConfig objects
+  /// (Cuplivo's native shape) or a list of plain key strings (Kelivo's
+  /// round-robin pool shape) when the backup originated from Kelivo.
   static List<ApiKeyConfig> readKeys(Map<String, dynamic> json) {
-    if (json['apiKeys'] != null) {
-      return (json['apiKeys'] as List)
+    final configs = json['keyConfigs'];
+    if (configs is List && configs.isNotEmpty) {
+      return configs
           .map((e) => ApiKeyConfig.fromJson(e as Map<String, dynamic>))
           .toList();
+    }
+    if (json['apiKeys'] != null) {
+      final rawKeys = json['apiKeys'] as List;
+      if (rawKeys.isNotEmpty && rawKeys.every((e) => e is Map)) {
+        return rawKeys
+            .map((e) => ApiKeyConfig.fromJson(e as Map<String, dynamic>))
+            .toList();
+      }
+      return [
+        for (final key in rawKeys)
+          if (key.toString().trim().isNotEmpty)
+            ApiKeyConfig.create(key.toString()),
+      ];
     }
     final legacy = json['apiKey'] as String?;
     if (legacy != null && legacy.isNotEmpty) {

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -342,7 +342,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
 
               const SliverToBoxAdapter(child: SizedBox(height: 10)),
 
-              _buildLocalBackupSliver(context, l10n, cs),
+              _buildLocalBackupSliver(context, l10n, cs, busy),
 
               const SliverToBoxAdapter(child: SizedBox(height: 10)),
 
@@ -899,6 +899,7 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
     BuildContext context,
     AppLocalizations l10n,
     ColorScheme cs,
+    bool busy,
   ) {
     return SliverToBoxAdapter(
       child: _sectionCard(
@@ -925,28 +926,30 @@ class _DesktopBackupPaneState extends State<DesktopBackupPane> {
                 label: l10n.backupPageExportToFile,
                 filled: false,
                 dense: true,
-                onTap: () async {
-                  final backupProvider = context.read<BackupProvider>();
-                  await _saveConfig();
-                  final file = await backupProvider.exportToFile();
-                  String? savePath = await FilePicker.platform.saveFile(
-                    dialogTitle: l10n.backupPageExportToFile,
-                    fileName: file.uri.pathSegments.last,
-                    type: FileType.custom,
-                    allowedExtensions: ['zip'],
-                  );
-                  if (savePath != null) {
-                    try {
-                      await File(savePath).parent.create(recursive: true);
-                      await file.copy(savePath);
-                      if (context.mounted) {
-                        await context
-                            .read<BackupReminderProvider>()
-                            .recordBackupCompleted();
-                      }
-                    } catch (_) {}
-                  }
-                },
+                onTap: busy
+                    ? () {}
+                    : () async {
+                        final backupProvider = context.read<BackupProvider>();
+                        await _saveConfig();
+                        final file = await backupProvider.exportToFile();
+                        String? savePath = await FilePicker.platform.saveFile(
+                          dialogTitle: l10n.backupPageExportToFile,
+                          fileName: file.uri.pathSegments.last,
+                          type: FileType.custom,
+                          allowedExtensions: ['zip'],
+                        );
+                        if (savePath != null) {
+                          try {
+                            await File(savePath).parent.create(recursive: true);
+                            await file.copy(savePath);
+                            if (context.mounted) {
+                              await context
+                                  .read<BackupReminderProvider>()
+                                  .recordBackupCompleted();
+                            }
+                          } catch (_) {}
+                        }
+                      },
               ),
               _DeskIosButton(
                 label: l10n.backupPageImportBackupFile,

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -712,6 +712,7 @@ void main() {
           final data =
               jsonDecode(utf8.decode((chatsEntry!.readBytes() ?? <int>[])))
                   as Map<String, dynamic>;
+          expect(data['version'], 1);
           final convs = data['conversations'] as List;
           final msgs = data['messages'] as List;
           final toolEvents = data['toolEvents'] as Map;
@@ -777,6 +778,7 @@ void main() {
           final data =
               jsonDecode(utf8.decode(chatsEntry!.readBytes() ?? <int>[]))
                   as Map<String, dynamic>;
+          expect(data['version'], 1);
           final convs = data['conversations'] as List;
           final msgs = data['messages'] as List;
 

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -19,6 +19,7 @@ import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/models/incremental_backup.dart';
 import 'package:Cuplivo/core/services/backup/data_sync.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/services/search/search_service.dart';
 
 class _FakePathProviderPlatform extends PathProviderPlatform {
   _FakePathProviderPlatform(this.root);
@@ -1217,6 +1218,122 @@ void main() {
                 )
                 as Map<String, dynamic>;
         expect(settings['image_upload_quality_v1'], 'original');
+      } finally {
+        archive?.clearSync();
+        input.closeSync();
+      }
+
+      await DataSync.cleanupTemporaryBackupFile(backupFile);
+    });
+
+    test(
+      'export converts search_services_v1 apiKeys to Kelivo string list',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'search_services_v1': jsonEncode([
+            {
+              'type': 'tavily',
+              'id': 'tavily-1',
+              'url': 'https://api.tavily.com/search',
+              'apiKey': 'primary-key',
+              'apiKeys': [
+                {
+                  'id': 'k1',
+                  'key': 'primary-key',
+                  'isEnabled': true,
+                  'priority': 5,
+                },
+                {
+                  'id': 'k2',
+                  'key': 'backup-key',
+                  'isEnabled': true,
+                  'priority': 6,
+                },
+              ],
+            },
+          ]),
+        });
+        final sync = DataSync(chatService: ChatService());
+        final backupFile = await sync.prepareBackupFile(
+          WebDavConfig(includeChats: false, includeFiles: false),
+        );
+
+        final input = InputFileStream(backupFile.path);
+        Archive? archive;
+        try {
+          archive = ZipDecoder().decodeStream(input);
+          final settings =
+              jsonDecode(
+                    utf8.decode(
+                      archive.findFile('settings.json')!.readBytes()!,
+                    ),
+                  )
+                  as Map<String, dynamic>;
+          final services =
+              jsonDecode(settings['search_services_v1'] as String) as List;
+          final service = services.single as Map<String, dynamic>;
+          expect(service['type'], 'tavily');
+          expect(service['apiKey'], 'primary-key');
+          expect(service['apiKeys'], ['primary-key', 'backup-key']);
+          expect(service['keyConfigs'], isA<List>());
+          expect(service['keyConfigs'], hasLength(2));
+        } finally {
+          archive?.clearSync();
+          input.closeSync();
+        }
+
+        await DataSync.cleanupTemporaryBackupFile(backupFile);
+      },
+    );
+
+    test('round-trip restores full keyConfigs for search services', () async {
+      SharedPreferences.setMockInitialValues({
+        'search_services_v1': jsonEncode([
+          {
+            'type': 'tavily',
+            'id': 'tavily-1',
+            'url': 'https://api.tavily.com/search',
+            'apiKey': 'primary-key',
+            'apiKeys': [
+              {
+                'id': 'k1',
+                'key': 'primary-key',
+                'isEnabled': true,
+                'priority': 5,
+              },
+              {
+                'id': 'k2',
+                'key': 'backup-key',
+                'isEnabled': true,
+                'priority': 6,
+              },
+            ],
+          },
+        ]),
+      });
+      final sync = DataSync(chatService: ChatService());
+      final backupFile = await sync.prepareBackupFile(
+        WebDavConfig(includeChats: false, includeFiles: false),
+      );
+
+      final input = InputFileStream(backupFile.path);
+      Archive? archive;
+      try {
+        archive = ZipDecoder().decodeStream(input);
+        final settings =
+            jsonDecode(
+                  utf8.decode(archive.findFile('settings.json')!.readBytes()!),
+                )
+                as Map<String, dynamic>;
+        final services =
+            jsonDecode(settings['search_services_v1'] as String) as List;
+        final service = services.single as Map<String, dynamic>;
+
+        final restored = SearchServiceOptions.fromJson(service);
+        expect(restored.apiKeys, hasLength(2));
+        expect(restored.apiKeys.first.key, 'primary-key');
+        expect(restored.apiKeys.last.key, 'backup-key');
+        expect(restored.apiKeys.last.isEnabled, isTrue);
       } finally {
         archive?.clearSync();
         input.closeSync();


### PR DESCRIPTION
## Problem

Backups exported from Cuplivo cannot be imported into Kelivo (upstream). This is a confirmed widespread issue: as a fork, Cuplivo's backup format is not upward-compatible.

**Root cause:** `_exportChatsToFile` writes `{"version":2,...}` (bumped when group chats were added). Kelivo's legacy chats.json importer (`_parseChatBackup`) only accepts `version == 1` (or a missing field) and throws `FormatException('version')` otherwise. So **every** Cuplivo export is rejected by Kelivo.

Cuplivo's own importer never reads the `version` field — it directly decodes `conversations`/`messages` — so self round-trips always worked and the incompatibility went unnoticed.

## Fix

Export `version: 1` in chats.json. Message format is already compatible: Kelivo's legacy path decodes `content`-style messages via `decodeLegacyContent` when `parts` is absent, which is exactly what Cuplivo exports.

Verified with a real Cuplivo default-config export (settings.json + chats.json + deleted.json):
- Kelivo `BackupSettingsValidator.normalizeAndValidate` passes all 16 settings keys
- With `version: 1`, the chats.json import no longer hits `FormatException('version')`

## Impact

- ✅ Cuplivo → Kelivo imports now work (upward compatibility restored)
- ✅ Cuplivo → Cuplivo round-trips unaffected (importer ignores version)
- Note: group chat data (groupChats/groupMembers) is not understood by Kelivo's legacy importer and is simply ignored there — expected, since upstream has no group chat support in this format.
