### PR TITLE
fix(memory): serialize add() to prevent duplicate IDs in parallel create_memory calls

### DIFF
--- a/lib/core/services/memory_store.dart
+++ b/lib/core/services/memory_store.dart
@@ -6,11 +6,32 @@ import '../models/assistant_memory.dart';
 class MemoryStore {
   static const String _memoriesKey = 'assistant_memories_v1';
 
-  /// Mutex to serialize add() calls and prevent duplicate ID assignment
-  /// when multiple create_memory tool calls happen in parallel.
-  static Completer<void>? _addLock;
+  /// Mutex that serializes every read-modify-write mutation
+  /// (add/update/delete) so concurrent tool calls cannot observe a stale
+  /// snapshot and assign duplicate IDs or drop each other's changes.
+  ///
+  /// The lock is reset to null after each release so waiters never chain onto
+  /// a future that outlives the call site's event loop zone.
+  ///
+  /// NOT reentrant: a locked action must never invoke another locked method,
+  /// or it will wait forever on its own uncompleted completer.
+  static Completer<void>? _lock;
 
   static List<AssistantMemory>? _cache;
+
+  static Future<T> _withLock<T>(Future<T> Function() action) async {
+    while (_lock != null) {
+      await _lock!.future;
+    }
+    final completer = Completer<void>();
+    _lock = completer;
+    try {
+      return await action();
+    } finally {
+      _lock = null;
+      completer.complete();
+    }
+  }
 
   static Future<List<AssistantMemory>> _loadAllInternal() async {
     final prefs = await SharedPreferences.getInstance();
@@ -35,6 +56,10 @@ class MemoryStore {
     return List<AssistantMemory>.of(_cache!);
   }
 
+  /// Replaces the whole memory list. Does NOT take the mutation lock.
+  ///
+  /// Callers outside the locked mutations (e.g. trash restore) must not run
+  /// concurrently with add/update/delete or they can clobber newer changes.
   static Future<void> saveAll(List<AssistantMemory> list) async {
     _cache = List<AssistantMemory>.of(list);
     final prefs = await SharedPreferences.getInstance();
@@ -63,14 +88,8 @@ class MemoryStore {
   static Future<AssistantMemory> add({
     required String assistantId,
     required String content,
-  }) async {
-    // Serialize concurrent add() calls to prevent duplicate ID assignment.
-    while (_addLock != null && !_addLock!.isCompleted) {
-      await _addLock!.future;
-    }
-    _addLock = Completer<void>();
-
-    try {
+  }) {
+    return _withLock(() async {
       final all = await getAll();
       final id = _nextId(all);
       final mem = AssistantMemory(
@@ -81,37 +100,40 @@ class MemoryStore {
       all.add(mem);
       await _saveAll(all);
       return mem;
-    } finally {
-      _addLock!.complete();
-      _addLock = null;
-    }
+    });
   }
 
   static Future<AssistantMemory?> update({
     required int id,
     required String content,
-  }) async {
-    final all = await getAll();
-    final idx = all.indexWhere((m) => m.id == id);
-    if (idx == -1) return null;
-    final updated = all[idx].copyWith(content: content);
-    all[idx] = updated;
-    await _saveAll(all);
-    return updated;
+  }) {
+    return _withLock(() async {
+      final all = await getAll();
+      final idx = all.indexWhere((m) => m.id == id);
+      if (idx == -1) return null;
+      final updated = all[idx].copyWith(content: content);
+      all[idx] = updated;
+      await _saveAll(all);
+      return updated;
+    });
   }
 
-  static Future<bool> delete({required int id}) async {
-    final all = await getAll();
-    final before = all.length;
-    all.removeWhere((m) => m.id == id);
-    final changed = all.length != before;
-    if (changed) await _saveAll(all);
-    return changed;
+  static Future<bool> delete({required int id}) {
+    return _withLock(() async {
+      final all = await getAll();
+      final before = all.length;
+      all.removeWhere((m) => m.id == id);
+      final changed = all.length != before;
+      if (changed) await _saveAll(all);
+      return changed;
+    });
   }
 
-  static Future<void> deleteForAssistant(String assistantId) async {
-    final all = await getAll();
-    all.removeWhere((m) => m.assistantId == assistantId);
-    await _saveAll(all);
+  static Future<void> deleteForAssistant(String assistantId) {
+    return _withLock(() async {
+      final all = await getAll();
+      all.removeWhere((m) => m.assistantId == assistantId);
+      await _saveAll(all);
+    });
   }
 }

--- a/lib/core/services/memory_store.dart
+++ b/lib/core/services/memory_store.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/assistant_memory.dart';
 
 class MemoryStore {
   static const String _memoriesKey = 'assistant_memories_v1';
+
+  /// Mutex to serialize add() calls and prevent duplicate ID assignment
+  /// when multiple create_memory tool calls happen in parallel.
+  static Completer<void>? _addLock;
 
   static List<AssistantMemory>? _cache;
 
@@ -59,16 +64,27 @@ class MemoryStore {
     required String assistantId,
     required String content,
   }) async {
-    final all = await getAll();
-    final id = _nextId(all);
-    final mem = AssistantMemory(
-      id: id,
-      assistantId: assistantId,
-      content: content,
-    );
-    all.add(mem);
-    await _saveAll(all);
-    return mem;
+    // Serialize concurrent add() calls to prevent duplicate ID assignment.
+    while (_addLock != null && !_addLock!.isCompleted) {
+      await _addLock!.future;
+    }
+    _addLock = Completer<void>();
+
+    try {
+      final all = await getAll();
+      final id = _nextId(all);
+      final mem = AssistantMemory(
+        id: id,
+        assistantId: assistantId,
+        content: content,
+      );
+      all.add(mem);
+      await _saveAll(all);
+      return mem;
+    } finally {
+      _addLock!.complete();
+      _addLock = null;
+    }
   }
 
   static Future<AssistantMemory?> update({

--- a/test/core/services/memory_store_test.dart
+++ b/test/core/services/memory_store_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/models/assistant_memory.dart';
+import 'package:Cuplivo/core/services/memory_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MemoryStore', () {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      await MemoryStore.saveAll(<AssistantMemory>[]);
+    });
+
+    test(
+      'parallel add() assigns unique ids without losing records (#478)',
+      () async {
+        final results = await Future.wait([
+          MemoryStore.add(assistantId: 'a1', content: 'm1'),
+          MemoryStore.add(assistantId: 'a1', content: 'm2'),
+          MemoryStore.add(assistantId: 'a1', content: 'm3'),
+          MemoryStore.add(assistantId: 'a1', content: 'm4'),
+        ]);
+
+        final ids = results.map((m) => m.id).toSet();
+        expect(
+          ids.length,
+          results.length,
+          reason: 'parallel adds must not share ids',
+        );
+
+        final all = await MemoryStore.getAll();
+        final stored = all.where((m) => m.assistantId == 'a1').toList();
+        expect(
+          stored.length,
+          results.length,
+          reason: 'no record may be overwritten',
+        );
+        expect(stored.map((m) => m.id).toSet().length, results.length);
+        expect(stored.map((m) => m.id), everyElement(isPositive));
+      },
+    );
+
+    test('parallel add() continues from existing ids monotonically', () async {
+      await MemoryStore.add(assistantId: 'a1', content: 'existing');
+
+      final results = await Future.wait([
+        MemoryStore.add(assistantId: 'a1', content: 'm1'),
+        MemoryStore.add(assistantId: 'a1', content: 'm2'),
+        MemoryStore.add(assistantId: 'a1', content: 'm3'),
+      ]);
+
+      final ids = results.map((m) => m.id).toSet();
+      expect(ids.length, results.length);
+      expect(ids, isNot(contains(1)));
+    });
+
+    test('parallel add and delete serialize without lost updates', () async {
+      final first = await MemoryStore.add(assistantId: 'a1', content: 'm1');
+
+      await Future.wait([
+        MemoryStore.add(assistantId: 'a1', content: 'm2'),
+        MemoryStore.delete(id: first.id),
+      ]);
+
+      final all = await MemoryStore.getAll();
+      final stored = all.where((m) => m.assistantId == 'a1').toList();
+      expect(
+        stored.length,
+        1,
+        reason: 'exactly one record must survive either order',
+      );
+      expect(stored.single.content, 'm2');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #478

## Problem
When multiple `create_memory` tool calls happen in parallel within the same AI response (e.g. "拿外卖" and "拿快递"), they race on the shared `_nextId` logic:

1. Both calls read the same cached `getAll()` snapshot  
2. Both compute the same `maxId + 1` → both get id=72  
3. Both insert records with identical IDs  
4. The second `saveAll()` silently overwrites the first  

Result: Only "拿快递" survives in the memory list; "拿外卖" is lost.

## Solution
Introduce a `Completer`-based mutex (`_addLock`) that serializes all `add()` calls. Each `add` waits for the previous one to fully complete (ID assignment + `saveAll`) before reading the list, ensuring monotonic ID allocation even under concurrent load.

## Changes
- `lib/core/services/memory_store.dart`:  
  - Added `_addLock` static field (nullable `Completer<void>`)  
  - Wrapped `add()` body in mutex: wait for existing lock → create new lock → execute → complete & clear lock  
- No new dependencies (uses `dart:async` Completer)

## Testing
Manual verification in development environment confirmed sequential add() continues to work. Parallel tool-call scenario will be validated post-merge (unit test can be added as follow-up if needed).

