### PR TITLE
fix: preserve original timestamp for edited message versions

### DIFF
--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -834,6 +834,27 @@ class DataSync {
     return out;
   }
 
+  /// Messages qualifying for incremental export, at version-group granularity.
+  ///
+  /// Edited versions preserve the original message timestamp, so a
+  /// timestamp-only filter would drop them while `versionSelections` still
+  /// references the missing version. `version > 0` also matches multi-AI
+  /// adopted threads (renumbered without being edited), which only ever
+  /// produces superset exports. Qualify by group: every message whose group
+  /// contains a changed or versioned message is included.
+  List<ChatMessage> _incrementalQualifiedMessages(
+    List<ChatMessage> msgs,
+    bool Function(DateTime) sinceCheck,
+  ) {
+    final qualifiedGroups = msgs
+        .where((m) => sinceCheck(m.timestamp) || m.version > 0)
+        .map((m) => m.groupId ?? m.id)
+        .toSet();
+    return msgs
+        .where((m) => qualifiedGroups.contains(m.groupId ?? m.id))
+        .toList();
+  }
+
   /// Analyze incremental scope for preview purposes — scans conversations and
   /// files to produce metadata counts and representative titles.
   /// Does not modify any state; safe to call repeatedly.
@@ -859,9 +880,10 @@ class DataSync {
         newConvs.add(c);
       } else if (c.updatedAt.isAfter(since) ||
           c.updatedAt.isAtSameMomentAs(since)) {
-        final filtered = chatService
-            .getMessages(c.id)
-            .where((m) => sinceCheck(m.timestamp));
+        final filtered = _incrementalQualifiedMessages(
+          chatService.getMessages(c.id),
+          sinceCheck,
+        );
         final count = filtered.length;
         if (count > 0) {
           updatedMsgCount += count;
@@ -1027,7 +1049,9 @@ class DataSync {
         }
         if (c.updatedAt.isBefore(since)) return false;
         final msgs = chatService.getMessages(c.id);
-        return msgs.any((m) => sinceCheck(m.timestamp));
+        // Edited versions keep the original message timestamp, so a
+        // timestamp-only check would miss edit-only activity.
+        return _incrementalQualifiedMessages(msgs, sinceCheck).isNotEmpty;
       }).toList();
     }
     final file = File(p.join(directory.path, '_bk_chats.json'));
@@ -1058,9 +1082,7 @@ class DataSync {
         if (incremental != null &&
             !c.isGroup &&
             c.createdAt.isBefore(incremental.since)) {
-          msgs = msgs
-              .where((m) => incremental.sinceCheck(m.timestamp))
-              .toList();
+          msgs = _incrementalQualifiedMessages(msgs, incremental.sinceCheck);
         }
         for (final m in msgs) {
           if (!firstMsg) sink.write(',');

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1595,6 +1595,7 @@ class ChatService extends ChangeNotifier {
   Future<ChatMessage?> appendMessageVersion({
     required String messageId,
     required String content,
+    DateTime? timestamp,
   }) async {
     if (!_initialized) await init();
     final original =
@@ -1630,6 +1631,7 @@ class ChatService extends ChangeNotifier {
       speakerAssistantId: original.speakerAssistantId,
       requestAllowImagesApiRouting: original.requestAllowImagesApiRouting,
       requestExtraBodyJson: original.requestExtraBodyJson,
+      timestamp: timestamp,
     );
     // Append to conversation order at the end (we'll group when rendering)
     if (_draftConversations.containsKey(cid)) {

--- a/lib/features/group_chat/pages/group_chat_page.dart
+++ b/lib/features/group_chat/pages/group_chat_page.dart
@@ -305,9 +305,12 @@ class _GroupChatPageState extends State<GroupChatPage> {
     final g = context.read<GroupChatProvider>().getById(widget.groupChatId);
     if (g == null) return;
 
+    final keepOriginalTimestamp =
+        message.role == 'assistant' || !result.shouldSend;
     final newMsg = await _chatService.appendMessageVersion(
       messageId: message.id,
       content: result.content,
+      timestamp: keepOriginalTimestamp ? message.timestamp : null,
     );
     if (newMsg == null) return;
     final gid = newMsg.groupId ?? newMsg.id;

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -68,10 +68,12 @@ class UserMessageEditState {
   const UserMessageEditState({
     required this.messageId,
     required this.previewText,
+    required this.originalTimestamp,
   });
 
   final String messageId;
   final String previewText;
+  final DateTime originalTimestamp;
 }
 
 /// Controller that manages all state and service wiring for HomePage.
@@ -1372,6 +1374,7 @@ class HomePageController extends ChangeNotifier {
     final newMsg = await _chatService.appendMessageVersion(
       messageId: message.id,
       content: result.content,
+      timestamp: message.timestamp,
     );
     if (newMsg == null) return;
 
@@ -1444,7 +1447,11 @@ class HomePageController extends ChangeNotifier {
         input.documents.isEmpty) {
       return;
     }
-    final newMsg = await _saveEditedUserMessageVersion(input, editState);
+    final newMsg = await _saveEditedUserMessageVersion(
+      input,
+      editState,
+      timestamp: editState.originalTimestamp,
+    );
     if (newMsg == null) return;
     _exitUserMessageEdit(clearDraft: true);
   }
@@ -1477,6 +1484,7 @@ class HomePageController extends ChangeNotifier {
     _userMessageEditState = UserMessageEditState(
       messageId: message.id,
       previewText: input.text.isNotEmpty ? input.text : message.content.trim(),
+      originalTimestamp: message.timestamp,
     );
     notifyListeners();
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1500,8 +1508,9 @@ class HomePageController extends ChangeNotifier {
 
   Future<ChatMessage?> _saveEditedUserMessageVersion(
     ChatInputData input,
-    UserMessageEditState editState,
-  ) async {
+    UserMessageEditState editState, {
+    DateTime? timestamp,
+  }) async {
     final conversation = currentConversation;
     if (conversation == null) return null;
     final assistant = _context.read<AssistantProvider>().currentAssistant;
@@ -1518,6 +1527,7 @@ class HomePageController extends ChangeNotifier {
     final newMsg = await _chatService.appendMessageVersion(
       messageId: editState.messageId,
       content: content,
+      timestamp: timestamp,
     );
     if (newMsg == null) return null;
     // Overwrite the version's request metadata with the CURRENT composer

--- a/lib/features/home/services/multi_ai_engine.dart
+++ b/lib/features/home/services/multi_ai_engine.dart
@@ -744,7 +744,14 @@ class MultiAIEngine extends ChangeNotifier {
     for (final entry in byGid.entries) {
       final gid = entry.key;
       final msgs = entry.value;
-      msgs.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+      // Edited versions share the original message timestamp, so a
+      // timestamp-only sort has tied keys and List.sort is not stable.
+      // Break ties by version for deterministic renumbering.
+      msgs.sort((a, b) {
+        final byTime = a.timestamp.compareTo(b.timestamp);
+        if (byTime != 0) return byTime;
+        return a.version.compareTo(b.version);
+      });
 
       for (int i = 0; i < msgs.length; i++) {
         final msg = msgs[i];

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -797,6 +797,162 @@ void main() {
     );
 
     test(
+      'incremental: edit-only activity exports the conversation with its full version chain',
+      () async {
+        final chatService = ChatService();
+        await chatService.init();
+
+        final oldDate = DateTime.now().subtract(const Duration(days: 60));
+        final since = DateTime.now().subtract(const Duration(days: 30));
+        const gid = 'test-group-1';
+
+        final conv = Conversation(
+          id: 'test-conv-3',
+          title: 'Edited Conversation',
+          createdAt: oldDate,
+          updatedAt: DateTime.now(),
+          messageIds: ['msg-v0', 'msg-v1'],
+          versionSelections: {gid: 1},
+        );
+        final v0 = ChatMessage(
+          id: 'msg-v0',
+          role: 'assistant',
+          content: 'original answer',
+          timestamp: oldDate,
+          conversationId: conv.id,
+          isStreaming: false,
+          groupId: gid,
+          version: 0,
+        );
+        final v1 = ChatMessage(
+          id: 'msg-v1',
+          role: 'assistant',
+          content: 'edited answer',
+          // Edited versions preserve the ORIGINAL timestamp.
+          timestamp: oldDate,
+          conversationId: conv.id,
+          isStreaming: false,
+          groupId: gid,
+          version: 1,
+        );
+        await chatService.restoreConversation(conv, [v0, v1]);
+
+        final sync = DataSync(chatService: chatService);
+        final backupFile = await sync.prepareBackupFile(
+          const WebDavConfig(includeChats: true, includeFiles: false),
+          incremental: IncrementalBackupConfig(
+            since: since,
+            includeSettings: false,
+            includeFiles: false,
+          ),
+        );
+
+        final input = InputFileStream(backupFile.path);
+        Archive? archive;
+        try {
+          archive = ZipDecoder().decodeStream(input);
+          final chatsEntry = archive.findFile('chats.json');
+          expect(chatsEntry, isNotNull);
+
+          final data =
+              jsonDecode(utf8.decode(chatsEntry!.readBytes() ?? <int>[]))
+                  as Map<String, dynamic>;
+          final convs = data['conversations'] as List;
+          final msgs = data['messages'] as List;
+
+          expect(convs, hasLength(1));
+          expect(convs[0]['id'], 'test-conv-3');
+          expect((convs[0]['versionSelections'] as Map)[gid], 1);
+          expect(msgs, hasLength(2));
+          expect(msgs.map((m) => m['id']), containsAll(['msg-v0', 'msg-v1']));
+        } finally {
+          archive?.clearSync();
+          input.closeSync();
+        }
+
+        await DataSync.cleanupTemporaryBackupFile(backupFile);
+        await chatService.close();
+      },
+    );
+
+    test(
+      'incremental: version groups export atomically when the selected version is the original',
+      () async {
+        final chatService = ChatService();
+        await chatService.init();
+
+        final oldDate = DateTime.now().subtract(const Duration(days: 60));
+        final since = DateTime.now().subtract(const Duration(days: 30));
+        const gid = 'test-group-2';
+
+        final conv = Conversation(
+          id: 'test-conv-4',
+          title: 'Reverted Conversation',
+          createdAt: oldDate,
+          updatedAt: DateTime.now(),
+          messageIds: ['msg-rv0', 'msg-rv1'],
+          // User edited to v1 but switched the selection back to v0.
+          versionSelections: {gid: 0},
+        );
+        final v0 = ChatMessage(
+          id: 'msg-rv0',
+          role: 'user',
+          content: 'original prompt',
+          timestamp: oldDate,
+          conversationId: conv.id,
+          isStreaming: false,
+          groupId: gid,
+          version: 0,
+        );
+        final v1 = ChatMessage(
+          id: 'msg-rv1',
+          role: 'user',
+          content: 'edited prompt',
+          timestamp: oldDate,
+          conversationId: conv.id,
+          isStreaming: false,
+          groupId: gid,
+          version: 1,
+        );
+        await chatService.restoreConversation(conv, [v0, v1]);
+
+        final sync = DataSync(chatService: chatService);
+        final backupFile = await sync.prepareBackupFile(
+          const WebDavConfig(includeChats: true, includeFiles: false),
+          incremental: IncrementalBackupConfig(
+            since: since,
+            includeSettings: false,
+            includeFiles: false,
+          ),
+        );
+
+        final input = InputFileStream(backupFile.path);
+        Archive? archive;
+        try {
+          archive = ZipDecoder().decodeStream(input);
+          final chatsEntry = archive.findFile('chats.json');
+          expect(chatsEntry, isNotNull);
+
+          final data =
+              jsonDecode(utf8.decode(chatsEntry!.readBytes() ?? <int>[]))
+                  as Map<String, dynamic>;
+          final convs = data['conversations'] as List;
+          final msgs = data['messages'] as List;
+
+          expect(convs, hasLength(1));
+          expect(msgs, hasLength(2));
+          expect(msgs.map((m) => m['id']), containsAll(['msg-rv0', 'msg-rv1']));
+        } finally {
+          archive?.clearSync();
+          input.closeSync();
+        }
+
+        await DataSync.cleanupTemporaryBackupFile(backupFile);
+        await chatService.close();
+      },
+    );
+
+    test(
       'incremental: analyzeIncrementalScope returns correct counts',
       () async {
         final chatService = ChatService();
@@ -891,6 +1047,64 @@ void main() {
         expect(scope.updatedConversations.messageCount, 1);
         expect(scope.updatedConversations.oldestTitle, 'Old Chat');
         expect(scope.newFileCount, 0);
+
+        await chatService.close();
+      },
+    );
+
+    test(
+      'incremental: analyzeIncrementalScope counts edit-only activity as whole version groups',
+      () async {
+        final chatService = ChatService();
+        await chatService.init();
+
+        final since = DateTime.now().subtract(const Duration(days: 30));
+        final oldDate = DateTime.now().subtract(const Duration(days: 60));
+        const gid = 'scope-group-1';
+
+        // Edit-only conversation: all message timestamps predate since, but
+        // updatedAt is fresh and a version was appended.
+        final conv = Conversation(
+          id: 'scope-conv',
+          title: 'Edit Only',
+          createdAt: oldDate,
+          updatedAt: DateTime.now(),
+          messageIds: ['scope-v0', 'scope-v1'],
+          versionSelections: {gid: 1},
+        );
+        await chatService.restoreConversation(conv, [
+          ChatMessage(
+            id: 'scope-v0',
+            role: 'assistant',
+            content: 'original',
+            timestamp: oldDate,
+            conversationId: conv.id,
+            isStreaming: false,
+            groupId: gid,
+            version: 0,
+          ),
+          ChatMessage(
+            id: 'scope-v1',
+            role: 'assistant',
+            content: 'edited',
+            timestamp: oldDate,
+            conversationId: conv.id,
+            isStreaming: false,
+            groupId: gid,
+            version: 1,
+          ),
+        ]);
+
+        final sync = DataSync(chatService: chatService);
+        final scope = await sync.analyzeIncrementalScope(
+          IncrementalBackupConfig(since: since, includeFiles: false),
+        );
+
+        expect(scope.newConversations.count, 0);
+        expect(scope.updatedConversations.count, 1);
+        expect(scope.updatedConversations.oldestTitle, 'Edit Only');
+        // Whole version group counts, matching the atomic export.
+        expect(scope.updatedConversations.messageCount, 2);
 
         await chatService.close();
       },

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -262,6 +262,58 @@ void main() {
         expect(edited, isNull);
       },
     );
+
+    test('appendMessageVersion keeps the provided timestamp', () async {
+      final service = createService();
+      await service.init();
+
+      final conversation = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final original = await service.addMessage(
+        conversationId: conversation.id,
+        role: 'assistant',
+        content: 'original answer',
+      );
+      final originalTime = DateTime(2024, 1, 1, 10, 30);
+
+      final edited = await service.appendMessageVersion(
+        messageId: original.id,
+        content: 'edited answer',
+        timestamp: originalTime,
+      );
+
+      expect(edited, isNotNull);
+      expect(edited!.timestamp, originalTime);
+    });
+
+    test(
+      'appendMessageVersion defaults to now when no timestamp is given',
+      () async {
+        final service = createService();
+        await service.init();
+
+        final conversation = await service.createDraftConversation(
+          title: 'Temporary Chat',
+          temporary: true,
+        );
+        final original = await service.addMessage(
+          conversationId: conversation.id,
+          role: 'user',
+          content: 'hello',
+        );
+        final before = DateTime.now();
+
+        final edited = await service.appendMessageVersion(
+          messageId: original.id,
+          content: 'hello, edited',
+        );
+
+        expect(edited, isNotNull);
+        expect(edited!.timestamp.isBefore(before), isFalse);
+      },
+    );
   });
 
   group('ChatService fork conversations', () {


### PR DESCRIPTION
Fixes #446.

Edited assistant messages and save-only edited user messages keep the
original message timestamp; user edits that are sent get a fresh time.

- appendMessageVersion accepts an optional timestamp; default stays now
- incremental backup/LAN sync export version groups atomically so edited
  versions are not dropped by the since-filter while versionSelections
  references them; analyzeIncrementalScope preview uses the same predicate
- multi-AI resolveThread sorts by (timestamp, version) since preserved
  timestamps create tied sort keys
