### PR TITLE
fix: math PNG export  transparent background, high-res capture, save to gallery

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -710,6 +710,7 @@
   "markdownMathCopyLatexLabel": "Copy LaTeX",
   "markdownMathCopyPngLabel": "Copy as PNG",
   "markdownMathDownloadPngLabel": "Download PNG",
+  "markdownMathSavePngLabel": "Save to Gallery",
   "markdownMathDefaultFileNameStem": "math",
   "codeBlockCollapsedLines": "… {n} lines folded",
   "@codeBlockCollapsedLines": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3317,6 +3317,12 @@ abstract class AppLocalizations {
   /// **'Download PNG'**
   String get markdownMathDownloadPngLabel;
 
+  /// No description provided for @markdownMathSavePngLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Save to Gallery'**
+  String get markdownMathSavePngLabel;
+
   /// No description provided for @markdownMathDefaultFileNameStem.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1793,6 +1793,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get markdownMathDownloadPngLabel => 'Download PNG';
 
   @override
+  String get markdownMathSavePngLabel => 'Save to Gallery';
+
+  @override
   String get markdownMathDefaultFileNameStem => 'math';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1728,6 +1728,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get markdownMathDownloadPngLabel => '下载 PNG';
 
   @override
+  String get markdownMathSavePngLabel => '保存到相册';
+
+  @override
   String get markdownMathDefaultFileNameStem => '公式';
 
   @override
@@ -9812,6 +9815,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get markdownMathDownloadPngLabel => '下载 PNG';
 
   @override
+  String get markdownMathSavePngLabel => '保存到相册';
+
+  @override
   String get markdownMathDefaultFileNameStem => '公式';
 
   @override
@@ -17894,6 +17900,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get markdownMathDownloadPngLabel => '下載 PNG';
+
+  @override
+  String get markdownMathSavePngLabel => '儲存到相簿';
 
   @override
   String get markdownMathDefaultFileNameStem => '公式';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -489,6 +489,7 @@
   "markdownMathCopyLatexLabel": "复制 LaTeX",
   "markdownMathCopyPngLabel": "复制为 PNG",
   "markdownMathDownloadPngLabel": "下载 PNG",
+  "markdownMathSavePngLabel": "保存到相册",
   "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已折叠 {n} 行",
   "@codeBlockCollapsedLines": {

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -493,6 +493,7 @@
   "markdownMathCopyLatexLabel": "复制 LaTeX",
   "markdownMathCopyPngLabel": "复制为 PNG",
   "markdownMathDownloadPngLabel": "下载 PNG",
+  "markdownMathSavePngLabel": "保存到相册",
   "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已折叠 {n} 行",
   "@codeBlockCollapsedLines": {

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -479,6 +479,7 @@
   "markdownMathCopyLatexLabel": "複製 LaTeX",
   "markdownMathCopyPngLabel": "複製為 PNG",
   "markdownMathDownloadPngLabel": "下載 PNG",
+  "markdownMathSavePngLabel": "儲存到相簿",
   "markdownMathDefaultFileNameStem": "公式",
   "codeBlockCollapsedLines": "… 已摺疊 {n} 行",
   "@codeBlockCollapsedLines": {

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -2781,24 +2781,52 @@ bool _markdownMathTargetPlatformIsDesktop() {
 /// 8-bit straight-alpha RGBA and re-encodes with `image` instead of using
 /// `ImageByteFormat.png` directly: on wide-gamut backends (iOS Impeller) the
 /// latter embeds 10/16-bit bytes that downstream consumers misinterpret as sRGB.
-Future<Uint8List?> _captureRepaintBoundaryPng(GlobalKey boundaryKey) async {
+///
+/// [pixelRatio] is the output sampling ratio. When [maxPixels] or
+/// [maxLongSide] is given, the effective ratio is clamped so the capture stays
+/// inside the pixel budget (prevents OOM on very wide or tall content).
+Future<Uint8List?> _captureRepaintBoundaryPng(
+  GlobalKey boundaryKey, {
+  double pixelRatio = 3.0,
+  int? maxPixels,
+  int? maxLongSide,
+}) async {
   await WidgetsBinding.instance.endOfFrame;
   final boundary =
       boundaryKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
   if (boundary == null) return null;
-  final image = await boundary.toImage(pixelRatio: 3.0);
-  final data = await image.toByteData(
-    format: ui.ImageByteFormat.rawStraightRgba,
+  final logicalPixels = math.max(
+    1.0,
+    boundary.size.width * boundary.size.height,
   );
-  if (data == null) return null;
-  return image_lib.encodePng(
-    image_lib.Image.fromBytes(
-      width: image.width,
-      height: image.height,
-      bytes: data.buffer,
-      numChannels: 4,
-    ),
-  );
+  var ratio = pixelRatio;
+  if (maxPixels != null) {
+    ratio = math.min(ratio, math.sqrt(maxPixels / logicalPixels));
+  }
+  if (maxLongSide != null) {
+    final longSide = math.max(boundary.size.width, boundary.size.height);
+    if (longSide > 0) {
+      ratio = math.min(ratio, maxLongSide / longSide);
+    }
+  }
+  if (!ratio.isFinite || ratio <= 0) ratio = 1.0;
+  final image = await boundary.toImage(pixelRatio: ratio);
+  try {
+    final data = await image.toByteData(
+      format: ui.ImageByteFormat.rawStraightRgba,
+    );
+    if (data == null) return null;
+    return image_lib.encodePng(
+      image_lib.Image.fromBytes(
+        width: image.width,
+        height: image.height,
+        bytes: data.buffer,
+        numChannels: 4,
+      ),
+    );
+  } finally {
+    image.dispose();
+  }
 }
 
 Future<File> _writePngTempFile(Uint8List bytes, String stem) async {
@@ -2835,6 +2863,26 @@ Future<String?> _savePngFile({
     allowedExtensions: const ['png'],
     bytes: bytes,
   );
+}
+
+/// Saves raw PNG [bytes] to the system photo gallery (mobile).
+///
+/// Shared by the markdown table block and the math formula block.
+Future<bool> _savePngBytesToGallery(
+  Uint8List bytes, {
+  required String name,
+}) async {
+  final result = await ImageGallerySaverPlus.saveImage(
+    bytes,
+    quality: 100,
+    name: name,
+  );
+  if (result is Map) {
+    final isSuccess = result['isSuccess'] == true || result['isSuccess'] == 1;
+    final filePath = result['filePath'] ?? result['file_path'];
+    return isSuccess || (filePath is String && filePath.isNotEmpty);
+  }
+  return false;
 }
 
 Future<bool> _copyPngToClipboard(Uint8List bytes, String suggestedName) async {
@@ -3255,7 +3303,10 @@ class _MarkdownTableBlock extends StatelessWidget {
     try {
       final bytes = await _captureTablePngBytes();
       if (bytes == null) throw 'render error';
-      final ok = await _savePngBytesToGallery(bytes);
+      final ok = await _savePngBytesToGallery(
+        bytes,
+        name: 'cuplivo-table-${DateTime.now().millisecondsSinceEpoch}',
+      );
       if (!context.mounted) return;
       showAppSnackBar(
         context,
@@ -3272,20 +3323,6 @@ class _MarkdownTableBlock extends StatelessWidget {
         type: NotificationType.error,
       );
     }
-  }
-
-  Future<bool> _savePngBytesToGallery(Uint8List bytes) async {
-    final result = await ImageGallerySaverPlus.saveImage(
-      bytes,
-      quality: 100,
-      name: 'cuplivo-table-${DateTime.now().millisecondsSinceEpoch}',
-    );
-    if (result is Map) {
-      final isSuccess = result['isSuccess'] == true || result['isSuccess'] == 1;
-      final filePath = result['filePath'] ?? result['file_path'];
-      return isSuccess || (filePath is String && filePath.isNotEmpty);
-    }
-    return false;
   }
 
   Future<void> _copyImage(BuildContext context) async {
@@ -4462,14 +4499,18 @@ class _MermaidBlockState extends State<_MermaidBlock> {
   void _removeRenderOverlay() {
     try {
       _renderOverlayEntry?.remove();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('mermaid render overlay removal failed: $e');
+    }
     _renderOverlayEntry = null;
   }
 
   void _removeSaveOverlay() {
     try {
       _saveOverlayEntry?.remove();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('mermaid save overlay removal failed: $e');
+    }
     _saveOverlayEntry = null;
   }
 
@@ -4700,7 +4741,8 @@ class LatexBlockScrollableMd extends BlockMd {
 }
 
 /// Display math block with an export gesture (long-press on mobile,
-/// right-click on desktop) and a capture boundary for PNG export.
+/// right-click on desktop). Export renders the formula off-screen so the PNG
+/// never inherits the chat background or display padding.
 class _LatexMathBlock extends StatefulWidget {
   const _LatexMathBlock({required this.body, required this.style});
 
@@ -4712,7 +4754,14 @@ class _LatexMathBlock extends StatefulWidget {
 }
 
 class _LatexMathBlockState extends State<_LatexMathBlock> {
-  final GlobalKey _boundaryKey = GlobalKey();
+  // Export-only pixel budget: keeps long matrices and very wide formulas from
+  // allocating unbounded image buffers at high pixelRatio.
+  static const double _exportPixelRatio = 4.0;
+  static const int _exportMaxPixels = 16 * 1000 * 1000;
+  static const int _exportMaxLongSide = 8000;
+
+  OverlayEntry? _exportOverlayEntry;
+  bool _exportInFlight = false;
 
   @override
   Widget build(BuildContext context) {
@@ -4724,23 +4773,71 @@ class _LatexMathBlockState extends State<_LatexMathBlock> {
       onSecondaryTapDown: isDesktop
           ? (details) => _showDesktopMenu(details.globalPosition)
           : null,
-      child: RepaintBoundary(
-        key: _boundaryKey,
-        child: Container(
-          // Matches the chat surface (cs.surface) so the box is invisible in
-          // the message; the color exists only so the captured PNG has a
-          // non-transparent, theme-matched background. Symmetric padding gives
-          // the PNG a small margin without shifting the formula's center.
-          color: cs.surface,
-          padding: const EdgeInsets.all(4),
-          child: _renderMath(
-            widget.body,
-            style: widget.style,
-            displayMode: true,
-          ),
-        ),
+      child: Container(
+        // Display-only: matches the chat surface so the box is invisible in
+        // the message. The background and padding intentionally live outside
+        // any capture boundary so they never leak into the exported PNG.
+        color: cs.surface,
+        padding: const EdgeInsets.all(4),
+        child: _renderMath(widget.body, style: widget.style, displayMode: true),
       ),
     );
+  }
+
+  void _removeExportOverlay() {
+    try {
+      _exportOverlayEntry?.remove();
+    } catch (e) {
+      debugPrint('math export overlay removal failed: $e');
+    }
+    _exportOverlayEntry = null;
+  }
+
+  /// Renders the formula in an off-screen overlay slot (transparent
+  /// background, no padding, unconstrained width so the export hugs the
+  /// formula's real bounds) and captures it at [_exportPixelRatio],
+  /// independent of the chat display size.
+  ///
+  /// Concurrent calls are ignored while a capture is in flight: the overlay
+  /// slot is shared and a second call would remove the first one's boundary.
+  Future<Uint8List?> _captureExportPng() async {
+    if (_exportInFlight) return null;
+    final overlay = Overlay.maybeOf(context);
+    if (overlay == null) return null;
+    _exportInFlight = true;
+    try {
+      _removeExportOverlay();
+      final boundaryKey = GlobalKey();
+      _exportOverlayEntry = OverlayEntry(
+        builder: (context) => Positioned(
+          left: -10000,
+          top: -10000,
+          child: Material(
+            color: Colors.transparent,
+            child: RepaintBoundary(
+              key: boundaryKey,
+              child: _renderMath(
+                widget.body,
+                style: widget.style,
+                displayMode: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      overlay.insert(_exportOverlayEntry!);
+      // _captureRepaintBoundaryPng awaits endOfFrame, which resolves after
+      // the frame that paints the freshly inserted overlay slot.
+      return await _captureRepaintBoundaryPng(
+        boundaryKey,
+        pixelRatio: _exportPixelRatio,
+        maxPixels: _exportMaxPixels,
+        maxLongSide: _exportMaxLongSide,
+      );
+    } finally {
+      _exportInFlight = false;
+      _removeExportOverlay();
+    }
   }
 
   void _showDesktopMenu(Offset globalPosition) {
@@ -4802,6 +4899,12 @@ class _LatexMathBlockState extends State<_LatexMathBlock> {
                   Lucide.Download,
                   l10n.markdownMathDownloadPngLabel,
                   _downloadPng,
+                ),
+                _menuItem(
+                  ctx,
+                  Lucide.ImageDown,
+                  l10n.markdownMathSavePngLabel,
+                  _savePngToGallery,
                 ),
               ],
             ),
@@ -4869,7 +4972,7 @@ class _LatexMathBlockState extends State<_LatexMathBlock> {
   Future<void> _copyPng() async {
     final l10n = AppLocalizations.of(context)!;
     try {
-      final bytes = await _captureRepaintBoundaryPng(_boundaryKey);
+      final bytes = await _captureExportPng();
       if (bytes == null) throw 'render error';
       final ok = await _copyPngToClipboard(bytes, 'cuplivo-math.png');
       if (!mounted) return;
@@ -4898,7 +5001,7 @@ class _LatexMathBlockState extends State<_LatexMathBlock> {
     );
     final filename = '${l10n.markdownMathDefaultFileNameStem}_$timestamp.png';
     try {
-      final bytes = await _captureRepaintBoundaryPng(_boundaryKey);
+      final bytes = await _captureExportPng();
       if (bytes == null) throw 'render error';
       final savePath = await _savePngFile(
         dialogTitle: l10n.backupPageExportToFile,
@@ -4917,6 +5020,33 @@ class _LatexMathBlockState extends State<_LatexMathBlock> {
       showAppSnackBar(
         context,
         message: l10n.messageExportSheetExportFailed('$e'),
+        type: NotificationType.error,
+      );
+    }
+  }
+
+  Future<void> _savePngToGallery() async {
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final bytes = await _captureExportPng();
+      if (bytes == null) throw 'render error';
+      final ok = await _savePngBytesToGallery(
+        bytes,
+        name: 'cuplivo-math-${DateTime.now().millisecondsSinceEpoch}',
+      );
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: ok
+            ? l10n.imagePreviewSheetSaveSuccess
+            : l10n.imagePreviewSheetSaveFailed('unknown'),
+        type: ok ? NotificationType.success : NotificationType.error,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.imagePreviewSheetSaveFailed('$e'),
         type: NotificationType.error,
       );
     }

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -6,6 +6,7 @@ import 'package:Cuplivo/shared/widgets/export_capture_scope.dart';
 import 'package:Cuplivo/shared/widgets/html_preview_block.dart';
 import 'package:Cuplivo/shared/widgets/mermaid_image_cache.dart';
 import 'package:Cuplivo/shared/widgets/mermaid_exporter.dart';
+import 'package:Cuplivo/shared/widgets/snackbar.dart';
 import 'package:Cuplivo/shared/widgets/tabbed_preview_block.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/icons/lucide_adapter.dart';
@@ -20,6 +21,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:flutter_math_fork/tex.dart' show TexEncoderExt;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as image_lib;
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -3820,6 +3822,7 @@ void main() {
       expect(find.text('Copy LaTeX'), findsOneWidget);
       expect(find.text('Copy as PNG'), findsOneWidget);
       expect(find.text('Download PNG'), findsOneWidget);
+      expect(find.text('Save to Gallery'), findsOneWidget);
     },
   );
 
@@ -3884,8 +3887,201 @@ void main() {
       expect(find.text('Copy LaTeX'), findsOneWidget);
       expect(find.text('Copy as PNG'), findsOneWidget);
       expect(find.text('Download PNG'), findsOneWidget);
+      // Photo-album save is mobile-only: desktop saves through the file dialog.
+      expect(find.text('Save to Gallery'), findsNothing);
     },
   );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight saves math PNG to gallery with transparent tight bounds',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      Uint8List? savedBytes;
+      String? savedName;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('image_gallery_saver_plus'),
+            (call) async {
+              if (call.method == 'saveImageToGallery') {
+                final args = Map<String, dynamic>.from(call.arguments as Map);
+                savedBytes = args['imageBytes'] as Uint8List?;
+                savedName = args['name'] as String?;
+                return <String, Object>{'isSuccess': true};
+              }
+              return null;
+            },
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('image_gallery_saver_plus'),
+              null,
+            );
+      });
+
+      await tester.pumpWidget(_markdownHarness(r'\[E = mc^2\]', width: 360));
+      await tester.pump();
+
+      await tester.longPress(
+        find.byType(Math),
+        warnIfMissed: false, // Math's RenderLine is paint-only; the gesture
+        // lands on the enclosing export GestureDetector.
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save to Gallery'));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(savedBytes, isNotNull);
+      expect(savedName, startsWith('cuplivo-math-'));
+      final decoded = image_lib.decodePng(savedBytes!);
+      expect(decoded, isNotNull);
+      // The off-screen export renderer has a transparent background: corner
+      // pixels keep alpha 0 instead of inheriting the chat surface color.
+      final corner = decoded!.getPixel(0, 0);
+      expect(corner.a, 0);
+      expect(corner.r, 0);
+      expect(corner.g, 0);
+      expect(corner.b, 0);
+      // Export scale is independent of the chat display: the captured height
+      // is ~4x the formula's logical height (exportPixelRatio = 4.0).
+      final mathBox = tester.renderObject<RenderBox>(find.byType(Math));
+      expect(decoded.height, greaterThanOrEqualTo(mathBox.size.height * 3.5));
+      expect(decoded.height, lessThan(mathBox.size.height * 4.5 + 2));
+      // The export hugs the formula bounds: the captured width matches the
+      // formula's logical width at ~4x (toImage rounds pixel counts up).
+      expect(decoded.width, greaterThan(mathBox.size.width * 4.0 - 2));
+      expect(decoded.width, lessThan(mathBox.size.width * 4.0 + 2));
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight exports a large formula within the pixel budget',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      Uint8List? savedBytes;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('image_gallery_saver_plus'),
+            (call) async {
+              if (call.method == 'saveImageToGallery') {
+                final args = Map<String, dynamic>.from(call.arguments as Map);
+                savedBytes = args['imageBytes'] as Uint8List?;
+                return <String, Object>{'isSuccess': true};
+              }
+              return null;
+            },
+          );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('image_gallery_saver_plus'),
+              null,
+            );
+      });
+
+      // A wide 4x4 matrix: flutter_math_fork sizes display math intrinsically
+      // (the chat width constraint never reflows it), so the export renderer
+      // must handle large single-line formulas without exceeding the pixel
+      // budget.
+      final tex =
+          r'\['
+          r'\begin{pmatrix}'
+          r'\frac{\alpha_{11}}{\beta_1} & \frac{\alpha_{12}}{\beta_1} & '
+          r'\frac{\alpha_{13}}{\beta_1} & \frac{\alpha_{14}}{\beta_1} \\'
+          r'\frac{\alpha_{21}}{\beta_2} & \frac{\alpha_{22}}{\beta_2} & '
+          r'\frac{\alpha_{23}}{\beta_2} & \frac{\alpha_{24}}{\beta_2} \\'
+          r'\frac{\alpha_{31}}{\beta_3} & \frac{\alpha_{32}}{\beta_3} & '
+          r'\frac{\alpha_{33}}{\beta_3} & \frac{\alpha_{34}}{\beta_3} \\'
+          r'\frac{\alpha_{41}}{\beta_4} & \frac{\alpha_{42}}{\beta_4} & '
+          r'\frac{\alpha_{43}}{\beta_4} & \frac{\alpha_{44}}{\beta_4}'
+          r'\end{pmatrix}'
+          r'\]';
+      await tester.pumpWidget(_markdownHarness(tex, width: 360));
+      await tester.pump();
+
+      await tester.longPress(find.byType(Math), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Save to Gallery'));
+      await tester.pump();
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      });
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(savedBytes, isNotNull);
+      final decoded = image_lib.decodePng(savedBytes!);
+      expect(decoded, isNotNull);
+      final corner = decoded!.getPixel(0, 0);
+      expect(corner.a, 0);
+      // Large formulas stay inside the export pixel budget
+      // (maxLongSide 8000, maxPixels 16M at 4x).
+      expect(decoded.width, lessThanOrEqualTo(8000));
+      expect(decoded.height, lessThanOrEqualTo(8000));
+      expect(
+        decoded.width * decoded.height,
+        lessThanOrEqualTo(16 * 1000 * 1000),
+      );
+    },
+  );
+
+  testWidgets('MarkdownWithCodeHighlight math gallery save reports failure', (
+    tester,
+  ) async {
+    markdownMathTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('image_gallery_saver_plus'),
+          (call) async {
+            if (call.method == 'saveImageToGallery') {
+              return <String, Object>{'isSuccess': false};
+            }
+            return null;
+          },
+        );
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('image_gallery_saver_plus'),
+            null,
+          );
+    });
+
+    await tester.pumpWidget(_markdownHarness(r'\[E = mc^2\]', width: 360));
+    await tester.pump();
+
+    await tester.longPress(find.byType(Math), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Save to Gallery'));
+    await tester.pump();
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pumpAndSettle();
+
+    // The harness has no AppSnackBarOverlay in the tree, so the toast is
+    // only observable through the snackbar manager's queue.
+    final toasts = AppSnackBarManager().activeToasts;
+    expect(toasts, isNotEmpty);
+    expect(toasts.first.notification.message, 'Save failed: unknown');
+
+    // Drain the toast auto-dismiss timer and its exit animation so no timers
+    // or tickers leak into the next test.
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pump(const Duration(milliseconds: 400));
+  });
 
   testWidgets(
     'MarkdownWithCodeHighlight math menu wins over enclosing SelectionArea',


### PR DESCRIPTION
## 变更内容

Fixes #398, Fixes #402.

- **#402 修复（PNG 白边 + 清晰度）**
  - 显示与导出分离：导出改为离屏 OverlayEntry 渲染器 —— 透明背景、无 padding、紧贴公式实际 bounds；聊天的 `cs.surface` 背景与 4px 留白不再进入 PNG（浅色主题白边/深色主题色块消除）
  - 导出倍率从固定 3× 提升至 4×，并加入像素预算（长边 ≤8000、总像素 ≤16M）防止超长矩阵 OOM
  - `image.dispose()` 修复连续导出时 GPU/CPU 图像资源累积
  - 复制 PNG / 下载 PNG / 保存到相册三个路径统一走新导出链路；iOS wide-gamut 的 `rawStraightRgba → image` 重编码路径原样保留
- **#398 新功能（公式保存到相册）**
  - 移动端长按菜单新增"保存到相册"，复用已有 `image_gallery_saver_plus` 基建（表格/mermaid 同款流程）
  - 桌面右键菜单不变（相册为移动端概念，"下载 PNG"已覆盖，有意排除）
- **l10n**：4 个 ARB 同步新增 `markdownMathSavePngLabel`
- **测试**：菜单项断言（移动/桌面）、保存到相册端到端（截获 PNG 字节断言透明角 + 4× 缩放 + 命名）、失败路径、大公式像素预算

## 验证

- `dart analyze --fatal-infos lib test` 通过
- `markdown_with_highlight_test.dart` 135 个测试全过

## 兼容性

- 表格导出保持 3.0×/无上限，行为不变
- 公式复制/下载 PNG 输出变为**透明背景**（此前为 theme surface 底色）—— 按 #402 验收标准的有意变更

## 手动测试路径

**前置**：真机 iOS + Android 各一台（需含浅色/深色主题）

1. **保存到相册（iOS，#398 主路径）**
   - 浅色主题下发送 `$$\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$`
   - 长按公式 → 点"保存到相册" → 提示"已保存到相册"
   - 打开相册：图片**透明背景无白边**，放大无锯齿；名称 `cuplivo-math-*`
2. **Android 同路径**：同上，确认相册出现、权限弹窗正常
3. **主题一致性（#402 验收）**
   - 深色主题导出同一公式，与浅色主题导出对比：背景行为一致（均透明），不受 theme surface 影响
4. **清晰度对比**：同一公式分别用旧版本"下载 PNG"与新版本导出，插入文档/PPT 后 200-300% 放大，新版本边缘明显更清晰
5. **复杂公式**：矩阵 `$$\begin{pmatrix} a & b \\ c & d \end{pmatrix}$$` 与长分式导出，边界紧贴、无白边
6. **大公式/长矩阵**：超长矩阵导出不崩溃、无明显卡顿（像素上限生效，输出 ≤8000px）
7. **复制/下载路径回归**：长按 → "复制为 PNG" 粘贴到备忘录/文档，透明底正常；"下载 PNG" iOS 分享面板仍可用
8. **桌面回归（Windows/macOS）**：右键菜单仍 3 项（无相册项）；"下载 PNG" 文件对话框正常；复制 PNG 正常
9. **边界**：极短公式 `$x$` 导出不报错；公式渲染失败（非法 LaTeX）时菜单操作走现有失败 toast
