### PR TITLE
fix(ios): install rootfs atomically via staging + verify + rollback

### DIFF
--- a/ios/Runner/iSHSandbox/CuplivoSandboxRootfsInstaller.swift
+++ b/ios/Runner/iSHSandbox/CuplivoSandboxRootfsInstaller.swift
@@ -32,7 +32,10 @@ enum SandboxRootfsInstallerError: Error, LocalizedError {
 final class CuplivoSandboxRootfsInstaller {
   static let resourceName = "alpine-rootfs"
 
-  /// Extract the bundled rootfs zip into `destDir` (created fresh).
+  /// Install the bundled rootfs zip into `destDir` atomically: the archive is
+  /// first extracted into a sibling staging directory and structurally
+  /// verified, then replaced with a backup for recovery. A failed
+  /// or cancelled install never deletes the previously usable rootfs.
   static func install(to destDir: URL, isCancelled: () -> Bool = { false }) throws {
     guard let zipURL = Bundle.main.url(forResource: resourceName, withExtension: "zip") else {
       throw SandboxRootfsInstallerError.bundleResourceMissing
@@ -42,47 +45,246 @@ final class CuplivoSandboxRootfsInstaller {
     }
 
     let fm = FileManager.default
+    let parent = destDir.deletingLastPathComponent()
+    try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+    try recoverInterruptedInstall(to: destDir, fileManager: fm)
+
+    let staging = parent.appendingPathComponent(
+      "\(destDir.lastPathComponent).staging-\(UUID().uuidString)"
+    )
+
     do {
       if isCancelled() {
         throw SandboxRootfsInstallerError.cancelled
       }
-      if fm.fileExists(atPath: destDir.path) {
-        try fm.removeItem(at: destDir)
-      }
-      try fm.createDirectory(at: destDir, withIntermediateDirectories: true)
-
-      let destBase = destDir.standardizedFileURL.path
-      for entry in archive.entries {
-        if isCancelled() {
-          throw SandboxRootfsInstallerError.cancelled
-        }
-        // Zip-slip guard: resolved path must stay inside destDir.
-        let entryURL = destDir.appendingPathComponent(entry.path).standardizedFileURL
-        guard entryURL.path == destBase || entryURL.path.hasPrefix(destBase + "/") else {
-          throw SandboxRootfsInstallerError.unsafeEntryPath(entry.path)
-        }
-        if entry.isDirectory {
-          try fm.createDirectory(at: entryURL, withIntermediateDirectories: true)
-          continue
-        }
-        let parent = entryURL.deletingLastPathComponent()
-        if !fm.fileExists(atPath: parent.path) {
-          try fm.createDirectory(at: parent, withIntermediateDirectories: true)
-        }
-        guard let data = try archive.extractData(for: entry) else {
-          throw SandboxRootfsInstallerError.extractionFailed("Failed to extract \(entry.path)")
-        }
-        if isCancelled() {
-          throw SandboxRootfsInstallerError.cancelled
-        }
-        try data.write(to: entryURL)
-      }
-      NSLog("CuplivoSandboxRootfsInstaller: extracted \(archive.entries.count) entries to \(destDir.path)")
+      try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+      try extract(archive: archive, into: staging, isCancelled: isCancelled)
+      try commitStagedRootfs(
+        staging,
+        to: destDir,
+        isCancelled: isCancelled,
+        fileManager: fm
+      )
+      cleanupArtifactsIfDestinationUsable(at: destDir, fileManager: fm)
+      NSLog(
+        "CuplivoSandboxRootfsInstaller: installed \(archive.entries.count) entries to \(destDir.path)"
+      )
     } catch {
-      // A cancelled or failed install must not leave a directory that looks
-      // like a usable rootfs to the next readiness probe.
-      try? fm.removeItem(at: destDir)
+      removeArtifact(staging, fileManager: fm)
       throw error
+    }
+  }
+
+  static func commitStagedRootfs(
+    _ staging: URL,
+    to destDir: URL,
+    isCancelled: () -> Bool = { false },
+    fileManager fm: FileManager = .default
+  ) throws {
+    try verifyRootfs(at: staging)
+    if isCancelled() {
+      throw SandboxRootfsInstallerError.cancelled
+    }
+
+    guard fm.fileExists(atPath: destDir.path) else {
+      try fm.moveItem(at: staging, to: destDir)
+      return
+    }
+
+    let backupName = "\(destDir.lastPathComponent).backup-\(UUID().uuidString)"
+    let backup = destDir.deletingLastPathComponent().appendingPathComponent(backupName)
+    do {
+      _ = try fm.replaceItemAt(
+        destDir,
+        withItemAt: staging,
+        backupItemName: backupName,
+        options: [.usingNewMetadataOnly, .withoutDeletingBackupItem]
+      )
+    } catch {
+      NSLog(
+        "CuplivoSandboxRootfsInstaller: atomic replace failed; "
+          + "original/backup retained when available: \(error)"
+      )
+      throw error
+    }
+    removeArtifact(backup, fileManager: fm)
+  }
+
+  static func recoverInterruptedInstall(
+    to destDir: URL,
+    fileManager fm: FileManager = .default
+  ) throws {
+    let parent = destDir.deletingLastPathComponent()
+    let candidates: [URL]
+    do {
+      candidates = try fm.contentsOfDirectory(
+        at: parent,
+        includingPropertiesForKeys: [.isRegularFileKey]
+      )
+    } catch {
+      throw SandboxRootfsInstallerError.extractionFailed(
+        "Failed to inspect interrupted rootfs installs: \(error.localizedDescription)"
+      )
+    }
+
+    if isUsableRootfs(at: destDir) {
+      cleanupArtifacts(candidates, for: destDir, fileManager: fm)
+      return
+    }
+
+    let backupPrefix = "\(destDir.lastPathComponent).backup-"
+    let usableBackups = candidates.filter {
+      $0.lastPathComponent.hasPrefix(backupPrefix) && isUsableRootfs(at: $0)
+    }
+    guard usableBackups.count <= 1 else {
+      throw SandboxRootfsInstallerError.extractionFailed(
+        "Multiple usable rootfs backups found; refusing ambiguous recovery"
+      )
+    }
+    guard let backup = usableBackups.first else {
+      return
+    }
+
+    let displaced = parent.appendingPathComponent(
+      "\(destDir.lastPathComponent).staging-recovery-\(UUID().uuidString)"
+    )
+    let hadDestination = fm.fileExists(atPath: destDir.path)
+    if hadDestination {
+      try fm.moveItem(at: destDir, to: displaced)
+    }
+    do {
+      try fm.moveItem(at: backup, to: destDir)
+    } catch {
+      if hadDestination {
+        do {
+          try fm.moveItem(at: displaced, to: destDir)
+        } catch let rollbackError {
+          NSLog(
+            "CuplivoSandboxRootfsInstaller: recovery rollback failed: \(rollbackError)"
+          )
+        }
+      }
+      throw SandboxRootfsInstallerError.extractionFailed(
+        "Failed to restore rootfs backup: \(error.localizedDescription)"
+      )
+    }
+
+    cleanupArtifactsIfDestinationUsable(at: destDir, fileManager: fm)
+    NSLog("CuplivoSandboxRootfsInstaller: restored interrupted rootfs backup")
+  }
+
+  private static func extract(
+    archive: SandboxZipArchive,
+    into destDir: URL,
+    isCancelled: () -> Bool
+  ) throws {
+    let fm = FileManager.default
+    let destBase = destDir.standardizedFileURL.path
+    for entry in archive.entries {
+      if isCancelled() {
+        throw SandboxRootfsInstallerError.cancelled
+      }
+      // Zip-slip guard: resolved path must stay inside destDir.
+      let entryURL = destDir.appendingPathComponent(entry.path).standardizedFileURL
+      guard entryURL.path == destBase || entryURL.path.hasPrefix(destBase + "/") else {
+        throw SandboxRootfsInstallerError.unsafeEntryPath(entry.path)
+      }
+      if entry.isDirectory {
+        try fm.createDirectory(at: entryURL, withIntermediateDirectories: true)
+        continue
+      }
+      let parent = entryURL.deletingLastPathComponent()
+      if !fm.fileExists(atPath: parent.path) {
+        try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+      }
+      guard let data = try archive.extractData(for: entry) else {
+        throw SandboxRootfsInstallerError.extractionFailed("Failed to extract \(entry.path)")
+      }
+      if isCancelled() {
+        throw SandboxRootfsInstallerError.cancelled
+      }
+      try data.write(to: entryURL)
+    }
+  }
+
+  /// Lightweight structural validation of a staged rootfs before it replaces
+  /// the live one. Complements the deeper ZIP-integrity work tracked
+  /// separately: a truncated or mis-extracted fakefs must never be committed
+  /// as the active rootfs.
+  static func verifyRootfs(at dir: URL) throws {
+    for probe in ["meta.db", "data/bin/busybox", ".arch"] {
+      let url = dir.appendingPathComponent(probe)
+      let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+      guard values?.isRegularFile == true else {
+        throw SandboxRootfsInstallerError.extractionFailed(
+          "staged rootfs missing regular file \(probe)"
+        )
+      }
+    }
+    let arch: String
+    do {
+      arch = try String(contentsOf: dir.appendingPathComponent(".arch"), encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    } catch {
+      throw SandboxRootfsInstallerError.extractionFailed(
+        "staged rootfs .arch unreadable: \(error.localizedDescription)"
+      )
+    }
+    guard arch == "aarch64" else {
+      throw SandboxRootfsInstallerError.extractionFailed(
+        "staged rootfs arch mismatch (\(arch))"
+      )
+    }
+  }
+
+  private static func isUsableRootfs(at url: URL) -> Bool {
+    do {
+      try verifyRootfs(at: url)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private static func cleanupArtifactsIfDestinationUsable(
+    at destDir: URL,
+    fileManager fm: FileManager
+  ) {
+    guard isUsableRootfs(at: destDir) else { return }
+    do {
+      let candidates = try fm.contentsOfDirectory(
+        at: destDir.deletingLastPathComponent(),
+        includingPropertiesForKeys: nil
+      )
+      cleanupArtifacts(candidates, for: destDir, fileManager: fm)
+    } catch {
+      NSLog("CuplivoSandboxRootfsInstaller: artifact scan failed: \(error)")
+    }
+  }
+
+  private static func cleanupArtifacts(
+    _ candidates: [URL],
+    for destDir: URL,
+    fileManager fm: FileManager
+  ) {
+    let stagingPrefix = "\(destDir.lastPathComponent).staging-"
+    let backupPrefix = "\(destDir.lastPathComponent).backup-"
+    for url in candidates where url.standardizedFileURL != destDir.standardizedFileURL {
+      let name = url.lastPathComponent
+      if name.hasPrefix(stagingPrefix) || name.hasPrefix(backupPrefix) {
+        removeArtifact(url, fileManager: fm)
+      }
+    }
+  }
+
+  private static func removeArtifact(_ url: URL, fileManager fm: FileManager) {
+    guard fm.fileExists(atPath: url.path) else { return }
+    do {
+      try fm.removeItem(at: url)
+    } catch {
+      NSLog(
+        "CuplivoSandboxRootfsInstaller: failed to clean \(url.lastPathComponent): \(error)"
+      )
     }
   }
 }

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,12 +1,157 @@
 import Flutter
 import UIKit
 import XCTest
+@testable import Runner
 
-class RunnerTests: XCTestCase {
+final class CuplivoSandboxRootfsInstallerTests: XCTestCase {
+  private let fm = FileManager.default
+  private var tempDirectory: URL!
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  override func setUpWithError() throws {
+    tempDirectory = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try fm.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
   }
 
+  override func tearDownWithError() throws {
+    if let tempDirectory, fm.fileExists(atPath: tempDirectory.path) {
+      try fm.removeItem(at: tempDirectory)
+    }
+  }
+
+  func testCommitReplacesExistingRootfsAndCleansBackup() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let staging = tempDirectory.appendingPathComponent("alpine-rootfs.staging-test")
+    try makeRootfs(at: destination, marker: "old")
+    try makeRootfs(at: staging, marker: "new")
+
+    try CuplivoSandboxRootfsInstaller.commitStagedRootfs(staging, to: destination)
+
+    XCTAssertEqual(try marker(at: destination), "new")
+    XCTAssertFalse(fm.fileExists(atPath: staging.path))
+    XCTAssertFalse(try artifactNames().contains { $0.hasPrefix("alpine-rootfs.backup-") })
+  }
+
+  func testInvalidStagingPreservesExistingRootfs() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let staging = tempDirectory.appendingPathComponent("alpine-rootfs.staging-test")
+    try makeRootfs(at: destination, marker: "old")
+    try makeRootfs(at: staging, marker: "new")
+    let busybox = staging.appendingPathComponent("data/bin/busybox")
+    try fm.removeItem(at: busybox)
+    try fm.createDirectory(at: busybox, withIntermediateDirectories: true)
+
+    XCTAssertThrowsError(
+      try CuplivoSandboxRootfsInstaller.commitStagedRootfs(staging, to: destination)
+    )
+
+    XCTAssertEqual(try marker(at: destination), "old")
+  }
+
+  func testCancelledCommitPreservesExistingRootfs() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let staging = tempDirectory.appendingPathComponent("alpine-rootfs.staging-test")
+    try makeRootfs(at: destination, marker: "old")
+    try makeRootfs(at: staging, marker: "new")
+
+    XCTAssertThrowsError(
+      try CuplivoSandboxRootfsInstaller.commitStagedRootfs(
+        staging,
+        to: destination,
+        isCancelled: { true }
+      )
+    ) { error in
+      guard let installerError = error as? SandboxRootfsInstallerError,
+        case .cancelled = installerError
+      else {
+        XCTFail("Expected cancellation, got \(error)")
+        return
+      }
+    }
+
+    XCTAssertEqual(try marker(at: destination), "old")
+  }
+
+  func testInterruptedInstallRestoresOnlyUsableBackup() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let backup = tempDirectory.appendingPathComponent("alpine-rootfs.backup-test")
+    let staging = tempDirectory.appendingPathComponent("alpine-rootfs.staging-test")
+    try makeRootfs(at: backup, marker: "old")
+    try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    try CuplivoSandboxRootfsInstaller.recoverInterruptedInstall(to: destination)
+
+    XCTAssertEqual(try marker(at: destination), "old")
+    XCTAssertFalse(fm.fileExists(atPath: backup.path))
+    XCTAssertFalse(fm.fileExists(atPath: staging.path))
+  }
+
+  func testUsableDestinationWinsAndCleansStaleArtifacts() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let backup = tempDirectory.appendingPathComponent("alpine-rootfs.backup-test")
+    let staging = tempDirectory.appendingPathComponent("alpine-rootfs.staging-test")
+    try makeRootfs(at: destination, marker: "current")
+    try makeRootfs(at: backup, marker: "old")
+    try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+
+    try CuplivoSandboxRootfsInstaller.recoverInterruptedInstall(to: destination)
+
+    XCTAssertEqual(try marker(at: destination), "current")
+    XCTAssertFalse(fm.fileExists(atPath: backup.path))
+    XCTAssertFalse(fm.fileExists(atPath: staging.path))
+  }
+
+  func testMultipleUsableBackupsArePreserved() throws {
+    let destination = tempDirectory.appendingPathComponent("alpine-rootfs")
+    let first = tempDirectory.appendingPathComponent("alpine-rootfs.backup-first")
+    let second = tempDirectory.appendingPathComponent("alpine-rootfs.backup-second")
+    try makeRootfs(at: first, marker: "first")
+    try makeRootfs(at: second, marker: "second")
+
+    XCTAssertThrowsError(
+      try CuplivoSandboxRootfsInstaller.recoverInterruptedInstall(to: destination)
+    )
+
+    XCTAssertTrue(fm.fileExists(atPath: first.path))
+    XCTAssertTrue(fm.fileExists(atPath: second.path))
+    XCTAssertFalse(fm.fileExists(atPath: destination.path))
+  }
+
+  func testVerifyRejectsDirectoryInPlaceOfRequiredFile() throws {
+    let rootfs = tempDirectory.appendingPathComponent("alpine-rootfs")
+    try makeRootfs(at: rootfs, marker: "current")
+    let meta = rootfs.appendingPathComponent("meta.db")
+    try fm.removeItem(at: meta)
+    try fm.createDirectory(at: meta, withIntermediateDirectories: true)
+
+    XCTAssertThrowsError(try CuplivoSandboxRootfsInstaller.verifyRootfs(at: rootfs))
+  }
+
+  private func makeRootfs(at url: URL, marker: String) throws {
+    try fm.createDirectory(
+      at: url.appendingPathComponent("data/bin"),
+      withIntermediateDirectories: true
+    )
+    try fm.createDirectory(
+      at: url.appendingPathComponent("data/root"),
+      withIntermediateDirectories: true
+    )
+    try Data([0]).write(to: url.appendingPathComponent("meta.db"))
+    try Data([0]).write(to: url.appendingPathComponent("data/bin/busybox"))
+    try Data("aarch64".utf8).write(to: url.appendingPathComponent(".arch"))
+    try Data(marker.utf8).write(to: url.appendingPathComponent("data/root/marker"))
+  }
+
+  private func marker(at rootfs: URL) throws -> String {
+    return try String(
+      contentsOf: rootfs.appendingPathComponent("data/root/marker"),
+      encoding: .utf8
+    )
+  }
+
+  private func artifactNames() throws -> [String] {
+    return try fm.contentsOfDirectory(
+      at: tempDirectory,
+      includingPropertiesForKeys: nil
+    ).map(\.lastPathComponent)
+  }
 }


### PR DESCRIPTION
## 变更

`CuplivoSandboxRootfsInstaller.install(to:)` 改为可恢复的原子安装，不再先删除旧环境：

- 先解压到同目录下的唯一 staging 目录；
- 提交前确认 `meta.db`、`data/bin/busybox`、`.arch` 都是普通文件，且 `.arch == aarch64`；
- 已有 rootfs 通过 `FileManager.replaceItemAt` 同卷替换，并保留临时 backup，成功后才清理；
- 启动安装时先协调上次中断状态：目标缺失时恢复唯一可用 backup，多个可用 backup 时保留全部并明确报错；
- 仅在当前 rootfs 已验证可用时清理遗留 staging/backup，清理和恢复失败均记录上下文；
- 保留 master 现有的 `isCancelled` 请求取消链路。

这样解压、校验、取消或提交失败时，旧环境（含用户安装的 Python、Node、Git 等）不会被提前删除，也不会把半成品 rootfs 提交为已安装环境。关联 #393，并为 #399 的深度 ZIP 校验提供提交前验证层；CRC、长度和 central-directory 深度校验仍由 #399 跟踪。

## 测试

新增 iOS 临时目录测试，覆盖：

- 成功替换并清理 backup；
- staging 无效或安装取消时保留旧 rootfs；
- 目标缺失时恢复唯一可用 backup；
- 当前目标有效时清理中断遗留物；
- 多个可用 backup 时拒绝猜测并保留数据；
- 关键路径为目录而非普通文件时拒绝提交。

验证结果：

- `dart analyze --fatal-infos lib test`
- `flutter test test/core/services/workspace/sandbox_readiness_test.dart`
- `git diff --check`
- `unzip -t ios/sandbox/resources/alpine-rootfs.zip`
- [PR Checks（完整 Flutter / Android Kotlin 测试）](https://github.com/cuplivo/cuplivo/actions/runs/32547886018)
- [远程 iOS release 无签名构建](https://github.com/cuplivo/cuplivo/actions/runs/32547914291)
- [远程 iOS RunnerTests build-for-testing 编译](https://github.com/cuplivo/cuplivo/actions/runs/32548679003)

Fixes #393.