### PR TITLE
fix(storage): count workspace data separately

### DIFF
--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -17,6 +17,7 @@ enum StorageUsageCategoryKey {
   cache,
   logs,
   other,
+  workspace,
   deletedRecords,
 }
 
@@ -150,6 +151,11 @@ abstract final class StorageUsageService {
       'other_logs': _MutableStats(),
     };
 
+    final workspaceSubs = <String, _MutableStats>{
+      'files': _MutableStats(),
+      'sandbox': _MutableStats(),
+    };
+
     int totalBytes = 0;
     int totalFiles = 0;
 
@@ -215,6 +221,14 @@ abstract final class StorageUsageService {
           case 'avatars':
             byCat[StorageUsageCategoryKey.assistantData]!.add(bytes);
             assistantSubs['avatars']!.add(bytes);
+            break;
+          case 'workspaces':
+            byCat[StorageUsageCategoryKey.workspace]!.add(bytes);
+            workspaceSubs['files']!.add(bytes);
+            break;
+          case 'linux-sandbox':
+            byCat[StorageUsageCategoryKey.workspace]!.add(bytes);
+            workspaceSubs['sandbox']!.add(bytes);
             break;
           case 'images':
             // Inline/generated images are stored under appData/images.
@@ -310,6 +324,34 @@ abstract final class StorageUsageService {
       } catch (_) {
         // If listing fails for any reason, fall back to 0s; UI will show load failed.
       }
+    }
+
+    // iOS stores the managed iSH rootfs in Application Support, outside the
+    // Documents directory scanned above. Count it as workspace storage.
+    final sandboxRuntime =
+        await AppDirectories.getLinuxSandboxRuntimeDirectory();
+    if (!p.isWithin(
+      p.normalize(root.absolute.path),
+      p.normalize(sandboxRuntime.absolute.path),
+    )) {
+      try {
+        if (await sandboxRuntime.exists()) {
+          await for (final ent in sandboxRuntime.list(
+            recursive: true,
+            followLinks: false,
+          )) {
+            if (ent is! File) continue;
+            int bytes = 0;
+            try {
+              bytes = await ent.length();
+            } catch (_) {}
+            totalFiles += 1;
+            totalBytes += bytes;
+            byCat[StorageUsageCategoryKey.workspace]!.add(bytes);
+            workspaceSubs['sandbox']!.add(bytes);
+          }
+        }
+      } catch (_) {}
     }
 
     final clearable = StorageUsageStats(
@@ -410,6 +452,24 @@ abstract final class StorageUsageService {
       ),
       // Deleted records — informational entry (actual bytes loaded by the
       // trash detail page via DeletedRecordsStore, not via filesystem scan).
+      StorageUsageCategory(
+        key: StorageUsageCategoryKey.workspace,
+        stats: byCat[StorageUsageCategoryKey.workspace]!.toStats(),
+        subcategories: [
+          StorageUsageSubcategory(
+            id: 'files',
+            stats: workspaceSubs['files']!.toStats(),
+            path: (await AppDirectories.getWorkspacesRootDirectory()).path,
+          ),
+          StorageUsageSubcategory(
+            id: 'sandbox',
+            stats: workspaceSubs['sandbox']!.toStats(),
+            path: (
+              await AppDirectories.getLinuxSandboxRuntimeDirectory()
+            ).path,
+          ),
+        ],
+      ),
       StorageUsageCategory(
         key: StorageUsageCategoryKey.deletedRecords,
         stats: const StorageUsageStats(fileCount: 0, bytes: 0),
@@ -655,6 +715,7 @@ const List<StorageUsageCategoryKey> _categoryOrder = <StorageUsageCategoryKey>[
   StorageUsageCategoryKey.assistantData,
   StorageUsageCategoryKey.cache,
   StorageUsageCategoryKey.logs,
+  StorageUsageCategoryKey.workspace,
   StorageUsageCategoryKey.deletedRecords,
   StorageUsageCategoryKey.other,
 ];

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -89,6 +89,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return const Color(0xFFEAB308); // yellow
       case StorageUsageCategoryKey.other:
         return cs.onSurface.withValues(alpha: 0.22);
+      case StorageUsageCategoryKey.workspace:
+        return const Color(0xFF14B8A6); // teal
       case StorageUsageCategoryKey.deletedRecords:
         return const Color(0xFF64748B); // slate
     }
@@ -110,6 +112,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return Lucide.FileText;
       case StorageUsageCategoryKey.other:
         return Lucide.Box;
+      case StorageUsageCategoryKey.workspace:
+        return Lucide.FolderOpen;
       case StorageUsageCategoryKey.deletedRecords:
         return Lucide.Trash2;
     }
@@ -131,6 +135,8 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return l10n.storageSpaceCategoryLogs;
       case StorageUsageCategoryKey.other:
         return l10n.storageSpaceCategoryOther;
+      case StorageUsageCategoryKey.workspace:
+        return l10n.storageSpaceCategoryWorkspace;
       case StorageUsageCategoryKey.deletedRecords:
         return l10n.storageSpaceCategoryDeletedRecords;
     }
@@ -168,6 +174,10 @@ class _StorageSpacePageState extends State<StorageSpacePage> {
         return l10n.storageSpaceSubLogsRequests;
       case 'other_logs':
         return l10n.storageSpaceSubLogsOther;
+      case 'files':
+        return l10n.storageSpaceCategoryWorkspace;
+      case 'sandbox':
+        return l10n.storageSpaceSubWorkspaceSandbox;
       default:
         return id;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -63,6 +63,8 @@
   "storageSpaceCategoryCache": "Cache",
   "storageSpaceCategoryLogs": "Logs",
   "storageSpaceCategoryOther": "App",
+  "storageSpaceCategoryWorkspace": "Workspace",
+  "storageSpaceSubWorkspaceSandbox": "Linux sandbox",
   "storageSpaceCategoryDeletedRecords": "Trash",
   "storageSpaceFilesCount": "{count} files",
   "@storageSpaceFilesCount": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -340,6 +340,9 @@ abstract class AppLocalizations {
   /// **'App'**
   String get storageSpaceCategoryOther;
 
+  String get storageSpaceCategoryWorkspace;
+  String get storageSpaceSubWorkspaceSandbox;
+
   /// No description provided for @storageSpaceCategoryDeletedRecords.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -340,7 +340,16 @@ abstract class AppLocalizations {
   /// **'App'**
   String get storageSpaceCategoryOther;
 
+  /// No description provided for @storageSpaceCategoryWorkspace.
+  ///
+  /// In en, this message translates to:
+  /// **'Workspace'**
   String get storageSpaceCategoryWorkspace;
+
+  /// No description provided for @storageSpaceSubWorkspaceSandbox.
+  ///
+  /// In en, this message translates to:
+  /// **'Linux sandbox'**
   String get storageSpaceSubWorkspaceSandbox;
 
   /// No description provided for @storageSpaceCategoryDeletedRecords.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -138,6 +138,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get storageSpaceCategoryOther => 'App';
 
   @override
+  String get storageSpaceCategoryWorkspace => 'Workspace';
+
+  @override
+  String get storageSpaceSubWorkspaceSandbox => 'Linux sandbox';
+
+  @override
   String get storageSpaceCategoryDeletedRecords => 'Trash';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8102,6 +8102,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get storageSpaceCategoryOther => '应用';
 
   @override
+  String get storageSpaceCategoryWorkspace => '工作区';
+
+  @override
+  String get storageSpaceSubWorkspaceSandbox => 'Linux 沙箱';
+
+  @override
   String get storageSpaceCategoryDeletedRecords => '回收站';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -135,6 +135,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get storageSpaceCategoryOther => '应用';
 
   @override
+  String get storageSpaceCategoryWorkspace => '工作区';
+
+  @override
+  String get storageSpaceSubWorkspaceSandbox => 'Linux 沙箱';
+
+  @override
   String get storageSpaceCategoryDeletedRecords => '回收站';
 
   @override
@@ -16055,6 +16061,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get storageSpaceCategoryOther => '應用';
+
+  @override
+  String get storageSpaceCategoryWorkspace => '工作區';
+
+  @override
+  String get storageSpaceSubWorkspaceSandbox => 'Linux 沙箱';
 
   @override
   String get storageSpaceCategoryDeletedRecords => '資源回收筒';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -39,6 +39,8 @@
   "storageSpaceCategoryCache": "缓存",
   "storageSpaceCategoryLogs": "日志",
   "storageSpaceCategoryOther": "应用",
+  "storageSpaceCategoryWorkspace": "工作区",
+  "storageSpaceSubWorkspaceSandbox": "Linux 沙箱",
   "storageSpaceCategoryDeletedRecords": "回收站",
   "storageSpaceFilesCount": "{count} 个文件",
   "storageSpaceSafeToClearHint": "可安全清理，不影响聊天记录。",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -39,6 +39,8 @@
   "storageSpaceCategoryCache": "缓存",
   "storageSpaceCategoryLogs": "日志",
   "storageSpaceCategoryOther": "应用",
+  "storageSpaceCategoryWorkspace": "工作区",
+  "storageSpaceSubWorkspaceSandbox": "Linux 沙箱",
   "storageSpaceCategoryDeletedRecords": "回收站",
   "storageSpaceFilesCount": "{count} 个文件",
   "storageSpaceSafeToClearHint": "可安全清理，不影响聊天记录。",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -39,6 +39,8 @@
   "storageSpaceCategoryCache": "快取",
   "storageSpaceCategoryLogs": "日誌",
   "storageSpaceCategoryOther": "應用",
+  "storageSpaceCategoryWorkspace": "工作區",
+  "storageSpaceSubWorkspaceSandbox": "Linux 沙箱",
   "storageSpaceCategoryDeletedRecords": "資源回收筒",
   "storageSpaceFilesCount": "{count} 個檔案",
   "storageSpaceSafeToClearHint": "可安全清理，不影響聊天記錄。",

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -138,6 +138,26 @@ void main() {
     },
   );
 
+  test('workspace files are counted in a dedicated category', () async {
+    final workspaceDir = Directory(p.join(appDataDir.path, 'workspaces', 'default'));
+    await workspaceDir.create(recursive: true);
+    await _writeSizedFile(workspaceDir, 'main.dart', 70);
+    await _writeSizedFile(workspaceDir, 'README.md', 30);
+
+    final report = await StorageUsageService.computeReport();
+    final workspace = report.categories.singleWhere(
+      (category) => category.key == StorageUsageCategoryKey.workspace,
+    );
+
+    expect(workspace.stats.bytes, 100);
+    expect(workspace.stats.fileCount, 2);
+    final files = workspace.subcategories.singleWhere(
+      (subcategory) => subcategory.id == 'files',
+    );
+    expect(files.stats.bytes, 100);
+    expect(report.totalBytes, 100);
+  });
+
   test(
     'iOS tmp directory is counted under cache when the channel resolves',
     () async {


### PR DESCRIPTION
Fixes #458

## Changes
- Add a dedicated Workspace storage category.
- Count built-in workspace files and the iOS sandbox runtime separately.
- Show workspace usage in the storage page with localized labels.
- Add a focused storage usage test.

The sandbox runtime is only scanned separately when it is outside the app-data tree, preventing double counting on Android, desktop, and non-iOS platforms.