### PR TITLE
fix(files): render html in-app on mobile and preview text/image uploads

### DIFF
--- a/lib/features/settings/pages/mount_files_page.dart
+++ b/lib/features/settings/pages/mount_files_page.dart
@@ -12,8 +12,10 @@ import '../../../core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.da
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/pages/file_preview_page.dart';
+import '../../../shared/pages/html_file_preview_page.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
+import '../../../utils/file_kind.dart';
 import '../../../utils/format.dart';
 import '../../../utils/platform_utils.dart';
 
@@ -331,6 +333,23 @@ class _MountFilesPageState extends State<MountFilesPage> {
   /// read-only external mounts too.
   Future<void> _openExternal(_DirEntry entry) async {
     final l10n = this.l10n;
+    // iOS/Android cannot hand html to the system reliably (iOS Quick Look
+    // has no html support and the "Open in…" menu is often empty; Android
+    // throws ActivityNotFoundException without a registered handler) — render
+    // it in-app instead so same-directory css/js/images resolve. Desktop
+    // keeps the system default app, which renders html fine.
+    if (PlatformUtils.isMobileTarget && FileKind.isHtmlFile(entry.name)) {
+      if (!mounted) return;
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => HtmlFilePreviewPage(
+            hostPath: entry.hostPath,
+            displayName: entry.name,
+          ),
+        ),
+      );
+      return;
+    }
     try {
       final res = await OpenFilex.open(entry.hostPath);
       if (res.type != ResultType.done) {

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -20,6 +20,9 @@ import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
+import '../../../shared/pages/file_preview_page.dart';
+import '../../../shared/pages/html_file_preview_page.dart';
+import '../../../utils/file_kind.dart';
 import '../../../utils/format.dart';
 import '../../../utils/platform_utils.dart';
 import '../../../utils/app_directories.dart';
@@ -1915,6 +1918,42 @@ class _UploadManagerState extends State<_UploadManager> {
 
   Future<void> _openFile(String path) async {
     final l10n = AppLocalizations.of(context)!;
+    // iOS/Android: route previewable kinds in-app — the system-open path
+    // (OpenFilex → UIDocumentInteractionController) cannot render html and
+    // shows an empty menu for types no app handles; OpenFilex also reports
+    // "done" as soon as the menu dismisses, lying about success. Desktop
+    // keeps the system default app.
+    if (PlatformUtils.isMobileTarget) {
+      final name = p.basename(path);
+      // SVG is excluded here: ImageViewerPage decodes with the built-in
+      // raster codec, which cannot render SVG — it falls through to
+      // FilePreviewPage, which renders SVG via SvgPicture.file.
+      if (FileKind.isImageFile(path) && !FileKind.isSvgFile(path)) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => ImageViewerPage(images: [path], initialIndex: 0),
+          ),
+        );
+        return;
+      }
+      if (FileKind.isHtmlFile(path)) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) =>
+                HtmlFilePreviewPage(hostPath: path, displayName: name),
+          ),
+        );
+        return;
+      }
+      if (!FileKind.isLikelyBinary(path)) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => FilePreviewPage(hostPath: path, displayName: name),
+          ),
+        );
+        return;
+      }
+    }
     try {
       final res = await OpenFilex.open(path);
       if (res.type != ResultType.done) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -222,6 +222,7 @@
   "mountFilesPreviewBinary": "{name} is a binary file — cannot preview",
   "mountFilesPreviewTooLarge": "{name} is too large to preview",
   "mountFilesPreviewReadFailed": "Failed to read {name}: {error}",
+  "filePreviewOpenWithSystem": "Open with another app",
   "mountFilesPreviewTruncated": "Preview truncated: showing the first lines of {total}",
   "mountFilesMoreButton": "More",
   "mountFilesOpenButton": "Open",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -916,6 +916,12 @@ abstract class AppLocalizations {
   /// **'Failed to read {name}: {error}'**
   String mountFilesPreviewReadFailed(Object error, Object name);
 
+  /// No description provided for @filePreviewOpenWithSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'Open with another app'**
+  String get filePreviewOpenWithSystem;
+
   /// No description provided for @mountFilesPreviewTruncated.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -494,6 +494,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get filePreviewOpenWithSystem => 'Open with another app';
+
+  @override
   String mountFilesPreviewTruncated(Object total) {
     return 'Preview truncated: showing the first lines of $total';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -475,6 +475,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get filePreviewOpenWithSystem => '用其他应用打开';
+
+  @override
   String mountFilesPreviewTruncated(Object total) {
     return '预览已截断：仅显示 $total 行中的开头部分';
   }
@@ -8559,6 +8562,9 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   }
 
   @override
+  String get filePreviewOpenWithSystem => '用其他应用打开';
+
+  @override
   String mountFilesPreviewTruncated(Object total) {
     return '预览已截断：仅显示 $total 行中的开头部分';
   }
@@ -16641,6 +16647,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String mountFilesPreviewReadFailed(Object error, Object name) {
     return '讀取 $name 失敗：$error';
   }
+
+  @override
+  String get filePreviewOpenWithSystem => '用其他應用程式開啟';
 
   @override
   String mountFilesPreviewTruncated(Object total) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -135,6 +135,7 @@
   "mountFilesPreviewBinary": "{name} 是二进制文件，无法预览",
   "mountFilesPreviewTooLarge": "{name} 过大，无法预览",
   "mountFilesPreviewReadFailed": "读取 {name} 失败：{error}",
+  "filePreviewOpenWithSystem": "用其他应用打开",
   "mountFilesPreviewTruncated": "预览已截断：仅显示 {total} 行中的开头部分",
   "mountFilesMoreButton": "更多",
   "mountFilesOpenButton": "打开",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -135,6 +135,7 @@
   "mountFilesPreviewBinary": "{name} 是二进制文件，无法预览",
   "mountFilesPreviewTooLarge": "{name} 过大，无法预览",
   "mountFilesPreviewReadFailed": "读取 {name} 失败：{error}",
+  "filePreviewOpenWithSystem": "用其他应用打开",
   "mountFilesPreviewTruncated": "预览已截断：仅显示 {total} 行中的开头部分",
   "mountFilesMoreButton": "更多",
   "mountFilesOpenButton": "打开",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -135,6 +135,7 @@
   "mountFilesPreviewBinary": "{name} 是二進位檔案，無法預覽",
   "mountFilesPreviewTooLarge": "{name} 過大，無法預覽",
   "mountFilesPreviewReadFailed": "讀取 {name} 失敗：{error}",
+  "filePreviewOpenWithSystem": "用其他應用程式開啟",
   "mountFilesPreviewTruncated": "預覽已截斷：僅顯示 {total} 行中的開頭部分",
   "mountFilesMoreButton": "更多",
   "mountFilesOpenButton": "開啟",

--- a/lib/shared/pages/file_preview_page.dart
+++ b/lib/shared/pages/file_preview_page.dart
@@ -5,12 +5,15 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' as p;
 
 import '../../core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
 import '../../icons/lucide_adapter.dart';
 import '../../l10n/app_localizations.dart';
+import '../../utils/file_kind.dart';
 import '../widgets/ios_tactile.dart';
+import '../widgets/snackbar.dart';
 
 /// File content preview. Read RULES are shared with `kelivo_read`
 /// (32 MB size cap, binary rejection, truncation note) but the preview's
@@ -50,15 +53,6 @@ class _FilePreviewPageState extends State<FilePreviewPage> {
   /// without ever materializing the full (up to 32 MB) file in memory.
   static const int _readCapBytes = _previewCharBudget * 4;
 
-  static const Set<String> _imageExtensions = {
-    '.png',
-    '.jpg',
-    '.jpeg',
-    '.gif',
-    '.webp',
-    '.svg',
-  };
-
   @override
   void initState() {
     super.initState();
@@ -87,7 +81,7 @@ class _FilePreviewPageState extends State<FilePreviewPage> {
         return;
       }
       final ext = p.extension(widget.hostPath).toLowerCase();
-      final isImage = _imageExtensions.contains(ext) && stat.size > 0;
+      final isImage = FileKind.imageExtensions.contains(ext) && stat.size > 0;
       if (isImage && ext == '.svg') {
         // SVG renders straight from disk via SvgPicture.file — reading the
         // bytes here would only duplicate I/O and memory.
@@ -166,6 +160,30 @@ class _FilePreviewPageState extends State<FilePreviewPage> {
     });
   }
 
+  /// Escape hatch for content the preview cannot render (binary probes,
+  /// oversized files, read failures): hand the file to the system default
+  /// app instead of leaving the user at a dead end.
+  Future<void> _openWithSystem() async {
+    try {
+      final res = await OpenFilex.open(widget.hostPath);
+      if (res.type != ResultType.done) {
+        if (!mounted) return;
+        showAppSnackBar(
+          context,
+          message: l10n.mountFilesOpenFailed(res.message, widget.displayName),
+          type: NotificationType.error,
+        );
+      }
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.mountFilesOpenFailed('$e', widget.displayName),
+        type: NotificationType.error,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -187,13 +205,39 @@ class _FilePreviewPageState extends State<FilePreviewPage> {
         _PreviewState.error => Center(
           child: Padding(
             padding: const EdgeInsets.all(24),
-            child: Text(
-              _errorMessage ?? '',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 13.5,
-                color: cs.onSurface.withValues(alpha: 0.7),
-              ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _errorMessage ?? '',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 13.5,
+                    color: cs.onSurface.withValues(alpha: 0.7),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                IosCardPress(
+                  onTap: _openWithSystem,
+                  borderRadius: BorderRadius.circular(12),
+                  baseColor: cs.primary.withValues(alpha: 0.12),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 10,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Lucide.ExternalLink, size: 16, color: cs.primary),
+                      const SizedBox(width: 8),
+                      Text(
+                        l10n.filePreviewOpenWithSystem,
+                        style: TextStyle(fontSize: 13.5, color: cs.primary),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/shared/pages/html_file_preview_page.dart
+++ b/lib/shared/pages/html_file_preview_page.dart
@@ -1,0 +1,173 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
+import '../../icons/lucide_adapter.dart';
+import '../../l10n/app_localizations.dart';
+import '../widgets/ios_tactile.dart';
+
+/// Full-screen WebView render of a local `.html`/`.htm` file (workspace
+/// mounts, storage uploads). Unlike the chat-side html preview (which
+/// renders a code string), this loads the file from disk via `loadFile`, so
+/// same-directory css/js/image resources resolve — on iOS the WKWebView read
+/// access covers the containing directory (webview_flutter_wkwebview
+/// `WebKitLoadFileParams.readAccessPath` defaults to `dirname`).
+///
+/// Only reachable on iOS/Android (desktop keeps the system default app);
+/// still guards load failures with a readable error view instead of the
+/// "success" lie the system-open path used to report.
+class HtmlFilePreviewPage extends StatefulWidget {
+  const HtmlFilePreviewPage({
+    super.key,
+    required this.hostPath,
+    required this.displayName,
+  });
+
+  final String hostPath;
+  final String displayName;
+
+  @override
+  State<HtmlFilePreviewPage> createState() => _HtmlFilePreviewPageState();
+}
+
+enum _HtmlFilePreviewState { loading, web, error }
+
+class _HtmlFilePreviewPageState extends State<HtmlFilePreviewPage> {
+  _HtmlFilePreviewState _state = _HtmlFilePreviewState.loading;
+  bool _pageLoading = true;
+  String? _errorMessage;
+  WebViewController? _controller;
+  int _generation = 0;
+
+  AppLocalizations get l10n => AppLocalizations.of(context)!;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    // Invalidate any in-flight load so its continuation cannot touch state
+    // after disposal.
+    _generation++;
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    final gen = ++_generation;
+    try {
+      final f = File(widget.hostPath);
+      final stat = await f.stat();
+      if (stat.size > KelivoFilesystemMcpServerEngine.readWindowBytes) {
+        _fail(l10n.mountFilesPreviewTooLarge(widget.displayName));
+        return;
+      }
+      final c = WebViewController()
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
+        ..setNavigationDelegate(
+          NavigationDelegate(
+            onPageStarted: (_) {
+              if (mounted && gen == _generation) {
+                setState(() => _pageLoading = true);
+              }
+            },
+            onPageFinished: (_) {
+              if (mounted && gen == _generation) {
+                setState(() => _pageLoading = false);
+              }
+            },
+            onWebResourceError: (err) {
+              if (!(err.isForMainFrame ?? false)) return;
+              if (mounted && gen == _generation) {
+                _fail(
+                  l10n.mountFilesPreviewReadFailed(
+                    widget.displayName,
+                    err.description,
+                  ),
+                );
+              }
+            },
+            onNavigationRequest: (req) async {
+              // Main-frame navigation away from the local page: hand http(s)
+              // to the system browser instead of losing the preview context
+              // inside the app. Relative file:// navigations stay in place.
+              final uri = Uri.tryParse(req.url);
+              if (uri != null &&
+                  (uri.scheme == 'http' || uri.scheme == 'https')) {
+                try {
+                  await launchUrl(uri, mode: LaunchMode.externalApplication);
+                } catch (e) {
+                  debugPrint('HtmlFilePreviewPage: open in browser failed: $e');
+                }
+                return NavigationDecision.prevent;
+              }
+              return NavigationDecision.navigate;
+            },
+          ),
+        );
+      await c.loadFile(widget.hostPath);
+      if (mounted && gen == _generation) {
+        setState(() {
+          _controller = c;
+          _state = _HtmlFilePreviewState.web;
+        });
+      }
+    } catch (e) {
+      if (!mounted || gen != _generation) return;
+      _fail(l10n.mountFilesPreviewReadFailed(widget.displayName, '$e'));
+    }
+  }
+
+  void _fail(String message) {
+    if (!mounted) return;
+    setState(() {
+      _errorMessage = message;
+      _state = _HtmlFilePreviewState.error;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        leading: IosIconButton(
+          icon: Lucide.ArrowLeft,
+          color: cs.onSurface,
+          size: 22,
+          onTap: () => Navigator.of(context).maybePop(),
+        ),
+        title: Text(widget.displayName),
+      ),
+      body: switch (_state) {
+        _HtmlFilePreviewState.loading => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        _HtmlFilePreviewState.error => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              _errorMessage ?? '',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13.5,
+                color: cs.onSurface.withValues(alpha: 0.7),
+              ),
+            ),
+          ),
+        ),
+        _HtmlFilePreviewState.web => Column(
+          children: [
+            if (_pageLoading) const LinearProgressIndicator(minHeight: 2),
+            Expanded(child: WebViewWidget(controller: _controller!)),
+          ],
+        ),
+      },
+    );
+  }
+}

--- a/lib/utils/file_kind.dart
+++ b/lib/utils/file_kind.dart
@@ -1,0 +1,110 @@
+import 'package:path/path.dart' as p;
+
+/// File-kind classification shared by the workspace file browser and the
+/// storage space file list, so every surface routes the same file type to
+/// the same in-app preview instead of the unreliable system-open fallback
+/// (iOS Quick Look has no html support; Android throws
+/// `ActivityNotFoundException` when no app handles the MIME).
+abstract final class FileKind {
+  FileKind._();
+
+  static const Set<String> htmlExtensions = {'.html', '.htm'};
+
+  /// Rendered by the built-in image codec (`FilePreviewPage` /
+  /// `ImageViewerPage`). Kept in sync with the image set used there.
+  static const Set<String> imageExtensions = {
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.webp',
+    '.svg',
+  };
+
+  /// Known binary formats that cannot be rendered or read as text in-app;
+  /// these fall back to the system open. Unknown extensions intentionally
+  /// return false so they route to the text preview, which binary-probes the
+  /// content and shows a clear error for actual binaries.
+  static const Set<String> binaryExtensions = {
+    // Documents
+    '.pdf',
+    '.doc',
+    '.docx',
+    '.xls',
+    '.xlsx',
+    '.ppt',
+    '.pptx',
+    '.rtf',
+    // Archives
+    '.zip',
+    '.rar',
+    '.7z',
+    '.tar',
+    '.gz',
+    '.bz2',
+    '.xz',
+    '.zst',
+    // Executables & containers
+    '.exe',
+    '.dll',
+    '.so',
+    '.dylib',
+    '.dmg',
+    '.iso',
+    '.msi',
+    '.apk',
+    '.aab',
+    '.ipa',
+    '.deb',
+    '.rpm',
+    '.bin',
+    '.class',
+    '.jar',
+    // Audio
+    '.mp3',
+    '.m4a',
+    '.aac',
+    '.wav',
+    '.flac',
+    '.ogg',
+    '.opus',
+    '.wma',
+    // Video
+    '.mp4',
+    '.m4v',
+    '.mov',
+    '.avi',
+    '.mkv',
+    '.wmv',
+    '.webm',
+    '.flv',
+    // Images the built-in codec does not render
+    '.bmp',
+    '.tif',
+    '.tiff',
+    '.heic',
+    '.heif',
+    '.ico',
+    // Fonts / vector / other
+    '.ttf',
+    '.otf',
+    '.woff',
+    '.woff2',
+    '.eot',
+    '.psd',
+    '.ai',
+    '.eps',
+  };
+
+  static bool isHtmlFile(String path) =>
+      htmlExtensions.contains(p.extension(path).toLowerCase());
+
+  static bool isImageFile(String path) =>
+      imageExtensions.contains(p.extension(path).toLowerCase());
+
+  static bool isSvgFile(String path) =>
+      p.extension(path).toLowerCase() == '.svg';
+
+  static bool isLikelyBinary(String path) =>
+      binaryExtensions.contains(p.extension(path).toLowerCase());
+}

--- a/test/features/settings/pages/mount_files_page_test.dart
+++ b/test/features/settings/pages/mount_files_page_test.dart
@@ -1,11 +1,18 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
 import 'package:Cuplivo/features/settings/pages/mount_files_page.dart';
+import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/pages/html_file_preview_page.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// The page loads its listing via real dart:io streams; each stream event is
 /// delivered on the real event loop, so pump+runAsync must cycle until the
@@ -86,5 +93,94 @@ void main() {
 
     await pumpUntilFound(tester, find.text('a.txt'));
     expect(find.text('@default'), findsOneWidget, reason: 'breadcrumb');
+  });
+
+  testWidgets('mobile "open" on an html file routes to the in-app WebView '
+      'preview instead of the system open', (tester) async {
+    final tmp = Directory.systemTemp.createTempSync('mount_page_test_');
+    addTearDown(() {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    File(
+      '${tmp.path}/page.html',
+    ).writeAsStringSync('<!doctype html><html><body>hello</body></html>');
+
+    // IosCardPress reads SettingsProvider on tap; its constructor loads
+    // shared_preferences, so the platform channel needs the in-memory mock.
+    SharedPreferences.setMockInitialValues({});
+    final mount = FilesystemMount(
+      alias: 'default',
+      path: tmp.path,
+      readOnly: false,
+    );
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => SettingsProvider(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: MountFilesPage(mount: mount),
+        ),
+      ),
+    );
+
+    await pumpUntilFound(tester, find.text('page.html'));
+    // Mobile entry: actions fold into the "more" sheet.
+    await tester.tap(find.byIcon(Lucide.Ellipsis));
+    await pumpUntilFound(
+      tester,
+      find.text(
+        AppLocalizations.of(
+          tester.element(find.byType(MountFilesPage)),
+        )!.mountFilesOpenButton,
+      ),
+    );
+    // Let the sheet finish sliding in before tapping its action.
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.text(
+        AppLocalizations.of(
+          tester.element(find.byType(MountFilesPage)),
+        )!.mountFilesOpenButton,
+      ),
+    );
+    await pumpUntilFound(tester, find.byType(HtmlFilePreviewPage));
+  });
+
+  testWidgets('desktop shows the system-open entry for html files without '
+      'routing into the in-app WebView', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    try {
+      final tmp = Directory.systemTemp.createTempSync('mount_page_test_');
+      addTearDown(() {
+        try {
+          tmp.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      File('${tmp.path}/page.html').writeAsStringSync('<html></html>');
+
+      final mount = FilesystemMount(
+        alias: 'default',
+        path: tmp.path,
+        readOnly: false,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: MountFilesPage(mount: mount),
+        ),
+      );
+
+      await pumpUntilFound(tester, find.text('page.html'));
+      // Desktop keeps the system default app: the row exposes the inline
+      // external-open icon and never routes into the in-app WebView preview.
+      // (Deliberately not tapped — OpenFilex's desktop branch spawns a real
+      // OS process that would open the browser mid-test.)
+      expect(find.byIcon(Lucide.ExternalLink), findsOneWidget);
+      expect(find.byType(HtmlFilePreviewPage), findsNothing);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 }

--- a/test/shared/pages/file_preview_page_test.dart
+++ b/test/shared/pages/file_preview_page_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/pages/file_preview_page.dart';
+
+/// The page reads via real dart:io; each future completes on the real event
+/// loop, so pump+runAsync must cycle until the state lands.
+Future<void> pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 3),
+}) async {
+  final end = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(end)) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 25)),
+    );
+    await tester.pump();
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Timed out waiting for $finder');
+}
+
+void main() {
+  Directory tempDir() {
+    // Sync creation: async dart:io futures never complete in the test's
+    // FakeAsync zone without runAsync.
+    final tmp = Directory.systemTemp.createTempSync('preview_page_test_');
+    addTearDown(() {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    return tmp;
+  }
+
+  testWidgets('binary file error state offers the system-open escape hatch', (
+    tester,
+  ) async {
+    final tmp = tempDir();
+    final path = '${tmp.path}/blob.dat';
+    // Null byte in the pilot window — the binary probe must reject it.
+    File(path).writeAsBytesSync([0x00, 0x01, 0x02, 0x03]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: FilePreviewPage(hostPath: path, displayName: 'blob.dat'),
+      ),
+    );
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(FilePreviewPage)),
+    )!;
+    await pumpUntilFound(
+      tester,
+      find.text(l10n.mountFilesPreviewBinary('blob.dat')),
+    );
+    // The dead-end is removed: a system-open action is offered.
+    expect(find.text(l10n.filePreviewOpenWithSystem), findsOneWidget);
+  });
+
+  testWidgets('text preview state shows no system-open button (no escape '
+      'hatch needed)', (tester) async {
+    final tmp = tempDir();
+    final path = '${tmp.path}/notes.txt';
+    File(path).writeAsStringSync('plain text');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: FilePreviewPage(hostPath: path, displayName: 'notes.txt'),
+      ),
+    );
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(FilePreviewPage)),
+    )!;
+    await pumpUntilFound(tester, find.text('plain text'));
+    expect(find.text(l10n.filePreviewOpenWithSystem), findsNothing);
+  });
+}

--- a/test/utils/file_kind_test.dart
+++ b/test/utils/file_kind_test.dart
@@ -1,0 +1,101 @@
+import 'package:Cuplivo/utils/file_kind.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FileKind.isHtmlFile', () {
+    test('matches .html and .htm case-insensitively, anywhere in the path', () {
+      expect(FileKind.isHtmlFile('page.html'), isTrue);
+      expect(FileKind.isHtmlFile('dir/sub/page.htm'), isTrue);
+      expect(FileKind.isHtmlFile('page.HTML'), isTrue);
+      expect(FileKind.isHtmlFile('page.Htm'), isTrue);
+    });
+
+    test('rejects other names', () {
+      expect(FileKind.isHtmlFile('page.txt'), isFalse);
+      expect(FileKind.isHtmlFile('page.html.backup'), isFalse);
+      expect(FileKind.isHtmlFile('html'), isFalse);
+      expect(FileKind.isHtmlFile('page'), isFalse);
+    });
+  });
+
+  group('FileKind.isImageFile', () {
+    test('matches the shared image set case-insensitively', () {
+      expect(FileKind.isImageFile('a.png'), isTrue);
+      expect(FileKind.isImageFile('a.jpg'), isTrue);
+      expect(FileKind.isImageFile('a.jpeg'), isTrue);
+      expect(FileKind.isImageFile('a.gif'), isTrue);
+      expect(FileKind.isImageFile('a.webp'), isTrue);
+      expect(FileKind.isImageFile('a.svg'), isTrue);
+      expect(FileKind.isImageFile('a.PNG'), isTrue);
+    });
+
+    test('rejects non-images', () {
+      expect(FileKind.isImageFile('a.txt'), isFalse);
+      expect(FileKind.isImageFile('a.html'), isFalse);
+      expect(FileKind.isImageFile('a.bmp'), isFalse);
+      expect(FileKind.isImageFile('a.tiff'), isFalse);
+    });
+  });
+
+  group('FileKind.isSvgFile', () {
+    test('matches .svg case-insensitively only', () {
+      expect(FileKind.isSvgFile('a.svg'), isTrue);
+      expect(FileKind.isSvgFile('dir/a.SVG'), isTrue);
+      expect(FileKind.isSvgFile('a.png'), isFalse);
+      expect(FileKind.isSvgFile('a.svgz'), isFalse);
+    });
+
+    test('svg is image-classified but must NOT route to the raster-only '
+        'ImageViewerPage (it decodes via FileImage)', () {
+      expect(FileKind.isImageFile('a.svg'), isTrue);
+      expect(FileKind.isSvgFile('a.svg'), isTrue);
+    });
+  });
+
+  group('FileKind.isLikelyBinary', () {
+    test('flags known binary formats case-insensitively', () {
+      for (final name in [
+        'a.pdf',
+        'a.docx',
+        'a.xlsx',
+        'a.pptx',
+        'a.zip',
+        'a.tar.gz',
+        'a.7z',
+        'a.exe',
+        'a.dmg',
+        'a.apk',
+        'a.mp3',
+        'a.mp4',
+        'a.mov',
+        'a.mkv',
+        'a.ttf',
+        'a.PDF',
+        'a.ZIP',
+      ]) {
+        expect(FileKind.isLikelyBinary(name), isTrue, reason: name);
+      }
+    });
+
+    test('leaves text-like and unknown extensions to the text preview', () {
+      for (final name in [
+        'a.txt',
+        'a.md',
+        'a.json',
+        'a.yaml',
+        'a.dart',
+        'a.py',
+        'a.csv',
+        'a.unknown',
+        'a',
+        'a.log',
+      ]) {
+        expect(FileKind.isLikelyBinary(name), isFalse, reason: name);
+      }
+    });
+
+    test('html is text-like for the storage router (handled before it)', () {
+      expect(FileKind.isLikelyBinary('a.html'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# fix(files): render html in-app on mobile and preview text/image uploads

Fixes #367. 同时缓解 #380（Android `ActivityNotFoundException`）中 html/文本/图片类场景。

## 变更

- **新增 `HtmlFilePreviewPage`**：移动端本地 html 应用内 WebView 渲染——`loadFile()` 加载，同目录 css/js/图片相对资源生效（iOS `readAccessPath` 覆盖所在目录，已验证 webview_flutter_wkwebview 实现）；主框架 http(s) 导航转交系统浏览器；加载失败/超限显示可读错误视图，不再"误报成功"
- **工作区文件浏览器**（`mount_files_page`）：移动端「打开」html → 应用内 WebView；桌面端保持系统默认应用打开（行为不变）
- **存储空间 → 文件分类**（`storage_space_page`，仅移动端）：
  - 图片（png/jpg/jpeg/gif/webp；**svg 除外**——`ImageViewerPage` 用内置光栅解码器无法渲染 SVG，落回 `FilePreviewPage` 经 `SvgPicture.file` 正确渲染）
  - html/htm → 应用内 WebView
  - 文本/代码/配置类 → `FilePreviewPage`（带行号预览）
  - 已知二进制（pdf/docx/zip/音视频等）→ 系统打开兜底（原行为）；图片路由带 32MB/0 字节守卫
- **新增共享分类器 `FileKind`**（html/image/svg/二进制黑名单），两个调用点统一路由，避免后续表面漂移
- **`FilePreviewPage` 错误态新增"用其他应用打开"按钮**：binary 探测失败/超限/读取失败不再是死路，可转系统默认应用（复用现有 `mountFilesOpenFailed` 错误提示）
- **l10n**：新 key `filePreviewOpenWithSystem`（en/zh/zh_Hans/zh_Hant 四文件同步，`flutter gen-l10n` 通过，无未翻译条目）

## 手动验证流程

> 前置：工作区放入 `index.html` + 同目录 `style.css` + `app.js` + `logo.png`；存储页上传 1 个 txt、1 个 png、1 个 svg、1 个 html、1 个 pdf

**iOS 真机（主验证）**
1. 工作区 → 文件 → `index.html` 行「⋯」→ 打开
   - 期望：全屏 WebView 渲染，样式/脚本/图片生效（相对资源）；标题为文件名；返回正常
2. `index.html` 内含 `<a href="https://example.com">` 与 `<a href="page2.html">`
   - 期望：外链点击 → 系统浏览器打开，WebView 停留原页；相对链接页内导航正常
3. 存储空间 → 文件分类：
   - txt/md/json → 带行号文本预览（`FilePreviewPage`）
   - png → `ImageViewerPage`；svg → `FilePreviewPage` 渲染出图形
   - html → 应用内 WebView；pdf → 系统 Open-in（原行为，无阅读器时菜单为空属系统行为）
4. 错误态：放一个含 null 字节的 `blob.dat` → 点按 → "binary 文件"错误 + "用其他应用打开"按钮 → 点击 → 系统菜单弹出
5. 大文件：>32MB html → 错误视图（too-large 文案），无"打开成功"误报

**Android 真机（回归 + 兜底）**
6. 重复 1、3 用例：html 相对资源渲染、文本/图片预览；未安装任何浏览器的 html 场景不再抛错（#380 缓解）

**桌面端（回归——行为必须不变）**
7. Windows/macOS 工作区 html「打开」（ExternalLink 图标）→ 默认浏览器打开
8. 存储页文件点按 → 系统默认应用打开

**边界**
9. `.HTML`/`.HTM` 大小写、无扩展名文件、未知扩展名（`.dat`）均不崩溃且行为符合上述路由

## 自动化测试

- `dart analyze --fatal-infos lib test`：0 issues
- 新增：`file_kind_test` 分类器 9 例；`file_preview_page_test` 错误态按钮 2 例；`mount_files_page_test` html 路由 2 例（移动端路由 + 桌面端无副作用断言——不再真实触发系统打开）
- 回归：`sandbox_files_page_test`

## 已知边界 / 风险

- iOS ATS：file:// 页面内外部 **http://** 资源被系统拦截（https 与相对资源正常）——有意不改 ATS（保持安全）
- WebView 安全姿态：file:// + 不受限 JS + 同目录读权限为功能所需（相对资源是核心），打开由用户主动触发
- 移动端 html 错误态**有意无**"用其他应用打开"按钮（html 系统打开即本 issue 根因）
