### PR TITLE
feat(chat): add nine-patch (.9.png) bubble support

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -1329,6 +1329,9 @@ class SettingsProvider extends ChangeNotifier {
       case 'solid':
         _chatMessageBackgroundStyle = ChatMessageBackgroundStyle.solid;
         break;
+      case 'ninePatch':
+        _chatMessageBackgroundStyle = ChatMessageBackgroundStyle.ninePatch;
+        break;
       default:
         _chatMessageBackgroundStyle = ChatMessageBackgroundStyle.defaultStyle;
     }
@@ -2660,6 +2663,7 @@ class SettingsProvider extends ChangeNotifier {
     final v = switch (style) {
       ChatMessageBackgroundStyle.frosted => 'frosted',
       ChatMessageBackgroundStyle.solid => 'solid',
+      ChatMessageBackgroundStyle.ninePatch => 'ninePatch',
       ChatMessageBackgroundStyle.defaultStyle => 'default',
     };
     await prefs.setString(_displayChatMessageBackgroundStyleKey, v);
@@ -5105,7 +5109,7 @@ class _SocksProxyHttpOverrides extends HttpOverrides {
 enum ProviderKind { openai, google, claude }
 
 // Background rendering mode for chat message bubbles
-enum ChatMessageBackgroundStyle { defaultStyle, frosted, solid }
+enum ChatMessageBackgroundStyle { defaultStyle, frosted, solid, ninePatch }
 
 enum AndroidBackgroundChatMode { off, on, onNotify }
 

--- a/lib/features/chat/utils/nine_patch_image.dart
+++ b/lib/features/chat/utils/nine_patch_image.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+import 'package:flutter/material.dart';
+
+/// Nine-patch parsed metadata extracted from a .9.png image.
+class NinePatchData {
+  /// Horizontal stretchable regions (list of [start, end] pairs, in pixels).
+  final List<_Range> xStretch;
+
+  /// Vertical stretchable regions (list of [start, end] pairs, in pixels).
+  final List<_Range> yStretch;
+
+  /// Content padding extracted from bottom/right guide pixels.
+  final EdgeInsets? contentPadding;
+
+  /// Source image width (excluding the 1px guide borders).
+  final int width;
+
+  /// Source image height (excluding the 1px guide borders).
+  final int height;
+
+  const NinePatchData({
+    required this.xStretch,
+    required this.yStretch,
+    required this.width,
+    required this.height,
+    this.contentPadding,
+  });
+}
+
+class _Range {
+  final int start;
+  final int end;
+  const _Range(this.start, this.end);
+  int get length => end - start;
+}
+
+/// Parse a .9.png image's guide pixels into stretch regions.
+///
+/// Nine-patch format:
+/// - Top edge: black pixels mark horizontal stretchable regions
+/// - Left edge: black pixels mark vertical stretchable regions
+/// - Bottom edge (optional): black pixels mark horizontal content area
+/// - Right edge (optional): black pixels mark vertical content area
+///
+/// Returns null if the image is not a valid nine-patch.
+Future<NinePatchData?> parseNinePatchAsync(ui.Image image) async {
+  if (image.width < 3 || image.height < 3) return null;
+
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  if (bytes == null) return null;
+
+  final w = image.width;
+  final h = image.height;
+  final data = bytes.buffer.asUint8List();
+
+  bool isBlack(int x, int y) {
+    final offset = (y * w + x) * 4;
+    if (offset + 3 >= data.length) return false;
+    final r = data[offset];
+    final g = data[offset + 1];
+    final b = data[offset + 2];
+    final a = data[offset + 3];
+    return a > 128 && r < 32 && g < 32 && b < 32;
+  }
+
+  // Parse top edge (x stretch regions)
+  final xStretch = <_Range>[];
+  int? rangeStart;
+  for (int x = 1; x < w - 1; x++) {
+    if (isBlack(x, 0)) {
+      rangeStart ??= x - 1;
+    } else if (rangeStart != null) {
+      xStretch.add(_Range(rangeStart, x - 1));
+      rangeStart = null;
+    }
+  }
+  if (rangeStart != null) {
+    xStretch.add(_Range(rangeStart, w - 2));
+  }
+
+  // Parse left edge (y stretch regions)
+  final yStretch = <_Range>[];
+  rangeStart = null;
+  for (int y = 1; y < h - 1; y++) {
+    if (isBlack(0, y)) {
+      rangeStart ??= y - 1;
+    } else if (rangeStart != null) {
+      yStretch.add(_Range(rangeStart, y - 1));
+      rangeStart = null;
+    }
+  }
+  if (rangeStart != null) {
+    yStretch.add(_Range(rangeStart, h - 2));
+  }
+
+  if (xStretch.isEmpty || yStretch.isEmpty) {
+    return null;
+  }
+
+  // Parse content padding (bottom and right edges)
+  int? contentLeft;
+  int? contentRight;
+  for (int x = 1; x < w - 1; x++) {
+    if (isBlack(x, h - 1)) {
+      contentLeft ??= x - 1;
+      contentRight = x - 1;
+    }
+  }
+
+  int? contentTop;
+  int? contentBottom;
+  for (int y = 1; y < h - 1; y++) {
+    if (isBlack(w - 1, y)) {
+      contentTop ??= y - 1;
+      contentBottom = y - 1;
+    }
+  }
+
+  EdgeInsets? padding;
+  if (contentLeft != null &&
+      contentRight != null &&
+      contentTop != null &&
+      contentBottom != null) {
+    final contentWidth = w - 2;
+    final contentHeight = h - 2;
+    padding = EdgeInsets.only(
+      left: contentLeft.toDouble(),
+      top: contentTop.toDouble(),
+      right: (contentWidth - contentRight - 1).toDouble(),
+      bottom: (contentHeight - contentBottom - 1).toDouble(),
+    );
+  }
+
+  return NinePatchData(
+    xStretch: xStretch,
+    yStretch: yStretch,
+    width: w - 2,
+    height: h - 2,
+    contentPadding: padding,
+  );
+}
+
+/// A CustomPainter that draws a nine-patch image.
+class NinePatchPainter extends CustomPainter {
+  final ui.Image image;
+  final NinePatchData ninePatch;
+
+  const NinePatchPainter({
+    required this.image,
+    required this.ninePatch,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..filterQuality = FilterQuality.low;
+
+    final xSegments =
+        _buildSegments(ninePatch.xStretch, ninePatch.width, size.width);
+    final ySegments =
+        _buildSegments(ninePatch.yStretch, ninePatch.height, size.height);
+
+    double dstY = 0;
+    for (final ySegment in ySegments) {
+      double dstX = 0;
+      for (final xSegment in xSegments) {
+        final srcRect = Rect.fromLTWH(
+          xSegment.srcStart.toDouble(),
+          ySegment.srcStart.toDouble(),
+          xSegment.srcLength.toDouble(),
+          ySegment.srcLength.toDouble(),
+        );
+        final dstRect =
+            Rect.fromLTWH(dstX, dstY, xSegment.dstLength, ySegment.dstLength);
+        canvas.drawImageRect(image, srcRect, dstRect, paint);
+        dstX += xSegment.dstLength;
+      }
+      dstY += ySegment.dstLength;
+    }
+  }
+
+  @override
+  bool shouldRepaint(NinePatchPainter oldDelegate) {
+    return oldDelegate.image != image || oldDelegate.ninePatch != ninePatch;
+  }
+
+  List<_Segment> _buildSegments(
+    List<_Range> stretch,
+    int srcTotal,
+    double dstTotal,
+  ) {
+    final segments = <_Segment>[];
+
+    int fixedSize = srcTotal;
+    for (final r in stretch) {
+      fixedSize -= r.length;
+    }
+
+    final availableStretch = dstTotal - fixedSize;
+    final totalStretchSrc =
+        stretch.fold<int>(0, (sum, r) => sum + r.length);
+    final double stretchRatio =
+        totalStretchSrc > 0 ? availableStretch / totalStretchSrc : 0.0;
+
+    int srcPos = 0;
+
+    for (int i = 0; i <= stretch.length; i++) {
+      final nextStretchStart =
+          i < stretch.length ? stretch[i].start : srcTotal;
+      if (srcPos < nextStretchStart) {
+        final len = nextStretchStart - srcPos;
+        segments.add(_Segment(srcPos, len, len.toDouble()));
+        srcPos += len;
+      }
+
+      if (i < stretch.length) {
+        final r = stretch[i];
+        final srcLen = r.length;
+        final dstLen = srcLen * stretchRatio;
+        segments.add(_Segment(r.start, srcLen, dstLen));
+        srcPos += srcLen;
+      }
+    }
+
+    return segments;
+  }
+}
+
+class _Segment {
+  final int srcStart;
+  final int srcLength;
+  final double dstLength;
+  const _Segment(this.srcStart, this.srcLength, this.dstLength);
+}
+
+/// A widget that displays a nine-patch image as background.
+class NinePatchImage extends StatefulWidget {
+  final ImageProvider imageProvider;
+  final Widget? child;
+  final EdgeInsetsGeometry? padding;
+
+  const NinePatchImage({
+    super.key,
+    required this.imageProvider,
+    this.child,
+    this.padding,
+  });
+
+  @override
+  State<NinePatchImage> createState() => _NinePatchImageState();
+}
+
+class _NinePatchImageState extends State<NinePatchImage> {
+  ui.Image? _image;
+  NinePatchData? _ninePatch;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadImage();
+  }
+
+  @override
+  void didUpdateWidget(NinePatchImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageProvider != widget.imageProvider) {
+      _loadImage();
+    }
+  }
+
+  Future<void> _loadImage() async {
+    setState(() => _loading = true);
+    final completer = Completer<ui.Image>();
+    final stream = widget.imageProvider.resolve(const ImageConfiguration());
+    stream.addListener(ImageStreamListener(
+      (info, _) => completer.complete(info.image),
+      onError: (e, st) => completer.completeError(e, st),
+    ));
+    try {
+      final image = await completer.future;
+      final ninePatch = await parseNinePatchAsync(image);
+      if (mounted) {
+        setState(() {
+          _image = image;
+          _ninePatch = ninePatch;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading || _image == null || _ninePatch == null) {
+      return widget.child ?? const SizedBox.shrink();
+    }
+
+    return CustomPaint(
+      painter: NinePatchPainter(image: _image!, ninePatch: _ninePatch!),
+      child: widget.padding != null
+          ? Padding(padding: widget.padding!, child: widget.child)
+          : widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _image?.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -51,6 +51,7 @@ import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
 import 'token_display_widget.dart';
 import '../../../theme/app_font_weights.dart';
+import '../utils/nine_patch_image.dart';
 
 final RegExp _urlSchemeRe = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:');
 
@@ -3260,7 +3261,11 @@ Widget _buildSharedChatSurface(
         ),
         child: paddedChild,
       );
-    case ChatMessageBackgroundStyle.defaultStyle:
+    case ChatMessageBackgroundStyle.ninePatch:
+      // TODO: Load user's custom .9.png path from settings
+      // For now, fall back to default style
+      return paddedChild;
+        case ChatMessageBackgroundStyle.defaultStyle:
       if (bareOnDefault) {
         return child;
       }


### PR DESCRIPTION
## 功能

添加 Nine-patch (.9.png) 聊天气泡支持，类似 QQ 自定义气泡。

## 什么是 .9 图？

标准 Android Nine-patch 格式：图片四周有 1px 引导像素，标记哪些区域可以拉伸。
- 角落装饰不变形
- 中间区域随内容自动拉伸
- 效果：不管消息多长，气泡都好看

## 改动

### 新增文件
- `lib/features/chat/utils/nine_patch_image.dart`
  - `parseNinePatchAsync()` 解析 .9.png 拉伸标记
  - `NinePatchPainter` (CustomPainter) 九宫格渲染
  - `NinePatchImage` widget

### 修改文件
- `lib/core/providers/settings_provider.dart`
  - enum 加 `ninePatch`
  - load/save 逻辑更新
  
- `lib/features/chat/widgets/chat_message_widget.dart`
  - `_buildSharedChatSurface` 加 `case ninePatch`
  - 添加 import

## 后续计划

- [ ] 设置界面：让用户选择 .9.png 文件
- [ ] 用户/助手分别设置不同气泡
- [ ] 内置默认气泡样本
- [ ] 缓存优化
- [ ] 测试

**1 commit / 3 files changed (+1 new file)**
