### PR TITLE
fix: strip <thinking> tags in mini map and global search (complete PR #354 refactor)

### DIFF
--- a/lib/features/search/services/global_session_search_service.dart
+++ b/lib/features/search/services/global_session_search_service.dart
@@ -30,7 +30,7 @@ class GlobalSessionSearchService {
     dotAll: true,
   );
   static final RegExp _thinkBlockRe = RegExp(
-    r'<(?:think|thought)>[\s\S]*?<\/(?:think|thought)>',
+    r'<(?:think|thinking|thought)>[\s\S]*?<\/(?:think|thinking|thought)>',
     caseSensitive: false,
   );
   static final RegExp _reasoningBlockRe = RegExp(

--- a/lib/shared/widgets/mini_map/mini_map_shared.dart
+++ b/lib/shared/widgets/mini_map/mini_map_shared.dart
@@ -39,15 +39,16 @@ List<MiniMapQaPair> buildMiniMapPairs(List<ChatMessage> messages) {
 }
 
 /// Flattens message content to a single line for mini map display bubbles.
-/// Strips vendor inline reasoning/thought blocks, `[image:]` / `[file:]`
-/// markers, collapses newlines and repeated whitespace. Unlike
-/// [miniMapHitSnippet], stripped regions are removed entirely — this is the
-/// DISPLAY text, while search matches against the raw content.
+/// Strips vendor inline reasoning/thought blocks (`<think>`/`<thinking>`/
+/// `<thought>`/`<reasoning>`), `[image:]` / `[file:]` markers, collapses
+/// newlines and repeated whitespace. Unlike [miniMapHitSnippet], stripped
+/// regions are removed entirely — this is the DISPLAY text, while search
+/// matches against the raw content.
 String miniMapOneLine(String s) {
   var t = s
       .replaceAll(
         RegExp(
-          r'<(?:think|thought)>[\s\S]*?<\/(?:think|thought)>',
+          r'<(?:think|thinking|thought)>[\s\S]*?<\/(?:think|thinking|thought)>',
           caseSensitive: false,
         ),
         '',
@@ -100,7 +101,8 @@ List<ChatMessage> filterMiniMapMessages(
 }
 
 final RegExp _vendorBlockRe = RegExp(
-  r'<(?:think|thought|reasoning)>[\s\S]*?<\/(?:think|thought|reasoning)>',
+  r'<(?:think|thinking|thought|reasoning)>[\s\S]*?'
+  r'<\/(?:think|thinking|thought|reasoning)>',
   caseSensitive: false,
 );
 
@@ -121,9 +123,10 @@ String _flattenMarker(Match m) {
 }
 
 /// Hit-centered snippet extracted from the RAW content with tag-flattening:
-/// `<think>/<thought>/<reasoning>` and `[image:]`/`[file:]` markers keep their
-/// inner text but lose their markup, so a hit inside a stripped region stays
-/// visible and explainable. Markdown syntax symbols are left untouched.
+/// `<think>/<thinking>/<thought>/<reasoning>` and `[image:]`/`[file:]`
+/// markers keep their inner text but lose their markup, so a hit inside a
+/// stripped region stays visible and explainable. Markdown syntax symbols are
+/// left untouched.
 String miniMapHitSnippet(
   String content,
   List<String> tokens, {
@@ -158,7 +161,7 @@ String miniMapHitSnippet(
   // A window cut mid-block leaves a stray open/close tag that never matched
   // _vendorBlockRe; scrub bare vendor tags so snippets never show raw markup.
   frag = frag.replaceAll(
-    RegExp(r'<\/?(?:think|thought|reasoning)>', caseSensitive: false),
+    RegExp(r'<\/?(?:think|thinking|thought|reasoning)>', caseSensitive: false),
     ' ',
   );
   // Likewise, a cut mid-marker leaves an unterminated `[image:`/`[file:`

--- a/test/features/search/services/global_session_search_service_test.dart
+++ b/test/features/search/services/global_session_search_service_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/database/chat_database_repository.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/features/search/services/global_session_search_service.dart';
+
+/// Minimal ChatService stand-in: the search service only reads
+/// [ChatService.searchConversationMatches], which we stub with pre-built
+/// candidates so the test exercises the service-level stripping of vendor
+/// thinking blocks (`<think>` / `<thinking>` / `<thought>` / `<reasoning>`).
+class _FakeChatService extends ChatService {
+  List<ConversationSearchMatch> matches = <ConversationSearchMatch>[];
+
+  @override
+  List<ConversationSearchMatch> searchConversationMatches({
+    required List<String> tokens,
+    int limit = 200,
+  }) {
+    return matches;
+  }
+}
+
+ConversationSearchMatch _match({
+  required String content,
+  String role = 'assistant',
+  String title = 'Conversation',
+}) {
+  return ConversationSearchMatch(
+    conversationId: 'conv-1',
+    conversationTitle: title,
+    updatedAt: DateTime(2026, 1, 1),
+    versionSelections: const <String, int>{},
+    messageId: 'msg-1',
+    messageContent: content,
+    messageRole: role,
+    groupId: 'msg-1',
+    version: 0,
+    maxVersion: 0,
+  );
+}
+
+void main() {
+  late _FakeChatService chatService;
+
+  setUp(() {
+    chatService = _FakeChatService();
+  });
+
+  group('GlobalSessionSearchService vendor thinking stripping', () {
+    test('long <thinking> content does not participate in search', () {
+      chatService.matches = [
+        _match(content: 'visible answer <thinking>hidden needle</thinking>'),
+      ];
+
+      // Token only present inside the <thinking> block must not match.
+      final results = GlobalSessionSearchService.search(
+        chatService: chatService,
+        query: 'needle',
+      );
+      expect(results, isEmpty);
+
+      // Visible content still matches normally.
+      final visible = GlobalSessionSearchService.search(
+        chatService: chatService,
+        query: 'visible',
+      );
+      expect(visible, hasLength(1));
+      expect(visible.first.snippet, contains('visible'));
+    });
+
+    test('mixed-case <THINKING> content is stripped', () {
+      chatService.matches = [
+        _match(content: '<THINKING>secret</THINKING> visible'),
+      ];
+
+      final results = GlobalSessionSearchService.search(
+        chatService: chatService,
+        query: 'secret',
+      );
+      expect(results, isEmpty);
+    });
+
+    test('legacy <think> content stays stripped (regression)', () {
+      chatService.matches = [
+        _match(content: '<think>secret</think> visible'),
+      ];
+
+      final results = GlobalSessionSearchService.search(
+        chatService: chatService,
+        query: 'secret',
+      );
+      expect(results, isEmpty);
+    });
+
+    test('<thought> and <reasoning> blocks stay stripped (regression)', () {
+      chatService.matches = [
+        _match(
+          content:
+              'a <thought>hidden thought</thought> b '
+              '<reasoning>hidden reasoning</reasoning> c',
+        ),
+      ];
+
+      expect(
+        GlobalSessionSearchService.search(
+          chatService: chatService,
+          query: 'hidden',
+        ),
+        isEmpty,
+      );
+      expect(
+        GlobalSessionSearchService.search(
+          chatService: chatService,
+          query: 'reasoning',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('unclosed <thinking> tag keeps the whole text searchable', () {
+      // Mirrors ThinkingTagParser: an unclosed tag is not a valid vendor
+      // block, so the raw text remains part of the searchable body.
+      chatService.matches = [
+        _match(content: 'streaming <thinking>partial reasoning'),
+      ];
+
+      final results = GlobalSessionSearchService.search(
+        chatService: chatService,
+        query: 'partial',
+      );
+      expect(results, hasLength(1));
+    });
+  });
+}

--- a/test/shared/widgets/mini_map/mini_map_shared_test.dart
+++ b/test/shared/widgets/mini_map/mini_map_shared_test.dart
@@ -77,6 +77,17 @@ void main() {
       expect(miniMapOneLine('<thought>t</thought>only'), 'only');
     });
 
+    test('strips long <thinking> blocks entirely', () {
+      expect(
+        miniMapOneLine('hi <thinking>inner</thinking> x'),
+        'hi x',
+      );
+      expect(
+        miniMapOneLine('<THINKING>t</THINKING>only'),
+        'only',
+      );
+    });
+
     test('strips image and file markers', () {
       expect(
         miniMapOneLine('see [image:foo.png] and [file:a.txt] done'),
@@ -160,6 +171,31 @@ void main() {
       expect(snippet, contains('needle'));
       expect(snippet, isNot(contains('<think>')));
       expect(snippet, isNot(contains('</think>')));
+    });
+
+    test('flattens long <thinking> tags but keeps inner text', () {
+      final snippet = miniMapHitSnippet(
+        'before <thinking>secret needle</thinking> after',
+        ['needle'],
+      );
+      expect(snippet, contains('needle'));
+      expect(snippet, isNot(contains('<thinking>')));
+      expect(snippet, isNot(contains('</thinking>')));
+    });
+
+    test('window cut mid-thinking-block leaves no stray thinking tags', () {
+      // Same mid-block cut as the <think> case, but with the longer
+      // `<thinking>` tag that PR #354 started parsing elsewhere.
+      final content =
+          '${List.filled(20, 'pad').join(' ')} <thinking>needle '
+          '${List.filled(60, 'x').join('')} </thinking> '
+          '${List.filled(20, 'tail').join(' ')}';
+      final snippet = miniMapHitSnippet(content, ['needle'], maxChars: 100);
+      expect(snippet, isNot(contains('<thinking>')));
+      expect(snippet, isNot(contains('</thinking>')));
+      expect(snippet, contains('needle'));
+      expect(snippet, startsWith('... '));
+      expect(snippet, endsWith(' ...'));
     });
 
     test('flattens image marker keeping inner text', () {


### PR DESCRIPTION
Fixes #454

## Problem

PR #354 (parse legacy `<thinking>` tags, synced from upstream kelivo #783) updated `ThinkingTagParser._openTagRe` to `(think|thinking|thought)`, but **four parallel vendor-block regexes were left on `think|thought`**, so `<thinking>` blocks are still mishandled outside the chat bubble renderer:

| Location | Regex | Effect |
|---|---|---|
| `mini_map_shared.dart` `miniMapOneLine()` | `<(?:think\|thought)>…` | mini map overview bubbles show raw `<thinking>…</thinking>` thinking text |
| `mini_map_shared.dart` `_vendorBlockRe` | `<(?:think\|thought\|reasoning)>…` | search-hit snippets do not flatten `<thinking>` blocks |
| `mini_map_shared.dart` bare-tag scrub | `<\/?(?:think\|thought\|reasoning)>` | window-cut snippets can leak raw `<thinking>` tags |
| `global_session_search_service.dart` `_thinkBlockRe` | `<(?:think\|thought)>…` | `<thinking>` reasoning leaks into the searchable body → global search results are polluted by thinking content |

## Fix

Unify all four regexes on `(think|thinking|thought|reasoning)` (case-insensitive), matching what `ThinkingTagParser` already does. Pure regex-string changes; no behavior change for the already-supported tags (`<think>`, `<thought>`, `<reasoning>`).

## Tests

- `test/shared/widgets/mini_map/mini_map_shared_test.dart`:
  - `miniMapOneLine` strips `<thinking>` / mixed-case `<THINKING>` blocks
  - `miniMapHitSnippet` flattens `<thinking>` blocks (keeps inner text, no raw tags)
  - window cut mid-`<thinking>`-block leaves no stray tags
- `test/features/search/services/global_session_search_service_test.dart` (new):
  - `<thinking>` content does **not** participate in search; visible content still matches
  - mixed-case `<THINKING>` stripped
  - legacy `<think>` / `<thought>` / `<reasoning>` still stripped (regression)
  - unclosed `<thinking>` tag keeps text searchable (consistent with `ThinkingTagParser`)

## Verification

- ⚠️ Not run locally: this sandbox has no Flutter/Dart SDK, so `dart format`, `dart analyze --fatal-infos lib test` and `flutter test` were **not** executed. The change is limited to four regex literals plus tests; CI (analyze + test) must confirm.
- Manual sanity: `miniMapOneLine('hi <thinking>inner</thinking> x')` → `'hi x'`; global search for a token only inside `<thinking>` no longer matches.

## Compatibility

- No schema/settings/backup changes. Existing `think|thought` handling is untouched (superset regex).