### PR TITLE
fix: drop non-string enum values from Google tool schemas

### DIFF
--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -150,6 +150,8 @@ class ToolHandlerService {
           'required',
           'items',
           'enum',
+          // Google/Gemini rejects additionalProperties, so it stays dropped
+          // there while openai/claude preserve it (see below).
         };
         break;
       case ProviderKind.openai:
@@ -171,6 +173,18 @@ class ToolHandlerService {
         break;
     }
     m.removeWhere((k, v) => !allowed.contains(k));
+
+    // Gemini only accepts enum as an array of strings. MCP schemas (and the
+    // `const` -> enum conversion above) may produce bool/num enum values,
+    // which Gemini rejects with HTTP 400 (upstream rikkahub fix
+    // a703930d, rikkahub#477). Keep string-only enums as useful hints,
+    // drop the whole key once a non-string value appears or it is empty.
+    if (kind == ProviderKind.google && m['enum'] is List) {
+      final values = m['enum'] as List;
+      if (values.isEmpty || values.any((e) => e is! String)) {
+        m.remove('enum');
+      }
+    }
     return m;
   }
 

--- a/test/features/home/services/tool_handler_service_test.dart
+++ b/test/features/home/services/tool_handler_service_test.dart
@@ -225,6 +225,33 @@ void main() {
         },
       );
 
+      test('keeps non-string enum values for $ProviderKind.openai', () {
+        final out = ToolHandlerService.sanitizeToolParametersForProvider({
+          'type': 'object',
+          'properties': {
+            'flag': {
+              'type': 'boolean',
+              'enum': [true, false],
+            },
+            'count': {
+              'type': 'number',
+              'enum': [1, 2, 3],
+            },
+          },
+        }, ProviderKind.openai);
+
+        final props = out['properties'] as Map<String, dynamic>;
+        expect((props['flag'] as Map)['enum'], const [
+          true,
+          false,
+        ], reason: 'only Google drops non-string enum values');
+        expect((props['count'] as Map)['enum'], const [
+          1,
+          2,
+          3,
+        ], reason: 'only Google drops non-string enum values');
+      });
+
       test('does not mutate the input schema (deep clone)', () {
         final input = _sampleSchema();
         ToolHandlerService.sanitizeToolParametersForProvider(
@@ -253,6 +280,73 @@ void main() {
         );
         expect((props['config'] as Map)['properties'], isA<Map>());
       });
+
+      test(
+        'keeps string-only enum but drops enum containing non-string values',
+        () {
+          final out = ToolHandlerService.sanitizeToolParametersForProvider({
+            'type': 'object',
+            'const': true,
+            'properties': {
+              'mode': {
+                'type': 'string',
+                'enum': ['read', 'write'],
+              },
+              'label': {'type': 'string', 'const': 'x'},
+              'flag': {
+                'type': 'boolean',
+                'enum': [true, false],
+              },
+              'count': {
+                'type': 'number',
+                'enum': [1, 2, 3],
+              },
+              'empty': {'type': 'string', 'enum': <String>[]},
+              'rows': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'active': {
+                      'type': 'boolean',
+                      'enum': [true],
+                    },
+                    'state': {
+                      'type': 'string',
+                      'enum': ['on', 'off'],
+                    },
+                  },
+                },
+              },
+            },
+          }, ProviderKind.google);
+
+          expect(out.containsKey('enum'), isFalse);
+          expect(out.containsKey('const'), isFalse);
+          final props = out['properties'] as Map<String, dynamic>;
+          expect((props['mode'] as Map)['enum'], const [
+            'read',
+            'write',
+          ], reason: 'string-only enum survives for Google');
+          expect((props['label'] as Map)['enum'], const [
+            'x',
+          ], reason: 'string const converted to enum survives for Google');
+          expect((props['flag'] as Map).containsKey('enum'), isFalse);
+          expect((props['count'] as Map).containsKey('enum'), isFalse);
+          expect(
+            (props['empty'] as Map).containsKey('enum'),
+            isFalse,
+            reason: 'empty enum is dropped for Google',
+          );
+          final rowProps =
+              ((props['rows'] as Map)['items'] as Map)['properties'] as Map;
+          expect(((rowProps['active'] as Map).containsKey('enum')), isFalse);
+          expect((rowProps['state'] as Map)['enum'], const [
+            'on',
+            'off',
+          ], reason: 'nested string-only enum survives for Google');
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Fixes #425. Port RikkaHub changes.
