### PR TITLE
fix(android): skip ./ root-dir entries instead of failing rootfs extraction (fixes #322)

### DIFF
--- a/android/app/src/main/kotlin/com/cup11/cuplivo/RootfsExtractor.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/RootfsExtractor.kt
@@ -404,7 +404,11 @@ object RootfsExtractor {
 
   private fun sanitizeEntryPath(raw: String): String {
     val cleaned = raw.replace('\\', '/').trim().trimStart('/').removePrefix("./")
-    if (cleaned.isEmpty()) throw IllegalArgumentException("Entry path is empty")
+    // A bare "." / "./" is the tarball root directory entry (Alpine
+    // minirootfs archives carry one). It maps to the extraction root and is
+    // skipped by nextEntry(), so return an empty name instead of failing the
+    // whole extraction.
+    if (cleaned.isEmpty()) return ""
     if (cleaned.contains('\u0000')) throw IllegalArgumentException("Entry path contains a NUL byte")
     if (cleaned.split('/').contains("..")) {
       throw IllegalArgumentException("Entry path escapes the extraction root: $raw")


### PR DESCRIPTION
## 变更

`RootfsExtractor.sanitizeEntryPath()` 不再把 tarball 根目录条目 `./`（Alpine minirootfs 常见）当作错误：

- `./` / `.` 解析后返回空名，由现有 `nextEntry()` 的空名跳过逻辑处理；
- 不再抛出 `Entry path is empty` 导致整个 rootfs 解压失败（#322）；
- `..` 逃逸、NUL 字节等校验保持不变。

关联：#322