### PR TITLE
feat: 增强「Ta 的来信」上下文构建

### DIFF
--- a/lib/core/services/chat/chat_context_transforms.dart
+++ b/lib/core/services/chat/chat_context_transforms.dart
@@ -1,0 +1,142 @@
+import '../../models/assistant.dart';
+import '../../models/conversation.dart';
+
+/// Pure context transformations shared by interactive and headless chat flows.
+class ChatContextTransforms {
+  const ChatContextTransforms._();
+
+  static final RegExp _attachmentMarkerPattern = RegExp(
+    r'\[image:.+?\]|\[file:.+?\|.+?\|.+?\]',
+  );
+
+  static const String timeNote =
+      '<time-note>A timestamp will be injected by the system after every user message. Just keep it in mind, and don\'t mention it when irrelevant.</time-note>';
+
+  static String appendTimestamp(String content, DateTime timestamp) {
+    return '$content\n\n(${formatTimestamp(timestamp)})';
+  }
+
+  static String formatTimestamp(DateTime timestamp) {
+    const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    return '${weekdays[timestamp.weekday % 7]} '
+        '${(timestamp.year % 100).toString().padLeft(2, '0')}-'
+        '${timestamp.month.toString().padLeft(2, '0')}-'
+        '${timestamp.day.toString().padLeft(2, '0')} '
+        '${timestamp.hour.toString().padLeft(2, '0')}:'
+        '${timestamp.minute.toString().padLeft(2, '0')}:'
+        '${timestamp.second.toString().padLeft(2, '0')}';
+  }
+
+  /// Applies [transform] to message text while preserving persisted attachment
+  /// markers byte-for-byte. Attachment loading remains the responsibility of
+  /// the interactive chat pipeline; headless context building only protects
+  /// their paths, names, and MIME types from user-authored regex rules.
+  static String transformTextPreservingAttachmentMarkers(
+    String content,
+    String Function(String text) transform,
+  ) {
+    final buffer = StringBuffer();
+    var cursor = 0;
+    for (final match in _attachmentMarkerPattern.allMatches(content)) {
+      buffer.write(transform(content.substring(cursor, match.start)));
+      buffer.write(match.group(0));
+      cursor = match.end;
+    }
+    buffer.write(transform(content.substring(cursor)));
+    return buffer.toString();
+  }
+
+  static void injectTimeNote(List<Map<String, dynamic>> messages) {
+    appendToSystemMessage(messages, timeNote);
+  }
+
+  static List<Conversation> selectRecentChats(
+    Iterable<Conversation> conversations, {
+    required String assistantId,
+    required String? currentConversationId,
+    int limit = 10,
+  }) {
+    final selected =
+        conversations
+            .where(
+              (conversation) =>
+                  !conversation.isGroup &&
+                  conversation.assistantId == assistantId &&
+                  conversation.id != currentConversationId &&
+                  conversation.title.trim().isNotEmpty,
+            )
+            .toList(growable: false)
+          ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    return selected.take(limit).toList(growable: false);
+  }
+
+  static String buildRecentChatsBlock(Iterable<Conversation> conversations) {
+    final chats = conversations.toList(growable: false);
+    if (chats.isEmpty) return '';
+
+    final buffer = StringBuffer();
+    buffer.writeln('<recent_chats>');
+    buffer.writeln('这是用户最近的一些对话标题和摘要，你可以参考这些内容了解用户偏好和关注点');
+    for (final conversation in chats) {
+      buffer.writeln('<conversation>');
+      final timestamp = conversation.updatedAt.toIso8601String().substring(
+        0,
+        10,
+      );
+      final title = conversation.title.trim();
+      final summary = (conversation.summary ?? '').trim();
+      if (summary.isNotEmpty) {
+        buffer.writeln('  $timestamp: $title || $summary');
+      } else {
+        buffer.writeln('  $timestamp: $title');
+      }
+      buffer.writeln('</conversation>');
+    }
+    buffer.writeln('</recent_chats>');
+    return buffer.toString();
+  }
+
+  static void applyMessageLimit(
+    List<Map<String, dynamic>> messages,
+    Assistant? assistant,
+  ) {
+    if (!(assistant?.limitContextMessages ?? true) ||
+        (assistant?.contextMessageSize ?? 0) <= 0) {
+      return;
+    }
+
+    final keep = assistant!.contextMessageSize.clamp(
+      Assistant.minContextMessageSize,
+      Assistant.maxContextMessageSize,
+    );
+    var startIndex = 0;
+    if (messages.isNotEmpty && messages.first['role'] == 'system') {
+      startIndex = 1;
+    }
+    final tail = messages.sublist(startIndex);
+    if (tail.length > keep) {
+      final trimmed = tail.sublist(tail.length - keep);
+      messages
+        ..removeRange(startIndex, messages.length)
+        ..addAll(trimmed);
+    }
+
+    // Trimming can cut into a tool-call triplet. Never retain dangling tools.
+    while (messages.length > startIndex &&
+        (messages[startIndex]['role'] ?? '').toString() == 'tool') {
+      messages.removeAt(startIndex);
+    }
+  }
+
+  static void appendToSystemMessage(
+    List<Map<String, dynamic>> messages,
+    String content,
+  ) {
+    if (messages.isNotEmpty && messages.first['role'] == 'system') {
+      messages[0]['content'] =
+          '${(messages[0]['content'] ?? '') as String}\n\n$content';
+    } else {
+      messages.insert(0, {'role': 'system', 'content': content});
+    }
+  }
+}

--- a/lib/core/services/proactive_care_alarm_service.dart
+++ b/lib/core/services/proactive_care_alarm_service.dart
@@ -12,6 +12,7 @@ import '../../utils/app_directories.dart';
 import '../../utils/avatar_cache.dart';
 import '../../utils/sandbox_path_resolver.dart';
 import '../models/assistant.dart';
+import '../models/conversation.dart';
 import 'logging/flutter_logger.dart';
 import 'notification_service.dart';
 import 'proactive_care_message_flow.dart';
@@ -103,12 +104,34 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
         await ProactiveCareHeadlessChatStore.loadRecentConversationFor(
           assistant.id,
         );
-    final history = recent.conversation == null
+    final careHistory = recent.conversation == null
         ? const <Map<String, dynamic>>[]
         : ProactiveCareMessageFlow.buildHistory(
             conversation: recent.conversation!,
             messages: recent.messages,
+            assistant: assistant,
+            applySendRegexes: true,
           );
+    final decisionHistory = recent.conversation == null
+        ? const <Map<String, dynamic>>[]
+        : ProactiveCareMessageFlow.buildHistory(
+            conversation: recent.conversation!,
+            messages: recent.messages,
+            assistant: assistant,
+            applySendRegexes: false,
+          );
+    var recentChats = const <Conversation>[];
+    if (assistant.enableRecentChatsReference) {
+      try {
+        recentChats =
+            await ProactiveCareHeadlessChatStore.loadRecentChatReferencesFor(
+              assistant.id,
+              currentConversationId: recent.conversation?.id,
+            );
+      } catch (e) {
+        debugPrint('[ProactiveCare] Recent chat references load failed: $e');
+      }
+    }
 
     final carePrompt = assistant.proactiveCarePrompt.trim().isNotEmpty
         ? assistant.proactiveCarePrompt
@@ -117,9 +140,11 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
       assistant: assistant,
       userNickname: await ProactiveCareMessageFlow.loadUserNicknameFromPrefs(),
       modelId: modelCfg.modelId,
-      history: history,
+      history: careHistory,
       carePrompt: carePrompt,
       now: DateTime.now(),
+      recentChats: recentChats,
+      reloadWorldBooks: true,
     );
 
     final reply = await ProactiveCareMessageFlow.requestCareReply(
@@ -164,7 +189,7 @@ Future<void> _runHeadlessCareFlow(Assistant assistant, int alarmId) async {
           userNickname:
               await ProactiveCareMessageFlow.loadUserNicknameFromPrefs(),
           history: <Map<String, dynamic>>[
-            ...history,
+            ...decisionHistory,
             {'role': 'assistant', 'content': reply},
           ],
           decisionPrompt: decisionPrompt,

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -7,12 +7,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqlite3/sqlite3.dart' as sqlite;
 
 import '../../utils/app_directories.dart';
+import '../../utils/assistant_regex.dart';
 import '../models/assistant.dart';
+import '../models/assistant_regex.dart';
 import '../models/chat_message.dart';
 import '../models/conversation.dart';
 import '../providers/settings_provider.dart';
 import 'api/chat_api_service.dart';
 import 'api/plain_text_collector.dart';
+import 'chat/chat_context_transforms.dart';
 import 'chat/chat_service.dart';
 import 'chat/prompt_transformer.dart';
 import 'instruction_injection_store.dart';
@@ -20,6 +23,8 @@ import 'logging/flutter_logger.dart';
 import 'memory_store.dart';
 import 'proactive_care_decision_tools.dart';
 import 'proactive_care_service.dart';
+import 'world_book_prompt_injector.dart';
+import 'world_book_store.dart';
 
 const String _logTag = 'ProactiveCareFlow';
 
@@ -308,12 +313,15 @@ class ProactiveCareMessageFlow {
     return out;
   }
 
-  /// Builds the plain-text LLM history for [conversation]: collapsed
-  /// versions, truncateIndex applied, only completed non-empty user/assistant
-  /// turns (mirrors the decision flow in HomeViewModel).
+  /// Builds the plain-text LLM history for [conversation]: collapsed versions,
+  /// truncateIndex applied, and only completed non-empty user/assistant turns.
+  /// Smart-time timestamps follow [Assistant.enableTimeInjection]. Send-only
+  /// assistant regexes are applied only when [applySendRegexes] is true.
   static List<Map<String, dynamic>> buildHistory({
     required Conversation conversation,
     required List<ChatMessage> messages,
+    required Assistant assistant,
+    required bool applySendRegexes,
   }) {
     final collapsed = collapseMessageVersions(
       messages,
@@ -328,13 +336,42 @@ class ProactiveCareMessageFlow {
     final effective = collapsedSkip > 0
         ? collapsed.sublist(collapsedSkip)
         : collapsed;
-    return <Map<String, dynamic>>[
-      for (final m in effective)
-        if ((m.role == 'user' || m.role == 'assistant') &&
-            !m.isStreaming &&
-            m.content.trim().isNotEmpty)
-          {'role': m.role, 'content': m.content},
-    ];
+    final history = <Map<String, dynamic>>[];
+    for (final message in effective) {
+      if ((message.role != 'user' && message.role != 'assistant') ||
+          message.isStreaming ||
+          message.content.trim().isEmpty) {
+        continue;
+      }
+
+      var content = message.content;
+      if (applySendRegexes) {
+        String applyRegexes(String text) => applyAssistantRegexes(
+          text,
+          assistant: assistant,
+          scope: message.role == 'assistant'
+              ? AssistantRegexScope.assistant
+              : AssistantRegexScope.user,
+          target: AssistantRegexTransformTarget.send,
+        );
+        content = message.role == 'user'
+            ? ChatContextTransforms.transformTextPreservingAttachmentMarkers(
+                content,
+                applyRegexes,
+              )
+            : applyRegexes(content);
+      }
+      if (message.role == 'user' &&
+          assistant.enableTimeInjection &&
+          !message.isPreset) {
+        content = ChatContextTransforms.appendTimestamp(
+          content,
+          message.timestamp,
+        );
+      }
+      history.add({'role': message.role, 'content': content});
+    }
+    return history;
   }
 
   /// System prompt placeholders without a BuildContext: locale comes from
@@ -370,9 +407,10 @@ class ProactiveCareMessageFlow {
   }
 
   /// Assembles the full silent care request (Pipeline ②):
-  /// system prompt (placeholders replaced) + memories + instruction
-  /// injections + conversation history + the care prompt with the current
-  /// system time as the final user turn.
+  /// system prompt (placeholders replaced) + memories + recent chats +
+  /// instruction/world-book injections + conversation history + the care
+  /// prompt with the current system time as the final user turn. Smart-time
+  /// notes and the assistant's context limit are applied last.
   static Future<List<Map<String, dynamic>>> buildCareApiMessages({
     required Assistant assistant,
     required String userNickname,
@@ -380,6 +418,8 @@ class ProactiveCareMessageFlow {
     required List<Map<String, dynamic>> history,
     required String carePrompt,
     required DateTime now,
+    List<Conversation> recentChats = const <Conversation>[],
+    bool reloadWorldBooks = false,
   }) async {
     final apiMessages = <Map<String, dynamic>>[
       for (final m in history) Map<String, dynamic>.of(m),
@@ -424,6 +464,16 @@ class ProactiveCareMessageFlow {
       }
     }
 
+    // Recent chat references use the same block shape as normal chat, but the
+    // caller supplies the already selected conversations because foreground
+    // and killed-process paths have different storage access.
+    if (assistant.enableRecentChatsReference && recentChats.isNotEmpty) {
+      final block = ChatContextTransforms.buildRecentChatsBlock(recentChats);
+      if (block.isNotEmpty) {
+        _appendToSystemMessage(apiMessages, block);
+      }
+    }
+
     // Instruction injections.
     try {
       final actives = await InstructionInjectionStore.getActives(
@@ -439,6 +489,36 @@ class ProactiveCareMessageFlow {
     } catch (e) {
       FlutterLogger.log('Instruction injection failed: $e', tag: _logTag);
     }
+
+    // World book entries. Load from the persistent store so this works in
+    // both the main isolate and a headless alarm isolate.
+    try {
+      final selection = reloadWorldBooks
+          ? await WorldBookStore.loadFreshForAssistant(
+              assistantId: assistant.id,
+            )
+          : (
+              books: await WorldBookStore.getAll(),
+              activeBookIds: await WorldBookStore.getActiveIds(
+                assistantId: assistant.id,
+              ),
+            );
+      WorldBookPromptInjector.inject(
+        messages: apiMessages,
+        books: selection.books,
+        activeBookIds: selection.activeBookIds,
+      );
+    } catch (e) {
+      FlutterLogger.log('World book injection failed: $e', tag: _logTag);
+    }
+
+    if (assistant.enableTimeInjection) {
+      ChatContextTransforms.injectTimeNote(apiMessages);
+    }
+
+    // Unlike the decision request, care generation follows the assistant's
+    // ordinary context-message limit.
+    ChatContextTransforms.applyMessageLimit(apiMessages, assistant);
 
     return apiMessages;
   }
@@ -535,6 +615,9 @@ class ProactiveCareMessageFlow {
       personaPrompt: personaPrompt,
       memoriesBlock: memoriesBlock,
     );
+    if (assistant.enableTimeInjection) {
+      ChatContextTransforms.injectTimeNote(apiMessages);
+    }
     final tools = ProactiveCareDecisionTools.definitions();
     final baseRequestId =
         'proactive-care-decision-${assistant.id}-${DateTime.now().microsecondsSinceEpoch}';
@@ -841,10 +924,12 @@ class ProactiveCareHeadlessChatStore {
   loadRecentConversationFor(String assistantId) async {
     final db = await _ensureDb();
 
-    // Find the most recent conversation for this assistant
+    // Find the most recent non-group conversation for this assistant.
     final convRows = db.select(
-      'SELECT * FROM conversation_rows WHERE assistant_id = ? ORDER BY updated_at DESC LIMIT 1',
-      [assistantId],
+      'SELECT * FROM conversation_rows '
+      'WHERE assistant_id = ? AND conversation_kind != ? '
+      'ORDER BY updated_at DESC LIMIT 1',
+      [assistantId, Conversation.kindGroup],
     );
     if (convRows.isEmpty) {
       return (conversation: null, messages: const <ChatMessage>[]);
@@ -862,6 +947,12 @@ class ProactiveCareHeadlessChatStore {
       versionSelections: _parseVersionSelections(
         row['version_selections_json'] as String?,
       ),
+      summary: row['summary'] as String?,
+      lastSummarizedMessageCount:
+          row['last_summarized_message_count'] as int? ?? 0,
+      parentConversationId: row['parent_conversation_id'] as String?,
+      conversationKind:
+          row['conversation_kind'] as String? ?? Conversation.kindNormal,
     );
 
     // Load messages for this conversation
@@ -885,11 +976,48 @@ class ProactiveCareHeadlessChatStore {
           groupId: mRow['group_id'] as String?,
           subgroupId: mRow['subgroup_id'] as String?,
           version: mRow['version'] as int? ?? 0,
+          isPreset: (mRow['is_preset'] as int? ?? 0) != 0,
         ),
       );
     }
 
     return (conversation: conversation, messages: messages);
+  }
+
+  /// Loads the same recent-chat references used by the foreground builder.
+  static Future<List<Conversation>> loadRecentChatReferencesFor(
+    String assistantId, {
+    required String? currentConversationId,
+  }) async {
+    final db = await _ensureDb();
+    final exclusion = currentConversationId == null ? '' : 'AND id != ? ';
+    final parameters = <Object?>[
+      assistantId,
+      Conversation.kindGroup,
+      if (currentConversationId != null) currentConversationId,
+    ];
+    final rows = db.select(
+      'SELECT id, title, created_at, updated_at, assistant_id, summary, '
+      'conversation_kind FROM conversation_rows '
+      'WHERE assistant_id = ? AND conversation_kind != ? '
+      '${exclusion}AND TRIM(title) != \'\' '
+      'ORDER BY updated_at DESC LIMIT 10',
+      parameters,
+    );
+    return rows
+        .map(
+          (row) => Conversation(
+            id: row['id'] as String,
+            title: row['title'] as String,
+            createdAt: _dateTimeFromSql(row['created_at']),
+            updatedAt: _dateTimeFromSql(row['updated_at']),
+            assistantId: row['assistant_id'] as String?,
+            summary: row['summary'] as String?,
+            conversationKind:
+                row['conversation_kind'] as String? ?? Conversation.kindNormal,
+          ),
+        )
+        .toList(growable: false);
   }
 
   /// Appends an assistant reply to [conversation], creating a new

--- a/lib/core/services/world_book_prompt_injector.dart
+++ b/lib/core/services/world_book_prompt_injector.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/world_book.dart';
+
+/// Applies world-book entries to an already assembled API message list.
+class WorldBookPromptInjector {
+  const WorldBookPromptInjector._();
+
+  static void inject({
+    required List<Map<String, dynamic>> messages,
+    required Iterable<WorldBook> books,
+    required Iterable<String> activeBookIds,
+  }) {
+    final activeSet = activeBookIds.toSet();
+    if (activeSet.isEmpty) return;
+
+    final activeBooks = books
+        .where((book) => book.enabled && activeSet.contains(book.id))
+        .toList(growable: false);
+    if (activeBooks.isEmpty) return;
+
+    String extractContextForDepth(int scanDepth) {
+      final depth = scanDepth <= 0 ? 1 : scanDepth;
+      final parts = <String>[];
+      for (var i = messages.length - 1; i >= 0 && parts.length < depth; i--) {
+        final role = (messages[i]['role'] ?? '').toString();
+        if (role != 'user' && role != 'assistant') continue;
+        final content = (messages[i]['content'] ?? '').toString().trim();
+        if (content.isEmpty) continue;
+        parts.add(content);
+      }
+      return parts.reversed.join('\n');
+    }
+
+    bool isTriggered(WorldBookEntry entry, String context) {
+      if (!entry.enabled) return false;
+      if (entry.constantActive) return true;
+      if (entry.keywords.isEmpty) return false;
+
+      for (final raw in entry.keywords) {
+        final keyword = raw.trim();
+        if (keyword.isEmpty) continue;
+        if (entry.useRegex) {
+          try {
+            final regex = RegExp(keyword, caseSensitive: entry.caseSensitive);
+            if (regex.hasMatch(context)) return true;
+          } on FormatException catch (error) {
+            debugPrint(
+              '[WorldBookPromptInjector] Invalid regex "$keyword": $error',
+            );
+          }
+        } else if (entry.caseSensitive) {
+          if (context.contains(keyword)) return true;
+        } else if (context.toLowerCase().contains(keyword.toLowerCase())) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    final contextCache = <int, String>{};
+    final triggered = <({WorldBookEntry entry, int sequence})>[];
+    var sequence = 0;
+    for (final book in activeBooks) {
+      for (final entry in book.entries) {
+        final depth = (entry.scanDepth <= 0 ? 1 : entry.scanDepth)
+            .clamp(1, 200)
+            .toInt();
+        final context = contextCache.putIfAbsent(
+          depth,
+          () => extractContextForDepth(depth),
+        );
+        if (isTriggered(entry, context)) {
+          triggered.add((entry: entry, sequence: sequence));
+        }
+        sequence++;
+      }
+    }
+    if (triggered.isEmpty) return;
+
+    triggered.sort((a, b) {
+      final priority = b.entry.priority.compareTo(a.entry.priority);
+      return priority != 0 ? priority : a.sequence.compareTo(b.sequence);
+    });
+
+    String joinContents(Iterable<WorldBookEntry> entries) => entries
+        .map((entry) => entry.content.trim())
+        .where((content) => content.isNotEmpty)
+        .join('\n');
+
+    List<Map<String, dynamic>> createMergedMessages(
+      List<WorldBookEntry> entries,
+    ) {
+      final byRole = <WorldBookInjectionRole, List<WorldBookEntry>>{};
+      for (final entry in entries) {
+        if (entry.content.trim().isEmpty) continue;
+        byRole.putIfAbsent(entry.role, () => <WorldBookEntry>[]).add(entry);
+      }
+      final result = <Map<String, dynamic>>[];
+      for (final role in byRole.keys) {
+        final merged = joinContents(byRole[role]!);
+        if (merged.isEmpty) continue;
+        result.add({
+          'role': role == WorldBookInjectionRole.assistant
+              ? 'assistant'
+              : 'user',
+          'content': role == WorldBookInjectionRole.assistant
+              ? merged
+              : '<system>\n$merged\n</system>',
+        });
+      }
+      return result;
+    }
+
+    int findSafeInsertIndex(int target) {
+      var index = target.clamp(0, messages.length);
+      while (index > 0 && index < messages.length) {
+        if ((messages[index]['role'] ?? '').toString() != 'tool') break;
+        index--;
+      }
+      return index;
+    }
+
+    final byPosition = <WorldBookInjectionPosition, List<WorldBookEntry>>{};
+    for (final item in triggered) {
+      byPosition
+          .putIfAbsent(item.entry.position, () => <WorldBookEntry>[])
+          .add(item.entry);
+    }
+
+    final before = joinContents(
+      byPosition[WorldBookInjectionPosition.beforeSystemPrompt] ??
+          const <WorldBookEntry>[],
+    );
+    final after = joinContents(
+      byPosition[WorldBookInjectionPosition.afterSystemPrompt] ??
+          const <WorldBookEntry>[],
+    );
+    if (before.isNotEmpty || after.isNotEmpty) {
+      final systemIndex = messages.indexWhere(
+        (message) => (message['role'] ?? '').toString() == 'system',
+      );
+      if (systemIndex >= 0) {
+        final original = (messages[systemIndex]['content'] ?? '').toString();
+        messages[systemIndex]['content'] = [
+          if (before.isNotEmpty) before,
+          original,
+          if (after.isNotEmpty) after,
+        ].join('\n');
+      } else {
+        messages.insert(0, {
+          'role': 'system',
+          'content': [
+            if (before.isNotEmpty) before,
+            if (after.isNotEmpty) after,
+          ].join('\n'),
+        });
+      }
+    }
+
+    final top = byPosition[WorldBookInjectionPosition.topOfChat];
+    if (top != null && top.isNotEmpty) {
+      var index = messages.indexWhere(
+        (message) => (message['role'] ?? '').toString() == 'user',
+      );
+      if (index < 0) index = messages.length;
+      messages.insertAll(findSafeInsertIndex(index), createMergedMessages(top));
+    }
+
+    final bottom = byPosition[WorldBookInjectionPosition.bottomOfChat];
+    if (bottom != null && bottom.isNotEmpty) {
+      final target = messages.isEmpty ? 0 : messages.length - 1;
+      messages.insertAll(
+        findSafeInsertIndex(target),
+        createMergedMessages(bottom),
+      );
+    }
+
+    final atDepth = byPosition[WorldBookInjectionPosition.atDepth];
+    if (atDepth != null && atDepth.isNotEmpty) {
+      final byDepth = <int, List<WorldBookEntry>>{};
+      for (final entry in atDepth) {
+        final depth = (entry.injectDepth <= 0 ? 1 : entry.injectDepth)
+            .clamp(1, 200)
+            .toInt();
+        byDepth.putIfAbsent(depth, () => <WorldBookEntry>[]).add(entry);
+      }
+      final depths = byDepth.keys.toList(growable: false)
+        ..sort((a, b) => b.compareTo(a));
+      for (final depth in depths) {
+        final index = findSafeInsertIndex(
+          (messages.length - depth).clamp(0, messages.length),
+        );
+        messages.insertAll(index, createMergedMessages(byDepth[depth]!));
+      }
+    }
+  }
+}

--- a/lib/core/services/world_book_store.dart
+++ b/lib/core/services/world_book_store.dart
@@ -28,6 +28,36 @@ class WorldBookStore {
         .toList(growable: false);
   }
 
+  static List<WorldBook> _decodeItems(String? raw) {
+    if (raw == null || raw.isEmpty) return const <WorldBook>[];
+    final list = jsonDecode(raw) as List;
+    return list
+        .whereType<Map>()
+        .map((e) => WorldBook.fromJson(e.cast<String, dynamic>()))
+        .toList(growable: true);
+  }
+
+  static Map<String, List<String>> _decodeActiveIdsMap(String? raw) {
+    final map = <String, List<String>>{};
+    if (raw == null || raw.isEmpty) return map;
+    final decoded = jsonDecode(raw) as Map;
+    decoded.forEach((key, value) {
+      final list = (value is List) ? value : const [];
+      map[key.toString()] = _cleanIds(list);
+    });
+    return map;
+  }
+
+  static List<String> _activeIdsForAssistant(
+    Map<String, List<String>> map,
+    String? assistantId,
+  ) {
+    final key = assistantKey(assistantId);
+    if (map.containsKey(key)) return List<String>.from(map[key]!);
+    final fallback = map[_defaultAssistantKey];
+    return fallback == null ? const <String>[] : List<String>.from(fallback);
+  }
+
   static Map<String, List<String>> _cloneActiveIdsMap(
     Map<String, List<String>> src,
   ) {
@@ -41,17 +71,8 @@ class WorldBookStore {
   static Future<List<WorldBook>> getAll() async {
     if (_cache != null) return List<WorldBook>.from(_cache!);
     final prefs = await SharedPreferences.getInstance();
-    final json = prefs.getString(_itemsKey);
-    if (json == null || json.isEmpty) {
-      _cache = const <WorldBook>[];
-      return const <WorldBook>[];
-    }
     try {
-      final list = jsonDecode(json) as List;
-      _cache = list
-          .whereType<Map>()
-          .map((e) => WorldBook.fromJson(e.cast<String, dynamic>()))
-          .toList(growable: true);
+      _cache = _decodeItems(prefs.getString(_itemsKey));
       return List<WorldBook>.from(_cache!);
     } catch (_) {
       _cache = const <WorldBook>[];
@@ -136,13 +157,27 @@ class WorldBookStore {
 
   static Future<List<String>> getActiveIds({String? assistantId}) async {
     final map = await _loadActiveIdsMap();
-    final key = assistantKey(assistantId);
-    if (map.containsKey(key)) {
-      return List<String>.from(map[key]!);
-    }
-    final fallback = map[_defaultAssistantKey];
-    if (fallback != null) return List<String>.from(fallback);
-    return const <String>[];
+    return _activeIdsForAssistant(map, assistantId);
+  }
+
+  /// Reads the world-book selection from persistent storage without using
+  /// this isolate's static or SharedPreferences caches.
+  ///
+  /// Android alarm callbacks can reuse one background isolate across multiple
+  /// invocations. Reloading here ensures edits made by the foreground isolate
+  /// after an earlier alarm are visible to the next headless request.
+  static Future<({List<WorldBook> books, List<String> activeBookIds})>
+  loadFreshForAssistant({String? assistantId}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.reload();
+    final books = _decodeItems(prefs.getString(_itemsKey));
+    final activeIdsMap = _decodeActiveIdsMap(
+      prefs.getString(_activeIdsByAssistantKey),
+    );
+    return (
+      books: books,
+      activeBookIds: _activeIdsForAssistant(activeIdsMap, assistantId),
+    );
   }
 
   static Future<Map<String, List<String>>> getActiveIdsByAssistant() async {
@@ -198,17 +233,11 @@ class WorldBookStore {
     }
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getString(_activeIdsByAssistantKey);
-    Map<String, List<String>> map = <String, List<String>>{};
-    if (raw != null && raw.isNotEmpty) {
-      try {
-        final decoded = jsonDecode(raw) as Map;
-        decoded.forEach((key, value) {
-          final list = (value is List) ? value : const [];
-          map[key.toString()] = _cleanIds(list);
-        });
-      } catch (_) {
-        map = <String, List<String>>{};
-      }
+    Map<String, List<String>> map;
+    try {
+      map = _decodeActiveIdsMap(raw);
+    } catch (_) {
+      map = <String, List<String>>{};
     }
     _activeIdsByAssistantCache = map;
     return _cloneActiveIdsMap(map);

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -9,6 +9,7 @@ import '../../../core/models/conversation.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../core/services/chat/chat_context_transforms.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/logging/flutter_logger.dart';
 import '../../../core/services/notification_service.dart';
@@ -1745,6 +1746,8 @@ class HomeViewModel extends ChangeNotifier {
     final history = ProactiveCareMessageFlow.buildHistory(
       conversation: convo,
       messages: _chatService.getMessages(convo.id),
+      assistant: assistant,
+      applySendRegexes: false,
     );
 
     final l10n = AppLocalizations.of(_contextProvider);
@@ -1844,7 +1847,16 @@ class HomeViewModel extends ChangeNotifier {
       final history = ProactiveCareMessageFlow.buildHistory(
         conversation: convo,
         messages: _chatService.getMessages(convo.id),
+        assistant: assistant,
+        applySendRegexes: true,
       );
+      final recentChats = assistant.enableRecentChatsReference
+          ? ChatContextTransforms.selectRecentChats(
+              _chatService.getAllConversations(),
+              assistantId: assistant.id,
+              currentConversationId: convo.id,
+            )
+          : const <Conversation>[];
       final carePrompt = assistant.proactiveCarePrompt.trim().isNotEmpty
           ? assistant.proactiveCarePrompt
           : (l10n?.assistantEditProactiveCarePromptDefault ?? '');
@@ -1855,6 +1867,7 @@ class HomeViewModel extends ChangeNotifier {
         history: history,
         carePrompt: carePrompt,
         now: DateTime.now(),
+        recentChats: recentChats,
       );
 
       final reply = await ProactiveCareMessageFlow.requestCareReply(

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -13,10 +13,12 @@ import '../../../core/providers/memory_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/user_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/chat/chat_context_transforms.dart';
 import '../../../core/services/chat/document_text_extractor.dart';
 import '../../../core/services/chat/prompt_transformer.dart';
 import '../../../core/services/instruction_injection_store.dart';
 import '../../../core/services/world_book_store.dart';
+import '../../../core/services/world_book_prompt_injector.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
@@ -43,9 +45,6 @@ class MessageBuilderService {
   static const String internalMediaPathsKey = multimodalInternalMediaPathsKey;
   static const String _isPresetKey = '_isPreset';
   static const String _timestampKey = '_timestamp';
-
-  static const String _timeNote =
-      '<time-note>A timestamp will be injected by the system after every user message. Just keep it in mind, and don\'t mention it when irrelevant.</time-note>';
 
   MessageBuilderService({
     required this.chatService,
@@ -578,8 +577,10 @@ class MessageBuilderService {
         if (tsStr != null) {
           final ts = DateTime.tryParse(tsStr);
           if (ts != null) {
-            apiMessages[i]['content'] =
-                '${apiMessages[i]['content']}\n\n(${_formatTimestamp(ts)})';
+            apiMessages[i]['content'] = ChatContextTransforms.appendTimestamp(
+              (apiMessages[i]['content'] ?? '').toString(),
+              ts,
+            );
           }
         }
       }
@@ -685,36 +686,16 @@ These memories are automatically included in future conversation contexts within
         _appendToSystemMessage(apiMessages, buf.toString());
       }
       if (assistant?.enableRecentChatsReference == true) {
-        final chats = chatService.getAllConversations();
-        final relevantChats = chats
-            .where(
-              (c) =>
-                  !c.isGroup &&
-                  c.assistantId == assistant!.id &&
-                  c.id != currentConversationId,
-            )
-            .where((c) => c.title.trim().isNotEmpty)
-            .take(10)
-            .toList();
+        final relevantChats = ChatContextTransforms.selectRecentChats(
+          chatService.getAllConversations(),
+          assistantId: assistant!.id,
+          currentConversationId: currentConversationId,
+        );
         if (relevantChats.isNotEmpty) {
-          final sb = StringBuffer();
-          sb.writeln('<recent_chats>');
-          sb.writeln('这是用户最近的一些对话标题和摘要，你可以参考这些内容了解用户偏好和关注点');
-          for (final c in relevantChats) {
-            sb.writeln('<conversation>');
-            // Format: timestamp: title || summary
-            final timestamp = c.updatedAt.toIso8601String().substring(0, 10);
-            final title = c.title.trim();
-            final summary = (c.summary ?? '').trim();
-            if (summary.isNotEmpty) {
-              sb.writeln('  $timestamp: $title || $summary');
-            } else {
-              sb.writeln('  $timestamp: $title');
-            }
-            sb.writeln('</conversation>');
-          }
-          sb.writeln('</recent_chats>');
-          _appendToSystemMessage(apiMessages, sb.toString());
+          _appendToSystemMessage(
+            apiMessages,
+            ChatContextTransforms.buildRecentChatsBlock(relevantChats),
+          );
         }
       }
     } catch (_) {}
@@ -742,24 +723,13 @@ These memories are automatically included in future conversation contexts within
         '${now.second.toString().padLeft(2, '0')}';
   }
 
-  static String _formatTimestamp(DateTime dt) {
-    const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    return '${weekdays[dt.weekday % 7]} '
-        '${(dt.year % 100).toString().padLeft(2, '0')}-'
-        '${dt.month.toString().padLeft(2, '0')}-'
-        '${dt.day.toString().padLeft(2, '0')} '
-        '${dt.hour.toString().padLeft(2, '0')}:'
-        '${dt.minute.toString().padLeft(2, '0')}:'
-        '${dt.second.toString().padLeft(2, '0')}';
-  }
-
   /// Inject `<time-note>` into the system message when time injection is enabled.
   void injectTimeNote(
     List<Map<String, dynamic>> apiMessages,
     Assistant? assistant,
   ) {
     if (assistant?.enableTimeInjection == true) {
-      _appendToSystemMessage(apiMessages, _timeNote);
+      ChatContextTransforms.injectTimeNote(apiMessages);
     }
   }
 
@@ -872,229 +842,11 @@ These memories are automatically included in future conversation contexts within
       }
 
       if (all.isEmpty || activeBookIds.isEmpty) return;
-
-      final activeSet = activeBookIds.toSet();
-      final books = all
-          .where((b) => b.enabled && activeSet.contains(b.id))
-          .toList(growable: false);
-      if (books.isEmpty) return;
-
-      String extractContextForDepth(int scanDepth) {
-        final depth = scanDepth <= 0 ? 1 : scanDepth;
-        final parts = <String>[];
-        for (
-          int i = apiMessages.length - 1;
-          i >= 0 && parts.length < depth;
-          i--
-        ) {
-          final role = (apiMessages[i]['role'] ?? '').toString();
-          if (role != 'user' && role != 'assistant') continue;
-          final content = (apiMessages[i]['content'] ?? '').toString().trim();
-          if (content.isEmpty) continue;
-          parts.add(content);
-        }
-        return parts.reversed.join('\n');
-      }
-
-      bool isTriggered(WorldBookEntry entry, String context) {
-        if (!entry.enabled) return false;
-        if (entry.constantActive) return true;
-        if (entry.keywords.isEmpty) return false;
-
-        for (final raw in entry.keywords) {
-          final keyword = raw.trim();
-          if (keyword.isEmpty) continue;
-
-          if (entry.useRegex) {
-            try {
-              final re = RegExp(keyword, caseSensitive: entry.caseSensitive);
-              if (re.hasMatch(context)) return true;
-            } catch (_) {}
-          } else {
-            if (entry.caseSensitive) {
-              if (context.contains(keyword)) return true;
-            } else {
-              if (context.toLowerCase().contains(keyword.toLowerCase())) {
-                return true;
-              }
-            }
-          }
-        }
-        return false;
-      }
-
-      final contextCache = <int, String>{};
-      final triggered = <({WorldBookEntry entry, int seq})>[];
-      int seq = 0;
-
-      for (final book in books) {
-        for (final entry in book.entries) {
-          final depth = (entry.scanDepth <= 0 ? 1 : entry.scanDepth)
-              .clamp(1, 200)
-              .toInt();
-          final ctx = contextCache.putIfAbsent(
-            depth,
-            () => extractContextForDepth(depth),
-          );
-          if (isTriggered(entry, ctx)) {
-            triggered.add((entry: entry, seq: seq));
-          }
-          seq++;
-        }
-      }
-
-      if (triggered.isEmpty) return;
-
-      triggered.sort((a, b) {
-        final pa = a.entry.priority;
-        final pb = b.entry.priority;
-        if (pb != pa) return pb.compareTo(pa);
-        return a.seq.compareTo(b.seq);
-      });
-
-      String wrapSystemTag(String content) => '<system>\n$content\n</system>';
-
-      String joinContents(Iterable<WorldBookEntry> items) {
-        return items
-            .map((e) => e.content.trim())
-            .where((c) => c.isNotEmpty)
-            .join('\n');
-      }
-
-      List<Map<String, dynamic>> createMergedInjectionMessages(
-        List<WorldBookEntry> injections,
-      ) {
-        final byRole = <WorldBookInjectionRole, List<WorldBookEntry>>{};
-        for (final e in injections) {
-          if (e.content.trim().isEmpty) continue;
-          byRole.putIfAbsent(e.role, () => <WorldBookEntry>[]).add(e);
-        }
-
-        final result = <Map<String, dynamic>>[];
-        for (final role in byRole.keys) {
-          final group = byRole[role]!;
-          final merged = joinContents(group);
-          if (merged.isEmpty) continue;
-          if (role == WorldBookInjectionRole.assistant) {
-            result.add({'role': 'assistant', 'content': merged});
-          } else {
-            result.add({'role': 'user', 'content': wrapSystemTag(merged)});
-          }
-        }
-        return result;
-      }
-
-      int findSafeInsertIndex(List<Map<String, dynamic>> messages, int target) {
-        var index = target.clamp(0, messages.length);
-        while (index > 0 && index < messages.length) {
-          final role = (messages[index]['role'] ?? '').toString();
-          if (role != 'tool') break;
-          index--;
-        }
-        return index;
-      }
-
-      final byPosition = <WorldBookInjectionPosition, List<WorldBookEntry>>{};
-      for (final t in triggered) {
-        byPosition
-            .putIfAbsent(t.entry.position, () => <WorldBookEntry>[])
-            .add(t.entry);
-      }
-
-      // BEFORE/AFTER_SYSTEM_PROMPT: merge into system message.
-      final beforeContent = joinContents(
-        byPosition[WorldBookInjectionPosition.beforeSystemPrompt] ??
-            const <WorldBookEntry>[],
+      WorldBookPromptInjector.inject(
+        messages: apiMessages,
+        books: all,
+        activeBookIds: activeBookIds,
       );
-      final afterContent = joinContents(
-        byPosition[WorldBookInjectionPosition.afterSystemPrompt] ??
-            const <WorldBookEntry>[],
-      );
-
-      if (beforeContent.isNotEmpty || afterContent.isNotEmpty) {
-        final systemIndex = apiMessages.indexWhere(
-          (m) => (m['role'] ?? '').toString() == 'system',
-        );
-        if (systemIndex >= 0) {
-          final original = (apiMessages[systemIndex]['content'] ?? '')
-              .toString();
-          final sb = StringBuffer();
-          if (beforeContent.isNotEmpty) {
-            sb.write(beforeContent);
-            sb.write('\n');
-          }
-          sb.write(original);
-          if (afterContent.isNotEmpty) {
-            sb.write('\n');
-            sb.write(afterContent);
-          }
-          apiMessages[systemIndex]['content'] = sb.toString();
-        } else {
-          final sb = StringBuffer();
-          if (beforeContent.isNotEmpty) sb.write(beforeContent);
-          if (afterContent.isNotEmpty) {
-            if (sb.isNotEmpty) sb.write('\n');
-            sb.write(afterContent);
-          }
-          if (sb.isNotEmpty) {
-            apiMessages.insert(0, {'role': 'system', 'content': sb.toString()});
-          }
-        }
-      }
-
-      // TOP_OF_CHAT: insert before first user message.
-      final topInjections = byPosition[WorldBookInjectionPosition.topOfChat];
-      if (topInjections != null && topInjections.isNotEmpty) {
-        var insertIndex = apiMessages.indexWhere(
-          (m) => (m['role'] ?? '').toString() == 'user',
-        );
-        if (insertIndex < 0) insertIndex = apiMessages.length;
-        insertIndex = findSafeInsertIndex(apiMessages, insertIndex);
-        apiMessages.insertAll(
-          insertIndex,
-          createMergedInjectionMessages(topInjections),
-        );
-      }
-
-      // BOTTOM_OF_CHAT: insert before last message.
-      final bottomInjections =
-          byPosition[WorldBookInjectionPosition.bottomOfChat];
-      if (bottomInjections != null && bottomInjections.isNotEmpty) {
-        var insertIndex = apiMessages.isEmpty ? 0 : (apiMessages.length - 1);
-        insertIndex = findSafeInsertIndex(apiMessages, insertIndex);
-        apiMessages.insertAll(
-          insertIndex,
-          createMergedInjectionMessages(bottomInjections),
-        );
-      }
-
-      // AT_DEPTH: insert at depth from end (depth=1 means before last message).
-      final atDepthInjections = byPosition[WorldBookInjectionPosition.atDepth];
-      if (atDepthInjections != null && atDepthInjections.isNotEmpty) {
-        final byDepth = <int, List<WorldBookEntry>>{};
-        for (final e in atDepthInjections) {
-          final depth = (e.injectDepth <= 0 ? 1 : e.injectDepth)
-              .clamp(1, 200)
-              .toInt();
-          byDepth.putIfAbsent(depth, () => <WorldBookEntry>[]).add(e);
-        }
-
-        final depths = byDepth.keys.toList(growable: false)
-          ..sort((a, b) => b.compareTo(a));
-
-        for (final depth in depths) {
-          final injections = byDepth[depth] ?? const <WorldBookEntry>[];
-          var insertIndex = (apiMessages.length - depth).clamp(
-            0,
-            apiMessages.length,
-          );
-          insertIndex = findSafeInsertIndex(apiMessages, insertIndex);
-          apiMessages.insertAll(
-            insertIndex,
-            createMergedInjectionMessages(injections),
-          );
-        }
-      }
     } catch (_) {}
   }
 
@@ -1116,29 +868,7 @@ These memories are automatically included in future conversation contexts within
     List<Map<String, dynamic>> apiMessages,
     Assistant? assistant,
   ) {
-    if ((assistant?.limitContextMessages ?? true) &&
-        (assistant?.contextMessageSize ?? 0) > 0) {
-      final int keep = (assistant!.contextMessageSize).clamp(
-        Assistant.minContextMessageSize,
-        Assistant.maxContextMessageSize,
-      );
-      int startIdx = 0;
-      if (apiMessages.isNotEmpty && apiMessages.first['role'] == 'system') {
-        startIdx = 1;
-      }
-      final tail = apiMessages.sublist(startIdx);
-      if (tail.length > keep) {
-        final trimmed = tail.sublist(tail.length - keep);
-        apiMessages
-          ..removeRange(startIdx, apiMessages.length)
-          ..addAll(trimmed);
-      }
-      // Context trimming can cut in the middle of a tool-call triplet; avoid sending dangling tool messages.
-      while (apiMessages.length > startIdx &&
-          (apiMessages[startIdx]['role'] ?? '').toString() == 'tool') {
-        apiMessages.removeAt(startIdx);
-      }
-    }
+    ChatContextTransforms.applyMessageLimit(apiMessages, assistant);
   }
 
   /// Convert local Markdown image links to inline base64 for model context.

--- a/test/core/services/chat_context_transforms_test.dart
+++ b/test/core/services/chat_context_transforms_test.dart
@@ -1,0 +1,135 @@
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/services/chat/chat_context_transforms.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Conversation conversation({
+  required String id,
+  required String title,
+  required DateTime updatedAt,
+  String assistantId = 'assistant-1',
+  String kind = Conversation.kindNormal,
+  String? summary,
+}) {
+  return Conversation(
+    id: id,
+    title: title,
+    updatedAt: updatedAt,
+    assistantId: assistantId,
+    conversationKind: kind,
+    summary: summary,
+  );
+}
+
+void main() {
+  group('ChatContextTransforms', () {
+    test('formats and appends the normal smart-time timestamp', () {
+      final timestamp = DateTime(2026, 8, 18, 9, 7, 5);
+
+      expect(
+        ChatContextTransforms.appendTimestamp('hello', timestamp),
+        'hello\n\n(Tue 26-08-18 09:07:05)',
+      );
+    });
+
+    test('selects the latest ten eligible recent chats', () {
+      final base = DateTime(2026, 8, 18);
+      final chats = <Conversation>[
+        for (var index = 0; index < 12; index++)
+          conversation(
+            id: 'chat-$index',
+            title: 'Chat $index',
+            updatedAt: base.add(Duration(days: index)),
+          ),
+        conversation(
+          id: 'current',
+          title: 'Current',
+          updatedAt: base.add(const Duration(days: 20)),
+        ),
+        conversation(
+          id: 'group',
+          title: 'Group',
+          updatedAt: base.add(const Duration(days: 21)),
+          kind: Conversation.kindGroup,
+        ),
+        conversation(
+          id: 'other-assistant',
+          title: 'Other',
+          updatedAt: base.add(const Duration(days: 22)),
+          assistantId: 'assistant-2',
+        ),
+        conversation(
+          id: 'empty-title',
+          title: '   ',
+          updatedAt: base.add(const Duration(days: 23)),
+        ),
+      ];
+
+      final selected = ChatContextTransforms.selectRecentChats(
+        chats,
+        assistantId: 'assistant-1',
+        currentConversationId: 'current',
+      );
+
+      expect(selected, hasLength(10));
+      expect(selected.map((chat) => chat.id), [
+        'chat-11',
+        'chat-10',
+        'chat-9',
+        'chat-8',
+        'chat-7',
+        'chat-6',
+        'chat-5',
+        'chat-4',
+        'chat-3',
+        'chat-2',
+      ]);
+    });
+
+    test('builds recent-chat references with title and optional summary', () {
+      final block = ChatContextTransforms.buildRecentChatsBlock([
+        conversation(
+          id: 'with-summary',
+          title: ' Plans ',
+          updatedAt: DateTime(2026, 8, 18),
+          summary: 'Pack tonight',
+        ),
+        conversation(
+          id: 'without-summary',
+          title: 'Music',
+          updatedAt: DateTime(2026, 8, 17),
+        ),
+      ]);
+
+      expect(block, contains('<conversation>'));
+      expect(block, contains('2026-08-18: Plans || Pack tonight'));
+      expect(block, contains('2026-08-17: Music'));
+      expect(block, endsWith('</recent_chats>\n'));
+    });
+
+    test('message limit preserves system and the newest tail', () {
+      final messages = <Map<String, dynamic>>[
+        {'role': 'system', 'content': 'system'},
+        {'role': 'user', 'content': 'old'},
+        {'role': 'assistant', 'content': 'middle'},
+        {'role': 'user', 'content': 'latest'},
+      ];
+
+      ChatContextTransforms.applyMessageLimit(
+        messages,
+        Assistant(
+          id: 'assistant-1',
+          name: 'Assistant',
+          limitContextMessages: true,
+          contextMessageSize: 2,
+        ),
+      );
+
+      expect(messages.map((message) => message['content']), [
+        'system',
+        'middle',
+        'latest',
+      ]);
+    });
+  });
+}

--- a/test/core/services/proactive_care_context_test.dart
+++ b/test/core/services/proactive_care_context_test.dart
@@ -1,0 +1,460 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/assistant_regex.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/models/world_book.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+import 'package:Cuplivo/core/services/chat/chat_context_transforms.dart';
+import 'package:Cuplivo/core/services/proactive_care_decision_tools.dart';
+import 'package:Cuplivo/core/services/proactive_care_message_flow.dart';
+import 'package:Cuplivo/core/services/world_book_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+ChatMessage message({
+  required String id,
+  required String role,
+  required String content,
+  required DateTime timestamp,
+  bool isPreset = false,
+}) {
+  return ChatMessage(
+    id: id,
+    role: role,
+    content: content,
+    timestamp: timestamp,
+    conversationId: 'conversation-1',
+    isPreset: isPreset,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    await WorldBookStore.clear();
+  });
+
+  group('ProactiveCareMessageFlow context', () {
+    test(
+      'care history applies send regexes and timestamps real users only',
+      () {
+        final assistant = Assistant(
+          id: 'assistant-1',
+          name: 'Assistant',
+          enableTimeInjection: true,
+          regexRules: const [
+            AssistantRegex(
+              id: 'user-regex',
+              name: 'User replacement',
+              pattern: 'alpha',
+              replacement: 'beta',
+              scopes: [AssistantRegexScope.user],
+              replaceOnly: true,
+            ),
+            AssistantRegex(
+              id: 'assistant-regex',
+              name: 'Assistant replacement',
+              pattern: 'hello',
+              replacement: 'goodbye',
+              scopes: [AssistantRegexScope.assistant],
+              replaceOnly: true,
+            ),
+          ],
+        );
+        final conversation = Conversation(id: 'conversation-1', title: 'Chat');
+        final timestamp = DateTime(2026, 8, 18, 9, 7, 5);
+        final messages = [
+          message(
+            id: 'user-real',
+            role: 'user',
+            content: 'alpha',
+            timestamp: timestamp,
+          ),
+          message(
+            id: 'user-preset',
+            role: 'user',
+            content: 'alpha preset',
+            timestamp: timestamp,
+            isPreset: true,
+          ),
+          message(
+            id: 'assistant',
+            role: 'assistant',
+            content: 'hello',
+            timestamp: timestamp,
+          ),
+        ];
+
+        final careHistory = ProactiveCareMessageFlow.buildHistory(
+          conversation: conversation,
+          messages: messages,
+          assistant: assistant,
+          applySendRegexes: true,
+        );
+        final decisionHistory = ProactiveCareMessageFlow.buildHistory(
+          conversation: conversation,
+          messages: messages,
+          assistant: assistant,
+          applySendRegexes: false,
+        );
+
+        expect(careHistory, [
+          {'role': 'user', 'content': 'beta\n\n(Tue 26-08-18 09:07:05)'},
+          {'role': 'user', 'content': 'beta preset'},
+          {'role': 'assistant', 'content': 'goodbye'},
+        ]);
+        expect(decisionHistory, [
+          {'role': 'user', 'content': 'alpha\n\n(Tue 26-08-18 09:07:05)'},
+          {'role': 'user', 'content': 'alpha preset'},
+          {'role': 'assistant', 'content': 'hello'},
+        ]);
+      },
+    );
+
+    test('disabled smart time leaves history unchanged', () {
+      final assistant = Assistant(id: 'assistant-1', name: 'Assistant');
+      final conversation = Conversation(id: 'conversation-1', title: 'Chat');
+
+      final history = ProactiveCareMessageFlow.buildHistory(
+        conversation: conversation,
+        messages: [
+          message(
+            id: 'user',
+            role: 'user',
+            content: 'hello',
+            timestamp: DateTime(2026, 8, 18),
+          ),
+        ],
+        assistant: assistant,
+        applySendRegexes: false,
+      );
+
+      expect(history.single['content'], 'hello');
+    });
+
+    test('care send regexes preserve attachment markers', () {
+      final assistant = Assistant(
+        id: 'assistant-1',
+        name: 'Assistant',
+        regexRules: const [
+          AssistantRegex(
+            id: 'user-regex',
+            name: 'User replacement',
+            pattern: 'alpha',
+            replacement: 'beta',
+            scopes: [AssistantRegexScope.user],
+            replaceOnly: true,
+          ),
+        ],
+      );
+      final conversation = Conversation(id: 'conversation-1', title: 'Chat');
+
+      final history = ProactiveCareMessageFlow.buildHistory(
+        conversation: conversation,
+        messages: [
+          message(
+            id: 'user',
+            role: 'user',
+            content:
+                'alpha [image:/tmp/alpha.png] '
+                '[file:/tmp/alpha.pdf|alpha.pdf|application/pdf] omega',
+            timestamp: DateTime(2026, 8, 18),
+          ),
+        ],
+        assistant: assistant,
+        applySendRegexes: true,
+      );
+
+      expect(
+        history.single['content'],
+        'beta [image:/tmp/alpha.png] '
+        '[file:/tmp/alpha.pdf|alpha.pdf|application/pdf] omega',
+      );
+    });
+
+    test(
+      'care request injects world book, recent chats, and time note',
+      () async {
+        const worldBook = WorldBook(
+          id: 'book-1',
+          entries: [
+            WorldBookEntry(
+              id: 'entry-1',
+              content: 'world-book-hit',
+              keywords: ['care-keyword'],
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+            ),
+          ],
+        );
+        await WorldBookStore.save(const [worldBook]);
+        // No assistant-specific selection: exercise the global fallback.
+        await WorldBookStore.setActiveIds(const ['book-1']);
+        final assistant = Assistant(
+          id: 'assistant-1',
+          name: 'Assistant',
+          systemPrompt: 'persona',
+          enableTimeInjection: true,
+          enableRecentChatsReference: true,
+          limitContextMessages: false,
+        );
+
+        final apiMessages = await ProactiveCareMessageFlow.buildCareApiMessages(
+          assistant: assistant,
+          userNickname: 'User',
+          modelId: 'model',
+          history: const [
+            {'role': 'user', 'content': 'history\n\n(Tue 26-08-18 09:07:05)'},
+          ],
+          carePrompt: 'care-keyword',
+          now: DateTime(2026, 8, 18, 10),
+          recentChats: [
+            Conversation(
+              id: 'recent',
+              title: 'Trip',
+              updatedAt: DateTime(2026, 8, 17),
+              assistantId: 'assistant-1',
+              summary: 'Pack tonight',
+            ),
+          ],
+        );
+
+        final system = apiMessages.first['content'] as String;
+        expect(system, startsWith('persona'));
+        expect(system, contains('<recent_chats>'));
+        expect(system, contains('2026-08-17: Trip || Pack tonight'));
+        expect(system, contains('world-book-hit'));
+        expect(system, contains(ChatContextTransforms.timeNote));
+        final careMessage = apiMessages.last['content'] as String;
+        expect(careMessage, contains('care-keyword'));
+        expect(careMessage, contains('2026-08-18T10:00:00.000'));
+        expect(careMessage, isNot(contains('Tue 26-08-18')));
+      },
+    );
+
+    test('assistant world-book selection overrides global fallback', () async {
+      await WorldBookStore.save(const [
+        WorldBook(
+          id: 'global-book',
+          entries: [
+            WorldBookEntry(
+              id: 'global-entry',
+              content: 'global-content',
+              constantActive: true,
+            ),
+          ],
+        ),
+        WorldBook(
+          id: 'assistant-book',
+          entries: [
+            WorldBookEntry(
+              id: 'assistant-entry',
+              content: 'assistant-content',
+              constantActive: true,
+            ),
+          ],
+        ),
+      ]);
+      await WorldBookStore.setActiveIds(const ['global-book']);
+      await WorldBookStore.setActiveIds(const [
+        'assistant-book',
+      ], assistantId: 'assistant-1');
+
+      final messages = await ProactiveCareMessageFlow.buildCareApiMessages(
+        assistant: Assistant(id: 'assistant-1', name: 'Assistant'),
+        userNickname: 'User',
+        modelId: 'model',
+        history: const <Map<String, dynamic>>[],
+        carePrompt: 'send care',
+        now: DateTime(2026, 8, 18, 10),
+      );
+
+      expect(messages.toString(), contains('assistant-content'));
+      expect(messages.toString(), isNot(contains('global-content')));
+    });
+
+    test(
+      'headless care reloads world books changed after cache fill',
+      () async {
+        const staleBook = WorldBook(
+          id: 'stale-book',
+          entries: [
+            WorldBookEntry(
+              id: 'stale-entry',
+              content: 'stale-world-book-content',
+              constantActive: true,
+            ),
+          ],
+        );
+        const cachedFreshBook = WorldBook(
+          id: 'fresh-book',
+          entries: [
+            WorldBookEntry(
+              id: 'fresh-entry',
+              content: 'outdated-fresh-world-book-content',
+              constantActive: true,
+            ),
+          ],
+        );
+        const freshBook = WorldBook(
+          id: 'fresh-book',
+          entries: [
+            WorldBookEntry(
+              id: 'fresh-entry',
+              content: 'fresh-world-book-content',
+              constantActive: true,
+            ),
+          ],
+        );
+        await WorldBookStore.save(const [staleBook, cachedFreshBook]);
+        await WorldBookStore.setActiveIds(const ['stale-book']);
+        expect(await WorldBookStore.getAll(), hasLength(2));
+
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'world_books_v1',
+          jsonEncode(
+            const [staleBook, freshBook].map((book) => book.toJson()).toList(),
+          ),
+        );
+        await prefs.setString(
+          'world_books_active_ids_by_assistant_v1',
+          jsonEncode(const {
+            '__global__': ['fresh-book'],
+          }),
+        );
+
+        final messages = await ProactiveCareMessageFlow.buildCareApiMessages(
+          assistant: Assistant(id: 'assistant-1', name: 'Assistant'),
+          userNickname: 'User',
+          modelId: 'model',
+          history: const <Map<String, dynamic>>[],
+          carePrompt: 'send care',
+          now: DateTime(2026, 8, 18, 10),
+          reloadWorldBooks: true,
+        );
+
+        expect(messages.toString(), contains('fresh-world-book-content'));
+        expect(
+          messages.toString(),
+          isNot(contains('stale-world-book-content')),
+        );
+        expect(
+          messages.toString(),
+          isNot(contains('outdated-fresh-world-book-content')),
+        );
+      },
+    );
+
+    test('care context limit keeps system and newest tail', () async {
+      final assistant = Assistant(
+        id: 'assistant-1',
+        name: 'Assistant',
+        systemPrompt: 'persona',
+        contextMessageSize: 2,
+        limitContextMessages: true,
+      );
+
+      final apiMessages = await ProactiveCareMessageFlow.buildCareApiMessages(
+        assistant: assistant,
+        userNickname: 'User',
+        modelId: 'model',
+        history: const [
+          {'role': 'user', 'content': 'old-user'},
+          {'role': 'assistant', 'content': 'old-assistant'},
+          {'role': 'user', 'content': 'latest-user'},
+          {'role': 'assistant', 'content': 'latest-assistant'},
+        ],
+        carePrompt: 'send care',
+        now: DateTime(2026, 8, 18, 10),
+      );
+
+      expect(apiMessages.map((item) => item['content']), [
+        'persona',
+        'latest-assistant',
+        'send care\n\n当前系统时间：2026-08-18T10:00:00.000',
+      ]);
+    });
+
+    test(
+      'decision adds only smart time context and does not crop history',
+      () async {
+        List<Map<String, dynamic>>? capturedMessages;
+        final assistant = Assistant(
+          id: 'assistant-1',
+          name: 'Assistant',
+          systemPrompt: 'persona-without-world-book',
+          enableTimeInjection: true,
+          contextMessageSize: 1,
+          limitContextMessages: true,
+        );
+
+        final result = await ProactiveCareMessageFlow.decideNextCareTime(
+          config: ProviderConfig.defaultsFor('TestProvider'),
+          modelId: 'test-model',
+          assistant: assistant,
+          userNickname: 'User',
+          history: const [
+            {'role': 'user', 'content': 'first\n\n(Tue 26-08-18 09:00:00)'},
+            {'role': 'assistant', 'content': 'second'},
+            {'role': 'user', 'content': 'third\n\n(Tue 26-08-18 09:05:00)'},
+          ],
+          decisionPrompt: 'decide',
+          sendMessageStream:
+              ({
+                required config,
+                required modelId,
+                required messages,
+                tools,
+                onToolCall,
+                thinkingBudget,
+                temperature,
+                topP,
+                maxTokens,
+                stream = true,
+                requestId,
+              }) {
+                capturedMessages = messages;
+                return Stream<ChatStreamChunk>.value(
+                  ChatStreamChunk(
+                    content: '',
+                    isDone: false,
+                    totalTokens: 0,
+                    toolCalls: [
+                      ToolCallInfo(
+                        id: 'keep',
+                        name: ProactiveCareDecisionTools.keepTime,
+                        arguments: <String, dynamic>{},
+                      ),
+                    ],
+                  ),
+                );
+              },
+        );
+
+        expect(result, isNull);
+        final captured = capturedMessages!;
+        expect(captured.first['role'], 'system');
+        expect(
+          captured.first['content'],
+          contains(ChatContextTransforms.timeNote),
+        );
+        expect(captured.any((item) => item['content'] == 'second'), isTrue);
+        expect(
+          captured.where(
+            (item) =>
+                (item['content'] ?? '').toString().contains('Tue 26-08-18'),
+          ),
+          hasLength(2),
+        );
+        expect(captured.toString(), isNot(contains('world-book-hit')));
+        expect(captured.toString(), isNot(contains('<recent_chats>')));
+      },
+    );
+  });
+}

--- a/test/core/services/proactive_care_headless_store_test.dart
+++ b/test/core/services/proactive_care_headless_store_test.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/services/proactive_care_message_flow.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+void main() {
+  late Directory tempDirectory;
+  late Future<String> Function() originalPathProvider;
+
+  setUp(() async {
+    await ProactiveCareHeadlessChatStore.close();
+    originalPathProvider = ProactiveCareHeadlessChatStore.dataDirPathProvider;
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'cuplivo-proactive-headless-',
+    );
+    ProactiveCareHeadlessChatStore.dataDirPathProvider = () async =>
+        tempDirectory.path;
+  });
+
+  tearDown(() async {
+    await ProactiveCareHeadlessChatStore.close();
+    ProactiveCareHeadlessChatStore.dataDirPathProvider = originalPathProvider;
+    if (await tempDirectory.exists()) {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+
+  test(
+    'recent references match foreground filters and map preset messages',
+    () async {
+      final database = sqlite.sqlite3.open(
+        p.join(tempDirectory.path, 'kelivo.sqlite'),
+      );
+      database.execute('''
+CREATE TABLE conversation_rows (
+  id TEXT NOT NULL PRIMARY KEY,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  is_pinned INTEGER NOT NULL DEFAULT 0,
+  assistant_id TEXT NULL,
+  truncate_index INTEGER NOT NULL DEFAULT -1,
+  version_selections_json TEXT NOT NULL DEFAULT '{}',
+  summary TEXT NULL,
+  last_summarized_message_count INTEGER NOT NULL DEFAULT 0,
+  parent_conversation_id TEXT NULL,
+  conversation_kind TEXT NOT NULL DEFAULT 'normal'
+);
+CREATE TABLE message_rows (
+  id TEXT NOT NULL PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  model_id TEXT NULL,
+  provider_id TEXT NULL,
+  total_tokens INTEGER NULL,
+  is_streaming INTEGER NOT NULL DEFAULT 0,
+  group_id TEXT NULL,
+  subgroup_id TEXT NULL,
+  version INTEGER NOT NULL DEFAULT 0,
+  message_order INTEGER NOT NULL,
+  is_preset INTEGER NOT NULL DEFAULT 0
+);
+''');
+
+      const baseTimestamp = 1787011200;
+
+      void insertConversation({
+        required String id,
+        required String title,
+        required int updatedAt,
+        String assistantId = 'assistant-1',
+        String kind = Conversation.kindNormal,
+        String? summary,
+      }) {
+        database.execute(
+          'INSERT INTO conversation_rows '
+          '(id, title, created_at, updated_at, assistant_id, summary, '
+          'conversation_kind) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          [id, title, baseTimestamp, updatedAt, assistantId, summary, kind],
+        );
+      }
+
+      for (var index = 0; index < 12; index++) {
+        insertConversation(
+          id: 'chat-$index',
+          title: 'Chat $index',
+          updatedAt: baseTimestamp + index,
+          summary: 'Summary $index',
+        );
+      }
+      insertConversation(
+        id: 'current',
+        title: 'Current',
+        updatedAt: baseTimestamp + 30,
+      );
+      insertConversation(
+        id: 'group',
+        title: 'Group',
+        updatedAt: baseTimestamp + 40,
+        kind: Conversation.kindGroup,
+      );
+      insertConversation(
+        id: 'other-assistant',
+        title: 'Other',
+        updatedAt: baseTimestamp + 50,
+        assistantId: 'assistant-2',
+      );
+      insertConversation(
+        id: 'empty-title',
+        title: '   ',
+        updatedAt: baseTimestamp + 25,
+      );
+      database.execute(
+        'INSERT INTO message_rows '
+        '(id, conversation_id, role, content, timestamp, message_order, '
+        'is_preset) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [
+          'preset-message',
+          'current',
+          'user',
+          'preset content',
+          baseTimestamp,
+          0,
+          1,
+        ],
+      );
+      database.close();
+
+      final references =
+          await ProactiveCareHeadlessChatStore.loadRecentChatReferencesFor(
+            'assistant-1',
+            currentConversationId: 'current',
+          );
+
+      expect(references.map((conversation) => conversation.id), [
+        'chat-11',
+        'chat-10',
+        'chat-9',
+        'chat-8',
+        'chat-7',
+        'chat-6',
+        'chat-5',
+        'chat-4',
+        'chat-3',
+        'chat-2',
+      ]);
+      expect(references.first.summary, 'Summary 11');
+
+      final recent =
+          await ProactiveCareHeadlessChatStore.loadRecentConversationFor(
+            'assistant-1',
+          );
+      expect(recent.conversation?.id, 'current');
+      expect(recent.messages.single.isPreset, isTrue);
+    },
+  );
+}

--- a/test/core/services/world_book_prompt_injector_test.dart
+++ b/test/core/services/world_book_prompt_injector_test.dart
@@ -1,0 +1,170 @@
+import 'package:Cuplivo/core/models/world_book.dart';
+import 'package:Cuplivo/core/services/world_book_prompt_injector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+WorldBookEntry entry({
+  required String id,
+  required String content,
+  required WorldBookInjectionPosition position,
+  int priority = 0,
+  int injectDepth = 1,
+  WorldBookInjectionRole role = WorldBookInjectionRole.user,
+  List<String> keywords = const <String>[],
+  bool useRegex = false,
+  bool constantActive = true,
+  bool enabled = true,
+}) {
+  return WorldBookEntry(
+    id: id,
+    content: content,
+    position: position,
+    priority: priority,
+    injectDepth: injectDepth,
+    role: role,
+    keywords: keywords,
+    useRegex: useRegex,
+    constantActive: constantActive,
+    enabled: enabled,
+  );
+}
+
+void main() {
+  group('WorldBookPromptInjector', () {
+    test('preserves priority, roles, and all injection positions', () {
+      final messages = <Map<String, dynamic>>[
+        {'role': 'system', 'content': 'persona'},
+        {'role': 'user', 'content': 'older context'},
+        {'role': 'assistant', 'content': 'reply'},
+        {'role': 'user', 'content': 'care trigger'},
+      ];
+      final book = WorldBook(
+        id: 'active',
+        entries: [
+          entry(
+            id: 'before-low',
+            content: 'before-low',
+            position: WorldBookInjectionPosition.beforeSystemPrompt,
+          ),
+          entry(
+            id: 'before-high',
+            content: 'before-high',
+            position: WorldBookInjectionPosition.beforeSystemPrompt,
+            priority: 10,
+          ),
+          entry(
+            id: 'after',
+            content: 'after',
+            position: WorldBookInjectionPosition.afterSystemPrompt,
+          ),
+          entry(
+            id: 'top',
+            content: 'top',
+            position: WorldBookInjectionPosition.topOfChat,
+          ),
+          entry(
+            id: 'bottom',
+            content: 'bottom',
+            position: WorldBookInjectionPosition.bottomOfChat,
+            role: WorldBookInjectionRole.assistant,
+          ),
+          entry(
+            id: 'depth',
+            content: 'depth',
+            position: WorldBookInjectionPosition.atDepth,
+          ),
+        ],
+      );
+
+      WorldBookPromptInjector.inject(
+        messages: messages,
+        books: [book],
+        activeBookIds: const ['active'],
+      );
+
+      expect(
+        messages.first['content'],
+        'before-high\nbefore-low\npersona\nafter',
+      );
+      expect(messages.map((message) => message['role']), [
+        'system',
+        'user',
+        'user',
+        'assistant',
+        'assistant',
+        'user',
+        'user',
+      ]);
+      expect(messages[1]['content'], '<system>\ntop\n</system>');
+      expect(messages[4]['content'], 'bottom');
+      expect(messages[5]['content'], '<system>\ndepth\n</system>');
+      expect(messages.last['content'], 'care trigger');
+    });
+
+    test('honors active books, enabled flags, and keyword regex matching', () {
+      final messages = <Map<String, dynamic>>[
+        {'role': 'user', 'content': 'The care prompt mentions ALPHA-42.'},
+      ];
+      final books = [
+        WorldBook(
+          id: 'active',
+          entries: [
+            entry(
+              id: 'keyword',
+              content: 'keyword-hit',
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+              keywords: const ['alpha-42'],
+              constantActive: false,
+            ),
+            entry(
+              id: 'regex',
+              content: 'regex-hit',
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+              keywords: const [r'ALPHA-\d+'],
+              useRegex: true,
+              constantActive: false,
+            ),
+            entry(
+              id: 'disabled-entry',
+              content: 'must-not-appear',
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+              enabled: false,
+            ),
+          ],
+        ),
+        WorldBook(
+          id: 'inactive',
+          entries: [
+            entry(
+              id: 'inactive-entry',
+              content: 'inactive-book-content',
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+            ),
+          ],
+        ),
+        WorldBook(
+          id: 'disabled-book',
+          enabled: false,
+          entries: [
+            entry(
+              id: 'disabled-book-entry',
+              content: 'disabled-book-content',
+              position: WorldBookInjectionPosition.afterSystemPrompt,
+            ),
+          ],
+        ),
+      ];
+
+      WorldBookPromptInjector.inject(
+        messages: messages,
+        books: books,
+        activeBookIds: const ['active', 'disabled-book'],
+      );
+
+      expect(messages.first['role'], 'system');
+      expect(messages.first['content'], 'keyword-hit\nregex-hit');
+      expect(messages.toString(), isNot(contains('must-not-appear')));
+      expect(messages.toString(), isNot(contains('inactive-book-content')));
+      expect(messages.toString(), isNot(contains('disabled-book-content')));
+    });
+  });
+}


### PR DESCRIPTION
## 变更说明

- 统一普通聊天与「Ta 的来信」可复用的上下文处理逻辑，避免时间注入、世界书和上下文裁剪行为漂移。
- 来信生成加入世界书、智能时间、近期聊天引用、发送时正则和上下文条数限制。
- 时间决策仅加入智能时间，继续使用完整历史，不读取世界书、近期聊天或发送时正则。
- 前台与 Android 后台闹钟链路使用一致规则；后台 SQLite 查询补齐预设消息字段与近期普通会话筛选。

## 审核问题修复

- 后台闹钟每次生成来信前调用 SharedPreferences.reload() 并绕过隔离区静态缓存，确保前台后续编辑、切换或停用的世界书能被下一次后台任务读取。
- 用户作用域的发送时正则只处理正文片段，图片与文件附件标记保持原样，避免路径、文件名和 MIME 类型被正则误改。
- 新增对应回归测试，覆盖世界书内容和启用选择同时变化，以及图片/文件标记保护。

## 测试

- [x] dart format（全部变更 Dart 文件）
- [x] 相关 flutter test：66 项通过
- [x] dart analyze --fatal-infos lib test：无问题
- [x] 分支已 rebase 到最新 origin/master

相关测试覆盖主动关怀上下文与决策、后台存储、闹钟服务、世界书注入、普通消息构建和 OCR 模式。

## 兼容性

- 不修改数据库结构、助手字段、持久化格式、用户设置、ARB 或生成代码。
- 不增加技能、工具调用、搜索/MCP 能力或历史附件处理。

## 手动验证边界

- [ ] Android 前台存活时触发来信
- [ ] Android 进程被系统结束后触发来信

当前环境未连接 Android 设备，因此以上两项真机验证未执行；通知投递与系统后台调度仍需合并前在 Android 设备上确认。

## Pre-launch Checklist

- [x] 已补充与需求和缺陷对应的测试
- [x] 已完成格式化、相关测试和 fatal-infos 静态分析
- [x] 已自审可维护性、性能、安全性、风格一致性与兼容性
- [x] 未包含无关改动、密钥、构建产物或生成文件
