### PR TITLE
feat(storage): count workspaces as a dedicated storage category

### DIFF
--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -14,6 +14,7 @@ enum StorageUsageCategoryKey {
   files,
   chatData,
   assistantData,
+  workspaceData,
   cache,
   logs,
   other,
@@ -137,6 +138,10 @@ abstract final class StorageUsageService {
 
     final assistantSubs = <String, _MutableStats>{'avatars': _MutableStats()};
 
+    // Per-workspace subcategories, keyed by workspace alias (the directory
+    // name directly under the workspaces root, e.g. `default`).
+    final workspaceSubs = <String, _MutableStats>{};
+
     final cacheSubs = <String, _MutableStats>{
       'avatar_cache': _MutableStats(),
       'other_cache': _MutableStats(),
@@ -216,6 +221,18 @@ abstract final class StorageUsageService {
             byCat[StorageUsageCategoryKey.assistantData]!.add(bytes);
             assistantSubs['avatars']!.add(bytes);
             break;
+          case 'workspaces':
+            // Workspace sandboxes live under appData/workspaces/<alias> on
+            // mobile (and desktop's default location), so the recursive walk
+            // covers them. Surface them as their own category with one
+            // subcategory per workspace alias instead of lumping them into
+            // "other".
+            byCat[StorageUsageCategoryKey.workspaceData]!.add(bytes);
+            if (parts.length >= 2) {
+              final alias = parts[1];
+              workspaceSubs.putIfAbsent(alias, _MutableStats.new).add(bytes);
+            }
+            break;
           case 'images':
             // Inline/generated images are stored under appData/images.
             // Treat them as "Images" so users can manage them together.
@@ -254,6 +271,40 @@ abstract final class StorageUsageService {
     final systemCacheDir = await AppDirectories.getSystemCacheDirectory();
     final avatarCacheDir = await AppDirectories.getAvatarCacheDirectory();
     final logsDir = Directory(p.join(root.path, 'logs'));
+
+    // Desktop users may relocate the workspaces root outside the app-data
+    // tree (`workspaces_dir_v1`). The recursive walk above only covers the
+    // default location, so scan a relocated root separately to keep
+    // workspace usage visible there too. No double counting: when the root
+    // is inside the app-data tree the `workspaces` case already counted it.
+    final workspacesRoot = await AppDirectories.getWorkspacesRootDirectory();
+    if (!_isWithin(root.path, workspacesRoot.path)) {
+      try {
+        if (await workspacesRoot.exists()) {
+          await for (final ent in workspacesRoot.list(
+            recursive: true,
+            followLinks: false,
+          )) {
+            if (ent is! File) continue;
+            int bytes = 0;
+            try {
+              bytes = await ent.length();
+            } catch (_) {
+              bytes = 0;
+            }
+            totalFiles += 1;
+            totalBytes += bytes;
+            byCat[StorageUsageCategoryKey.workspaceData]!.add(bytes);
+            final rel = p.relative(ent.path, from: workspacesRoot.path);
+            final parts = p.split(rel);
+            final alias = parts.isEmpty ? '' : parts.first;
+            if (alias.isNotEmpty) {
+              workspaceSubs.putIfAbsent(alias, _MutableStats.new).add(bytes);
+            }
+          }
+        }
+      } catch (_) {}
+    }
 
     // Real iOS app tmp directory (<container>/tmp, via platform channel).
     // path_provider's getTemporaryDirectory() returns Caches on iOS, so the
@@ -352,6 +403,19 @@ abstract final class StorageUsageService {
             stats: assistantSubs['avatars']!.toStats(),
             path: avatarsDir.path,
           ),
+        ],
+      ),
+      StorageUsageCategory(
+        key: StorageUsageCategoryKey.workspaceData,
+        stats: byCat[StorageUsageCategoryKey.workspaceData]!.toStats(),
+        subcategories: [
+          for (final e in workspaceSubs.entries)
+            if (e.value.bytes > 0 || e.value.fileCount > 0)
+              StorageUsageSubcategory(
+                id: e.key,
+                stats: e.value.toStats(),
+                path: p.join(workspacesRoot.path, e.key),
+              ),
         ],
       ),
       StorageUsageCategory(
@@ -595,6 +659,15 @@ abstract final class StorageUsageService {
     return deleted;
   }
 
+  /// True when [child] equals [parent] or is nested inside it (both
+  /// normalized to absolute paths). Used to decide whether the workspaces
+  /// root is already covered by the app-data recursive walk.
+  static bool _isWithin(String parent, String child) {
+    final pa = p.normalize(p.absolute(parent));
+    final ch = p.normalize(p.absolute(child));
+    return ch == pa || p.isWithin(pa, ch);
+  }
+
   static Future<void> _deleteDirectoryContents(Directory dir) async {
     if (!await dir.exists()) return;
     try {
@@ -653,6 +726,7 @@ const List<StorageUsageCategoryKey> _categoryOrder = <StorageUsageCategoryKey>[
   StorageUsageCategoryKey.files,
   StorageUsageCategoryKey.chatData,
   StorageUsageCategoryKey.assistantData,
+  StorageUsageCategoryKey.workspaceData,
   StorageUsageCategoryKey.cache,
   StorageUsageCategoryKey.logs,
   StorageUsageCategoryKey.deletedRecords,

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -83,6 +83,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return const Color(0xFF22C55E);
       case StorageUsageCategoryKey.assistantData:
         return const Color(0xFF3B82F6); // blue (distinct from chat green)
+      case StorageUsageCategoryKey.workspaceData:
+        return const Color(0xFF14B8A6); // teal
       case StorageUsageCategoryKey.cache:
         return const Color(0xFFEF4444); // red
       case StorageUsageCategoryKey.logs:
@@ -104,6 +106,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return Lucide.MessagesSquare;
       case StorageUsageCategoryKey.assistantData:
         return Lucide.Bot;
+      case StorageUsageCategoryKey.workspaceData:
+        return Lucide.Folder;
       case StorageUsageCategoryKey.cache:
         return Lucide.Boxes;
       case StorageUsageCategoryKey.logs:
@@ -125,6 +129,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return l10n.storageSpaceCategoryChatData;
       case StorageUsageCategoryKey.assistantData:
         return l10n.storageSpaceCategoryAssistantData;
+      case StorageUsageCategoryKey.workspaceData:
+        return l10n.settingsPageWorkspace;
       case StorageUsageCategoryKey.cache:
         return l10n.storageSpaceCategoryCache;
       case StorageUsageCategoryKey.logs:

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -77,6 +77,39 @@ void main() {
   }
 
   test(
+    'workspaces are counted as their own category with per-alias breakdown',
+    () async {
+      final wsDefault = Directory(p.join(appDataDir.path, 'workspaces/default'));
+      final wsOther = Directory(p.join(appDataDir.path, 'workspaces/ws_2'));
+      await wsDefault.create(recursive: true);
+      await wsOther.create(recursive: true);
+      await _writeSizedFile(wsDefault, 'notes.txt', 30);
+      await _writeSizedFile(wsDefault, 'sub/data.bin', 20);
+      await _writeSizedFile(wsOther, 'output.log', 50);
+
+      final report = await StorageUsageService.computeReport();
+      final ws = report.categories.singleWhere(
+        (category) => category.key == StorageUsageCategoryKey.workspaceData,
+      );
+
+      expect(ws.stats.bytes, 100);
+      expect(ws.stats.fileCount, 3);
+      expect(
+        ws.subcategories.map((subcategory) => subcategory.id),
+        containsAllInOrder(['default', 'ws_2']),
+      );
+      final defSub = ws.subcategories.singleWhere((s) => s.id == 'default');
+      expect(defSub.stats.bytes, 50);
+      expect(defSub.stats.fileCount, 2);
+      expect(
+        p.basename(defSub.path!),
+        'default',
+      );
+      expect(report.totalBytes, 100);
+    },
+  );
+
+  test(
     'chat records size uses SQLite files instead of legacy Hive files',
     () async {
       await _writeSizedFile(appDataDir, AppDatabase.databaseFileName, 11);


### PR DESCRIPTION
## Problem

The storage statistics page (`Settings → Storage`) never surfaces workspace usage. `StorageUsageService.computeReport()` counts every file under the app-data tree, including `workspaces/**`, but:

- there is no `workspace` category in `StorageUsageCategoryKey`, and
- the `other` bucket is not even rendered in the report's `categories` list,

so workspace storage is completely invisible to users (only folded into the grand total). On iOS the workspace host directories live at `<container>/Documents/workspaces/<alias>` (custom host paths are desktop-only), so they *are* scanned — they just end up in the unrendered `other` bucket.

## Change

- Add `StorageUsageCategoryKey.workspaceData` with one subcategory per workspace alias (`default`, `workspace_N`, …), so users can see per-workspace size + file count + path from the storage page.
- Categorize `appData/workspaces/**` in `computeReport()`. On desktop, also scan a user-relocated workspaces root (`workspaces_dir_v1`) that lives outside the app-data tree so it is not missed; no double counting when the root is inside the app-data tree.
- Surface the new category in the storage page: teal bar color, folder icon, title reuses the existing `settingsPageWorkspace` l10n key (no new strings needed).
- Add a unit test covering the per-alias breakdown.

## Files changed

- `lib/core/services/storage/storage_usage_service.dart`
- `lib/features/settings/pages/storage_space_page.dart`
- `test/core/services/storage/storage_usage_service_test.dart`

## Notes for maintainers

- I could not run `flutter gen-l10n` / `flutter test` in this environment; no new l10n keys were introduced (existing `settingsPageWorkspace` is reused), so generated localization files are untouched. Please run `flutter analyze` + the storage service tests before merging.

Related issue: (linked below)