### PR TITLE
feat：支持助手与会话级工作目录

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -30,6 +30,8 @@ class ConversationRows extends Table {
   /// 'normal' | 'group' — group public transcripts use kind=group.
   TextColumn get conversationKind =>
       text().withDefault(const Constant('normal'))();
+  TextColumn get workspaceDirectoryOverridesJson =>
+      text().withDefault(const Constant('{}'))();
 
   @override
   Set<Column<Object>> get primaryKey => {id};
@@ -135,6 +137,8 @@ class AssistantRows extends Table {
   BoolColumn get workspaceEnabled =>
       boolean().withDefault(const Constant(false))();
   TextColumn get workspaceId => text().nullable()();
+  TextColumn get workspaceDefaultDirectoriesJson =>
+      text().withDefault(const Constant('{}'))();
   TextColumn get regexRulesJson => text().withDefault(const Constant('[]'))();
 
   // --- Proactive Care ("Ta的来信") ---
@@ -435,7 +439,7 @@ class AppDatabase extends _$AppDatabase {
   /// Repair incomplete upgrades where user_version already advanced but some
   /// ALTER TABLE / CREATE TABLE steps were skipped/failed (silent catch).
   ///
-  /// Covers every column/table added by the v5–v13/v16–v17 migrations that are
+  /// Covers every column/table added by the v5–v20 migrations that are
   /// wrapped in silent try/catch — missing these makes inserts crash with
   /// "table X has no column named Y". Runs in beforeOpen (rescues existing
   /// broken DBs whose user_version already passed the failed step) and at the
@@ -445,7 +449,7 @@ class AppDatabase extends _$AppDatabase {
   /// this heal set and the regression tests in the same change. See AGENTS.md
   /// §3.20.
   Future<void> _healSchemaIfNeeded() async {
-    // --- assistant_rows (v5–v12) ---
+    // --- assistant_rows (v5–v20) ---
     await _ensureColumn(
       'assistant_rows',
       'memory_mode',
@@ -530,6 +534,11 @@ class AppDatabase extends _$AppDatabase {
       'workspace_id',
       'ALTER TABLE assistant_rows ADD COLUMN workspace_id TEXT NULL',
     );
+    await _ensureColumn(
+      'assistant_rows',
+      'workspace_default_directories_json',
+      "ALTER TABLE assistant_rows ADD COLUMN workspace_default_directories_json TEXT NOT NULL DEFAULT '{}'",
+    );
 
     // --- message_rows ---
     await _ensureColumn(
@@ -579,6 +588,11 @@ class AppDatabase extends _$AppDatabase {
       'conversation_rows',
       'conversation_kind',
       "ALTER TABLE conversation_rows ADD COLUMN conversation_kind TEXT NOT NULL DEFAULT 'normal'",
+    );
+    await _ensureColumn(
+      'conversation_rows',
+      'workspace_directory_overrides_json',
+      "ALTER TABLE conversation_rows ADD COLUMN workspace_directory_overrides_json TEXT NOT NULL DEFAULT '{}'",
     );
     await customStatement(
       "UPDATE conversation_rows SET conversation_kind = 'normal' "
@@ -838,12 +852,35 @@ class AppDatabase extends _$AppDatabase {
         } catch (_) {}
       }
       if (from < 20) {
-        // Message reply citation (issue #312, docs/adr/0042). Nullable TEXT —
-        // no backfill, non-reply rows stay NULL.
+        // v20 combines reply citations with workspace working-directory
+        // preferences. Pre-existing v20 variants are completed by the schema
+        // heal below before Drift reads or writes them.
         try {
           await migrator.addColumn(messageRows, messageRows.quoteJson);
-        } catch (_) {
-          // The column may already exist (migration replay / partial retry).
+        } catch (error) {
+          debugPrint('v20 migration could not add reply citations: $error');
+        }
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.workspaceDefaultDirectoriesJson,
+          );
+        } catch (error) {
+          debugPrint(
+            'v20 migration could not add assistant working directories: '
+            '$error',
+          );
+        }
+        try {
+          await migrator.addColumn(
+            conversationRows,
+            conversationRows.workspaceDirectoryOverridesJson,
+          );
+        } catch (error) {
+          debugPrint(
+            'v20 migration could not add conversation working directories: '
+            '$error',
+          );
         }
       }
       // Final pass: heal any column/table that still did not land.

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -139,6 +139,8 @@ class AssistantRows extends Table {
   TextColumn get workspaceId => text().nullable()();
   TextColumn get workspaceDefaultDirectoriesJson =>
       text().withDefault(const Constant('{}'))();
+  BoolColumn get autoLoadAgentsMd =>
+      boolean().withDefault(const Constant(true))();
   TextColumn get regexRulesJson => text().withDefault(const Constant('[]'))();
 
   // --- Proactive Care ("Ta的来信") ---
@@ -386,7 +388,7 @@ class AppDatabase extends _$AppDatabase {
   // self-heal below repairs such gaps on every open; without it the gap is
   // permanent because later upgrades skip the failed step's `from < N` block.
   // See docs/adr/0019-schema-self-heal.md.
-  int get schemaVersion => 20;
+  int get schemaVersion => 21;
 
   /// Whether [table] has a physical column named [column] (sqlite name).
   Future<bool> _hasColumn(String table, String column) async {
@@ -439,7 +441,7 @@ class AppDatabase extends _$AppDatabase {
   /// Repair incomplete upgrades where user_version already advanced but some
   /// ALTER TABLE / CREATE TABLE steps were skipped/failed (silent catch).
   ///
-  /// Covers every column/table added by the v5–v20 migrations that are
+  /// Covers every column/table added by the v5–v21 migrations that are
   /// wrapped in silent try/catch — missing these makes inserts crash with
   /// "table X has no column named Y". Runs in beforeOpen (rescues existing
   /// broken DBs whose user_version already passed the failed step) and at the
@@ -449,7 +451,7 @@ class AppDatabase extends _$AppDatabase {
   /// this heal set and the regression tests in the same change. See AGENTS.md
   /// §3.20.
   Future<void> _healSchemaIfNeeded() async {
-    // --- assistant_rows (v5–v20) ---
+    // --- assistant_rows (v5–v21) ---
     await _ensureColumn(
       'assistant_rows',
       'memory_mode',
@@ -538,6 +540,11 @@ class AppDatabase extends _$AppDatabase {
       'assistant_rows',
       'workspace_default_directories_json',
       "ALTER TABLE assistant_rows ADD COLUMN workspace_default_directories_json TEXT NOT NULL DEFAULT '{}'",
+    );
+    await _ensureColumn(
+      'assistant_rows',
+      'auto_load_agents_md',
+      'ALTER TABLE assistant_rows ADD COLUMN auto_load_agents_md INTEGER NOT NULL DEFAULT 1',
     );
 
     // --- message_rows ---
@@ -879,6 +886,19 @@ class AppDatabase extends _$AppDatabase {
         } catch (error) {
           debugPrint(
             'v20 migration could not add conversation working directories: '
+            '$error',
+          );
+        }
+      }
+      if (from < 21) {
+        try {
+          await migrator.addColumn(
+            assistantRows,
+            assistantRows.autoLoadAgentsMd,
+          );
+        } catch (error) {
+          debugPrint(
+            'v21 migration could not add automatic AGENTS.md loading: '
             '$error',
           );
         }

--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -388,7 +388,7 @@ class AppDatabase extends _$AppDatabase {
   // self-heal below repairs such gaps on every open; without it the gap is
   // permanent because later upgrades skip the failed step's `from < N` block.
   // See docs/adr/0019-schema-self-heal.md.
-  int get schemaVersion => 21;
+  int get schemaVersion => 20;
 
   /// Whether [table] has a physical column named [column] (sqlite name).
   Future<bool> _hasColumn(String table, String column) async {
@@ -441,7 +441,7 @@ class AppDatabase extends _$AppDatabase {
   /// Repair incomplete upgrades where user_version already advanced but some
   /// ALTER TABLE / CREATE TABLE steps were skipped/failed (silent catch).
   ///
-  /// Covers every column/table added by the v5–v21 migrations that are
+  /// Covers every column/table added by the v5–v20 migrations that are
   /// wrapped in silent try/catch — missing these makes inserts crash with
   /// "table X has no column named Y". Runs in beforeOpen (rescues existing
   /// broken DBs whose user_version already passed the failed step) and at the
@@ -451,7 +451,7 @@ class AppDatabase extends _$AppDatabase {
   /// this heal set and the regression tests in the same change. See AGENTS.md
   /// §3.20.
   Future<void> _healSchemaIfNeeded() async {
-    // --- assistant_rows (v5–v21) ---
+    // --- assistant_rows (v5–v20) ---
     await _ensureColumn(
       'assistant_rows',
       'memory_mode',
@@ -889,8 +889,6 @@ class AppDatabase extends _$AppDatabase {
             '$error',
           );
         }
-      }
-      if (from < 21) {
         try {
           await migrator.addColumn(
             assistantRows,
@@ -898,7 +896,7 @@ class AppDatabase extends _$AppDatabase {
           );
         } catch (error) {
           debugPrint(
-            'v21 migration could not add automatic AGENTS.md loading: '
+            'v20 migration could not add automatic AGENTS.md loading: '
             '$error',
           );
         }

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -157,6 +157,18 @@ class $ConversationRowsTable extends ConversationRows
     requiredDuringInsert: false,
     defaultValue: const Constant('normal'),
   );
+  static const VerificationMeta _workspaceDirectoryOverridesJsonMeta =
+      const VerificationMeta('workspaceDirectoryOverridesJson');
+  @override
+  late final GeneratedColumn<String> workspaceDirectoryOverridesJson =
+      GeneratedColumn<String>(
+        'workspace_directory_overrides_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('{}'),
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -172,6 +184,7 @@ class $ConversationRowsTable extends ConversationRows
     chatSuggestionsJson,
     parentConversationId,
     conversationKind,
+    workspaceDirectoryOverridesJson,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -289,6 +302,15 @@ class $ConversationRowsTable extends ConversationRows
         ),
       );
     }
+    if (data.containsKey('workspace_directory_overrides_json')) {
+      context.handle(
+        _workspaceDirectoryOverridesJsonMeta,
+        workspaceDirectoryOverridesJson.isAcceptableOrUnknown(
+          data['workspace_directory_overrides_json']!,
+          _workspaceDirectoryOverridesJsonMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -350,6 +372,10 @@ class $ConversationRowsTable extends ConversationRows
         DriftSqlType.string,
         data['${effectivePrefix}conversation_kind'],
       )!,
+      workspaceDirectoryOverridesJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}workspace_directory_overrides_json'],
+      )!,
     );
   }
 
@@ -375,6 +401,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
 
   /// 'normal' | 'group' — group public transcripts use kind=group.
   final String conversationKind;
+  final String workspaceDirectoryOverridesJson;
   const ConversationRow({
     required this.id,
     required this.title,
@@ -389,6 +416,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     required this.chatSuggestionsJson,
     this.parentConversationId,
     required this.conversationKind,
+    required this.workspaceDirectoryOverridesJson,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -414,6 +442,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       map['parent_conversation_id'] = Variable<String>(parentConversationId);
     }
     map['conversation_kind'] = Variable<String>(conversationKind);
+    map['workspace_directory_overrides_json'] = Variable<String>(
+      workspaceDirectoryOverridesJson,
+    );
     return map;
   }
 
@@ -438,6 +469,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ? const Value.absent()
           : Value(parentConversationId),
       conversationKind: Value(conversationKind),
+      workspaceDirectoryOverridesJson: Value(workspaceDirectoryOverridesJson),
     );
   }
 
@@ -468,6 +500,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
         json['parentConversationId'],
       ),
       conversationKind: serializer.fromJson<String>(json['conversationKind']),
+      workspaceDirectoryOverridesJson: serializer.fromJson<String>(
+        json['workspaceDirectoryOverridesJson'],
+      ),
     );
   }
   @override
@@ -489,6 +524,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       'chatSuggestionsJson': serializer.toJson<String>(chatSuggestionsJson),
       'parentConversationId': serializer.toJson<String?>(parentConversationId),
       'conversationKind': serializer.toJson<String>(conversationKind),
+      'workspaceDirectoryOverridesJson': serializer.toJson<String>(
+        workspaceDirectoryOverridesJson,
+      ),
     };
   }
 
@@ -506,6 +544,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     String? chatSuggestionsJson,
     Value<String?> parentConversationId = const Value.absent(),
     String? conversationKind,
+    String? workspaceDirectoryOverridesJson,
   }) => ConversationRow(
     id: id ?? this.id,
     title: title ?? this.title,
@@ -523,6 +562,8 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
         ? parentConversationId.value
         : this.parentConversationId,
     conversationKind: conversationKind ?? this.conversationKind,
+    workspaceDirectoryOverridesJson:
+        workspaceDirectoryOverridesJson ?? this.workspaceDirectoryOverridesJson,
   );
   ConversationRow copyWithCompanion(ConversationRowsCompanion data) {
     return ConversationRow(
@@ -553,6 +594,10 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       conversationKind: data.conversationKind.present
           ? data.conversationKind.value
           : this.conversationKind,
+      workspaceDirectoryOverridesJson:
+          data.workspaceDirectoryOverridesJson.present
+          ? data.workspaceDirectoryOverridesJson.value
+          : this.workspaceDirectoryOverridesJson,
     );
   }
 
@@ -571,7 +616,10 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ..write('lastSummarizedMessageCount: $lastSummarizedMessageCount, ')
           ..write('chatSuggestionsJson: $chatSuggestionsJson, ')
           ..write('parentConversationId: $parentConversationId, ')
-          ..write('conversationKind: $conversationKind')
+          ..write('conversationKind: $conversationKind, ')
+          ..write(
+            'workspaceDirectoryOverridesJson: $workspaceDirectoryOverridesJson',
+          )
           ..write(')'))
         .toString();
   }
@@ -591,6 +639,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     chatSuggestionsJson,
     parentConversationId,
     conversationKind,
+    workspaceDirectoryOverridesJson,
   );
   @override
   bool operator ==(Object other) =>
@@ -608,7 +657,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           other.lastSummarizedMessageCount == this.lastSummarizedMessageCount &&
           other.chatSuggestionsJson == this.chatSuggestionsJson &&
           other.parentConversationId == this.parentConversationId &&
-          other.conversationKind == this.conversationKind);
+          other.conversationKind == this.conversationKind &&
+          other.workspaceDirectoryOverridesJson ==
+              this.workspaceDirectoryOverridesJson);
 }
 
 class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
@@ -625,6 +676,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
   final Value<String> chatSuggestionsJson;
   final Value<String?> parentConversationId;
   final Value<String> conversationKind;
+  final Value<String> workspaceDirectoryOverridesJson;
   final Value<int> rowid;
   const ConversationRowsCompanion({
     this.id = const Value.absent(),
@@ -640,6 +692,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     this.chatSuggestionsJson = const Value.absent(),
     this.parentConversationId = const Value.absent(),
     this.conversationKind = const Value.absent(),
+    this.workspaceDirectoryOverridesJson = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ConversationRowsCompanion.insert({
@@ -656,6 +709,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     this.chatSuggestionsJson = const Value.absent(),
     this.parentConversationId = const Value.absent(),
     this.conversationKind = const Value.absent(),
+    this.workspaceDirectoryOverridesJson = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        title = Value(title),
@@ -675,6 +729,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     Expression<String>? chatSuggestionsJson,
     Expression<String>? parentConversationId,
     Expression<String>? conversationKind,
+    Expression<String>? workspaceDirectoryOverridesJson,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -695,6 +750,8 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
       if (parentConversationId != null)
         'parent_conversation_id': parentConversationId,
       if (conversationKind != null) 'conversation_kind': conversationKind,
+      if (workspaceDirectoryOverridesJson != null)
+        'workspace_directory_overrides_json': workspaceDirectoryOverridesJson,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -713,6 +770,7 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     Value<String>? chatSuggestionsJson,
     Value<String?>? parentConversationId,
     Value<String>? conversationKind,
+    Value<String>? workspaceDirectoryOverridesJson,
     Value<int>? rowid,
   }) {
     return ConversationRowsCompanion(
@@ -731,6 +789,9 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
       chatSuggestionsJson: chatSuggestionsJson ?? this.chatSuggestionsJson,
       parentConversationId: parentConversationId ?? this.parentConversationId,
       conversationKind: conversationKind ?? this.conversationKind,
+      workspaceDirectoryOverridesJson:
+          workspaceDirectoryOverridesJson ??
+          this.workspaceDirectoryOverridesJson,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -785,6 +846,11 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
     if (conversationKind.present) {
       map['conversation_kind'] = Variable<String>(conversationKind.value);
     }
+    if (workspaceDirectoryOverridesJson.present) {
+      map['workspace_directory_overrides_json'] = Variable<String>(
+        workspaceDirectoryOverridesJson.value,
+      );
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -807,6 +873,9 @@ class ConversationRowsCompanion extends UpdateCompanion<ConversationRow> {
           ..write('chatSuggestionsJson: $chatSuggestionsJson, ')
           ..write('parentConversationId: $parentConversationId, ')
           ..write('conversationKind: $conversationKind, ')
+          ..write(
+            'workspaceDirectoryOverridesJson: $workspaceDirectoryOverridesJson, ',
+          )
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -2777,6 +2846,18 @@ class $AssistantRowsTable extends AssistantRows
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _workspaceDefaultDirectoriesJsonMeta =
+      const VerificationMeta('workspaceDefaultDirectoriesJson');
+  @override
+  late final GeneratedColumn<String> workspaceDefaultDirectoriesJson =
+      GeneratedColumn<String>(
+        'workspace_default_directories_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('{}'),
+      );
   static const VerificationMeta _regexRulesJsonMeta = const VerificationMeta(
     'regexRulesJson',
   );
@@ -3064,6 +3145,7 @@ class $AssistantRowsTable extends AssistantRows
     skillIdsJson,
     workspaceEnabled,
     workspaceId,
+    workspaceDefaultDirectoriesJson,
     regexRulesJson,
     enableProactiveCare,
     proactiveCareNextMessageAt,
@@ -3312,6 +3394,15 @@ class $AssistantRowsTable extends AssistantRows
         workspaceId.isAcceptableOrUnknown(
           data['workspace_id']!,
           _workspaceIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('workspace_default_directories_json')) {
+      context.handle(
+        _workspaceDefaultDirectoriesJsonMeta,
+        workspaceDefaultDirectoriesJson.isAcceptableOrUnknown(
+          data['workspace_default_directories_json']!,
+          _workspaceDefaultDirectoriesJsonMeta,
         ),
       );
     }
@@ -3599,6 +3690,10 @@ class $AssistantRowsTable extends AssistantRows
         DriftSqlType.string,
         data['${effectivePrefix}workspace_id'],
       ),
+      workspaceDefaultDirectoriesJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}workspace_default_directories_json'],
+      )!,
       regexRulesJson: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}regex_rules_json'],
@@ -3719,6 +3814,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
   final String skillIdsJson;
   final bool workspaceEnabled;
   final String? workspaceId;
+  final String workspaceDefaultDirectoriesJson;
   final String regexRulesJson;
   final bool enableProactiveCare;
   final DateTime? proactiveCareNextMessageAt;
@@ -3767,6 +3863,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     required this.skillIdsJson,
     required this.workspaceEnabled,
     this.workspaceId,
+    required this.workspaceDefaultDirectoriesJson,
     required this.regexRulesJson,
     required this.enableProactiveCare,
     this.proactiveCareNextMessageAt,
@@ -3836,6 +3933,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     if (!nullToAbsent || workspaceId != null) {
       map['workspace_id'] = Variable<String>(workspaceId);
     }
+    map['workspace_default_directories_json'] = Variable<String>(
+      workspaceDefaultDirectoriesJson,
+    );
     map['regex_rules_json'] = Variable<String>(regexRulesJson);
     map['enable_proactive_care'] = Variable<bool>(enableProactiveCare);
     if (!nullToAbsent || proactiveCareNextMessageAt != null) {
@@ -3918,6 +4018,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       workspaceId: workspaceId == null && nullToAbsent
           ? const Value.absent()
           : Value(workspaceId),
+      workspaceDefaultDirectoriesJson: Value(workspaceDefaultDirectoriesJson),
       regexRulesJson: Value(regexRulesJson),
       enableProactiveCare: Value(enableProactiveCare),
       proactiveCareNextMessageAt:
@@ -3987,6 +4088,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       skillIdsJson: serializer.fromJson<String>(json['skillIdsJson']),
       workspaceEnabled: serializer.fromJson<bool>(json['workspaceEnabled']),
       workspaceId: serializer.fromJson<String?>(json['workspaceId']),
+      workspaceDefaultDirectoriesJson: serializer.fromJson<String>(
+        json['workspaceDefaultDirectoriesJson'],
+      ),
       regexRulesJson: serializer.fromJson<String>(json['regexRulesJson']),
       enableProactiveCare: serializer.fromJson<bool>(
         json['enableProactiveCare'],
@@ -4058,6 +4162,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       'skillIdsJson': serializer.toJson<String>(skillIdsJson),
       'workspaceEnabled': serializer.toJson<bool>(workspaceEnabled),
       'workspaceId': serializer.toJson<String?>(workspaceId),
+      'workspaceDefaultDirectoriesJson': serializer.toJson<String>(
+        workspaceDefaultDirectoriesJson,
+      ),
       'regexRulesJson': serializer.toJson<String>(regexRulesJson),
       'enableProactiveCare': serializer.toJson<bool>(enableProactiveCare),
       'proactiveCareNextMessageAt': serializer.toJson<DateTime?>(
@@ -4117,6 +4224,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     String? skillIdsJson,
     bool? workspaceEnabled,
     Value<String?> workspaceId = const Value.absent(),
+    String? workspaceDefaultDirectoriesJson,
     String? regexRulesJson,
     bool? enableProactiveCare,
     Value<DateTime?> proactiveCareNextMessageAt = const Value.absent(),
@@ -4169,6 +4277,8 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     skillIdsJson: skillIdsJson ?? this.skillIdsJson,
     workspaceEnabled: workspaceEnabled ?? this.workspaceEnabled,
     workspaceId: workspaceId.present ? workspaceId.value : this.workspaceId,
+    workspaceDefaultDirectoriesJson:
+        workspaceDefaultDirectoriesJson ?? this.workspaceDefaultDirectoriesJson,
     regexRulesJson: regexRulesJson ?? this.regexRulesJson,
     enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
     proactiveCareNextMessageAt: proactiveCareNextMessageAt.present
@@ -4268,6 +4378,10 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       workspaceId: data.workspaceId.present
           ? data.workspaceId.value
           : this.workspaceId,
+      workspaceDefaultDirectoriesJson:
+          data.workspaceDefaultDirectoriesJson.present
+          ? data.workspaceDefaultDirectoriesJson.value
+          : this.workspaceDefaultDirectoriesJson,
       regexRulesJson: data.regexRulesJson.present
           ? data.regexRulesJson.value
           : this.regexRulesJson,
@@ -4350,6 +4464,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           ..write('skillIdsJson: $skillIdsJson, ')
           ..write('workspaceEnabled: $workspaceEnabled, ')
           ..write('workspaceId: $workspaceId, ')
+          ..write(
+            'workspaceDefaultDirectoriesJson: $workspaceDefaultDirectoriesJson, ',
+          )
           ..write('regexRulesJson: $regexRulesJson, ')
           ..write('enableProactiveCare: $enableProactiveCare, ')
           ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
@@ -4405,6 +4522,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     skillIdsJson,
     workspaceEnabled,
     workspaceId,
+    workspaceDefaultDirectoriesJson,
     regexRulesJson,
     enableProactiveCare,
     proactiveCareNextMessageAt,
@@ -4457,6 +4575,8 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           other.skillIdsJson == this.skillIdsJson &&
           other.workspaceEnabled == this.workspaceEnabled &&
           other.workspaceId == this.workspaceId &&
+          other.workspaceDefaultDirectoriesJson ==
+              this.workspaceDefaultDirectoriesJson &&
           other.regexRulesJson == this.regexRulesJson &&
           other.enableProactiveCare == this.enableProactiveCare &&
           other.proactiveCareNextMessageAt == this.proactiveCareNextMessageAt &&
@@ -4509,6 +4629,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
   final Value<String> skillIdsJson;
   final Value<bool> workspaceEnabled;
   final Value<String?> workspaceId;
+  final Value<String> workspaceDefaultDirectoriesJson;
   final Value<String> regexRulesJson;
   final Value<bool> enableProactiveCare;
   final Value<DateTime?> proactiveCareNextMessageAt;
@@ -4558,6 +4679,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.skillIdsJson = const Value.absent(),
     this.workspaceEnabled = const Value.absent(),
     this.workspaceId = const Value.absent(),
+    this.workspaceDefaultDirectoriesJson = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
     this.enableProactiveCare = const Value.absent(),
     this.proactiveCareNextMessageAt = const Value.absent(),
@@ -4608,6 +4730,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.skillIdsJson = const Value.absent(),
     this.workspaceEnabled = const Value.absent(),
     this.workspaceId = const Value.absent(),
+    this.workspaceDefaultDirectoriesJson = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
     this.enableProactiveCare = const Value.absent(),
     this.proactiveCareNextMessageAt = const Value.absent(),
@@ -4662,6 +4785,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Expression<String>? skillIdsJson,
     Expression<bool>? workspaceEnabled,
     Expression<String>? workspaceId,
+    Expression<String>? workspaceDefaultDirectoriesJson,
     Expression<String>? regexRulesJson,
     Expression<bool>? enableProactiveCare,
     Expression<DateTime>? proactiveCareNextMessageAt,
@@ -4716,6 +4840,8 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       if (skillIdsJson != null) 'skill_ids_json': skillIdsJson,
       if (workspaceEnabled != null) 'workspace_enabled': workspaceEnabled,
       if (workspaceId != null) 'workspace_id': workspaceId,
+      if (workspaceDefaultDirectoriesJson != null)
+        'workspace_default_directories_json': workspaceDefaultDirectoriesJson,
       if (regexRulesJson != null) 'regex_rules_json': regexRulesJson,
       if (enableProactiveCare != null)
         'enable_proactive_care': enableProactiveCare,
@@ -4776,6 +4902,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Value<String>? skillIdsJson,
     Value<bool>? workspaceEnabled,
     Value<String?>? workspaceId,
+    Value<String>? workspaceDefaultDirectoriesJson,
     Value<String>? regexRulesJson,
     Value<bool>? enableProactiveCare,
     Value<DateTime?>? proactiveCareNextMessageAt,
@@ -4826,6 +4953,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       skillIdsJson: skillIdsJson ?? this.skillIdsJson,
       workspaceEnabled: workspaceEnabled ?? this.workspaceEnabled,
       workspaceId: workspaceId ?? this.workspaceId,
+      workspaceDefaultDirectoriesJson:
+          workspaceDefaultDirectoriesJson ??
+          this.workspaceDefaultDirectoriesJson,
       regexRulesJson: regexRulesJson ?? this.regexRulesJson,
       enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
       proactiveCareNextMessageAt:
@@ -4938,6 +5068,11 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     if (workspaceId.present) {
       map['workspace_id'] = Variable<String>(workspaceId.value);
     }
+    if (workspaceDefaultDirectoriesJson.present) {
+      map['workspace_default_directories_json'] = Variable<String>(
+        workspaceDefaultDirectoriesJson.value,
+      );
+    }
     if (regexRulesJson.present) {
       map['regex_rules_json'] = Variable<String>(regexRulesJson.value);
     }
@@ -5046,6 +5181,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
           ..write('skillIdsJson: $skillIdsJson, ')
           ..write('workspaceEnabled: $workspaceEnabled, ')
           ..write('workspaceId: $workspaceId, ')
+          ..write(
+            'workspaceDefaultDirectoriesJson: $workspaceDefaultDirectoriesJson, ',
+          )
           ..write('regexRulesJson: $regexRulesJson, ')
           ..write('enableProactiveCare: $enableProactiveCare, ')
           ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
@@ -8535,6 +8673,7 @@ typedef $$ConversationRowsTableCreateCompanionBuilder =
       Value<String> chatSuggestionsJson,
       Value<String?> parentConversationId,
       Value<String> conversationKind,
+      Value<String> workspaceDirectoryOverridesJson,
       Value<int> rowid,
     });
 typedef $$ConversationRowsTableUpdateCompanionBuilder =
@@ -8552,6 +8691,7 @@ typedef $$ConversationRowsTableUpdateCompanionBuilder =
       Value<String> chatSuggestionsJson,
       Value<String?> parentConversationId,
       Value<String> conversationKind,
+      Value<String> workspaceDirectoryOverridesJson,
       Value<int> rowid,
     });
 
@@ -8701,6 +8841,12 @@ class $$ConversationRowsTableFilterComposer
     column: $table.conversationKind,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get workspaceDirectoryOverridesJson =>
+      $composableBuilder(
+        column: $table.workspaceDirectoryOverridesJson,
+        builder: (column) => ColumnFilters(column),
+      );
 
   Expression<bool> messageRowsRefs(
     Expression<bool> Function($$MessageRowsTableFilterComposer f) f,
@@ -8853,6 +8999,12 @@ class $$ConversationRowsTableOrderingComposer
     column: $table.conversationKind,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get workspaceDirectoryOverridesJson =>
+      $composableBuilder(
+        column: $table.workspaceDirectoryOverridesJson,
+        builder: (column) => ColumnOrderings(column),
+      );
 }
 
 class $$ConversationRowsTableAnnotationComposer
@@ -8916,6 +9068,12 @@ class $$ConversationRowsTableAnnotationComposer
     column: $table.conversationKind,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get workspaceDirectoryOverridesJson =>
+      $composableBuilder(
+        column: $table.workspaceDirectoryOverridesJson,
+        builder: (column) => column,
+      );
 
   Expression<T> messageRowsRefs<T extends Object>(
     Expression<T> Function($$MessageRowsTableAnnotationComposer a) f,
@@ -9042,6 +9200,8 @@ class $$ConversationRowsTableTableManager
                 Value<String> chatSuggestionsJson = const Value.absent(),
                 Value<String?> parentConversationId = const Value.absent(),
                 Value<String> conversationKind = const Value.absent(),
+                Value<String> workspaceDirectoryOverridesJson =
+                    const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationRowsCompanion(
                 id: id,
@@ -9057,6 +9217,8 @@ class $$ConversationRowsTableTableManager
                 chatSuggestionsJson: chatSuggestionsJson,
                 parentConversationId: parentConversationId,
                 conversationKind: conversationKind,
+                workspaceDirectoryOverridesJson:
+                    workspaceDirectoryOverridesJson,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -9074,6 +9236,8 @@ class $$ConversationRowsTableTableManager
                 Value<String> chatSuggestionsJson = const Value.absent(),
                 Value<String?> parentConversationId = const Value.absent(),
                 Value<String> conversationKind = const Value.absent(),
+                Value<String> workspaceDirectoryOverridesJson =
+                    const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationRowsCompanion.insert(
                 id: id,
@@ -9089,6 +9253,8 @@ class $$ConversationRowsTableTableManager
                 chatSuggestionsJson: chatSuggestionsJson,
                 parentConversationId: parentConversationId,
                 conversationKind: conversationKind,
+                workspaceDirectoryOverridesJson:
+                    workspaceDirectoryOverridesJson,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
@@ -10238,6 +10404,7 @@ typedef $$AssistantRowsTableCreateCompanionBuilder =
       Value<String> skillIdsJson,
       Value<bool> workspaceEnabled,
       Value<String?> workspaceId,
+      Value<String> workspaceDefaultDirectoriesJson,
       Value<String> regexRulesJson,
       Value<bool> enableProactiveCare,
       Value<DateTime?> proactiveCareNextMessageAt,
@@ -10289,6 +10456,7 @@ typedef $$AssistantRowsTableUpdateCompanionBuilder =
       Value<String> skillIdsJson,
       Value<bool> workspaceEnabled,
       Value<String?> workspaceId,
+      Value<String> workspaceDefaultDirectoriesJson,
       Value<String> regexRulesJson,
       Value<bool> enableProactiveCare,
       Value<DateTime?> proactiveCareNextMessageAt,
@@ -10451,6 +10619,12 @@ class $$AssistantRowsTableFilterComposer
     column: $table.workspaceId,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get workspaceDefaultDirectoriesJson =>
+      $composableBuilder(
+        column: $table.workspaceDefaultDirectoriesJson,
+        builder: (column) => ColumnFilters(column),
+      );
 
   ColumnFilters<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
@@ -10697,6 +10871,12 @@ class $$AssistantRowsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get workspaceDefaultDirectoriesJson =>
+      $composableBuilder(
+        column: $table.workspaceDefaultDirectoriesJson,
+        builder: (column) => ColumnOrderings(column),
+      );
+
   ColumnOrderings<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
     builder: (column) => ColumnOrderings(column),
@@ -10933,6 +11113,12 @@ class $$AssistantRowsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get workspaceDefaultDirectoriesJson =>
+      $composableBuilder(
+        column: $table.workspaceDefaultDirectoriesJson,
+        builder: (column) => column,
+      );
+
   GeneratedColumn<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
     builder: (column) => column,
@@ -11083,6 +11269,8 @@ class $$AssistantRowsTableTableManager
                 Value<String> skillIdsJson = const Value.absent(),
                 Value<bool> workspaceEnabled = const Value.absent(),
                 Value<String?> workspaceId = const Value.absent(),
+                Value<String> workspaceDefaultDirectoriesJson =
+                    const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
                 Value<bool> enableProactiveCare = const Value.absent(),
                 Value<DateTime?> proactiveCareNextMessageAt =
@@ -11135,6 +11323,8 @@ class $$AssistantRowsTableTableManager
                 skillIdsJson: skillIdsJson,
                 workspaceEnabled: workspaceEnabled,
                 workspaceId: workspaceId,
+                workspaceDefaultDirectoriesJson:
+                    workspaceDefaultDirectoriesJson,
                 regexRulesJson: regexRulesJson,
                 enableProactiveCare: enableProactiveCare,
                 proactiveCareNextMessageAt: proactiveCareNextMessageAt,
@@ -11186,6 +11376,8 @@ class $$AssistantRowsTableTableManager
                 Value<String> skillIdsJson = const Value.absent(),
                 Value<bool> workspaceEnabled = const Value.absent(),
                 Value<String?> workspaceId = const Value.absent(),
+                Value<String> workspaceDefaultDirectoriesJson =
+                    const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
                 Value<bool> enableProactiveCare = const Value.absent(),
                 Value<DateTime?> proactiveCareNextMessageAt =
@@ -11238,6 +11430,8 @@ class $$AssistantRowsTableTableManager
                 skillIdsJson: skillIdsJson,
                 workspaceEnabled: workspaceEnabled,
                 workspaceId: workspaceId,
+                workspaceDefaultDirectoriesJson:
+                    workspaceDefaultDirectoriesJson,
                 regexRulesJson: regexRulesJson,
                 enableProactiveCare: enableProactiveCare,
                 proactiveCareNextMessageAt: proactiveCareNextMessageAt,

--- a/lib/core/database/app_database.g.dart
+++ b/lib/core/database/app_database.g.dart
@@ -2858,6 +2858,21 @@ class $AssistantRowsTable extends AssistantRows
         requiredDuringInsert: false,
         defaultValue: const Constant('{}'),
       );
+  static const VerificationMeta _autoLoadAgentsMdMeta = const VerificationMeta(
+    'autoLoadAgentsMd',
+  );
+  @override
+  late final GeneratedColumn<bool> autoLoadAgentsMd = GeneratedColumn<bool>(
+    'auto_load_agents_md',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("auto_load_agents_md" IN (0, 1))',
+    ),
+    defaultValue: const Constant(true),
+  );
   static const VerificationMeta _regexRulesJsonMeta = const VerificationMeta(
     'regexRulesJson',
   );
@@ -3146,6 +3161,7 @@ class $AssistantRowsTable extends AssistantRows
     workspaceEnabled,
     workspaceId,
     workspaceDefaultDirectoriesJson,
+    autoLoadAgentsMd,
     regexRulesJson,
     enableProactiveCare,
     proactiveCareNextMessageAt,
@@ -3403,6 +3419,15 @@ class $AssistantRowsTable extends AssistantRows
         workspaceDefaultDirectoriesJson.isAcceptableOrUnknown(
           data['workspace_default_directories_json']!,
           _workspaceDefaultDirectoriesJsonMeta,
+        ),
+      );
+    }
+    if (data.containsKey('auto_load_agents_md')) {
+      context.handle(
+        _autoLoadAgentsMdMeta,
+        autoLoadAgentsMd.isAcceptableOrUnknown(
+          data['auto_load_agents_md']!,
+          _autoLoadAgentsMdMeta,
         ),
       );
     }
@@ -3694,6 +3719,10 @@ class $AssistantRowsTable extends AssistantRows
         DriftSqlType.string,
         data['${effectivePrefix}workspace_default_directories_json'],
       )!,
+      autoLoadAgentsMd: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}auto_load_agents_md'],
+      )!,
       regexRulesJson: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}regex_rules_json'],
@@ -3815,6 +3844,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
   final bool workspaceEnabled;
   final String? workspaceId;
   final String workspaceDefaultDirectoriesJson;
+  final bool autoLoadAgentsMd;
   final String regexRulesJson;
   final bool enableProactiveCare;
   final DateTime? proactiveCareNextMessageAt;
@@ -3864,6 +3894,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     required this.workspaceEnabled,
     this.workspaceId,
     required this.workspaceDefaultDirectoriesJson,
+    required this.autoLoadAgentsMd,
     required this.regexRulesJson,
     required this.enableProactiveCare,
     this.proactiveCareNextMessageAt,
@@ -3936,6 +3967,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     map['workspace_default_directories_json'] = Variable<String>(
       workspaceDefaultDirectoriesJson,
     );
+    map['auto_load_agents_md'] = Variable<bool>(autoLoadAgentsMd);
     map['regex_rules_json'] = Variable<String>(regexRulesJson);
     map['enable_proactive_care'] = Variable<bool>(enableProactiveCare);
     if (!nullToAbsent || proactiveCareNextMessageAt != null) {
@@ -4019,6 +4051,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           ? const Value.absent()
           : Value(workspaceId),
       workspaceDefaultDirectoriesJson: Value(workspaceDefaultDirectoriesJson),
+      autoLoadAgentsMd: Value(autoLoadAgentsMd),
       regexRulesJson: Value(regexRulesJson),
       enableProactiveCare: Value(enableProactiveCare),
       proactiveCareNextMessageAt:
@@ -4091,6 +4124,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       workspaceDefaultDirectoriesJson: serializer.fromJson<String>(
         json['workspaceDefaultDirectoriesJson'],
       ),
+      autoLoadAgentsMd: serializer.fromJson<bool>(json['autoLoadAgentsMd']),
       regexRulesJson: serializer.fromJson<String>(json['regexRulesJson']),
       enableProactiveCare: serializer.fromJson<bool>(
         json['enableProactiveCare'],
@@ -4165,6 +4199,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
       'workspaceDefaultDirectoriesJson': serializer.toJson<String>(
         workspaceDefaultDirectoriesJson,
       ),
+      'autoLoadAgentsMd': serializer.toJson<bool>(autoLoadAgentsMd),
       'regexRulesJson': serializer.toJson<String>(regexRulesJson),
       'enableProactiveCare': serializer.toJson<bool>(enableProactiveCare),
       'proactiveCareNextMessageAt': serializer.toJson<DateTime?>(
@@ -4225,6 +4260,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     bool? workspaceEnabled,
     Value<String?> workspaceId = const Value.absent(),
     String? workspaceDefaultDirectoriesJson,
+    bool? autoLoadAgentsMd,
     String? regexRulesJson,
     bool? enableProactiveCare,
     Value<DateTime?> proactiveCareNextMessageAt = const Value.absent(),
@@ -4279,6 +4315,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     workspaceId: workspaceId.present ? workspaceId.value : this.workspaceId,
     workspaceDefaultDirectoriesJson:
         workspaceDefaultDirectoriesJson ?? this.workspaceDefaultDirectoriesJson,
+    autoLoadAgentsMd: autoLoadAgentsMd ?? this.autoLoadAgentsMd,
     regexRulesJson: regexRulesJson ?? this.regexRulesJson,
     enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
     proactiveCareNextMessageAt: proactiveCareNextMessageAt.present
@@ -4382,6 +4419,9 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           data.workspaceDefaultDirectoriesJson.present
           ? data.workspaceDefaultDirectoriesJson.value
           : this.workspaceDefaultDirectoriesJson,
+      autoLoadAgentsMd: data.autoLoadAgentsMd.present
+          ? data.autoLoadAgentsMd.value
+          : this.autoLoadAgentsMd,
       regexRulesJson: data.regexRulesJson.present
           ? data.regexRulesJson.value
           : this.regexRulesJson,
@@ -4467,6 +4507,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           ..write(
             'workspaceDefaultDirectoriesJson: $workspaceDefaultDirectoriesJson, ',
           )
+          ..write('autoLoadAgentsMd: $autoLoadAgentsMd, ')
           ..write('regexRulesJson: $regexRulesJson, ')
           ..write('enableProactiveCare: $enableProactiveCare, ')
           ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
@@ -4523,6 +4564,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
     workspaceEnabled,
     workspaceId,
     workspaceDefaultDirectoriesJson,
+    autoLoadAgentsMd,
     regexRulesJson,
     enableProactiveCare,
     proactiveCareNextMessageAt,
@@ -4577,6 +4619,7 @@ class AssistantRow extends DataClass implements Insertable<AssistantRow> {
           other.workspaceId == this.workspaceId &&
           other.workspaceDefaultDirectoriesJson ==
               this.workspaceDefaultDirectoriesJson &&
+          other.autoLoadAgentsMd == this.autoLoadAgentsMd &&
           other.regexRulesJson == this.regexRulesJson &&
           other.enableProactiveCare == this.enableProactiveCare &&
           other.proactiveCareNextMessageAt == this.proactiveCareNextMessageAt &&
@@ -4630,6 +4673,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
   final Value<bool> workspaceEnabled;
   final Value<String?> workspaceId;
   final Value<String> workspaceDefaultDirectoriesJson;
+  final Value<bool> autoLoadAgentsMd;
   final Value<String> regexRulesJson;
   final Value<bool> enableProactiveCare;
   final Value<DateTime?> proactiveCareNextMessageAt;
@@ -4680,6 +4724,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.workspaceEnabled = const Value.absent(),
     this.workspaceId = const Value.absent(),
     this.workspaceDefaultDirectoriesJson = const Value.absent(),
+    this.autoLoadAgentsMd = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
     this.enableProactiveCare = const Value.absent(),
     this.proactiveCareNextMessageAt = const Value.absent(),
@@ -4731,6 +4776,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     this.workspaceEnabled = const Value.absent(),
     this.workspaceId = const Value.absent(),
     this.workspaceDefaultDirectoriesJson = const Value.absent(),
+    this.autoLoadAgentsMd = const Value.absent(),
     this.regexRulesJson = const Value.absent(),
     this.enableProactiveCare = const Value.absent(),
     this.proactiveCareNextMessageAt = const Value.absent(),
@@ -4786,6 +4832,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Expression<bool>? workspaceEnabled,
     Expression<String>? workspaceId,
     Expression<String>? workspaceDefaultDirectoriesJson,
+    Expression<bool>? autoLoadAgentsMd,
     Expression<String>? regexRulesJson,
     Expression<bool>? enableProactiveCare,
     Expression<DateTime>? proactiveCareNextMessageAt,
@@ -4842,6 +4889,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       if (workspaceId != null) 'workspace_id': workspaceId,
       if (workspaceDefaultDirectoriesJson != null)
         'workspace_default_directories_json': workspaceDefaultDirectoriesJson,
+      if (autoLoadAgentsMd != null) 'auto_load_agents_md': autoLoadAgentsMd,
       if (regexRulesJson != null) 'regex_rules_json': regexRulesJson,
       if (enableProactiveCare != null)
         'enable_proactive_care': enableProactiveCare,
@@ -4903,6 +4951,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
     Value<bool>? workspaceEnabled,
     Value<String?>? workspaceId,
     Value<String>? workspaceDefaultDirectoriesJson,
+    Value<bool>? autoLoadAgentsMd,
     Value<String>? regexRulesJson,
     Value<bool>? enableProactiveCare,
     Value<DateTime?>? proactiveCareNextMessageAt,
@@ -4956,6 +5005,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
       workspaceDefaultDirectoriesJson:
           workspaceDefaultDirectoriesJson ??
           this.workspaceDefaultDirectoriesJson,
+      autoLoadAgentsMd: autoLoadAgentsMd ?? this.autoLoadAgentsMd,
       regexRulesJson: regexRulesJson ?? this.regexRulesJson,
       enableProactiveCare: enableProactiveCare ?? this.enableProactiveCare,
       proactiveCareNextMessageAt:
@@ -5073,6 +5123,9 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
         workspaceDefaultDirectoriesJson.value,
       );
     }
+    if (autoLoadAgentsMd.present) {
+      map['auto_load_agents_md'] = Variable<bool>(autoLoadAgentsMd.value);
+    }
     if (regexRulesJson.present) {
       map['regex_rules_json'] = Variable<String>(regexRulesJson.value);
     }
@@ -5184,6 +5237,7 @@ class AssistantRowsCompanion extends UpdateCompanion<AssistantRow> {
           ..write(
             'workspaceDefaultDirectoriesJson: $workspaceDefaultDirectoriesJson, ',
           )
+          ..write('autoLoadAgentsMd: $autoLoadAgentsMd, ')
           ..write('regexRulesJson: $regexRulesJson, ')
           ..write('enableProactiveCare: $enableProactiveCare, ')
           ..write('proactiveCareNextMessageAt: $proactiveCareNextMessageAt, ')
@@ -10405,6 +10459,7 @@ typedef $$AssistantRowsTableCreateCompanionBuilder =
       Value<bool> workspaceEnabled,
       Value<String?> workspaceId,
       Value<String> workspaceDefaultDirectoriesJson,
+      Value<bool> autoLoadAgentsMd,
       Value<String> regexRulesJson,
       Value<bool> enableProactiveCare,
       Value<DateTime?> proactiveCareNextMessageAt,
@@ -10457,6 +10512,7 @@ typedef $$AssistantRowsTableUpdateCompanionBuilder =
       Value<bool> workspaceEnabled,
       Value<String?> workspaceId,
       Value<String> workspaceDefaultDirectoriesJson,
+      Value<bool> autoLoadAgentsMd,
       Value<String> regexRulesJson,
       Value<bool> enableProactiveCare,
       Value<DateTime?> proactiveCareNextMessageAt,
@@ -10625,6 +10681,11 @@ class $$AssistantRowsTableFilterComposer
         column: $table.workspaceDefaultDirectoriesJson,
         builder: (column) => ColumnFilters(column),
       );
+
+  ColumnFilters<bool> get autoLoadAgentsMd => $composableBuilder(
+    column: $table.autoLoadAgentsMd,
+    builder: (column) => ColumnFilters(column),
+  );
 
   ColumnFilters<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
@@ -10877,6 +10938,11 @@ class $$AssistantRowsTableOrderingComposer
         builder: (column) => ColumnOrderings(column),
       );
 
+  ColumnOrderings<bool> get autoLoadAgentsMd => $composableBuilder(
+    column: $table.autoLoadAgentsMd,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
     builder: (column) => ColumnOrderings(column),
@@ -11119,6 +11185,11 @@ class $$AssistantRowsTableAnnotationComposer
         builder: (column) => column,
       );
 
+  GeneratedColumn<bool> get autoLoadAgentsMd => $composableBuilder(
+    column: $table.autoLoadAgentsMd,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get regexRulesJson => $composableBuilder(
     column: $table.regexRulesJson,
     builder: (column) => column,
@@ -11271,6 +11342,7 @@ class $$AssistantRowsTableTableManager
                 Value<String?> workspaceId = const Value.absent(),
                 Value<String> workspaceDefaultDirectoriesJson =
                     const Value.absent(),
+                Value<bool> autoLoadAgentsMd = const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
                 Value<bool> enableProactiveCare = const Value.absent(),
                 Value<DateTime?> proactiveCareNextMessageAt =
@@ -11325,6 +11397,7 @@ class $$AssistantRowsTableTableManager
                 workspaceId: workspaceId,
                 workspaceDefaultDirectoriesJson:
                     workspaceDefaultDirectoriesJson,
+                autoLoadAgentsMd: autoLoadAgentsMd,
                 regexRulesJson: regexRulesJson,
                 enableProactiveCare: enableProactiveCare,
                 proactiveCareNextMessageAt: proactiveCareNextMessageAt,
@@ -11378,6 +11451,7 @@ class $$AssistantRowsTableTableManager
                 Value<String?> workspaceId = const Value.absent(),
                 Value<String> workspaceDefaultDirectoriesJson =
                     const Value.absent(),
+                Value<bool> autoLoadAgentsMd = const Value.absent(),
                 Value<String> regexRulesJson = const Value.absent(),
                 Value<bool> enableProactiveCare = const Value.absent(),
                 Value<DateTime?> proactiveCareNextMessageAt =
@@ -11432,6 +11506,7 @@ class $$AssistantRowsTableTableManager
                 workspaceId: workspaceId,
                 workspaceDefaultDirectoriesJson:
                     workspaceDefaultDirectoriesJson,
+                autoLoadAgentsMd: autoLoadAgentsMd,
                 regexRulesJson: regexRulesJson,
                 enableProactiveCare: enableProactiveCare,
                 proactiveCareNextMessageAt: proactiveCareNextMessageAt,

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -1055,6 +1055,9 @@ class ChatDatabaseRepository {
       'skillIds': (jsonDecode(row.skillIdsJson) as List).cast<String>(),
       'workspaceEnabled': row.workspaceEnabled,
       'workspaceId': row.workspaceId,
+      'workspaceDefaultDirectories': jsonDecode(
+        row.workspaceDefaultDirectoriesJson,
+      ),
       'customHeaders': jsonDecode(row.customHeadersJson),
       'customBody': jsonDecode(row.customBodyJson),
       'enableMemory': row.enableMemory,
@@ -1107,6 +1110,9 @@ class ChatDatabaseRepository {
       skillIdsJson: Value(jsonEncode(a.skillIds)),
       workspaceEnabled: Value(a.workspaceEnabled),
       workspaceId: Value(a.workspaceId),
+      workspaceDefaultDirectoriesJson: Value(
+        jsonEncode(a.workspaceDefaultDirectories),
+      ),
       customHeadersJson: Value(jsonEncode(a.customHeaders)),
       customBodyJson: Value(jsonEncode(a.customBody)),
       enableMemory: Value(a.enableMemory),
@@ -1169,6 +1175,9 @@ class ChatDatabaseRepository {
       chatSuggestions: _decodeStringList(row.chatSuggestionsJson),
       parentConversationId: row.parentConversationId,
       conversationKind: row.conversationKind,
+      workspaceDirectoryOverrides: _decodeStringStringMap(
+        row.workspaceDirectoryOverridesJson,
+      ),
     );
   }
 
@@ -1215,6 +1224,9 @@ class ChatDatabaseRepository {
       conversationKind:
           _readOptionalString(row, 'conversation_kind') ??
           Conversation.kindNormal,
+      workspaceDirectoryOverrides: _decodeStringStringMap(
+        _readOptionalString(row, 'workspace_directory_overrides_json') ?? '{}',
+      ),
     );
   }
 
@@ -1259,6 +1271,9 @@ class ChatDatabaseRepository {
       chatSuggestionsJson: Value(jsonEncode(conversation.chatSuggestions)),
       parentConversationId: Value(conversation.parentConversationId),
       conversationKind: Value(conversation.conversationKind),
+      workspaceDirectoryOverridesJson: Value(
+        jsonEncode(conversation.workspaceDirectoryOverrides),
+      ),
     );
   }
 
@@ -1528,6 +1543,34 @@ class ChatDatabaseRepository {
       });
     } catch (_) {
       return <String, int>{};
+    }
+  }
+
+  Map<String, String> _decodeStringStringMap(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map) {
+        throw const FormatException('Expected a JSON object.');
+      }
+      final result = <String, String>{};
+      for (final entry in decoded.entries) {
+        if (entry.key is! String || entry.value is! String) {
+          throw const FormatException(
+            'Workspace directory override keys and values must be strings.',
+          );
+        }
+        result[entry.key as String] = entry.value as String;
+      }
+      return result;
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Failed to decode workspace directory overrides: '
+        '$error\n$stackTrace',
+      );
+      throw FormatException(
+        'Invalid workspace directory overrides JSON.',
+        error,
+      );
     }
   }
 

--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -1058,6 +1058,7 @@ class ChatDatabaseRepository {
       'workspaceDefaultDirectories': jsonDecode(
         row.workspaceDefaultDirectoriesJson,
       ),
+      'autoLoadAgentsMd': row.autoLoadAgentsMd,
       'customHeaders': jsonDecode(row.customHeadersJson),
       'customBody': jsonDecode(row.customBodyJson),
       'enableMemory': row.enableMemory,
@@ -1113,6 +1114,7 @@ class ChatDatabaseRepository {
       workspaceDefaultDirectoriesJson: Value(
         jsonEncode(a.workspaceDefaultDirectories),
       ),
+      autoLoadAgentsMd: Value(a.autoLoadAgentsMd),
       customHeadersJson: Value(jsonEncode(a.customHeaders)),
       customBodyJson: Value(jsonEncode(a.customBody)),
       enableMemory: Value(a.enableMemory),

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -70,6 +70,9 @@ Do **not** store sensitive information, including:
 
   /// Bound workspace entity id (single bind).
   final String? workspaceId;
+
+  /// Default guest working directory per workspace entity id.
+  final Map<String, String> workspaceDefaultDirectories;
   final String? background; // chat background (color/image ref)
   // Custom request overrides (per assistant)
   final List<Map<String, String>>
@@ -132,6 +135,7 @@ Do **not** store sensitive information, including:
     this.skillIds = const <String>[],
     this.workspaceEnabled = false,
     this.workspaceId,
+    Map<String, String>? workspaceDefaultDirectories,
     this.background,
     this.customHeaders = const <Map<String, String>>[],
     this.customBody = const <Map<String, String>>[],
@@ -156,7 +160,12 @@ Do **not** store sensitive information, including:
     this.handoffDescription,
     DateTime? createdAt,
     DateTime? updatedAt,
-  }) : createdAt = createdAt ?? DateTime.now(),
+  }) : workspaceDefaultDirectories = Map.unmodifiable(
+         Map<String, String>.of(
+           workspaceDefaultDirectories ?? const <String, String>{},
+         ),
+       ),
+       createdAt = createdAt ?? DateTime.now(),
        updatedAt = updatedAt ?? DateTime.now(),
        localToolIds = _normalizeLocalToolIds(localToolIds ?? const <String>[]);
 
@@ -194,6 +203,7 @@ Do **not** store sensitive information, including:
     List<String>? skillIds,
     bool? workspaceEnabled,
     String? workspaceId,
+    Map<String, String>? workspaceDefaultDirectories,
     bool clearWorkspaceId = false,
     String? background,
     List<Map<String, String>>? customHeaders,
@@ -257,6 +267,8 @@ Do **not** store sensitive information, including:
       skillIds: skillIds ?? this.skillIds,
       workspaceEnabled: workspaceEnabled ?? this.workspaceEnabled,
       workspaceId: clearWorkspaceId ? null : (workspaceId ?? this.workspaceId),
+      workspaceDefaultDirectories:
+          workspaceDefaultDirectories ?? this.workspaceDefaultDirectories,
       background: clearBackground ? null : (background ?? this.background),
       customHeaders: customHeaders ?? this.customHeaders,
       customBody: customBody ?? this.customBody,
@@ -314,6 +326,7 @@ Do **not** store sensitive information, including:
     'skillIds': skillIds,
     'workspaceEnabled': workspaceEnabled,
     'workspaceId': workspaceId,
+    'workspaceDefaultDirectories': workspaceDefaultDirectories,
     'background': background,
     'customHeaders': customHeaders,
     'customBody': customBody,
@@ -366,6 +379,13 @@ Do **not** store sensitive information, including:
     skillIds: (json['skillIds'] as List?)?.cast<String>() ?? const <String>[],
     workspaceEnabled: json['workspaceEnabled'] as bool? ?? false,
     workspaceId: json['workspaceId'] as String?,
+    workspaceDefaultDirectories: (() {
+      final raw = json['workspaceDefaultDirectories'];
+      if (raw is! Map) return const <String, String>{};
+      return raw.map(
+        (key, value) => MapEntry(key.toString(), value.toString()),
+      );
+    })(),
     background: json['background'] as String?,
     customHeaders: (() {
       final raw = json['customHeaders'];

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -73,6 +73,9 @@ Do **not** store sensitive information, including:
 
   /// Default guest working directory per workspace entity id.
   final Map<String, String> workspaceDefaultDirectories;
+
+  /// Whether project-level AGENTS.md files are added to the system prompt.
+  final bool autoLoadAgentsMd;
   final String? background; // chat background (color/image ref)
   // Custom request overrides (per assistant)
   final List<Map<String, String>>
@@ -136,6 +139,7 @@ Do **not** store sensitive information, including:
     this.workspaceEnabled = false,
     this.workspaceId,
     Map<String, String>? workspaceDefaultDirectories,
+    this.autoLoadAgentsMd = true,
     this.background,
     this.customHeaders = const <Map<String, String>>[],
     this.customBody = const <Map<String, String>>[],
@@ -204,6 +208,7 @@ Do **not** store sensitive information, including:
     bool? workspaceEnabled,
     String? workspaceId,
     Map<String, String>? workspaceDefaultDirectories,
+    bool? autoLoadAgentsMd,
     bool clearWorkspaceId = false,
     String? background,
     List<Map<String, String>>? customHeaders,
@@ -269,6 +274,7 @@ Do **not** store sensitive information, including:
       workspaceId: clearWorkspaceId ? null : (workspaceId ?? this.workspaceId),
       workspaceDefaultDirectories:
           workspaceDefaultDirectories ?? this.workspaceDefaultDirectories,
+      autoLoadAgentsMd: autoLoadAgentsMd ?? this.autoLoadAgentsMd,
       background: clearBackground ? null : (background ?? this.background),
       customHeaders: customHeaders ?? this.customHeaders,
       customBody: customBody ?? this.customBody,
@@ -327,6 +333,7 @@ Do **not** store sensitive information, including:
     'workspaceEnabled': workspaceEnabled,
     'workspaceId': workspaceId,
     'workspaceDefaultDirectories': workspaceDefaultDirectories,
+    'autoLoadAgentsMd': autoLoadAgentsMd,
     'background': background,
     'customHeaders': customHeaders,
     'customBody': customBody,
@@ -386,6 +393,7 @@ Do **not** store sensitive information, including:
         (key, value) => MapEntry(key.toString(), value.toString()),
       );
     })(),
+    autoLoadAgentsMd: json['autoLoadAgentsMd'] as bool? ?? true,
     background: json['background'] as String?,
     customHeaders: (() {
       final raw = json['customHeaders'];

--- a/lib/core/models/conversation.dart
+++ b/lib/core/models/conversation.dart
@@ -40,6 +40,10 @@ class Conversation {
   /// 'normal' | 'group'
   String conversationKind;
 
+  /// Conversation-specific guest working directory per workspace entity id.
+  /// A missing key means the assistant default is inherited dynamically.
+  Map<String, String> workspaceDirectoryOverrides;
+
   static const String kindNormal = 'normal';
   static const String kindGroup = 'group';
 
@@ -61,6 +65,7 @@ class Conversation {
     int? lastSummarizedMessageCount,
     List<String>? chatSuggestions,
     this.conversationKind = kindNormal,
+    Map<String, String>? workspaceDirectoryOverrides,
   }) : id = id ?? const Uuid().v4(),
        createdAt = createdAt ?? DateTime.now(),
        updatedAt = updatedAt ?? DateTime.now(),
@@ -69,7 +74,10 @@ class Conversation {
        truncateIndex = truncateIndex ?? -1,
        versionSelections = versionSelections ?? <String, int>{},
        lastSummarizedMessageCount = lastSummarizedMessageCount ?? 0,
-       chatSuggestions = chatSuggestions ?? [];
+       chatSuggestions = chatSuggestions ?? [],
+       workspaceDirectoryOverrides = Map<String, String>.of(
+         workspaceDirectoryOverrides ?? const <String, String>{},
+       );
 
   Conversation copyWith({
     String? id,
@@ -88,6 +96,7 @@ class Conversation {
     List<String>? chatSuggestions,
     bool clearSummary = false,
     String? conversationKind,
+    Map<String, String>? workspaceDirectoryOverrides,
   }) {
     return Conversation(
       id: id ?? this.id,
@@ -106,6 +115,8 @@ class Conversation {
           lastSummarizedMessageCount ?? this.lastSummarizedMessageCount,
       chatSuggestions: chatSuggestions ?? this.chatSuggestions,
       conversationKind: conversationKind ?? this.conversationKind,
+      workspaceDirectoryOverrides:
+          workspaceDirectoryOverrides ?? this.workspaceDirectoryOverrides,
     );
   }
 
@@ -126,6 +137,7 @@ class Conversation {
       'lastSummarizedMessageCount': lastSummarizedMessageCount,
       'chatSuggestions': chatSuggestions,
       'conversationKind': conversationKind,
+      'workspaceDirectoryOverrides': workspaceDirectoryOverrides,
     };
   }
 
@@ -153,6 +165,11 @@ class Conversation {
       chatSuggestions:
           (json['chatSuggestions'] as List?)?.cast<String>() ?? <String>[],
       conversationKind: json['conversationKind'] as String? ?? kindNormal,
+      workspaceDirectoryOverrides:
+          (json['workspaceDirectoryOverrides'] as Map?)?.map(
+            (key, value) => MapEntry(key.toString(), value.toString()),
+          ) ??
+          <String, String>{},
     );
   }
 }

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -1005,6 +1005,48 @@ class ChatService extends ChangeNotifier {
     await setConversationMcpServers(conversationId, set.toList());
   }
 
+  Future<void> setConversationWorkspaceDirectoryOverride(
+    String conversationId,
+    String workspaceId,
+    String directory,
+  ) async {
+    await _updateConversationWorkspaceDirectories(
+      conversationId,
+      (current) => current[workspaceId] = directory,
+    );
+  }
+
+  Future<void> clearConversationWorkspaceDirectoryOverride(
+    String conversationId,
+    String workspaceId,
+  ) async {
+    await _updateConversationWorkspaceDirectories(
+      conversationId,
+      (current) => current.remove(workspaceId),
+    );
+  }
+
+  Future<void> _updateConversationWorkspaceDirectories(
+    String conversationId,
+    void Function(Map<String, String> current) update,
+  ) async {
+    if (!_initialized) await init();
+    final conversation =
+        _draftConversations[conversationId] ??
+        _conversationsCache[conversationId];
+    if (conversation == null) return;
+    final directories = Map<String, String>.of(
+      conversation.workspaceDirectoryOverrides,
+    );
+    update(directories);
+    conversation.workspaceDirectoryOverrides = directories;
+    conversation.updatedAt = DateTime.now();
+    if (!_draftConversations.containsKey(conversationId)) {
+      await _saveConversation(conversation);
+    }
+    notifyListeners();
+  }
+
   Future<List<Assistant>> getAllAssistants() => _repo.getAllAssistants();
   Future<void> putAssistants(List<Assistant> list) => _repo.putAssistants(list);
   Future<void> putAssistant(Assistant a) => _repo.putAssistant(a);

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -902,6 +902,8 @@ class ProactiveCareHeadlessChatStore {
       'workspaceDefaultDirectories': jsonDecode(
         _readOptionalString(row, 'workspace_default_directories_json') ?? '{}',
       ),
+      'autoLoadAgentsMd':
+          (_readOptionalString(row, 'auto_load_agents_md') ?? '1') != '0',
       'customHeaders': jsonDecode(row['custom_headers_json'] as String),
       'customBody': jsonDecode(row['custom_body_json'] as String),
       'enableMemory': (row['enable_memory'] as int) != 0,

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -832,6 +832,18 @@ class ProactiveCareHeadlessChatStore {
     return _dateTimeFromSql(value);
   }
 
+  static String? _readOptionalString(sqlite.Row row, String column) {
+    try {
+      return row[column]?.toString();
+    } catch (error) {
+      FlutterLogger.log(
+        'Optional assistant column $column is unavailable: $error',
+        tag: _logTag,
+      );
+      return null;
+    }
+  }
+
   /// Converts [DateTime] to unix timestamp seconds for drift compatibility.
   static int _dateTimeToSql(DateTime dt) => dt.millisecondsSinceEpoch ~/ 1000;
 
@@ -887,6 +899,9 @@ class ProactiveCareHeadlessChatStore {
           .cast<String>(),
       'workspaceEnabled': (row['workspace_enabled'] as int? ?? 0) != 0,
       'workspaceId': row['workspace_id'] as String?,
+      'workspaceDefaultDirectories': jsonDecode(
+        _readOptionalString(row, 'workspace_default_directories_json') ?? '{}',
+      ),
       'customHeaders': jsonDecode(row['custom_headers_json'] as String),
       'customBody': jsonDecode(row['custom_body_json'] as String),
       'enableMemory': (row['enable_memory'] as int) != 0,

--- a/lib/core/services/workspace/workspace_execution_context.dart
+++ b/lib/core/services/workspace/workspace_execution_context.dart
@@ -1,0 +1,277 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import '../../models/assistant.dart';
+import '../../models/conversation.dart';
+import '../../models/workspace.dart';
+import '../../providers/workspace_provider.dart';
+
+class WorkspacePathException implements Exception {
+  const WorkspacePathException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Immutable workspace state captured for one model generation.
+class WorkspaceExecutionContext {
+  const WorkspaceExecutionContext({
+    required this.workspace,
+    required this.workingDirectory,
+  });
+
+  final Workspace workspace;
+  final String workingDirectory;
+
+  static WorkspaceExecutionContext? resolve({
+    required Assistant? assistant,
+    required Conversation? conversation,
+    required WorkspaceProvider workspaces,
+  }) {
+    if (assistant == null || !assistant.workspaceEnabled) return null;
+    final workspaceId = assistant.workspaceId;
+    if (workspaceId == null || workspaceId.isEmpty) return null;
+    final workspace = workspaces.getById(workspaceId);
+    if (workspace == null) return null;
+    final configured = effectiveWorkspaceDirectory(
+      assistant: assistant,
+      conversation: conversation,
+      workspaceId: workspaceId,
+    );
+    return WorkspaceExecutionContext(
+      workspace: workspace,
+      workingDirectory: configured,
+    );
+  }
+}
+
+String effectiveWorkspaceDirectory({
+  required Assistant assistant,
+  required Conversation? conversation,
+  required String workspaceId,
+}) {
+  return normalizeWorkspaceDirectory(
+    conversation?.workspaceDirectoryOverrides[workspaceId] ??
+        assistant.workspaceDefaultDirectories[workspaceId] ??
+        '/workspace',
+  );
+}
+
+/// Normalizes a saved directory to the portable guest `/workspace/...` form.
+/// Relative input is interpreted from the workspace root.
+String normalizeWorkspaceDirectory(String raw) {
+  return resolveWorkspaceGuestPath(
+    raw,
+    baseDirectory: '/workspace',
+    allowMountListingRoot: false,
+  );
+}
+
+/// Resolves a model path using standard cwd semantics without allowing it to
+/// escape the bound workspace.
+String resolveWorkspaceGuestPath(
+  String raw, {
+  required String baseDirectory,
+  bool allowMountListingRoot = true,
+  bool preserveTrailingSlash = false,
+}) {
+  if (raw.trim() != raw) {
+    throw WorkspacePathException(
+      'Leading or trailing whitespace is not allowed: $raw',
+    );
+  }
+  if (raw.isEmpty) {
+    throw const WorkspacePathException('Path is required.');
+  }
+  if (raw.contains(r'\')) {
+    throw const WorkspacePathException(
+      'Backslashes are not allowed in workspace paths.',
+    );
+  }
+  if (allowMountListingRoot && raw == '/') return '/';
+  final hasTrailingSlash =
+      preserveTrailingSlash && raw.length > 1 && raw.endsWith('/');
+  final input = hasTrailingSlash ? raw.substring(0, raw.length - 1) : raw;
+  if (RegExp(r'^[A-Za-z]:').hasMatch(input)) {
+    throw WorkspacePathException(
+      'Host absolute paths are not allowed in a workspace: $raw',
+    );
+  }
+  if (input.startsWith('@')) {
+    throw WorkspacePathException(
+      'Use /workspace/rel/path instead of a mount alias: $raw',
+    );
+  }
+
+  final base = _workspaceSegments(baseDirectory, allowRelative: false);
+  final List<String> segments;
+  if (input == '/workspace') {
+    segments = <String>[];
+  } else if (input.startsWith('/workspace/')) {
+    segments = <String>[];
+    _appendNormalized(segments, input.substring('/workspace/'.length), raw);
+  } else if (input.startsWith('/')) {
+    throw WorkspacePathException(
+      'Only absolute paths under /workspace are allowed: $raw',
+    );
+  } else {
+    segments = List<String>.of(base);
+    _appendNormalized(segments, input, raw);
+  }
+
+  final resolved = segments.isEmpty
+      ? '/workspace'
+      : '/workspace/${segments.join('/')}';
+  return hasTrailingSlash ? '$resolved/' : resolved;
+}
+
+List<String> _workspaceSegments(String raw, {required bool allowRelative}) {
+  if (raw == '/workspace') return <String>[];
+  if (!raw.startsWith('/workspace/')) {
+    if (!allowRelative) {
+      throw WorkspacePathException('Invalid workspace directory: $raw');
+    }
+    final out = <String>[];
+    _appendNormalized(out, raw, raw);
+    return out;
+  }
+  final out = <String>[];
+  _appendNormalized(out, raw.substring('/workspace/'.length), raw);
+  return out;
+}
+
+void _appendNormalized(List<String> target, String relative, String original) {
+  final parts = relative.split('/');
+  for (var i = 0; i < parts.length; i++) {
+    final segment = parts[i];
+    if (segment.isEmpty) {
+      throw WorkspacePathException(
+        'Empty path segment is not allowed: $original',
+      );
+    }
+    if (segment == '.') continue;
+    if (segment == '..') {
+      if (target.isEmpty) {
+        throw WorkspacePathException(
+          'Path escapes the workspace root: $original',
+        );
+      }
+      target.removeLast();
+      continue;
+    }
+    if (segment.endsWith(' ') ||
+        segment.endsWith('.') ||
+        RegExp(r'^\.+$').hasMatch(segment) ||
+        segment.contains(':') ||
+        segment.contains('\u0000')) {
+      throw WorkspacePathException('Unsafe workspace path segment: $original');
+    }
+    target.add(segment);
+  }
+}
+
+/// Ensures the configured working directory exists and returns its host path.
+Future<String> ensureWorkspaceWorkingDirectory({
+  required WorkspaceExecutionContext context,
+  required WorkspaceProvider workspaces,
+}) async {
+  final hostRoot = workspaces.hostPathFor(context.workspace);
+  if (hostRoot == null || hostRoot.isEmpty) {
+    throw const WorkspacePathException('Workspace host path is not ready.');
+  }
+  return ensureWorkspaceDirectoryAtHostRoot(
+    workspace: context.workspace,
+    hostRoot: hostRoot,
+    workingDirectory: context.workingDirectory,
+  );
+}
+
+Future<String> ensureWorkspaceDirectoryAtHostRoot({
+  required Workspace workspace,
+  required String hostRoot,
+  required String workingDirectory,
+}) async {
+  final segments = _workspaceSegments(workingDirectory, allowRelative: false);
+  final root = Directory(hostRoot);
+  if (!await root.exists()) {
+    if (workspace.readOnly) {
+      throw const WorkspacePathException(
+        'The workspace root is missing and the workspace is read-only.',
+      );
+    }
+    try {
+      await root.create(recursive: true);
+    } on FileSystemException catch (error) {
+      throw WorkspacePathException(
+        'Unable to create the workspace root: ${error.message}',
+      );
+    }
+  }
+
+  final canonicalRoot = await _resolveDirectoryLinks(
+    root,
+    description: 'workspace root',
+  );
+  var current = canonicalRoot;
+  for (final segment in segments) {
+    current = p.join(current, segment);
+    var type = await FileSystemEntity.type(current, followLinks: false);
+    if (type == FileSystemEntityType.link) {
+      throw const WorkspacePathException(
+        'Symbolic links are not allowed in workspace working directories.',
+      );
+    }
+    if (type == FileSystemEntityType.notFound) {
+      if (workspace.readOnly) {
+        throw const WorkspacePathException(
+          'The working directory is missing and the workspace is read-only.',
+        );
+      }
+      try {
+        // Create one level at a time so an existing link cannot be traversed
+        // by a recursive mkdir before it has been checked.
+        await Directory(current).create();
+      } on FileSystemException catch (error) {
+        throw WorkspacePathException(
+          'Unable to create the workspace working directory: '
+          '${error.message}',
+        );
+      }
+      type = await FileSystemEntity.type(current, followLinks: false);
+    }
+    if (type != FileSystemEntityType.directory) {
+      throw const WorkspacePathException(
+        'The workspace working directory contains a non-directory entry.',
+      );
+    }
+  }
+
+  final target = Directory(current);
+  final canonicalTarget = await _resolveDirectoryLinks(
+    target,
+    description: 'workspace working directory',
+  );
+  if (!p.equals(canonicalRoot, canonicalTarget) &&
+      !p.isWithin(canonicalRoot, canonicalTarget)) {
+    throw const WorkspacePathException(
+      'The workspace working directory escapes the workspace root.',
+    );
+  }
+  return canonicalTarget;
+}
+
+Future<String> _resolveDirectoryLinks(
+  Directory directory, {
+  required String description,
+}) async {
+  try {
+    return p.normalize(await directory.resolveSymbolicLinks());
+  } on FileSystemException catch (error) {
+    throw WorkspacePathException(
+      'Unable to resolve the $description: ${error.message}',
+    );
+  }
+}

--- a/lib/core/services/workspace/workspace_execution_context.dart
+++ b/lib/core/services/workspace/workspace_execution_context.dart
@@ -16,6 +16,19 @@ class WorkspacePathException implements Exception {
   String toString() => message;
 }
 
+/// Stable error code surfaced when project AGENTS.md instructions cannot be
+/// loaded safely for a generation request.
+const String workspaceAgentsMdLoadErrorCode = 'workspace_agents_md_load_failed';
+
+class WorkspaceAgentsMdLoadException implements Exception {
+  const WorkspaceAgentsMdLoadException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => workspaceAgentsMdLoadErrorCode;
+}
+
 /// Immutable workspace state captured for one model generation.
 class WorkspaceExecutionContext {
   const WorkspaceExecutionContext({
@@ -261,6 +274,118 @@ Future<String> ensureWorkspaceDirectoryAtHostRoot({
     );
   }
   return canonicalTarget;
+}
+
+/// Loads all project-level AGENTS.md files from [context.workingDirectory]
+/// upward through the workspace root, closest directory first.
+///
+/// The returned prompt uses guest paths only. AGENTS.md files must resolve to
+/// regular files inside the workspace root; this prevents a project symlink
+/// from causing unrelated host data to be sent to the model provider.
+Future<String?> loadWorkspaceAgentsMdInstructions({
+  required WorkspaceExecutionContext context,
+  required WorkspaceProvider workspaces,
+}) async {
+  try {
+    final hostRoot = workspaces.hostPathFor(context.workspace);
+    if (hostRoot == null || hostRoot.isEmpty) {
+      throw const WorkspaceAgentsMdLoadException(
+        'Workspace host path is not ready.',
+      );
+    }
+
+    final canonicalRoot = await _resolveDirectoryLinks(
+      Directory(hostRoot),
+      description: 'workspace root',
+    );
+    final segments = _workspaceSegments(
+      context.workingDirectory,
+      allowRelative: false,
+    );
+    final workingDirectory = Directory(
+      p.joinAll(<String>[canonicalRoot, ...segments]),
+    );
+    if (await FileSystemEntity.type(workingDirectory.path) !=
+        FileSystemEntityType.directory) {
+      throw const WorkspaceAgentsMdLoadException(
+        'The workspace working directory no longer exists.',
+      );
+    }
+    final canonicalWorkingDirectory = await _resolveDirectoryLinks(
+      workingDirectory,
+      description: 'workspace working directory',
+    );
+    if (!p.equals(canonicalRoot, canonicalWorkingDirectory) &&
+        !p.isWithin(canonicalRoot, canonicalWorkingDirectory)) {
+      throw const WorkspaceAgentsMdLoadException(
+        'The workspace working directory escapes the workspace root.',
+      );
+    }
+
+    final instructions = <String>[];
+    var current = canonicalWorkingDirectory;
+    while (true) {
+      final candidatePath = p.join(current, 'AGENTS.md');
+      final candidateType = await FileSystemEntity.type(
+        candidatePath,
+        followLinks: false,
+      );
+      if (candidateType != FileSystemEntityType.notFound) {
+        if (candidateType != FileSystemEntityType.file &&
+            candidateType != FileSystemEntityType.link) {
+          throw WorkspaceAgentsMdLoadException(
+            'AGENTS.md is not a file: ${_guestDirectoryPath(canonicalRoot, current)}',
+          );
+        }
+
+        final file = File(candidatePath);
+        final canonicalFile = p.normalize(await file.resolveSymbolicLinks());
+        if (!p.isWithin(canonicalRoot, canonicalFile) ||
+            await FileSystemEntity.type(canonicalFile, followLinks: false) !=
+                FileSystemEntityType.file) {
+          throw WorkspaceAgentsMdLoadException(
+            'AGENTS.md resolves outside the workspace root: '
+            '${_guestDirectoryPath(canonicalRoot, current)}',
+          );
+        }
+
+        final content = await file.readAsString();
+        instructions.add(
+          'Instructions from: '
+          '${_guestDirectoryPath(canonicalRoot, current)}/AGENTS.md\n$content',
+        );
+      }
+
+      if (p.equals(current, canonicalRoot)) break;
+      final parent = p.dirname(current);
+      if (!p.equals(parent, canonicalRoot) &&
+          !p.isWithin(canonicalRoot, parent)) {
+        throw const WorkspaceAgentsMdLoadException(
+          'Instruction discovery escaped the workspace root.',
+        );
+      }
+      current = parent;
+    }
+
+    return instructions.isEmpty ? null : instructions.join('\n\n');
+  } on WorkspaceAgentsMdLoadException {
+    rethrow;
+  } on WorkspacePathException catch (error) {
+    throw WorkspaceAgentsMdLoadException(
+      'Unable to resolve the workspace for AGENTS.md loading: '
+      '${error.message}',
+    );
+  } on FileSystemException catch (error) {
+    throw WorkspaceAgentsMdLoadException(
+      'Unable to load workspace AGENTS.md instructions: ${error.message}',
+    );
+  }
+}
+
+String _guestDirectoryPath(String canonicalRoot, String directory) {
+  final relative = p.relative(directory, from: canonicalRoot);
+  if (relative == '.' || relative.isEmpty) return '/workspace';
+  return '/workspace/${relative.replaceAll('\\', '/')}';
 }
 
 Future<String> _resolveDirectoryLinks(

--- a/lib/core/services/workspace/workspace_execution_context.dart
+++ b/lib/core/services/workspace/workspace_execution_context.dart
@@ -76,11 +76,18 @@ String effectiveWorkspaceDirectory({
 /// Normalizes a saved directory to the portable guest `/workspace/...` form.
 /// Relative input is interpreted from the workspace root.
 String normalizeWorkspaceDirectory(String raw) {
-  return resolveWorkspaceGuestPath(
+  final normalized = resolveWorkspaceGuestPath(
     raw,
     baseDirectory: '/workspace',
     allowMountListingRoot: false,
   );
+  if (normalized == '/workspace/.mounts' ||
+      normalized.startsWith('/workspace/.mounts/')) {
+    throw WorkspacePathException(
+      'The /workspace/.mounts namespace is reserved for SAF mounts.',
+    );
+  }
+  return normalized;
 }
 
 /// Resolves a model path using standard cwd semantics without allowing it to

--- a/lib/core/services/workspace/workspace_path_presentation.dart
+++ b/lib/core/services/workspace/workspace_path_presentation.dart
@@ -8,7 +8,9 @@
 /// shell view; filesystem tools and shell now share one vocabulary).
 library;
 
-/// Thrown when a model-supplied path does not use the `/workspace/...` form.
+import 'workspace_execution_context.dart';
+
+/// Thrown when a model-supplied path cannot be resolved inside `/workspace`.
 class ModelPathException implements Exception {
   final String message;
   ModelPathException(this.message);
@@ -17,7 +19,7 @@ class ModelPathException implements Exception {
   String toString() => message;
 }
 
-/// Strict input translation: the model must use `/workspace/...`; canonical
+/// Resolves relative model paths from [workingDirectory]. Canonical
 /// `@alias/...` paths and arbitrary absolute paths are rejected.
 ///
 /// - `/` is passed through unchanged (engine special case: list mounts).
@@ -27,62 +29,44 @@ class ModelPathException implements Exception {
 ///   be a known SAF mount alias; anything else under `.mounts/` is rejected.
 /// - Trailing slashes are preserved so the engine's existing validation
 ///   applies unchanged (read tolerates one, the other tools reject it).
-/// - Segment-level validation (traversal, malformed segments) still happens
-///   inside the engine against the translated canonical path.
+/// - `.` and `..` are normalized, but traversal above `/workspace` is rejected.
+/// - Remaining malformed segments are also checked by the filesystem engine.
 String parseModelPath(
   String raw,
   String alias, {
+  String workingDirectory = '/workspace',
   Set<String> safAliases = const <String>{},
 }) {
-  if (raw.trim() != raw) {
-    throw ModelPathException(
-      'Invalid path: leading/trailing whitespace is not allowed: $raw',
+  try {
+    final resolved = resolveWorkspaceGuestPath(
+      raw,
+      baseDirectory: workingDirectory,
+      preserveTrailingSlash: true,
     );
-  }
-  if (raw.isEmpty) {
-    throw ModelPathException('Invalid path: path is required');
-  }
-  if (raw == '/') return '/';
-  if (raw.startsWith('@')) {
-    throw ModelPathException(
-      'Invalid path: use the /workspace/rel/path form, not $raw',
-    );
-  }
-  if (raw != '/workspace' && !raw.startsWith('/workspace/')) {
-    throw ModelPathException(
-      'Invalid path: only paths under /workspace are allowed: $raw',
-    );
-  }
-  if (raw == '/workspace') return '@$alias';
-  final rest = raw.substring('/workspace/'.length);
-  // External SAF mounts live under the reserved .mounts/ guest directory.
-  // The path is ONLY interpreted as a mount reference; a literal workspace
-  // folder named ".mounts" is shadowed by design (ADR-0037) — same
-  // convention as .sandbox/.fetch_cache dotdirs.
-  if (rest == '.mounts') {
-    throw ModelPathException(
-      'Invalid path: name a mount: /workspace/.mounts/<alias>',
-    );
-  }
-  if (rest.startsWith('.mounts/')) {
-    final seg = rest.substring('.mounts/'.length);
-    final slash = seg.indexOf('/');
-    final mountAlias = slash < 0 ? seg : seg.substring(0, slash);
-    if (mountAlias.isEmpty) {
-      throw ModelPathException(
-        'Invalid path: name a mount: /workspace/.mounts/<alias>',
+    if (resolved == '/') return '/';
+    if (resolved == '/workspace') return '@$alias';
+    final rest = resolved.substring('/workspace/'.length);
+    if (rest == '.mounts' || rest == '.mounts/') {
+      throw const WorkspacePathException(
+        'Name a mount: /workspace/.mounts/<alias>.',
       );
     }
-    if (!safAliases.contains(mountAlias)) {
-      throw ModelPathException(
-        'Invalid path: unknown mount alias: /workspace/.mounts/$mountAlias',
-      );
+    if (rest.startsWith('.mounts/')) {
+      final mountPath = rest.substring('.mounts/'.length);
+      final slash = mountPath.indexOf('/');
+      final mountAlias = slash < 0 ? mountPath : mountPath.substring(0, slash);
+      if (mountAlias.isEmpty || !safAliases.contains(mountAlias)) {
+        throw WorkspacePathException(
+          'Unknown mount alias: /workspace/.mounts/$mountAlias.',
+        );
+      }
+      if (slash < 0) return '@$mountAlias';
+      return '@$mountAlias/${mountPath.substring(slash + 1)}';
     }
-    if (slash < 0) return '@$mountAlias';
-    final rel = seg.substring(slash + 1);
-    return '@$mountAlias/$rel';
+    return '@$alias/$rest';
+  } on WorkspacePathException catch (e) {
+    throw ModelPathException('Invalid path: ${e.message}');
   }
-  return '@$alias/$rest';
 }
 
 /// Canonical wire path → model-facing `/workspace/...` form.

--- a/lib/core/services/workspace/workspace_tools_service.dart
+++ b/lib/core/services/workspace/workspace_tools_service.dart
@@ -4,14 +4,15 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 
 import '../../models/assistant.dart';
+import '../../models/conversation.dart';
 import '../../models/workspace.dart';
 import '../../providers/workspace_provider.dart';
 import '../../services/chat/chat_service.dart';
 import '../mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
 import '../saf/saf_mount_sync_service.dart';
-import 'guest_cwd.dart';
 import 'linux_sandbox_service.dart';
 import 'workspace_download_service.dart';
+import 'workspace_execution_context.dart';
 import 'workspace_path_presentation.dart';
 
 /// Builds and dispatches workspace local tools (filesystem + shell).
@@ -22,8 +23,7 @@ class WorkspaceToolsService {
       'Run a shell command inside the Linux sandbox for the bound workspace. '
       'Prefer the workspace filesystem tools for file reads, writes, search, '
       'moves, archives, and downloads; use shell only when Linux command or '
-      'package semantics are required. Working directory defaults to '
-      '/workspace (the workspace root). Output is truncated. Requires base '
+      'package semantics are required. Output is truncated. Requires base '
       'dependency installed.';
 
   /// Workspace root plus the Android SAF mounts owned by this workspace.
@@ -82,12 +82,17 @@ class WorkspaceToolsService {
     required bool supportsTools,
     LinuxSandboxService? sandbox,
     SafMountSyncService? safMounts,
+    Conversation? conversation,
+    WorkspaceExecutionContext? executionContext,
   }) {
-    if (!supportsTools || assistant == null || !assistant.workspaceEnabled) {
+    if (!supportsTools) {
       return const <Map<String, dynamic>>[];
     }
-    final ws = _boundWorkspace(assistant, workspaces);
-    if (ws == null) return const <Map<String, dynamic>>[];
+    final context =
+        executionContext ??
+        _resolveContext(assistant, conversation, workspaces);
+    if (context == null) return const <Map<String, dynamic>>[];
+    final ws = context.workspace;
 
     final enabled = <String>{
       for (final t in WorkspaceToolNames.filesystemTools)
@@ -107,26 +112,34 @@ class WorkspaceToolsService {
     for (final t in defs) {
       // Model-facing copy only: canonical wire format stays unchanged.
       final presented = presentDefMap(t);
+      final description =
+          '${presented['description'] ?? ''}\n'
+          'Relative paths resolve from ${context.workingDirectory}; '
+          'absolute /workspace/... paths resolve from the workspace root.';
       out.add({
         'type': 'function',
         'function': {
           'name': presented['name'],
-          'description': presented['description'],
+          'description': description,
           'parameters': presented['inputSchema'] ?? {'type': 'object'},
         },
       });
     }
     if (enabled.contains(WorkspaceToolNames.shell)) {
-      out.add(_shellToolDef());
+      out.add(_shellToolDef(context.workingDirectory));
     }
     return out;
   }
 
-  static Map<String, dynamic> _shellToolDef() => {
+  static Map<String, dynamic> _shellToolDef(String workingDirectory) => {
     'type': 'function',
     'function': {
       'name': WorkspaceToolNames.shell,
-      'description': shellToolDescription,
+      'description':
+          '$shellToolDescription Working directory defaults to '
+          '$workingDirectory. '
+          'Relative cwd values resolve from that directory; absolute '
+          '/workspace/... values resolve from the workspace root.',
       'parameters': {
         'type': 'object',
         'properties': {
@@ -158,25 +171,35 @@ class WorkspaceToolsService {
     return true;
   }
 
-  static Workspace? _boundWorkspace(
-    Assistant assistant,
+  static WorkspaceExecutionContext? _resolveContext(
+    Assistant? assistant,
+    Conversation? conversation,
     WorkspaceProvider workspaces,
   ) {
-    final id = assistant.workspaceId;
-    if (id == null || id.isEmpty) return null;
-    return workspaces.getById(id);
+    try {
+      return WorkspaceExecutionContext.resolve(
+        assistant: assistant,
+        conversation: conversation,
+        workspaces: workspaces,
+      );
+    } on WorkspacePathException catch (e) {
+      debugPrint('workspace context invalid: ${e.message}');
+      return null;
+    }
   }
 
   static Set<String> enabledToolNames(
     Assistant? assistant,
     WorkspaceProvider workspaces, {
     LinuxSandboxService? sandbox,
+    Conversation? conversation,
+    WorkspaceExecutionContext? executionContext,
   }) {
-    if (assistant == null || !assistant.workspaceEnabled) {
-      return const <String>{};
-    }
-    final ws = _boundWorkspace(assistant, workspaces);
-    if (ws == null) return const <String>{};
+    final context =
+        executionContext ??
+        _resolveContext(assistant, conversation, workspaces);
+    if (context == null) return const <String>{};
+    final ws = context.workspace;
     final names = <String>{
       for (final t in WorkspaceToolNames.filesystemTools)
         if (ws.isToolEnabled(t)) t,
@@ -201,17 +224,24 @@ class WorkspaceToolsService {
     WorkspaceDownloadAbortToken? downloadAbortToken,
     String? toolCallId,
     String? conversationId,
+    Conversation? conversation,
+    WorkspaceExecutionContext? executionContext,
   }) async {
-    if (assistant == null || !assistant.workspaceEnabled) return null;
     if (!WorkspaceToolNames.isWorkspaceTool(name)) return null;
-
-    final ws = _boundWorkspace(assistant, workspaces);
-    if (ws == null) {
+    if (executionContext == null &&
+        (assistant == null || !assistant.workspaceEnabled)) {
+      return null;
+    }
+    final context =
+        executionContext ??
+        _resolveContext(assistant, conversation, workspaces);
+    if (context == null) {
       return jsonEncode({
         'error': 'workspace_unbound',
         'message': 'No workspace bound to this assistant.',
       });
     }
+    final ws = context.workspace;
     if (name == WorkspaceToolNames.shell) {
       if (!ws.shellEnabled ||
           !ws.isToolEnabled(WorkspaceToolNames.shell) ||
@@ -220,6 +250,18 @@ class WorkspaceToolsService {
       }
     } else if (!ws.isToolEnabled(name)) {
       return null;
+    }
+    try {
+      await ensureWorkspaceWorkingDirectory(
+        context: context,
+        workspaces: workspaces,
+      );
+    } catch (e, st) {
+      debugPrint('workspace working directory unavailable: $e\n$st');
+      return jsonEncode({
+        'error': 'working_directory_unavailable',
+        'message': e.toString(),
+      });
     }
 
     if (name == WorkspaceToolNames.shell) {
@@ -231,6 +273,7 @@ class WorkspaceToolsService {
         safMounts: safMounts,
         requestId: toolCallId,
         conversationId: conversationId,
+        workingDirectory: context.workingDirectory,
       );
     }
 
@@ -260,6 +303,7 @@ class WorkspaceToolsService {
       translatedArgs = _translateModelArgs(
         args,
         ws.alias,
+        context.workingDirectory,
         safAliases: safAliases,
       );
     } on ModelPathException catch (e) {
@@ -274,19 +318,24 @@ class WorkspaceToolsService {
     return _mcpResultToText(result);
   }
 
-  /// Strict model-facing path translation: the model must use
-  /// `/workspace/...`; canonical `@alias/...` is rejected (see
-  /// `workspace_path_presentation.dart`).
+  /// Resolves relative model-facing paths from the captured working directory
+  /// and translates them to the canonical `@alias/...` wire format.
   static Map<String, dynamic> _translateModelArgs(
     Map<String, dynamic> args,
-    String alias, {
+    String alias,
+    String workingDirectory, {
     Set<String> safAliases = const <String>{},
   }) {
     final out = Map<String, dynamic>.from(args);
     for (final key in const ['path', 'source', 'destination']) {
       final v = out[key];
       if (v == null || v is! String) continue;
-      out[key] = parseModelPath(v, alias, safAliases: safAliases);
+      out[key] = parseModelPath(
+        v,
+        alias,
+        workingDirectory: workingDirectory,
+        safAliases: safAliases,
+      );
     }
     return out;
   }
@@ -317,6 +366,7 @@ class WorkspaceToolsService {
     SafMountSyncService? safMounts,
     String? requestId,
     String? conversationId,
+    required String workingDirectory,
   }) async {
     if (!Platform.isAndroid && !Platform.isIOS) {
       return jsonEncode({
@@ -339,20 +389,22 @@ class WorkspaceToolsService {
         'message': 'command is required',
       });
     }
-    final cwd = args['cwd']?.toString();
-    final normalizedCwd = normalizeGuestCwd(cwd);
-    if (normalizedCwd == null) {
-      return jsonEncode({
-        'error': 'invalid_cwd',
-        'message': 'cwd must be a relative path or under /workspace',
-      });
+    final String cwd;
+    try {
+      cwd = resolveWorkspaceGuestPath(
+        args['cwd']?.toString() ?? workingDirectory,
+        baseDirectory: workingDirectory,
+        allowMountListingRoot: false,
+      );
+    } on WorkspacePathException catch (e) {
+      return jsonEncode({'error': 'invalid_path', 'message': e.message});
     }
     final timeout = (args['timeout'] as num?)?.toInt() ?? 30;
     try {
       final result = await svc.exec(
         workspaceHostPath: host,
         command: command,
-        cwd: normalizedCwd,
+        cwd: cwd,
         timeoutSeconds: timeout
             .clamp(1, LinuxSandboxService.maxShellTimeoutSeconds)
             .toInt(),
@@ -398,27 +450,39 @@ class WorkspaceToolsService {
     required Assistant? assistant,
     required WorkspaceProvider workspaces,
     LinuxSandboxService? sandbox,
+    Conversation? conversation,
+    WorkspaceExecutionContext? executionContext,
   }) {
-    if (assistant == null || !assistant.workspaceEnabled) return null;
-    final ws = _boundWorkspace(assistant, workspaces);
-    if (ws == null) return null;
+    final context =
+        executionContext ??
+        _resolveContext(assistant, conversation, workspaces);
+    if (context == null) return null;
+    final ws = context.workspace;
     final tools = enabledToolNames(
       assistant,
       workspaces,
       sandbox: sandbox,
+      conversation: conversation,
+      executionContext: context,
     ).join(', ');
     if (tools.isEmpty) return null;
     final buf = StringBuffer()
       ..writeln('<workspace>')
       ..writeln('Bound workspace: /workspace (${ws.displayName})')
-      ..writeln('Paths use the /workspace/rel/path form')
+      ..writeln('Current working directory: ${context.workingDirectory}')
+      ..writeln(
+        'Relative paths resolve from the current working directory; '
+        'absolute /workspace/... paths resolve from the workspace root.',
+      )
       ..writeln('Enabled tools: $tools');
     if (enabledToolNames(
       assistant,
       workspaces,
       sandbox: sandbox,
+      conversation: conversation,
+      executionContext: context,
     ).contains(WorkspaceToolNames.shell)) {
-      buf.writeln('Shell guest cwd default: /workspace');
+      buf.writeln('Shell guest cwd default: ${context.workingDirectory}');
     }
     buf.writeln('</workspace>');
     return buf.toString();

--- a/lib/desktop/tools_hub_popover.dart
+++ b/lib/desktop/tools_hub_popover.dart
@@ -8,6 +8,7 @@ Future<void> showDesktopToolsHubPopover(
   BuildContext context, {
   required GlobalKey anchorKey,
   required String assistantId,
+  required String? conversationId,
 }) async {
   final overlay = Overlay.maybeOf(context);
   if (overlay == null) return;
@@ -31,6 +32,7 @@ Future<void> showDesktopToolsHubPopover(
       anchorRect: anchorRect,
       anchorWidth: size.width,
       assistantId: assistantId,
+      conversationId: conversationId,
       onClose: () {
         try {
           entry.remove();
@@ -46,12 +48,14 @@ class _ToolsHubPopover extends StatefulWidget {
     required this.anchorRect,
     required this.anchorWidth,
     required this.assistantId,
+    required this.conversationId,
     required this.onClose,
   });
 
   final Rect anchorRect;
   final double anchorWidth;
   final String assistantId;
+  final String? conversationId;
   final VoidCallback onClose;
 
   @override
@@ -145,6 +149,7 @@ class _ToolsHubPopoverState extends State<_ToolsHubPopover>
                             padding: const EdgeInsets.fromLTRB(12, 10, 12, 6),
                             child: ToolsHubContent(
                               assistantId: widget.assistantId,
+                              conversationId: widget.conversationId,
                               onClose: () => widget.onClose(),
                             ),
                           ),

--- a/lib/features/assistant/pages/assistant_settings_edit_local_tools_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_local_tools_tab.dart
@@ -120,7 +120,9 @@ class _LocalToolsTab extends StatelessWidget {
     }
 
     final workspaceOn = assistant.workspaceEnabled;
+    var workspaceReady = false;
     String workspaceSubtitle = l10n.workspaceEntrySubtitleOff;
+    String directorySubtitle = l10n.workspaceBindDisabledHint;
     if (workspaceOn) {
       try {
         final wp = context.watch<WorkspaceProvider>();
@@ -128,6 +130,11 @@ class _LocalToolsTab extends StatelessWidget {
             ? null
             : wp.getById(assistant.workspaceId!);
         workspaceSubtitle = ws?.displayName ?? l10n.workspaceBindTitle;
+        workspaceReady = ws != null;
+        if (ws != null) {
+          directorySubtitle =
+              assistant.workspaceDefaultDirectories[ws.id] ?? '/workspace';
+        }
       } on ProviderNotFoundException catch (e) {
         debugPrint('workspace provider missing: $e');
       } catch (e) {
@@ -145,6 +152,19 @@ class _LocalToolsTab extends StatelessWidget {
               title: l10n.assistantEditLocalToolWorkspaceTitle,
               subtitle: workspaceSubtitle,
               onTap: () => showWorkspaceBindSheet(context, assistant),
+            ),
+            _iosDivider(context),
+            _LocalToolNavRow(
+              icon: Lucide.FolderOpen,
+              title: l10n.workspaceDefaultDirectoryTitle,
+              subtitle: directorySubtitle,
+              enabled: workspaceReady,
+              onTap: workspaceReady
+                  ? () => showWorkspaceDirectorySettings(
+                      context,
+                      assistantId: assistant.id,
+                    )
+                  : null,
             ),
             _iosDivider(context),
             _LocalToolRow(
@@ -299,12 +319,14 @@ class _LocalToolNavRow extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.onTap,
+    this.enabled = true,
   });
 
   final IconData icon;
   final String title;
   final String subtitle;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -313,56 +335,62 @@ class _LocalToolNavRow extends StatelessWidget {
       onTap: onTap,
       builder: (pressed) {
         final baseColor = cs.onSurface.withValues(alpha: 0.9);
-        return _AnimatedPressColor(
-          pressed: pressed,
-          base: baseColor,
-          builder: (color) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-              child: Row(
-                children: [
-                  SizedBox(
-                    width: 36,
-                    child: Icon(icon, size: 20, color: cs.primary),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontSize: 15,
-                            color: color,
-                            fontWeight: AppFontWeights.semibold,
-                          ),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          subtitle,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            fontSize: 12,
-                            height: 1.25,
-                            color: cs.onSurface.withValues(alpha: 0.62),
-                          ),
-                        ),
-                      ],
+        return Opacity(
+          opacity: enabled ? 1 : 0.55,
+          child: _AnimatedPressColor(
+            pressed: pressed,
+            base: baseColor,
+            builder: (color) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    SizedBox(
+                      width: 36,
+                      child: Icon(icon, size: 20, color: cs.primary),
                     ),
-                  ),
-                  Icon(
-                    Lucide.ChevronRight,
-                    size: 18,
-                    color: cs.onSurface.withValues(alpha: 0.35),
-                  ),
-                ],
-              ),
-            );
-          },
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 15,
+                              color: color,
+                              fontWeight: AppFontWeights.semibold,
+                            ),
+                          ),
+                          const SizedBox(height: 3),
+                          Text(
+                            subtitle,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 12,
+                              height: 1.25,
+                              color: cs.onSurface.withValues(alpha: 0.62),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      Lucide.ChevronRight,
+                      size: 18,
+                      color: cs.onSurface.withValues(alpha: 0.35),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
         );
       },
     );

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -38,6 +38,7 @@ import '../../../desktop/desktop_context_menu.dart';
 import '../../../desktop/desktop_settings_navigation_bus.dart';
 import '../../home/services/local_tools_service.dart';
 import '../../skills/skill_manager.dart';
+import '../../workspace/widgets/workspace_settings_sheet.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/collapsible_group_header.dart';

--- a/lib/features/home/controllers/generation_controller.dart
+++ b/lib/features/home/controllers/generation_controller.dart
@@ -2,10 +2,12 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/conversation.dart';
 import '../../../core/providers/model_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/workspace/workspace_execution_context.dart';
 import '../../model/utils/ocr_model_capability.dart';
 import '../../../utils/assistant_regex.dart';
 import '../../../core/models/assistant_regex.dart';
@@ -126,8 +128,10 @@ class GenerationController {
     Assistant? assistant,
     String providerKey,
     String modelId,
-    bool hasBuiltInSearch,
-  ) {
+    bool hasBuiltInSearch, {
+    Conversation? conversation,
+    WorkspaceExecutionContext? workspaceExecutionContext,
+  }) {
     return toolHandlerService.buildToolDefinitions(
       settings,
       assistant,
@@ -135,8 +139,28 @@ class GenerationController {
       modelId,
       hasBuiltInSearch,
       isToolModel: isToolModel,
+      conversation: conversation,
+      workspaceExecutionContext: workspaceExecutionContext,
     );
   }
+
+  WorkspaceExecutionContext? resolveWorkspaceExecutionContext(
+    Assistant? assistant,
+    Conversation? conversation,
+  ) => toolHandlerService.resolveWorkspaceExecutionContext(
+    assistant,
+    conversation,
+  );
+
+  String? buildWorkspacePromptReminder({
+    required Assistant? assistant,
+    required Conversation? conversation,
+    WorkspaceExecutionContext? workspaceExecutionContext,
+  }) => toolHandlerService.buildWorkspacePromptReminder(
+    assistant: assistant,
+    conversation: conversation,
+    executionContext: workspaceExecutionContext,
+  );
 
   /// Build tool call handler function.
   /// Delegates to ToolHandlerService.buildToolCallHandler.
@@ -146,6 +170,8 @@ class GenerationController {
     ToolApprovalService? approvalService,
     AskUserInteractionService? askUserService,
     String? conversationId,
+    Conversation? conversation,
+    WorkspaceExecutionContext? workspaceExecutionContext,
   }) {
     return toolHandlerService.buildToolCallHandler(
       settings,
@@ -153,6 +179,8 @@ class GenerationController {
       approvalService: approvalService,
       askUserService: askUserService,
       conversationId: conversationId,
+      conversation: conversation,
+      workspaceExecutionContext: workspaceExecutionContext,
     );
   }
 

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -29,6 +29,7 @@ import '../../../core/services/proactive_care_alarm_service.dart';
 import '../../../core/services/logging/flutter_logger.dart';
 import '../../../core/services/storage/message_locate_bus.dart';
 import '../../../core/services/workspace/linux_sandbox_service.dart';
+import '../../../core/services/workspace/workspace_execution_context.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/platform_utils.dart';
@@ -532,6 +533,8 @@ class HomePageController extends ChangeNotifier {
     switch (error) {
       case 'audio_attachment_unsupported':
         return l10n.homePageAudioAttachmentUnsupported;
+      case workspaceAgentsMdLoadErrorCode:
+        return l10n.workspaceAgentsMdLoadFailed;
       default:
         return '${l10n.generationInterrupted}: $error';
     }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1595,9 +1595,14 @@ class _HomePageState extends State<HomePage>
               context,
               anchorKey: _inputBarKey,
               assistantId: a.id,
+              conversationId: _controller.currentConversation?.id,
             );
           } else {
-            showToolsHubSheet(context, assistantId: a.id);
+            showToolsHubSheet(
+              context,
+              assistantId: a.id,
+              conversationId: _controller.currentConversation?.id,
+            );
           }
         }
       },
@@ -2035,7 +2040,11 @@ class _HomePageState extends State<HomePage>
                 : () {
                     Navigator.of(ctx).maybePop();
                     if (a != null) {
-                      showToolsHubSheet(context, assistantId: a.id);
+                      showToolsHubSheet(
+                        context,
+                        assistantId: a.id,
+                        conversationId: _controller.currentConversation?.id,
+                      );
                     }
                   },
           ),

--- a/lib/features/home/services/handoff_tool_service.dart
+++ b/lib/features/home/services/handoff_tool_service.dart
@@ -216,22 +216,27 @@ class HandoffToolService {
         providerKey: providerKey,
         modelId: modelId,
       );
+      // ignore: use_build_context_synchronously (root context)
+      final toolHandler = ToolHandlerService(contextProvider: context);
+      final workspaceExecutionContext = toolHandler
+          .resolveWorkspaceExecutionContext(target, conversation);
       messageBuilder.injectSystemPrompt(apiMessages, target, modelId);
+      await messageBuilder.injectWorkspaceAgentsMdInstructions(
+        apiMessages,
+        assistant: target,
+        workspaceExecutionContext: workspaceExecutionContext,
+      );
       await messageBuilder.injectMemoryAndRecentChats(
         apiMessages,
         target,
         currentConversationId: conversation.id,
       );
-      messageBuilder.injectInstructionPrompts(apiMessages, target.id);
+      await messageBuilder.injectInstructionPrompts(apiMessages, target.id);
       await messageBuilder.injectWorldBookPrompts(apiMessages, target.id);
       messageBuilder.injectSkillListPrompt(apiMessages, target.id);
       messageBuilder.injectTimeNote(apiMessages, target);
       messageBuilder.applyContextLimit(apiMessages, target);
 
-      // ignore: use_build_context_synchronously (root context)
-      final toolHandler = ToolHandlerService(contextProvider: context);
-      final workspaceExecutionContext = toolHandler
-          .resolveWorkspaceExecutionContext(target, conversation);
       messageBuilder.injectWorkspacePrompt(
         apiMessages,
         toolHandler.buildWorkspacePromptReminder(

--- a/lib/features/home/services/handoff_tool_service.dart
+++ b/lib/features/home/services/handoff_tool_service.dart
@@ -230,6 +230,16 @@ class HandoffToolService {
 
       // ignore: use_build_context_synchronously (root context)
       final toolHandler = ToolHandlerService(contextProvider: context);
+      final workspaceExecutionContext = toolHandler
+          .resolveWorkspaceExecutionContext(target, conversation);
+      messageBuilder.injectWorkspacePrompt(
+        apiMessages,
+        toolHandler.buildWorkspacePromptReminder(
+          assistant: target,
+          conversation: conversation,
+          executionContext: workspaceExecutionContext,
+        ),
+      );
       final toolDefs = toolHandler.buildToolDefinitions(
         settings,
         target,
@@ -237,6 +247,8 @@ class HandoffToolService {
         modelId,
         false,
         isToolModel: (_, _) => true,
+        conversation: conversation,
+        workspaceExecutionContext: workspaceExecutionContext,
       );
       final onToolCall = toolDefs.isNotEmpty
           ? toolHandler.buildToolCallHandler(
@@ -249,6 +261,8 @@ class HandoffToolService {
               // ignore: use_build_context_synchronously (root context)
               askUserService: context.read<AskUserInteractionService>(),
               conversationId: conversation.id,
+              conversation: conversation,
+              workspaceExecutionContext: workspaceExecutionContext,
             )
           : null;
 

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -683,6 +683,14 @@ class MessageBuilderService {
     }
   }
 
+  void injectWorkspacePrompt(
+    List<Map<String, dynamic>> apiMessages,
+    String? prompt,
+  ) {
+    if (prompt == null || prompt.trim().isEmpty) return;
+    _appendToSystemMessage(apiMessages, prompt);
+  }
+
   /// Inject memory prompts and recent chats reference into apiMessages.
   Future<void> injectMemoryAndRecentChats(
     List<Map<String, dynamic>> apiMessages,

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -13,10 +13,12 @@ import '../../../core/models/assistant_memory.dart';
 import '../../../core/providers/memory_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/user_provider.dart';
+import '../../../core/providers/workspace_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/chat/chat_context_transforms.dart';
 import '../../../core/services/chat/document_text_extractor.dart';
 import '../../../core/services/chat/prompt_transformer.dart';
+import '../../../core/services/workspace/workspace_execution_context.dart';
 import '../../../core/services/instruction_injection_store.dart';
 import '../../../core/services/world_book_store.dart';
 import '../../../core/services/world_book_prompt_injector.dart';
@@ -821,6 +823,42 @@ These memories are automatically included in future conversation contexts within
         _appendToSystemMessage(apiMessages, lp);
       }
     } catch (_) {}
+  }
+
+  /// Inject project-level AGENTS.md instructions for the effective workspace
+  /// directory. A read failure aborts this generation so project instructions
+  /// are never only partially applied.
+  Future<void> injectWorkspaceAgentsMdInstructions(
+    List<Map<String, dynamic>> apiMessages, {
+    required Assistant? assistant,
+    required WorkspaceExecutionContext? workspaceExecutionContext,
+  }) async {
+    if (assistant?.autoLoadAgentsMd != true ||
+        workspaceExecutionContext == null) {
+      return;
+    }
+
+    try {
+      final instructions = await loadWorkspaceAgentsMdInstructions(
+        context: workspaceExecutionContext,
+        workspaces: contextProvider.read<WorkspaceProvider>(),
+      );
+      if (instructions != null) {
+        _appendToSystemMessage(apiMessages, instructions);
+      }
+    } on WorkspaceAgentsMdLoadException catch (error, stackTrace) {
+      debugPrint(
+        'Failed to load workspace AGENTS.md instructions: '
+        '${error.message}\n$stackTrace',
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Unexpected workspace AGENTS.md loading failure: '
+        '$error\n$stackTrace',
+      );
+      throw WorkspaceAgentsMdLoadException(error.toString());
+    }
   }
 
   /// Inject available skill list (metadata only) into apiMessages.

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -174,6 +174,13 @@ class MessageGenerationService {
 
     // Inject prompts
     messageBuilderService.injectSystemPrompt(apiMessages, assistant, modelId);
+    final workspaceExecutionContext = generationController
+        .resolveWorkspaceExecutionContext(assistant, currentConversation);
+    await messageBuilderService.injectWorkspaceAgentsMdInstructions(
+      apiMessages,
+      assistant: assistant,
+      workspaceExecutionContext: workspaceExecutionContext,
+    );
     await messageBuilderService.injectMemoryAndRecentChats(
       apiMessages,
       assistant,
@@ -201,8 +208,6 @@ class MessageGenerationService {
     );
     await messageBuilderService.injectSkillListPrompt(apiMessages, assistantId);
 
-    final workspaceExecutionContext = generationController
-        .resolveWorkspaceExecutionContext(assistant, currentConversation);
     messageBuilderService.injectWorkspacePrompt(
       apiMessages,
       generationController.buildWorkspacePromptReminder(

--- a/lib/features/home/services/message_generation_service.dart
+++ b/lib/features/home/services/message_generation_service.dart
@@ -201,6 +201,17 @@ class MessageGenerationService {
     );
     await messageBuilderService.injectSkillListPrompt(apiMessages, assistantId);
 
+    final workspaceExecutionContext = generationController
+        .resolveWorkspaceExecutionContext(assistant, currentConversation);
+    messageBuilderService.injectWorkspacePrompt(
+      apiMessages,
+      generationController.buildWorkspacePromptReminder(
+        assistant: assistant,
+        conversation: currentConversation,
+        workspaceExecutionContext: workspaceExecutionContext,
+      ),
+    );
+
     // Inject time note (at the end of system message, after all other injections)
     messageBuilderService.injectTimeNote(apiMessages, assistant);
 
@@ -215,6 +226,8 @@ class MessageGenerationService {
       providerKey,
       modelId,
       hasBuiltInSearch,
+      conversation: currentConversation,
+      workspaceExecutionContext: workspaceExecutionContext,
     );
     final onToolCall = toolDefs.isNotEmpty
         ? generationController.buildToolCallHandler(
@@ -223,6 +236,8 @@ class MessageGenerationService {
             approvalService: approvalService,
             askUserService: askUserService,
             conversationId: currentConversation?.id,
+            conversation: currentConversation,
+            workspaceExecutionContext: workspaceExecutionContext,
           )
         : null;
 

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/assistant_memory.dart';
+import '../../../core/models/conversation.dart';
 import '../../../core/models/workspace.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/download_progress_store.dart';
@@ -20,6 +21,7 @@ import '../../../core/services/mcp/mcp_tool_service.dart';
 import '../../../core/services/saf/saf_mount_sync_service.dart';
 import '../../../core/services/search/search_tool_service.dart';
 import '../../../core/services/workspace/linux_sandbox_service.dart';
+import '../../../core/services/workspace/workspace_execution_context.dart';
 import '../../../core/services/workspace/workspace_tools_service.dart';
 import 'ask_user_interaction_service.dart';
 import 'handoff_tool_service.dart';
@@ -51,6 +53,50 @@ class ToolHandlerService {
 
   /// Build context (used for accessing providers)
   final BuildContext contextProvider;
+
+  WorkspaceExecutionContext? resolveWorkspaceExecutionContext(
+    Assistant? assistant,
+    Conversation? conversation,
+  ) {
+    try {
+      return WorkspaceExecutionContext.resolve(
+        assistant: assistant,
+        conversation: conversation,
+        workspaces: contextProvider.read<WorkspaceProvider>(),
+      );
+    } on ProviderNotFoundException catch (e) {
+      debugPrint(
+        'workspace context unavailable: WorkspaceProvider is not registered '
+        '(${e.runtimeType})',
+      );
+      return null;
+    } on WorkspacePathException catch (e) {
+      debugPrint('workspace context invalid: ${e.message}');
+      return null;
+    }
+  }
+
+  String? buildWorkspacePromptReminder({
+    required Assistant? assistant,
+    required Conversation? conversation,
+    WorkspaceExecutionContext? executionContext,
+  }) {
+    try {
+      return WorkspaceToolsService.buildPromptReminder(
+        assistant: assistant,
+        conversation: conversation,
+        workspaces: contextProvider.read<WorkspaceProvider>(),
+        sandbox: LinuxSandboxService.instance,
+        executionContext: executionContext,
+      );
+    } on ProviderNotFoundException catch (e) {
+      debugPrint(
+        'workspace reminder skipped: WorkspaceProvider is not registered '
+        '(${e.runtimeType})',
+      );
+      return null;
+    }
+  }
 
   // ============================================================================
   // Tool Schema Sanitization
@@ -345,6 +391,8 @@ class ToolHandlerService {
     String modelId,
     bool hasBuiltInSearch, {
     required bool Function(String providerKey, String modelId) isToolModel,
+    Conversation? conversation,
+    WorkspaceExecutionContext? workspaceExecutionContext,
   }) {
     final List<Map<String, dynamic>> toolDefs = <Map<String, dynamic>>[];
     final supportsTools = isToolModel(providerKey, modelId);
@@ -398,10 +446,15 @@ class ToolHandlerService {
           supportsTools: supportsTools,
           sandbox: LinuxSandboxService.instance,
           safMounts: safMounts,
+          conversation: conversation,
+          executionContext: workspaceExecutionContext,
         ),
       );
     } on ProviderNotFoundException catch (e) {
-      debugPrint('workspace tools defs skipped: $e');
+      debugPrint(
+        'workspace tools defs skipped: WorkspaceProvider is not registered '
+        '(${e.runtimeType})',
+      );
     }
 
     // MCP tools
@@ -581,6 +634,8 @@ class ToolHandlerService {
     ToolApprovalService? approvalService,
     AskUserInteractionService? askUserService,
     String? conversationId,
+    Conversation? conversation,
+    WorkspaceExecutionContext? workspaceExecutionContext,
   }) {
     final mcp = contextProvider.read<McpProvider>();
     final toolSvc = contextProvider.read<McpToolService>();
@@ -592,8 +647,24 @@ class ToolHandlerService {
     try {
       workspaceProvider = contextProvider.read<WorkspaceProvider>();
       chatService = contextProvider.read<ChatService>();
-    } catch (_) {
-      // Headless / tests without WorkspaceProvider.
+    } on ProviderNotFoundException catch (e) {
+      debugPrint(
+        'workspace providers unavailable in tool handler '
+        '(${e.runtimeType})',
+      );
+    }
+    WorkspaceExecutionContext? capturedWorkspaceContext =
+        workspaceExecutionContext;
+    if (capturedWorkspaceContext == null && workspaceProvider != null) {
+      try {
+        capturedWorkspaceContext = WorkspaceExecutionContext.resolve(
+          assistant: assistant,
+          conversation: conversation,
+          workspaces: workspaceProvider,
+        );
+      } on WorkspacePathException catch (e) {
+        debugPrint('workspace context invalid: ${e.message}');
+      }
     }
 
     return (name, args, {toolCallId}) async {
@@ -775,8 +846,7 @@ class ToolHandlerService {
               tool: name,
             );
           }
-          final boundId = assistant?.workspaceId;
-          final boundWs = boundId != null ? wp.getById(boundId) : null;
+          final boundWs = capturedWorkspaceContext?.workspace;
           final needsApproval =
               boundWs?.isToolNeedsApproval(name) ??
               WorkspaceToolNames.defaultApprovalFor(name);
@@ -848,6 +918,8 @@ class ToolHandlerService {
               downloadAbortToken: downloadJob?.abortToken,
               toolCallId: toolCallId,
               conversationId: conversationId,
+              conversation: conversation,
+              executionContext: capturedWorkspaceContext,
             );
             if (wsResult != null) return wsResult;
           } catch (e) {

--- a/lib/features/home/widgets/tools_hub_content.dart
+++ b/lib/features/home/widgets/tools_hub_content.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/models/assistant.dart';
+import '../../../core/models/conversation.dart';
 import '../../../core/models/workspace.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/mcp_provider.dart';
 import '../../../core/providers/workspace_provider.dart';
+import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/haptics.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
@@ -24,6 +26,7 @@ import '../../workspace/pages/workspace_list_page.dart';
 import '../../workspace/pages/workspace_terminal_page.dart';
 import '../../workspace/widgets/workspace_bind_sheet.dart';
 import '../../assistant/pages/assistant_settings_page.dart';
+import '../../workspace/widgets/workspace_settings_sheet.dart';
 import '../services/local_tools_service.dart';
 import 'subagent_target_sheet.dart';
 
@@ -35,9 +38,15 @@ import 'subagent_target_sheet.dart';
 /// check-mark rows on desktop (hover highlight), card rows with switches on
 /// mobile.
 class ToolsHubContent extends StatefulWidget {
-  const ToolsHubContent({super.key, required this.assistantId, this.onClose});
+  const ToolsHubContent({
+    super.key,
+    required this.assistantId,
+    required this.conversationId,
+    this.onClose,
+  });
 
   final String assistantId;
+  final String? conversationId;
 
   /// Invoked before navigation actions (dialog/routes) so hosting shells
   /// (e.g. the desktop popover with its full-screen dismiss barrier) can
@@ -184,6 +193,9 @@ class _ToolsHubContentState extends State<ToolsHubContent>
     final boundWs = assistant.workspaceId == null
         ? null
         : wp.getById(assistant.workspaceId!);
+    final conversation = widget.conversationId == null
+        ? null
+        : context.watch<ChatService>().getConversation(widget.conversationId!);
     final wsTerminalReady =
         Platform.isAndroid &&
         assistant.workspaceEnabled &&
@@ -241,6 +253,7 @@ class _ToolsHubContentState extends State<ToolsHubContent>
                 assistant,
                 boundWs,
                 wsTerminalReady,
+                conversation,
               ),
             ],
           ),
@@ -481,8 +494,34 @@ class _ToolsHubContentState extends State<ToolsHubContent>
     Assistant a,
     Workspace? boundWs,
     bool wsTerminalReady,
+    Conversation? conversation,
   ) {
     final boundLabel = boundWs?.displayName ?? l10n.toolsHubWorkspaceUnbound;
+    final directoryReady =
+        a.workspaceEnabled && boundWs != null && conversation != null;
+    final directoryLabel = directoryReady
+        ? conversation.workspaceDirectoryOverrides[boundWs.id] ??
+              a.workspaceDefaultDirectories[boundWs.id] ??
+              '/workspace'
+        : l10n.workspaceBindDisabledHint;
+
+    void openDirectorySettings() {
+      final conversationId = widget.conversationId;
+      if (!directoryReady || conversationId == null) return;
+      Haptics.light();
+      final launchContext = widget.onClose == null
+          ? context
+          : Navigator.of(context, rootNavigator: true).context;
+      widget.onClose?.call();
+      unawaited(
+        showWorkspaceDirectorySettings(
+          launchContext,
+          assistantId: a.id,
+          conversationId: conversationId,
+        ),
+      );
+    }
+
     final children = <Widget>[
       if (_isMobileStyle)
         _SheetNavRow(
@@ -523,6 +562,39 @@ class _ToolsHubContentState extends State<ToolsHubContent>
             showWorkspaceBindSheet(context, a);
           },
         ),
+      if (_isMobileStyle)
+        _SheetNavRow(
+          icon: Lucide.FolderOpen,
+          title: l10n.workspaceDirectoryPickerTitle,
+          trailingText: directoryLabel,
+          enabled: directoryReady,
+          onTap: directoryReady ? openDirectorySettings : null,
+        )
+      else
+        _DesktopToolRow(
+          icon: Lucide.FolderOpen,
+          label: l10n.workspaceDirectoryPickerTitle,
+          enabled: directoryReady,
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                directoryLabel,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: cs.onSurface.withValues(alpha: 0.55),
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                Lucide.ChevronRight,
+                size: 16,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ],
+          ),
+          onTap: directoryReady ? openDirectorySettings : null,
+        ),
     ];
     if (Platform.isAndroid) {
       children.add(
@@ -551,7 +623,7 @@ class _ToolsHubContentState extends State<ToolsHubContent>
     return _buildGroup(
       keyName: _workspaceKey,
       groupName: l10n.settingsPageWorkspace,
-      count: Platform.isAndroid ? 2 : 1,
+      count: Platform.isAndroid ? 3 : 2,
       trailing: Tooltip(
         message: l10n.toolsHubWorkspaceManage,
         child: IosIconButton(
@@ -639,6 +711,7 @@ class _DesktopToolRow extends StatefulWidget {
     required this.icon,
     required this.label,
     this.selected = false,
+    this.enabled = true,
     this.onTap,
     this.trailing,
   });
@@ -646,6 +719,7 @@ class _DesktopToolRow extends StatefulWidget {
   final IconData icon;
   final String label;
   final bool selected;
+  final bool enabled;
   final VoidCallback? onTap;
   final Widget? trailing;
 
@@ -665,57 +739,62 @@ class _DesktopToolRowState extends State<_DesktopToolRow> {
     final hoverBg = (isDark ? Colors.white : Colors.black).withValues(
       alpha: isDark ? 0.12 : 0.10,
     );
-    return MouseRegion(
-      cursor: widget.onTap == null
-          ? MouseCursor.defer
-          : SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: widget.onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 120),
-          height: 40,
-          padding: const EdgeInsets.symmetric(horizontal: 8),
-          decoration: BoxDecoration(
-            color: _hovered ? hoverBg : Colors.transparent,
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Row(
-            children: [
-              SizedBox(
-                width: 22,
-                height: 22,
-                child: Center(
-                  child: Icon(
-                    widget.icon,
-                    size: 16,
-                    color: widget.selected ? cs.primary : onColor,
+    return Opacity(
+      opacity: widget.enabled ? 1 : 0.55,
+      child: MouseRegion(
+        cursor: !widget.enabled || widget.onTap == null
+            ? MouseCursor.defer
+            : SystemMouseCursors.click,
+        onEnter: (_) {
+          if (widget.enabled) setState(() => _hovered = true);
+        },
+        onExit: (_) => setState(() => _hovered = false),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: widget.enabled ? widget.onTap : null,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            height: 40,
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            decoration: BoxDecoration(
+              color: _hovered ? hoverBg : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 22,
+                  height: 22,
+                  child: Center(
+                    child: Icon(
+                      widget.icon,
+                      size: 16,
+                      color: widget.selected ? cs.primary : onColor,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  widget.label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: AppFontWeights.regular,
-                    decoration: TextDecoration.none,
-                    color: onColor,
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    widget.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: AppFontWeights.regular,
+                      decoration: TextDecoration.none,
+                      color: onColor,
+                    ),
                   ),
                 ),
-              ),
-              if (widget.trailing != null)
-                widget.trailing!
-              else if (widget.selected)
-                Icon(Lucide.Check, size: 16, color: cs.primary)
-              else
-                const SizedBox(width: 16),
-            ],
+                if (widget.trailing != null)
+                  widget.trailing!
+                else if (widget.selected)
+                  Icon(Lucide.Check, size: 16, color: cs.primary)
+                else
+                  const SizedBox(width: 16),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/features/home/widgets/tools_hub_sheet.dart
+++ b/lib/features/home/widgets/tools_hub_sheet.dart
@@ -6,6 +6,7 @@ import 'tools_hub_content.dart';
 Future<void> showToolsHubSheet(
   BuildContext context, {
   required String assistantId,
+  required String? conversationId,
 }) async {
   final cs = Theme.of(context).colorScheme;
   await showModalBottomSheet<void>(
@@ -15,14 +16,21 @@ Future<void> showToolsHubSheet(
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
     ),
-    builder: (_) => _ToolsHubSheet(assistantId: assistantId),
+    builder: (_) => _ToolsHubSheet(
+      assistantId: assistantId,
+      conversationId: conversationId,
+    ),
   );
 }
 
 class _ToolsHubSheet extends StatelessWidget {
-  const _ToolsHubSheet({required this.assistantId});
+  const _ToolsHubSheet({
+    required this.assistantId,
+    required this.conversationId,
+  });
 
   final String assistantId;
+  final String? conversationId;
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +59,10 @@ class _ToolsHubSheet extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 6),
-              ToolsHubContent(assistantId: assistantId),
+              ToolsHubContent(
+                assistantId: assistantId,
+                conversationId: conversationId,
+              ),
             ],
           ),
         ),

--- a/lib/features/settings/pages/mount_files_page.dart
+++ b/lib/features/settings/pages/mount_files_page.dart
@@ -14,6 +14,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/pages/file_preview_page.dart';
 import '../../../shared/pages/html_file_preview_page.dart';
 import '../../../shared/widgets/ios_tactile.dart';
+import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/file_kind.dart';
 import '../../../utils/format.dart';
@@ -48,9 +49,16 @@ class _DirEntry {
 /// - content entering `@workspaces` gets mtime=now (backup/sync protocol);
 /// - read-only mounts hide upload/delete but keep preview + download.
 class MountFilesPage extends StatefulWidget {
-  const MountFilesPage({super.key, required this.mount});
+  const MountFilesPage({
+    super.key,
+    required this.mount,
+    this.selectDirectory = false,
+    this.initialDirectory = '/workspace',
+  });
 
   final FilesystemMount mount;
+  final bool selectDirectory;
+  final String initialDirectory;
 
   @override
   State<MountFilesPage> createState() => _MountFilesPageState();
@@ -77,6 +85,12 @@ class _MountFilesPageState extends State<MountFilesPage> {
   @override
   void initState() {
     super.initState();
+    if (widget.selectDirectory &&
+        widget.initialDirectory.startsWith('/workspace/')) {
+      _segments = widget.initialDirectory
+          .substring('/workspace/'.length)
+          .split('/');
+    }
     _load();
   }
 
@@ -103,7 +117,7 @@ class _MountFilesPageState extends State<MountFilesPage> {
                 modifiedAt: DateTime.now(),
               ),
             );
-          } else if (ent is File) {
+          } else if (!widget.selectDirectory && ent is File) {
             try {
               final stat = await ent.stat();
               entries.add(
@@ -496,7 +510,10 @@ class _MountFilesPageState extends State<MountFilesPage> {
   Widget _breadcrumb(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final crumbs = <Widget>[
-      _crumbChip(widget.mount.wireName, () => _navigateTo(const [])),
+      _crumbChip(
+        widget.selectDirectory ? '/workspace' : widget.mount.wireName,
+        () => _navigateTo(const []),
+      ),
       for (var i = 0; i < _segments.length; i++)
         _crumbChip(
           _segments[i],
@@ -599,9 +616,13 @@ class _MountFilesPageState extends State<MountFilesPage> {
           size: 22,
           onTap: () => Navigator.of(context).maybePop(),
         ),
-        title: Text(l10n.mountFilesPageTitle(widget.mount.wireName)),
+        title: Text(
+          widget.selectDirectory
+              ? l10n.workspaceDirectoryPickerTitle
+              : l10n.mountFilesPageTitle(widget.mount.wireName),
+        ),
         actions: [
-          if (!readOnly)
+          if (!readOnly && !widget.selectDirectory)
             IosIconButton(
               icon: Lucide.Upload,
               size: 20,
@@ -612,6 +633,25 @@ class _MountFilesPageState extends State<MountFilesPage> {
         ],
       ),
       body: content,
+      bottomNavigationBar: widget.selectDirectory
+          ? SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                child: IosTileButton(
+                  label: l10n.workspaceDirectorySelectCurrent,
+                  icon: Lucide.Check,
+                  backgroundColor: cs.primary,
+                  onTap: () {
+                    final selected = _segments.isEmpty
+                        ? '/workspace'
+                        : '/workspace/${_segments.join('/')}';
+                    Navigator.of(context).pop(selected);
+                  },
+                ),
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/features/workspace/widgets/workspace_directory_picker.dart
+++ b/lib/features/workspace/widgets/workspace_directory_picker.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/workspace.dart';
+import '../../../core/providers/workspace_provider.dart';
+import '../../../core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
+import '../../../shared/responsive/breakpoints.dart';
+import '../../../utils/platform_utils.dart';
+import '../../settings/pages/mount_files_page.dart';
+
+Future<String?> showWorkspaceDirectoryPicker(
+  BuildContext context, {
+  required Workspace workspace,
+  required WorkspaceProvider workspaces,
+  required String initialDirectory,
+}) async {
+  final hostPath = workspaces.hostPathFor(workspace);
+  if (hostPath == null) return null;
+  final page = MountFilesPage(
+    mount: FilesystemMount(
+      alias: workspace.alias,
+      path: hostPath,
+      readOnly: workspace.readOnly,
+    ),
+    selectDirectory: true,
+    initialDirectory: initialDirectory,
+  );
+  final useConstrainedDialog =
+      PlatformUtils.isDesktopTarget ||
+      MediaQuery.sizeOf(context).width >= AppBreakpoints.tablet;
+  if (!useConstrainedDialog) {
+    return Navigator.of(
+      context,
+    ).push<String>(MaterialPageRoute(builder: (_) => page));
+  }
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) => Dialog(
+      clipBehavior: Clip.antiAlias,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 720, maxHeight: 640),
+        child: page,
+      ),
+    ),
+  );
+}

--- a/lib/features/workspace/widgets/workspace_settings_sheet.dart
+++ b/lib/features/workspace/widgets/workspace_settings_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -10,6 +12,7 @@ import '../../../core/services/workspace/workspace_execution_context.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_form_text_field.dart';
+import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
@@ -94,6 +97,8 @@ class _WorkspaceDirectorySettingsState
   final TextEditingController _directoryController = TextEditingController();
   bool _initialized = false;
   bool _saving = false;
+  bool _autoLoadAgentsMd = true;
+  String? _lastInvalidDirectoryComparison;
 
   bool get _conversationMode => widget.conversationId != null;
 
@@ -101,8 +106,11 @@ class _WorkspaceDirectorySettingsState
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (_initialized) return;
-    _syncDirectoryText(_assistant());
+    final assistant = _assistant();
+    _syncDirectoryText(assistant);
+    _autoLoadAgentsMd = assistant?.autoLoadAgentsMd ?? true;
     _initialized = true;
+    _pruneRedundantConversationDirectoryOverride(assistant);
   }
 
   @override
@@ -124,11 +132,99 @@ class _WorkspaceDirectorySettingsState
       assistant?.workspaceDefaultDirectories[widget.workspaceId] ??
       '/workspace';
 
+  String? _conversationDirectoryOverride() =>
+      _conversation()?.workspaceDirectoryOverrides[widget.workspaceId];
+
+  bool _directoriesAreEquivalent(String first, String second) {
+    try {
+      return normalizeWorkspaceDirectory(first) ==
+          normalizeWorkspaceDirectory(second);
+    } on WorkspacePathException catch (error) {
+      final comparison = '$first\u0000$second';
+      if (_lastInvalidDirectoryComparison != comparison) {
+        _lastInvalidDirectoryComparison = comparison;
+        debugPrint('Cannot compare workspace working directories: $error');
+      }
+      return false;
+    }
+  }
+
+  bool _hasConversationDirectoryOverride(Assistant? assistant) {
+    final override = _conversationDirectoryOverride();
+    return override != null &&
+        !_directoriesAreEquivalent(override, _assistantDefault(assistant));
+  }
+
   void _syncDirectoryText(Assistant? assistant) {
-    _directoryController.text = _conversationMode
-        ? _conversation()?.workspaceDirectoryOverrides[widget.workspaceId] ??
-              _assistantDefault(assistant)
-        : _assistantDefault(assistant);
+    final assistantDefault = _assistantDefault(assistant);
+    final override = _conversationDirectoryOverride();
+    _directoryController.text =
+        _conversationMode &&
+            override != null &&
+            _directoriesAreEquivalent(override, assistantDefault)
+        ? normalizeWorkspaceDirectory(assistantDefault)
+        : (_conversationMode ? override : null) ?? assistantDefault;
+  }
+
+  void _pruneRedundantConversationDirectoryOverride(Assistant? assistant) {
+    if (!_conversationMode) return;
+    final override = _conversationDirectoryOverride();
+    if (override == null ||
+        !_directoriesAreEquivalent(override, _assistantDefault(assistant))) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_clearRedundantConversationDirectoryOverride());
+    });
+  }
+
+  Future<void> _clearRedundantConversationDirectoryOverride() async {
+    try {
+      await context
+          .read<ChatService>()
+          .clearConversationWorkspaceDirectoryOverride(
+            widget.conversationId!,
+            widget.workspaceId,
+          );
+      if (mounted) _syncDirectoryText(_assistant());
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Failed to prune redundant conversation working directory override: '
+        '$error\n$stackTrace',
+      );
+    }
+  }
+
+  Future<void> _setAutoLoadAgentsMd(bool value) async {
+    if (_saving || value == _autoLoadAgentsMd) return;
+    final assistant = _assistant();
+    if (assistant == null) return;
+
+    final previous = _autoLoadAgentsMd;
+    setState(() {
+      _autoLoadAgentsMd = value;
+      _saving = true;
+    });
+    try {
+      await context.read<AssistantProvider>().updateAssistant(
+        assistant.copyWith(autoLoadAgentsMd: value),
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Failed to save automatic AGENTS.md loading setting: '
+        '$error\n$stackTrace',
+      );
+      if (!mounted) return;
+      setState(() => _autoLoadAgentsMd = previous);
+      showAppSnackBar(
+        context,
+        message: AppLocalizations.of(context)!.workspaceAgentsMdSaveFailed,
+        type: NotificationType.error,
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
   }
 
   Future<void> _saveDirectory(String raw) async {
@@ -143,19 +239,37 @@ class _WorkspaceDirectorySettingsState
     setState(() => _saving = true);
     try {
       final normalized = normalizeWorkspaceDirectory(raw);
-      await ensureWorkspaceWorkingDirectory(
-        context: WorkspaceExecutionContext(
-          workspace: workspace,
-          workingDirectory: normalized,
-        ),
-        workspaces: workspaces,
-      );
-      if (_conversationMode) {
-        await chatService!.setConversationWorkspaceDirectoryOverride(
-          widget.conversationId!,
-          widget.workspaceId,
-          normalized,
+      final assistant = _conversationMode
+          ? assistantProvider.getById(widget.assistantId)
+          : null;
+      final assistantDefault = assistant == null
+          ? null
+          : normalizeWorkspaceDirectory(_assistantDefault(assistant));
+      final inheritsAssistantDefault =
+          _conversationMode && normalized == assistantDefault;
+      // Restoring inheritance does not create a conversation-specific path.
+      if (!inheritsAssistantDefault) {
+        await ensureWorkspaceWorkingDirectory(
+          context: WorkspaceExecutionContext(
+            workspace: workspace,
+            workingDirectory: normalized,
+          ),
+          workspaces: workspaces,
         );
+      }
+      if (_conversationMode) {
+        if (inheritsAssistantDefault) {
+          await chatService!.clearConversationWorkspaceDirectoryOverride(
+            widget.conversationId!,
+            widget.workspaceId,
+          );
+        } else {
+          await chatService!.setConversationWorkspaceDirectoryOverride(
+            widget.conversationId!,
+            widget.workspaceId,
+            normalized,
+          );
+        }
       } else {
         final assistant = assistantProvider.getById(widget.assistantId);
         if (assistant == null) return;
@@ -260,11 +374,7 @@ class _WorkspaceDirectorySettingsState
     final workspace = context.watch<WorkspaceProvider>().getById(
       widget.workspaceId,
     );
-    final hasOverride =
-        _conversation()?.workspaceDirectoryOverrides.containsKey(
-          widget.workspaceId,
-        ) ==
-        true;
+    final hasOverride = _hasConversationDirectoryOverride(_assistant());
     final enabled = workspace != null && !_saving;
 
     return SafeArea(
@@ -308,6 +418,39 @@ class _WorkspaceDirectorySettingsState
                   icon: Lucide.X,
                   semanticLabel: l10n.homePageCancel,
                   onTap: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        l10n.workspaceAutoLoadAgentsMdTitle,
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: AppFontWeights.medium,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        l10n.workspaceAutoLoadAgentsMdSubtitle,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: cs.onSurface.withValues(alpha: 0.58),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 12),
+                IosSwitch(
+                  value: _autoLoadAgentsMd,
+                  onChanged: enabled ? _setAutoLoadAgentsMd : null,
+                  semanticLabel: l10n.workspaceAutoLoadAgentsMdTitle,
                 ),
               ],
             ),

--- a/lib/features/workspace/widgets/workspace_settings_sheet.dart
+++ b/lib/features/workspace/widgets/workspace_settings_sheet.dart
@@ -1,0 +1,385 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../core/models/assistant.dart';
+import '../../../core/models/conversation.dart';
+import '../../../core/providers/assistant_provider.dart';
+import '../../../core/providers/workspace_provider.dart';
+import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/workspace/workspace_execution_context.dart';
+import '../../../icons/lucide_adapter.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../shared/widgets/ios_form_text_field.dart';
+import '../../../shared/widgets/ios_tactile.dart';
+import '../../../shared/widgets/ios_tile_button.dart';
+import '../../../shared/widgets/snackbar.dart';
+import '../../../theme/app_font_weights.dart';
+import '../../../utils/platform_utils.dart';
+import 'workspace_directory_picker.dart';
+
+/// Opens a directory-only editor for either the assistant default or a
+/// conversation override. Workspace enablement and binding stay in the
+/// existing workspace bind sheet.
+Future<void> showWorkspaceDirectorySettings(
+  BuildContext context, {
+  required String assistantId,
+  String? conversationId,
+}) async {
+  final assistants = context.read<AssistantProvider>();
+  final workspaces = context.read<WorkspaceProvider>();
+  await workspaces.init();
+  if (!context.mounted) return;
+
+  final assistant = assistants.getById(assistantId);
+  final workspaceId = assistant?.workspaceId;
+  if (assistant == null ||
+      !assistant.workspaceEnabled ||
+      workspaceId == null ||
+      workspaces.getById(workspaceId) == null) {
+    debugPrint(
+      'Workspace directory settings unavailable: assistant is not bound to '
+      'an enabled workspace.',
+    );
+    return;
+  }
+
+  final content = _WorkspaceDirectorySettings(
+    assistantId: assistantId,
+    workspaceId: workspaceId,
+    conversationId: conversationId,
+  );
+  if (PlatformUtils.isDesktopTarget) {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => Dialog(
+        clipBehavior: Clip.antiAlias,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: content,
+        ),
+      ),
+    );
+    return;
+  }
+
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Theme.of(context).colorScheme.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (_) => content,
+  );
+}
+
+class _WorkspaceDirectorySettings extends StatefulWidget {
+  const _WorkspaceDirectorySettings({
+    required this.assistantId,
+    required this.workspaceId,
+    this.conversationId,
+  });
+
+  final String assistantId;
+  final String workspaceId;
+  final String? conversationId;
+
+  @override
+  State<_WorkspaceDirectorySettings> createState() =>
+      _WorkspaceDirectorySettingsState();
+}
+
+class _WorkspaceDirectorySettingsState
+    extends State<_WorkspaceDirectorySettings> {
+  final TextEditingController _directoryController = TextEditingController();
+  bool _initialized = false;
+  bool _saving = false;
+
+  bool get _conversationMode => widget.conversationId != null;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    _syncDirectoryText(_assistant());
+    _initialized = true;
+  }
+
+  @override
+  void dispose() {
+    _directoryController.dispose();
+    super.dispose();
+  }
+
+  Assistant? _assistant() =>
+      context.read<AssistantProvider>().getById(widget.assistantId);
+
+  Conversation? _conversation() {
+    final id = widget.conversationId;
+    if (id == null) return null;
+    return context.read<ChatService>().getConversation(id);
+  }
+
+  String _assistantDefault(Assistant? assistant) =>
+      assistant?.workspaceDefaultDirectories[widget.workspaceId] ??
+      '/workspace';
+
+  void _syncDirectoryText(Assistant? assistant) {
+    _directoryController.text = _conversationMode
+        ? _conversation()?.workspaceDirectoryOverrides[widget.workspaceId] ??
+              _assistantDefault(assistant)
+        : _assistantDefault(assistant);
+  }
+
+  Future<void> _saveDirectory(String raw) async {
+    if (_saving) return;
+    final l10n = AppLocalizations.of(context)!;
+    final workspaces = context.read<WorkspaceProvider>();
+    final chatService = _conversationMode ? context.read<ChatService>() : null;
+    final assistantProvider = context.read<AssistantProvider>();
+    final workspace = workspaces.getById(widget.workspaceId);
+    if (workspace == null) return;
+
+    setState(() => _saving = true);
+    try {
+      final normalized = normalizeWorkspaceDirectory(raw);
+      await ensureWorkspaceWorkingDirectory(
+        context: WorkspaceExecutionContext(
+          workspace: workspace,
+          workingDirectory: normalized,
+        ),
+        workspaces: workspaces,
+      );
+      if (_conversationMode) {
+        await chatService!.setConversationWorkspaceDirectoryOverride(
+          widget.conversationId!,
+          widget.workspaceId,
+          normalized,
+        );
+      } else {
+        final assistant = assistantProvider.getById(widget.assistantId);
+        if (assistant == null) return;
+        final directories = Map<String, String>.of(
+          assistant.workspaceDefaultDirectories,
+        )..[widget.workspaceId] = normalized;
+        await assistantProvider.updateAssistant(
+          assistant.copyWith(workspaceDefaultDirectories: directories),
+        );
+      }
+      if (!mounted) return;
+      _directoryController.text = normalized;
+      showAppSnackBar(
+        context,
+        message: l10n.workspaceDirectorySaved,
+        type: NotificationType.success,
+      );
+      setState(() {});
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Failed to save workspace working directory: $error\n$stackTrace',
+      );
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.workspaceDirectorySaveFailed(error.toString()),
+        type: NotificationType.error,
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<void> _browse() async {
+    if (_saving) return;
+    final workspaces = context.read<WorkspaceProvider>();
+    final workspace = workspaces.getById(widget.workspaceId);
+    if (workspace == null) return;
+
+    String initialDirectory;
+    try {
+      initialDirectory = normalizeWorkspaceDirectory(_directoryController.text);
+    } on WorkspacePathException catch (error, stackTrace) {
+      debugPrint(
+        'Workspace directory picker reset an unsafe initial path: '
+        '$error\n$stackTrace',
+      );
+      initialDirectory = '/workspace';
+    }
+    if (!mounted) return;
+    final selected = await showWorkspaceDirectoryPicker(
+      context,
+      workspace: workspace,
+      workspaces: workspaces,
+      initialDirectory: initialDirectory,
+    );
+    if (selected == null || !mounted) return;
+    setState(() => _directoryController.text = selected);
+  }
+
+  Future<void> _useAssistantDefault() async {
+    if (!_conversationMode || _saving) return;
+    setState(() => _saving = true);
+    try {
+      await context
+          .read<ChatService>()
+          .clearConversationWorkspaceDirectoryOverride(
+            widget.conversationId!,
+            widget.workspaceId,
+          );
+      if (!mounted) return;
+      _syncDirectoryText(_assistant());
+      showAppSnackBar(
+        context,
+        message: AppLocalizations.of(context)!.workspaceDirectorySaved,
+        type: NotificationType.success,
+      );
+      setState(() {});
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Failed to restore assistant working directory: $error\n$stackTrace',
+      );
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: AppLocalizations.of(
+          context,
+        )!.workspaceDirectorySaveFailed(error.toString()),
+        type: NotificationType.error,
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    context.watch<AssistantProvider>();
+    if (_conversationMode) context.watch<ChatService>();
+    final workspace = context.watch<WorkspaceProvider>().getById(
+      widget.workspaceId,
+    );
+    final hasOverride =
+        _conversation()?.workspaceDirectoryOverrides.containsKey(
+          widget.workspaceId,
+        ) ==
+        true;
+    final enabled = workspace != null && !_saving;
+
+    return SafeArea(
+      top: false,
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          PlatformUtils.isDesktopTarget ? 12 : 10,
+          16,
+          20 + MediaQuery.viewInsetsOf(context).bottom,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (!PlatformUtils.isDesktopTarget) ...[
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: cs.onSurface.withValues(alpha: 0.2),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 10),
+            ],
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    l10n.workspaceDirectoryPickerTitle,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: AppFontWeights.emphasis,
+                    ),
+                  ),
+                ),
+                IosIconButton(
+                  icon: Lucide.X,
+                  semanticLabel: l10n.homePageCancel,
+                  onTap: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            IosFormTextField(
+              label: _conversationMode
+                  ? l10n.workspaceConversationDirectoryTitle
+                  : l10n.workspaceDefaultDirectoryTitle,
+              controller: _directoryController,
+              hintText: l10n.workspaceDirectoryHint,
+              enabled: enabled,
+              inlineLabel: false,
+              outerPadding: EdgeInsets.zero,
+            ),
+            if (_conversationMode) ...[
+              const SizedBox(height: 6),
+              Text(
+                hasOverride
+                    ? l10n.workspaceDirectoryOverride
+                    : l10n.workspaceDirectoryInherited,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: cs.onSurface.withValues(alpha: 0.58),
+                ),
+              ),
+            ],
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: IosTileButton(
+                    label: l10n.workspaceDirectoryBrowse,
+                    icon: Lucide.FolderOpen,
+                    enabled: enabled,
+                    onTap: _browse,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: IosTileButton(
+                    label: l10n.workspaceDirectorySave,
+                    icon: Lucide.Check,
+                    enabled: enabled,
+                    backgroundColor: cs.primary,
+                    onTap: () => _saveDirectory(_directoryController.text),
+                  ),
+                ),
+              ],
+            ),
+            if (_conversationMode && hasOverride) ...[
+              const SizedBox(height: 10),
+              IosTileButton(
+                label: l10n.workspaceDirectoryUseAssistantDefault,
+                icon: Lucide.RotateCcw,
+                enabled: enabled,
+                onTap: _useAssistantDefault,
+              ),
+            ],
+            if (workspace != null) ...[
+              const SizedBox(height: 10),
+              Text(
+                workspace.displayName,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: cs.onSurface.withValues(alpha: 0.55),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3873,6 +3873,25 @@
   "workspaceBindDisabledHint": "Enable workspace to select",
   "workspaceEntryTitle": "Workspace",
   "workspaceEntrySubtitleOff": "Off",
+  "workspaceDefaultDirectoryTitle": "Default working directory",
+  "workspaceConversationDirectoryTitle": "Conversation working directory",
+  "workspaceDirectoryHint": "/workspace or a path relative to the workspace root",
+  "workspaceDirectoryBrowse": "Browse",
+  "workspaceDirectorySave": "Save",
+  "workspaceDirectoryUseAssistantDefault": "Use assistant default",
+  "workspaceDirectoryInherited": "Following the assistant default",
+  "workspaceDirectoryOverride": "Overridden for this conversation",
+  "workspaceDirectorySaved": "Working directory saved",
+  "workspaceDirectorySaveFailed": "Failed to save working directory: {error}",
+  "@workspaceDirectorySaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "workspaceDirectoryPickerTitle": "Choose working directory",
+  "workspaceDirectorySelectCurrent": "Use this folder",
   "workspaceShellMobileOnly": "Shell is only available on Android or iOS",
   "workspaceToolShellTitle": "Shell",
   "workspaceToolShellUserDesc": "Run commands in the Linux sandbox (Android or iOS, requires base dependency)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3890,6 +3890,10 @@
       }
     }
   },
+  "workspaceAutoLoadAgentsMdTitle": "Automatically load AGENTS.md",
+  "workspaceAutoLoadAgentsMdSubtitle": "Load project instructions from this directory up to the workspace root",
+  "workspaceAgentsMdLoadFailed": "Couldn't load AGENTS.md instructions. Fix the file or turn off automatic loading.",
+  "workspaceAgentsMdSaveFailed": "Couldn't save the AGENTS.md loading setting.",
   "workspaceDirectoryPickerTitle": "Choose working directory",
   "workspaceDirectorySelectCurrent": "Use this folder",
   "workspaceShellMobileOnly": "Shell is only available on Android or iOS",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15779,6 +15779,78 @@ abstract class AppLocalizations {
   /// **'Off'**
   String get workspaceEntrySubtitleOff;
 
+  /// No description provided for @workspaceDefaultDirectoryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Default working directory'**
+  String get workspaceDefaultDirectoryTitle;
+
+  /// No description provided for @workspaceConversationDirectoryTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation working directory'**
+  String get workspaceConversationDirectoryTitle;
+
+  /// No description provided for @workspaceDirectoryHint.
+  ///
+  /// In en, this message translates to:
+  /// **'/workspace or a path relative to the workspace root'**
+  String get workspaceDirectoryHint;
+
+  /// No description provided for @workspaceDirectoryBrowse.
+  ///
+  /// In en, this message translates to:
+  /// **'Browse'**
+  String get workspaceDirectoryBrowse;
+
+  /// No description provided for @workspaceDirectorySave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get workspaceDirectorySave;
+
+  /// No description provided for @workspaceDirectoryUseAssistantDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Use assistant default'**
+  String get workspaceDirectoryUseAssistantDefault;
+
+  /// No description provided for @workspaceDirectoryInherited.
+  ///
+  /// In en, this message translates to:
+  /// **'Following the assistant default'**
+  String get workspaceDirectoryInherited;
+
+  /// No description provided for @workspaceDirectoryOverride.
+  ///
+  /// In en, this message translates to:
+  /// **'Overridden for this conversation'**
+  String get workspaceDirectoryOverride;
+
+  /// No description provided for @workspaceDirectorySaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Working directory saved'**
+  String get workspaceDirectorySaved;
+
+  /// No description provided for @workspaceDirectorySaveFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to save working directory: {error}'**
+  String workspaceDirectorySaveFailed(String error);
+
+  /// No description provided for @workspaceDirectoryPickerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose working directory'**
+  String get workspaceDirectoryPickerTitle;
+
+  /// No description provided for @workspaceDirectorySelectCurrent.
+  ///
+  /// In en, this message translates to:
+  /// **'Use this folder'**
+  String get workspaceDirectorySelectCurrent;
+
   /// No description provided for @workspaceShellMobileOnly.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15839,6 +15839,30 @@ abstract class AppLocalizations {
   /// **'Failed to save working directory: {error}'**
   String workspaceDirectorySaveFailed(String error);
 
+  /// No description provided for @workspaceAutoLoadAgentsMdTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically load AGENTS.md'**
+  String get workspaceAutoLoadAgentsMdTitle;
+
+  /// No description provided for @workspaceAutoLoadAgentsMdSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Load project instructions from this directory up to the workspace root'**
+  String get workspaceAutoLoadAgentsMdSubtitle;
+
+  /// No description provided for @workspaceAgentsMdLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load AGENTS.md instructions. Fix the file or turn off automatic loading.'**
+  String get workspaceAgentsMdLoadFailed;
+
+  /// No description provided for @workspaceAgentsMdSaveFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save the AGENTS.md loading setting.'**
+  String get workspaceAgentsMdSaveFailed;
+
   /// No description provided for @workspaceDirectoryPickerTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8818,6 +8818,21 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get workspaceAutoLoadAgentsMdTitle => 'Automatically load AGENTS.md';
+
+  @override
+  String get workspaceAutoLoadAgentsMdSubtitle =>
+      'Load project instructions from this directory up to the workspace root';
+
+  @override
+  String get workspaceAgentsMdLoadFailed =>
+      'Couldn\'t load AGENTS.md instructions. Fix the file or turn off automatic loading.';
+
+  @override
+  String get workspaceAgentsMdSaveFailed =>
+      'Couldn\'t save the AGENTS.md loading setting.';
+
+  @override
   String get workspaceDirectoryPickerTitle => 'Choose working directory';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8784,6 +8784,46 @@ class AppLocalizationsEn extends AppLocalizations {
   String get workspaceEntrySubtitleOff => 'Off';
 
   @override
+  String get workspaceDefaultDirectoryTitle => 'Default working directory';
+
+  @override
+  String get workspaceConversationDirectoryTitle =>
+      'Conversation working directory';
+
+  @override
+  String get workspaceDirectoryHint =>
+      '/workspace or a path relative to the workspace root';
+
+  @override
+  String get workspaceDirectoryBrowse => 'Browse';
+
+  @override
+  String get workspaceDirectorySave => 'Save';
+
+  @override
+  String get workspaceDirectoryUseAssistantDefault => 'Use assistant default';
+
+  @override
+  String get workspaceDirectoryInherited => 'Following the assistant default';
+
+  @override
+  String get workspaceDirectoryOverride => 'Overridden for this conversation';
+
+  @override
+  String get workspaceDirectorySaved => 'Working directory saved';
+
+  @override
+  String workspaceDirectorySaveFailed(String error) {
+    return 'Failed to save working directory: $error';
+  }
+
+  @override
+  String get workspaceDirectoryPickerTitle => 'Choose working directory';
+
+  @override
+  String get workspaceDirectorySelectCurrent => 'Use this folder';
+
+  @override
   String get workspaceShellMobileOnly =>
       'Shell is only available on Android or iOS';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8389,6 +8389,44 @@ class AppLocalizationsZh extends AppLocalizations {
   String get workspaceEntrySubtitleOff => '未开启';
 
   @override
+  String get workspaceDefaultDirectoryTitle => '默认工作目录';
+
+  @override
+  String get workspaceConversationDirectoryTitle => '当前会话工作目录';
+
+  @override
+  String get workspaceDirectoryHint => '/workspace 或相对于工作区根目录的路径';
+
+  @override
+  String get workspaceDirectoryBrowse => '浏览';
+
+  @override
+  String get workspaceDirectorySave => '保存';
+
+  @override
+  String get workspaceDirectoryUseAssistantDefault => '使用助手默认目录';
+
+  @override
+  String get workspaceDirectoryInherited => '正在继承助手默认目录';
+
+  @override
+  String get workspaceDirectoryOverride => '当前会话已覆盖';
+
+  @override
+  String get workspaceDirectorySaved => '工作目录已保存';
+
+  @override
+  String workspaceDirectorySaveFailed(String error) {
+    return '保存工作目录失败：$error';
+  }
+
+  @override
+  String get workspaceDirectoryPickerTitle => '选择工作目录';
+
+  @override
+  String get workspaceDirectorySelectCurrent => '选择当前文件夹';
+
+  @override
   String get workspaceShellMobileOnly => 'Shell 仅在 Android 或 iOS 可用';
 
   @override
@@ -17077,6 +17115,44 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get workspaceEntrySubtitleOff => '未开启';
+
+  @override
+  String get workspaceDefaultDirectoryTitle => '默认工作目录';
+
+  @override
+  String get workspaceConversationDirectoryTitle => '当前会话工作目录';
+
+  @override
+  String get workspaceDirectoryHint => '/workspace 或相对于工作区根目录的路径';
+
+  @override
+  String get workspaceDirectoryBrowse => '浏览';
+
+  @override
+  String get workspaceDirectorySave => '保存';
+
+  @override
+  String get workspaceDirectoryUseAssistantDefault => '使用助手默认目录';
+
+  @override
+  String get workspaceDirectoryInherited => '正在继承助手默认目录';
+
+  @override
+  String get workspaceDirectoryOverride => '当前会话已覆盖';
+
+  @override
+  String get workspaceDirectorySaved => '工作目录已保存';
+
+  @override
+  String workspaceDirectorySaveFailed(String error) {
+    return '保存工作目录失败：$error';
+  }
+
+  @override
+  String get workspaceDirectoryPickerTitle => '选择工作目录';
+
+  @override
+  String get workspaceDirectorySelectCurrent => '选择当前文件夹';
 
   @override
   String get workspaceShellMobileOnly => 'Shell 仅在 Android 或 iOS 可用';
@@ -25769,6 +25845,44 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get workspaceEntrySubtitleOff => '未開啟';
+
+  @override
+  String get workspaceDefaultDirectoryTitle => '預設工作目錄';
+
+  @override
+  String get workspaceConversationDirectoryTitle => '目前對話工作目錄';
+
+  @override
+  String get workspaceDirectoryHint => '/workspace 或相對於工作區根目錄的路徑';
+
+  @override
+  String get workspaceDirectoryBrowse => '瀏覽';
+
+  @override
+  String get workspaceDirectorySave => '儲存';
+
+  @override
+  String get workspaceDirectoryUseAssistantDefault => '使用助手預設目錄';
+
+  @override
+  String get workspaceDirectoryInherited => '正在沿用助手預設目錄';
+
+  @override
+  String get workspaceDirectoryOverride => '目前對話已覆寫';
+
+  @override
+  String get workspaceDirectorySaved => '工作目錄已儲存';
+
+  @override
+  String workspaceDirectorySaveFailed(String error) {
+    return '儲存工作目錄失敗：$error';
+  }
+
+  @override
+  String get workspaceDirectoryPickerTitle => '選擇工作目錄';
+
+  @override
+  String get workspaceDirectorySelectCurrent => '選擇目前資料夾';
 
   @override
   String get workspaceShellMobileOnly => 'Shell 僅在 Android 或 iOS 可用';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8421,6 +8421,18 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get workspaceAutoLoadAgentsMdTitle => '自动加载 AGENTS.md';
+
+  @override
+  String get workspaceAutoLoadAgentsMdSubtitle => '从此目录向上到工作区根目录加载项目指令';
+
+  @override
+  String get workspaceAgentsMdLoadFailed => '无法加载 AGENTS.md 指令。请修复该文件或关闭自动加载。';
+
+  @override
+  String get workspaceAgentsMdSaveFailed => '无法保存 AGENTS.md 加载设置。';
+
+  @override
   String get workspaceDirectoryPickerTitle => '选择工作目录';
 
   @override
@@ -17147,6 +17159,18 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String workspaceDirectorySaveFailed(String error) {
     return '保存工作目录失败：$error';
   }
+
+  @override
+  String get workspaceAutoLoadAgentsMdTitle => '自动加载 AGENTS.md';
+
+  @override
+  String get workspaceAutoLoadAgentsMdSubtitle => '从此目录向上到工作区根目录加载项目指令';
+
+  @override
+  String get workspaceAgentsMdLoadFailed => '无法加载 AGENTS.md 指令。请修复该文件或关闭自动加载。';
+
+  @override
+  String get workspaceAgentsMdSaveFailed => '无法保存 AGENTS.md 加载设置。';
 
   @override
   String get workspaceDirectoryPickerTitle => '选择工作目录';
@@ -25877,6 +25901,18 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String workspaceDirectorySaveFailed(String error) {
     return '儲存工作目錄失敗：$error';
   }
+
+  @override
+  String get workspaceAutoLoadAgentsMdTitle => '自動載入 AGENTS.md';
+
+  @override
+  String get workspaceAutoLoadAgentsMdSubtitle => '從此目錄向上至工作區根目錄載入專案指令';
+
+  @override
+  String get workspaceAgentsMdLoadFailed => '無法載入 AGENTS.md 指令。請修正該檔案或關閉自動載入。';
+
+  @override
+  String get workspaceAgentsMdSaveFailed => '無法儲存 AGENTS.md 載入設定。';
 
   @override
   String get workspaceDirectoryPickerTitle => '選擇工作目錄';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3292,6 +3292,10 @@
       }
     }
   },
+  "workspaceAutoLoadAgentsMdTitle": "自动加载 AGENTS.md",
+  "workspaceAutoLoadAgentsMdSubtitle": "从此目录向上到工作区根目录加载项目指令",
+  "workspaceAgentsMdLoadFailed": "无法加载 AGENTS.md 指令。请修复该文件或关闭自动加载。",
+  "workspaceAgentsMdSaveFailed": "无法保存 AGENTS.md 加载设置。",
   "workspaceDirectoryPickerTitle": "选择工作目录",
   "workspaceDirectorySelectCurrent": "选择当前文件夹",
   "workspaceShellMobileOnly": "Shell 仅在 Android 或 iOS 可用",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3275,6 +3275,25 @@
   "workspaceBindDisabledHint": "开启工作区后选择",
   "workspaceEntryTitle": "工作区",
   "workspaceEntrySubtitleOff": "未开启",
+  "workspaceDefaultDirectoryTitle": "默认工作目录",
+  "workspaceConversationDirectoryTitle": "当前会话工作目录",
+  "workspaceDirectoryHint": "/workspace 或相对于工作区根目录的路径",
+  "workspaceDirectoryBrowse": "浏览",
+  "workspaceDirectorySave": "保存",
+  "workspaceDirectoryUseAssistantDefault": "使用助手默认目录",
+  "workspaceDirectoryInherited": "正在继承助手默认目录",
+  "workspaceDirectoryOverride": "当前会话已覆盖",
+  "workspaceDirectorySaved": "工作目录已保存",
+  "workspaceDirectorySaveFailed": "保存工作目录失败：{error}",
+  "@workspaceDirectorySaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "workspaceDirectoryPickerTitle": "选择工作目录",
+  "workspaceDirectorySelectCurrent": "选择当前文件夹",
   "workspaceShellMobileOnly": "Shell 仅在 Android 或 iOS 可用",
   "workspaceToolShellTitle": "Shell",
   "workspaceToolShellUserDesc": "在 Linux 沙箱中运行命令（Android 或 iOS，需先安装基础依赖）",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3293,6 +3293,10 @@
       }
     }
   },
+  "workspaceAutoLoadAgentsMdTitle": "自动加载 AGENTS.md",
+  "workspaceAutoLoadAgentsMdSubtitle": "从此目录向上到工作区根目录加载项目指令",
+  "workspaceAgentsMdLoadFailed": "无法加载 AGENTS.md 指令。请修复该文件或关闭自动加载。",
+  "workspaceAgentsMdSaveFailed": "无法保存 AGENTS.md 加载设置。",
   "workspaceDirectoryPickerTitle": "选择工作目录",
   "workspaceDirectorySelectCurrent": "选择当前文件夹",
   "workspaceShellMobileOnly": "Shell 仅在 Android 或 iOS 可用",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3276,6 +3276,25 @@
   "workspaceBindDisabledHint": "开启工作区后选择",
   "workspaceEntryTitle": "工作区",
   "workspaceEntrySubtitleOff": "未开启",
+  "workspaceDefaultDirectoryTitle": "默认工作目录",
+  "workspaceConversationDirectoryTitle": "当前会话工作目录",
+  "workspaceDirectoryHint": "/workspace 或相对于工作区根目录的路径",
+  "workspaceDirectoryBrowse": "浏览",
+  "workspaceDirectorySave": "保存",
+  "workspaceDirectoryUseAssistantDefault": "使用助手默认目录",
+  "workspaceDirectoryInherited": "正在继承助手默认目录",
+  "workspaceDirectoryOverride": "当前会话已覆盖",
+  "workspaceDirectorySaved": "工作目录已保存",
+  "workspaceDirectorySaveFailed": "保存工作目录失败：{error}",
+  "@workspaceDirectorySaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "workspaceDirectoryPickerTitle": "选择工作目录",
+  "workspaceDirectorySelectCurrent": "选择当前文件夹",
   "workspaceShellMobileOnly": "Shell 仅在 Android 或 iOS 可用",
   "workspaceToolShellTitle": "Shell",
   "workspaceToolShellUserDesc": "在 Linux 沙箱中运行命令（Android 或 iOS，需先安装基础依赖）",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3293,6 +3293,10 @@
       }
     }
   },
+  "workspaceAutoLoadAgentsMdTitle": "自動載入 AGENTS.md",
+  "workspaceAutoLoadAgentsMdSubtitle": "從此目錄向上至工作區根目錄載入專案指令",
+  "workspaceAgentsMdLoadFailed": "無法載入 AGENTS.md 指令。請修正該檔案或關閉自動載入。",
+  "workspaceAgentsMdSaveFailed": "無法儲存 AGENTS.md 載入設定。",
   "workspaceDirectoryPickerTitle": "選擇工作目錄",
   "workspaceDirectorySelectCurrent": "選擇目前資料夾",
   "workspaceShellMobileOnly": "Shell 僅在 Android 或 iOS 可用",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3276,6 +3276,25 @@
   "workspaceBindDisabledHint": "開啟工作區後選擇",
   "workspaceEntryTitle": "工作區",
   "workspaceEntrySubtitleOff": "未開啟",
+  "workspaceDefaultDirectoryTitle": "預設工作目錄",
+  "workspaceConversationDirectoryTitle": "目前對話工作目錄",
+  "workspaceDirectoryHint": "/workspace 或相對於工作區根目錄的路徑",
+  "workspaceDirectoryBrowse": "瀏覽",
+  "workspaceDirectorySave": "儲存",
+  "workspaceDirectoryUseAssistantDefault": "使用助手預設目錄",
+  "workspaceDirectoryInherited": "正在沿用助手預設目錄",
+  "workspaceDirectoryOverride": "目前對話已覆寫",
+  "workspaceDirectorySaved": "工作目錄已儲存",
+  "workspaceDirectorySaveFailed": "儲存工作目錄失敗：{error}",
+  "@workspaceDirectorySaveFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "workspaceDirectoryPickerTitle": "選擇工作目錄",
+  "workspaceDirectorySelectCurrent": "選擇目前資料夾",
   "workspaceShellMobileOnly": "Shell 僅在 Android 或 iOS 可用",
   "workspaceToolShellTitle": "Shell",
   "workspaceToolShellUserDesc": "在 Linux 沙箱中執行命令（Android 或 iOS，需先安裝基礎依賴）",

--- a/test/core/database/chat_database_repository_test.dart
+++ b/test/core/database/chat_database_repository_test.dart
@@ -4,6 +4,7 @@ import 'package:Cuplivo/core/database/app_database.dart';
 import 'package:Cuplivo/core/database/chat_database_repository.dart';
 import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/models/assistant_regex.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/models/preset_message.dart';
 
 void main() {
@@ -227,5 +228,37 @@ void main() {
       expect(await repo.getCacheEntry('ocr', 'img2'), isNull);
       expect(await repo.getCacheEntry('other', 'k'), isNotNull);
     });
+  });
+
+  group('ChatDatabaseRepository — ConversationRows', () {
+    late AppDatabase db;
+    late ChatDatabaseRepository repo;
+
+    setUp(() {
+      db = AppDatabase(NativeDatabase.memory());
+      repo = ChatDatabaseRepository(db);
+    });
+
+    tearDown(() async {
+      await repo.close();
+    });
+
+    test(
+      'malformed workspace override JSON fails instead of using root',
+      () async {
+        final conversation = Conversation(title: 'Conversation');
+        await repo.putConversation(conversation);
+        await db.customStatement(
+          'UPDATE conversation_rows '
+          'SET workspace_directory_overrides_json = ? WHERE id = ?',
+          ['not-json', conversation.id],
+        );
+
+        await expectLater(
+          repo.getAllConversations(),
+          throwsA(isA<FormatException>()),
+        );
+      },
+    );
   });
 }

--- a/test/core/database/schema_heal_discoverable_test.dart
+++ b/test/core/database/schema_heal_discoverable_test.dart
@@ -325,6 +325,47 @@ CREATE TABLE group_chat_rows (
 
     await repo.close();
   });
+
+  test('heal adds workspace directory maps before assistant and conversation '
+      'inserts (v20 column shape)', () async {
+    _createLegacyDb(
+      dbFile,
+      userVersion: 20,
+      missingIsPreset: false,
+      missingHandoffColumns: false,
+      missingContextTokens: false,
+    );
+
+    final repo = ChatDatabaseRepository.open(file: dbFile);
+    await repo.ensureReady();
+
+    await repo.putAssistant(
+      Assistant(
+        id: 'a1',
+        name: 'Alpha',
+        workspaceDefaultDirectories: const {'w1': '/workspace/project'},
+      ),
+      sortOrder: 0,
+    );
+    await repo.putConversation(
+      Conversation(
+        title: 'Conv',
+        assistantId: 'a1',
+        workspaceDirectoryOverrides: const {'w1': '/workspace/project/session'},
+      ),
+    );
+
+    final assistants = await repo.getAllAssistants();
+    final conversations = await repo.getAllConversations();
+    expect(assistants.single.workspaceDefaultDirectories, {
+      'w1': '/workspace/project',
+    });
+    expect(conversations.single.workspaceDirectoryOverrides, {
+      'w1': '/workspace/project/session',
+    });
+
+    await repo.close();
+  });
 }
 
 /// Builds a v13-era DB shape (assistant/conversation/message tables only —

--- a/test/core/database/schema_heal_discoverable_test.dart
+++ b/test/core/database/schema_heal_discoverable_test.dart
@@ -326,11 +326,11 @@ CREATE TABLE group_chat_rows (
     await repo.close();
   });
 
-  test('heal adds workspace directory maps before assistant and conversation '
-      'inserts (v20 column shape)', () async {
+  test('heal adds workspace directory maps and AGENTS.md loading before '
+      'assistant and conversation inserts (v21 column shape)', () async {
     _createLegacyDb(
       dbFile,
-      userVersion: 20,
+      userVersion: 21,
       missingIsPreset: false,
       missingHandoffColumns: false,
       missingContextTokens: false,
@@ -344,6 +344,7 @@ CREATE TABLE group_chat_rows (
         id: 'a1',
         name: 'Alpha',
         workspaceDefaultDirectories: const {'w1': '/workspace/project'},
+        autoLoadAgentsMd: false,
       ),
       sortOrder: 0,
     );
@@ -360,6 +361,7 @@ CREATE TABLE group_chat_rows (
     expect(assistants.single.workspaceDefaultDirectories, {
       'w1': '/workspace/project',
     });
+    expect(assistants.single.autoLoadAgentsMd, isFalse);
     expect(conversations.single.workspaceDirectoryOverrides, {
       'w1': '/workspace/project/session',
     });

--- a/test/core/database/schema_heal_discoverable_test.dart
+++ b/test/core/database/schema_heal_discoverable_test.dart
@@ -235,41 +235,40 @@ void main() {
     },
   );
 
-  test(
-    'heal adds quote_json before message insert (v20 column shape)',
-    () async {
-      _createLegacyDb(
-        dbFile,
-        userVersion: 20,
-        missingIsPreset: false,
-        missingHandoffColumns: false,
-        missingV15RequestMetadata: false,
-        missingQuoteJson: true,
-      );
+  test('heal adds quote_json to a workspace-complete v20 database', () async {
+    _createLegacyDb(
+      dbFile,
+      userVersion: 20,
+      missingIsPreset: false,
+      missingHandoffColumns: false,
+      missingV15RequestMetadata: false,
+      missingQuoteJson: true,
+      includeWorkspaceBindingColumns: true,
+      includeWorkspaceV20Columns: true,
+    );
 
-      final repo = ChatDatabaseRepository.open(file: dbFile);
-      await repo.ensureReady();
+    final repo = ChatDatabaseRepository.open(file: dbFile);
+    await repo.ensureReady();
 
-      // Must succeed: heal adds quote_json before Drift INSERT, and the
-      // citation round-trips through the repository.
-      final conv = Conversation(title: 'Conv', assistantId: 'a1');
-      await repo.putConversation(conv);
-      await repo.putMessage(
-        ChatMessage(
-          role: 'user',
-          content: 'reply',
-          conversationId: conv.id,
-          quoteJson: '{"id":"msg-1","start":3,"end":9}',
-        ),
-      );
+    // Must succeed: heal adds quote_json before Drift INSERT, and the
+    // citation round-trips through the repository.
+    final conv = Conversation(title: 'Conv', assistantId: 'a1');
+    await repo.putConversation(conv);
+    await repo.putMessage(
+      ChatMessage(
+        role: 'user',
+        content: 'reply',
+        conversationId: conv.id,
+        quoteJson: '{"id":"msg-1","start":3,"end":9}',
+      ),
+    );
 
-      final rows = await repo.db.select(repo.db.messageRows).get();
-      expect(rows, hasLength(1));
-      expect(rows.first.quoteJson, '{"id":"msg-1","start":3,"end":9}');
+    final rows = await repo.db.select(repo.db.messageRows).get();
+    expect(rows, hasLength(1));
+    expect(rows.first.quoteJson, '{"id":"msg-1","start":3,"end":9}');
 
-      await repo.close();
-    },
-  );
+    await repo.close();
+  });
 
   test('heal adds inject_group_members column on group_chat_rows '
       '(v17 column shape)', () async {
@@ -327,13 +326,15 @@ CREATE TABLE group_chat_rows (
   });
 
   test('heal adds workspace directory maps and AGENTS.md loading before '
-      'assistant and conversation inserts (v21 column shape)', () async {
+      'assistant and conversation inserts (v20 column shape)', () async {
     _createLegacyDb(
       dbFile,
-      userVersion: 21,
+      userVersion: 20,
       missingIsPreset: false,
       missingHandoffColumns: false,
       missingContextTokens: false,
+      missingQuoteJson: false,
+      includeWorkspaceBindingColumns: true,
     );
 
     final repo = ChatDatabaseRepository.open(file: dbFile);
@@ -368,6 +369,88 @@ CREATE TABLE group_chat_rows (
 
     await repo.close();
   });
+
+  test('upgrades v19 workspace bindings to the complete v20 shape', () async {
+    _createLegacyDb(
+      dbFile,
+      userVersion: 19,
+      missingIsPreset: false,
+      missingHandoffColumns: false,
+      missingContextTokens: false,
+      includeWorkspaceBindingColumns: true,
+    );
+
+    final repo = ChatDatabaseRepository.open(file: dbFile);
+    await repo.ensureReady();
+
+    final assistantColumns = await repo.db
+        .customSelect('PRAGMA table_info(assistant_rows)')
+        .get();
+    final assistantColumnNames = assistantColumns
+        .map((row) => row.read<String>('name'))
+        .toSet();
+    expect(
+      assistantColumnNames,
+      containsAll(<String>[
+        'workspace_default_directories_json',
+        'auto_load_agents_md',
+      ]),
+    );
+    final conversationColumns = await repo.db
+        .customSelect('PRAGMA table_info(conversation_rows)')
+        .get();
+    expect(
+      conversationColumns.map((row) => row.read<String>('name')),
+      contains('workspace_directory_overrides_json'),
+    );
+    final messageColumns = await repo.db
+        .customSelect('PRAGMA table_info(message_rows)')
+        .get();
+    expect(
+      messageColumns.map((row) => row.read<String>('name')),
+      contains('quote_json'),
+    );
+
+    await repo.putAssistant(
+      Assistant(
+        id: 'a1',
+        name: 'Alpha',
+        workspaceEnabled: true,
+        workspaceId: 'w1',
+        workspaceDefaultDirectories: const {'w1': '/workspace/project'},
+        autoLoadAgentsMd: false,
+      ),
+      sortOrder: 0,
+    );
+    final assistant = (await repo.getAllAssistants()).single;
+    expect(assistant.workspaceDefaultDirectories, {'w1': '/workspace/project'});
+    expect(assistant.autoLoadAgentsMd, isFalse);
+
+    final conversation = Conversation(
+      title: 'Conv',
+      assistantId: assistant.id,
+      workspaceDirectoryOverrides: const {'w1': '/workspace/project/session'},
+    );
+    await repo.putConversation(conversation);
+    await repo.putMessage(
+      ChatMessage(
+        role: 'user',
+        content: 'reply',
+        conversationId: conversation.id,
+        quoteJson: '{"id":"msg-1","start":3,"end":9}',
+      ),
+    );
+    expect(
+      (await repo.getAllConversations()).single.workspaceDirectoryOverrides,
+      {'w1': '/workspace/project/session'},
+    );
+    expect(
+      (await repo.db.select(repo.db.messageRows).get()).single.quoteJson,
+      '{"id":"msg-1","start":3,"end":9}',
+    );
+
+    await repo.close();
+  });
 }
 
 /// Builds a v13-era DB shape (assistant/conversation/message tables only —
@@ -383,6 +466,8 @@ void _createLegacyDb(
   bool missingContextTokens = true,
   bool missingV15RequestMetadata = false,
   bool missingQuoteJson = true,
+  bool includeWorkspaceBindingColumns = false,
+  bool includeWorkspaceV20Columns = false,
 }) {
   final raw = sqlite.sqlite3.open(dbFile.path);
   raw.execute('PRAGMA user_version = $userVersion;');
@@ -398,6 +483,21 @@ void _createLegacyDb(
       : '''
   ocr_mode TEXT NOT NULL DEFAULT 'auto',
 ''';
+  final workspaceBindingColumns = includeWorkspaceBindingColumns
+      ? '''
+  workspace_enabled INTEGER NOT NULL DEFAULT 0,
+  workspace_id TEXT NULL,
+'''
+      : '';
+  final workspaceV20AssistantColumns = includeWorkspaceV20Columns
+      ? '''
+  workspace_default_directories_json TEXT NOT NULL DEFAULT '{}',
+  auto_load_agents_md INTEGER NOT NULL DEFAULT 1,
+'''
+      : '';
+  final workspaceV20ConversationColumn = includeWorkspaceV20Columns
+      ? ",\n  workspace_directory_overrides_json TEXT NOT NULL DEFAULT '{}'"
+      : '';
   raw.execute('''
 CREATE TABLE assistant_rows (
   id TEXT NOT NULL PRIMARY KEY,
@@ -440,6 +540,8 @@ CREATE TABLE assistant_rows (
   $ocrModeColumn
   enable_time_injection INTEGER NOT NULL DEFAULT 0,
   $handoffColumns
+  $workspaceBindingColumns
+  $workspaceV20AssistantColumns
   sort_order INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
@@ -458,7 +560,7 @@ CREATE TABLE conversation_rows (
   summary TEXT NULL,
   last_summarized_message_count INTEGER NOT NULL DEFAULT 0,
   chat_suggestions_json TEXT NOT NULL DEFAULT '[]',
-  parent_conversation_id TEXT NULL
+  parent_conversation_id TEXT NULL$workspaceV20ConversationColumn
 );
 ''');
   final isPresetColumn = missingIsPreset

--- a/test/core/models/workspace_directory_model_test.dart
+++ b/test/core/models/workspace_directory_model_test.dart
@@ -16,6 +16,7 @@ void main() {
     final restored = Assistant.fromJson(assistant.toJson());
     expect(restored.workspaceDefaultDirectories['workspace-a'], '/workspace/a');
     expect(restored.workspaceDefaultDirectories['workspace-b'], '/workspace/b');
+    expect(restored.autoLoadAgentsMd, isTrue);
     expect(
       restored
           .copyWith(
@@ -25,6 +26,12 @@ void main() {
           )
           .workspaceDefaultDirectories,
       {'workspace-a': '/workspace/other'},
+    );
+    expect(
+      Assistant.fromJson(
+        assistant.copyWith(autoLoadAgentsMd: false).toJson(),
+      ).autoLoadAgentsMd,
+      isFalse,
     );
   });
 
@@ -60,6 +67,7 @@ void main() {
     });
 
     expect(assistant.workspaceDefaultDirectories, isEmpty);
+    expect(assistant.autoLoadAgentsMd, isTrue);
     expect(conversation.workspaceDirectoryOverrides, isEmpty);
   });
 }

--- a/test/core/models/workspace_directory_model_test.dart
+++ b/test/core/models/workspace_directory_model_test.dart
@@ -1,0 +1,65 @@
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('assistant defaults round-trip and remain separate per workspace', () {
+    final assistant = Assistant(
+      id: 'a1',
+      name: 'Assistant',
+      workspaceDefaultDirectories: const {
+        'workspace-a': '/workspace/a',
+        'workspace-b': '/workspace/b',
+      },
+    );
+
+    final restored = Assistant.fromJson(assistant.toJson());
+    expect(restored.workspaceDefaultDirectories['workspace-a'], '/workspace/a');
+    expect(restored.workspaceDefaultDirectories['workspace-b'], '/workspace/b');
+    expect(
+      restored
+          .copyWith(
+            workspaceDefaultDirectories: const {
+              'workspace-a': '/workspace/other',
+            },
+          )
+          .workspaceDefaultDirectories,
+      {'workspace-a': '/workspace/other'},
+    );
+  });
+
+  test('conversation overrides round-trip and missing keys stay absent', () {
+    final conversation = Conversation(
+      id: 'c1',
+      title: 'Conversation',
+      workspaceDirectoryOverrides: const {
+        'workspace-a': '/workspace/session',
+        'workspace-b': '/workspace',
+      },
+    );
+
+    final restored = Conversation.fromJson(conversation.toJson());
+    expect(restored.workspaceDirectoryOverrides, {
+      'workspace-a': '/workspace/session',
+      'workspace-b': '/workspace',
+    });
+    expect(
+      restored.workspaceDirectoryOverrides.containsKey('workspace-c'),
+      isFalse,
+    );
+  });
+
+  test('legacy JSON defaults both maps to empty', () {
+    final assistant = Assistant.fromJson({'id': 'a1', 'name': 'Assistant'});
+    final now = DateTime.utc(2026).toIso8601String();
+    final conversation = Conversation.fromJson({
+      'id': 'c1',
+      'title': 'Conversation',
+      'createdAt': now,
+      'updatedAt': now,
+    });
+
+    expect(assistant.workspaceDefaultDirectories, isEmpty);
+    expect(conversation.workspaceDirectoryOverrides, isEmpty);
+  });
+}

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -54,6 +54,41 @@ void main() {
   }
 
   group('ChatService temporary conversations', () {
+    test(
+      'workspace directory override updates and clears on a draft',
+      () async {
+        final service = createService();
+        await service.init();
+        final conversation = await service.createDraftConversation(
+          title: 'Chat',
+        );
+
+        await service.setConversationWorkspaceDirectoryOverride(
+          conversation.id,
+          'workspace-a',
+          '/workspace/session-a',
+        );
+        expect(
+          service
+              .getConversation(conversation.id)
+              ?.workspaceDirectoryOverrides['workspace-a'],
+          '/workspace/session-a',
+        );
+
+        await service.clearConversationWorkspaceDirectoryOverride(
+          conversation.id,
+          'workspace-a',
+        );
+        expect(
+          service
+              .getConversation(conversation.id)
+              ?.workspaceDirectoryOverrides
+              .containsKey('workspace-a'),
+          isFalse,
+        );
+      },
+    );
+
     test('ordinary draft persists when its first message is added', () async {
       final service = createService();
       await service.init();

--- a/test/core/services/proactive_care_headless_chat_store_test.dart
+++ b/test/core/services/proactive_care_headless_chat_store_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/database/app_database.dart';
+import 'package:Cuplivo/core/database/chat_database_repository.dart';
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/services/proactive_care_message_flow.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as sqlite;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Future<String> Function() originalDataDirPathProvider;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('cuplivo_headless_db_');
+    originalDataDirPathProvider =
+        ProactiveCareHeadlessChatStore.dataDirPathProvider;
+    await ProactiveCareHeadlessChatStore.close();
+    ProactiveCareHeadlessChatStore.dataDirPathProvider = () async =>
+        tempDir.path;
+  });
+
+  tearDown(() async {
+    await ProactiveCareHeadlessChatStore.close();
+    ProactiveCareHeadlessChatStore.dataDirPathProvider =
+        originalDataDirPathProvider;
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  test(
+    'loads an assistant from a pre-v20 table without the cwd column',
+    () async {
+      final dbFile = File(p.join(tempDir.path, AppDatabase.databaseFileName));
+      final repository = ChatDatabaseRepository.open(file: dbFile);
+      await repository.ensureReady();
+      await repository.putAssistant(
+        Assistant(id: 'assistant-1', name: 'Legacy Assistant'),
+      );
+      await repository.close();
+
+      final rawDb = sqlite.sqlite3.open(dbFile.path);
+      rawDb.execute(
+        'ALTER TABLE assistant_rows '
+        'DROP COLUMN workspace_default_directories_json',
+      );
+      rawDb.close();
+
+      final assistant = await ProactiveCareHeadlessChatStore.loadAssistantFor(
+        'assistant-1',
+      );
+
+      expect(assistant, isNotNull);
+      expect(assistant!.workspaceDefaultDirectories, isEmpty);
+    },
+  );
+}

--- a/test/core/services/workspace/workspace_execution_context_test.dart
+++ b/test/core/services/workspace/workspace_execution_context_test.dart
@@ -55,6 +55,19 @@ void main() {
         );
       }
     });
+
+    test('rejects the reserved SAF mount namespace', () {
+      for (final path in <String>[
+        '/workspace/.mounts',
+        '/workspace/.mounts/notes',
+        '.mounts/notes',
+      ]) {
+        expect(
+          () => normalizeWorkspaceDirectory(path),
+          throwsA(isA<WorkspacePathException>()),
+        );
+      }
+    });
   });
 
   group('resolveWorkspaceGuestPath', () {

--- a/test/core/services/workspace/workspace_execution_context_test.dart
+++ b/test/core/services/workspace/workspace_execution_context_test.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/services/workspace/workspace_execution_context.dart';
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/models/workspace.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('normalizeWorkspaceDirectory', () {
+    test('stores root-relative and absolute input canonically', () {
+      expect(normalizeWorkspaceDirectory('/workspace'), '/workspace');
+      expect(
+        normalizeWorkspaceDirectory('project/src'),
+        '/workspace/project/src',
+      );
+      expect(
+        normalizeWorkspaceDirectory('/workspace/project/./src/../test'),
+        '/workspace/project/test',
+      );
+    });
+
+    test('rejects empty, foreign absolute, backslash, and escaping input', () {
+      for (final path in <String>[
+        '',
+        '/tmp/project',
+        r'project\src',
+        '../outside',
+        'project/bad:',
+        'project/trailing.',
+      ]) {
+        expect(
+          () => normalizeWorkspaceDirectory(path),
+          throwsA(isA<WorkspacePathException>()),
+          reason: path,
+        );
+      }
+    });
+  });
+
+  group('resolveWorkspaceGuestPath', () {
+    test('normalizes dot segments inside the workspace', () {
+      expect(
+        resolveWorkspaceGuestPath(
+          './lib/../test/a.dart',
+          baseDirectory: '/workspace/project',
+        ),
+        '/workspace/project/test/a.dart',
+      );
+    });
+
+    test('absolute workspace paths stay root-anchored', () {
+      expect(
+        resolveWorkspaceGuestPath(
+          '/workspace/other',
+          baseDirectory: '/workspace/project',
+        ),
+        '/workspace/other',
+      );
+    });
+  });
+
+  test(
+    'conversation override wins, otherwise assistant default is inherited',
+    () {
+      final assistant = Assistant(
+        id: 'a1',
+        name: 'Assistant',
+        workspaceDefaultDirectories: const {
+          'a': '/workspace/assistant-a',
+          'b': '/workspace/assistant-b',
+        },
+      );
+      final conversation = Conversation(
+        title: 'Conversation',
+        workspaceDirectoryOverrides: const {'a': '/workspace/conversation-a'},
+      );
+
+      expect(
+        effectiveWorkspaceDirectory(
+          assistant: assistant,
+          conversation: conversation,
+          workspaceId: 'a',
+        ),
+        '/workspace/conversation-a',
+      );
+      expect(
+        effectiveWorkspaceDirectory(
+          assistant: assistant,
+          conversation: conversation,
+          workspaceId: 'b',
+        ),
+        '/workspace/assistant-b',
+      );
+      expect(
+        effectiveWorkspaceDirectory(
+          assistant: assistant,
+          conversation: conversation,
+          workspaceId: 'c',
+        ),
+        '/workspace',
+      );
+    },
+  );
+
+  test(
+    'missing configured directory is created and recreated after deletion',
+    () async {
+      final root = await Directory.systemTemp.createTemp('cuplivo_cwd_');
+      addTearDown(() => root.delete(recursive: true));
+      final workspace = Workspace.createDefault();
+
+      final hostPath = await ensureWorkspaceDirectoryAtHostRoot(
+        workspace: workspace,
+        hostRoot: root.path,
+        workingDirectory: '/workspace/project/session',
+      );
+      expect(await Directory(hostPath).exists(), isTrue);
+      await Directory(hostPath).delete(recursive: true);
+      await ensureWorkspaceDirectoryAtHostRoot(
+        workspace: workspace,
+        hostRoot: root.path,
+        workingDirectory: '/workspace/project/session',
+      );
+      expect(await Directory(hostPath).exists(), isTrue);
+    },
+  );
+
+  test(
+    'read-only workspace rejects a missing directory without fallback',
+    () async {
+      final root = await Directory.systemTemp.createTemp('cuplivo_cwd_ro_');
+      addTearDown(() => root.delete(recursive: true));
+      final workspace = Workspace.createDefault().copyWith(readOnly: true);
+
+      expect(
+        () => ensureWorkspaceDirectoryAtHostRoot(
+          workspace: workspace,
+          hostRoot: root.path,
+          workingDirectory: '/workspace/missing',
+        ),
+        throwsA(isA<WorkspacePathException>()),
+      );
+    },
+  );
+
+  test('working directory rejects a symbolic-link escape', () async {
+    if (Platform.isWindows) return;
+    final root = await Directory.systemTemp.createTemp('cuplivo_cwd_root_');
+    final outside = await Directory.systemTemp.createTemp(
+      'cuplivo_cwd_outside_',
+    );
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+      if (await outside.exists()) await outside.delete(recursive: true);
+    });
+    await Link('${root.path}/escape').create(outside.path);
+
+    await expectLater(
+      ensureWorkspaceDirectoryAtHostRoot(
+        workspace: Workspace.createDefault(),
+        hostRoot: root.path,
+        workingDirectory: '/workspace/escape/created-outside',
+      ),
+      throwsA(isA<WorkspacePathException>()),
+    );
+    expect(
+      await Directory('${outside.path}/created-outside').exists(),
+      isFalse,
+    );
+  });
+}

--- a/test/core/services/workspace/workspace_execution_context_test.dart
+++ b/test/core/services/workspace/workspace_execution_context_test.dart
@@ -4,9 +4,28 @@ import 'package:Cuplivo/core/services/workspace/workspace_execution_context.dart
 import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/models/workspace.dart';
+import 'package:Cuplivo/core/providers/workspace_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
   group('normalizeWorkspaceDirectory', () {
     test('stores root-relative and absolute input canonically', () {
       expect(normalizeWorkspaceDirectory('/workspace'), '/workspace');
@@ -167,6 +186,177 @@ void main() {
     expect(
       await Directory('${outside.path}/created-outside').exists(),
       isFalse,
+    );
+  });
+
+  test(
+    'loads AGENTS.md from the working directory up to the workspace root',
+    () async {
+      final container = await Directory.systemTemp.createTemp(
+        'cuplivo_agents_md_',
+      );
+      final root = Directory('${container.path}/workspace');
+      final originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProvider(container.path);
+      addTearDown(() => container.delete(recursive: true));
+      addTearDown(() => PathProviderPlatform.instance = originalPathProvider);
+      await Directory('${root.path}/project/nested').create(recursive: true);
+      await File('${root.path}/AGENTS.md').writeAsString('root instructions');
+      await File(
+        '${root.path}/project/AGENTS.md',
+      ).writeAsString('project instructions');
+      await File(
+        '${container.path}/AGENTS.md',
+      ).writeAsString('outside instructions');
+
+      final workspace = Workspace(
+        id: 'workspace-a',
+        displayName: 'Workspace',
+        alias: 'workspace',
+        customHostPath: root.path,
+      );
+      final workspaces = WorkspaceProvider();
+      await workspaces.init();
+      final instructions = await loadWorkspaceAgentsMdInstructions(
+        context: WorkspaceExecutionContext(
+          workspace: workspace,
+          workingDirectory: '/workspace/project/nested',
+        ),
+        workspaces: workspaces,
+      );
+
+      expect(
+        instructions,
+        'Instructions from: /workspace/project/AGENTS.md\n'
+        'project instructions\n\n'
+        'Instructions from: /workspace/AGENTS.md\nroot instructions',
+      );
+      expect(instructions, isNot(contains('outside instructions')));
+    },
+  );
+
+  test(
+    'keeps an empty AGENTS.md and returns null when none are found',
+    () async {
+      final root = await Directory.systemTemp.createTemp(
+        'cuplivo_agents_empty_',
+      );
+      final originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProvider(root.path);
+      addTearDown(() => root.delete(recursive: true));
+      addTearDown(() => PathProviderPlatform.instance = originalPathProvider);
+      await Directory('${root.path}/project').create();
+      final workspace = Workspace(
+        id: 'workspace-a',
+        displayName: 'Workspace',
+        alias: 'workspace',
+        customHostPath: root.path,
+      );
+      final context = WorkspaceExecutionContext(
+        workspace: workspace,
+        workingDirectory: '/workspace/project',
+      );
+      final workspaces = WorkspaceProvider();
+      await workspaces.init();
+
+      expect(
+        await loadWorkspaceAgentsMdInstructions(
+          context: context,
+          workspaces: workspaces,
+        ),
+        isNull,
+      );
+      await File('${root.path}/project/AGENTS.md').writeAsString('');
+      expect(
+        await loadWorkspaceAgentsMdInstructions(
+          context: context,
+          workspaces: workspaces,
+        ),
+        'Instructions from: /workspace/project/AGENTS.md\n',
+      );
+    },
+  );
+
+  test(
+    'rejects AGENTS.md entries that resolve outside the workspace',
+    () async {
+      if (Platform.isWindows) return;
+      final root = await Directory.systemTemp.createTemp(
+        'cuplivo_agents_root_',
+      );
+      final outside = await Directory.systemTemp.createTemp(
+        'cuplivo_agents_outside_',
+      );
+      final originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = _FakePathProvider(root.path);
+      addTearDown(() async {
+        if (await root.exists()) await root.delete(recursive: true);
+        if (await outside.exists()) await outside.delete(recursive: true);
+      });
+      addTearDown(() => PathProviderPlatform.instance = originalPathProvider);
+      await Directory('${root.path}/project').create();
+      final outsideAgents = File('${outside.path}/AGENTS.md');
+      await outsideAgents.writeAsString('outside');
+      await Link('${root.path}/project/AGENTS.md').create(outsideAgents.path);
+      final workspaces = WorkspaceProvider();
+      await workspaces.init();
+
+      await expectLater(
+        loadWorkspaceAgentsMdInstructions(
+          context: WorkspaceExecutionContext(
+            workspace: Workspace(
+              id: 'workspace-a',
+              displayName: 'Workspace',
+              alias: 'workspace',
+              customHostPath: root.path,
+            ),
+            workingDirectory: '/workspace/project',
+          ),
+          workspaces: workspaces,
+        ),
+        throwsA(isA<WorkspaceAgentsMdLoadException>()),
+      );
+    },
+  );
+
+  test('rejects a missing working directory and directory AGENTS.md', () async {
+    final root = await Directory.systemTemp.createTemp(
+      'cuplivo_agents_invalid_',
+    );
+    final originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProvider(root.path);
+    addTearDown(() => root.delete(recursive: true));
+    addTearDown(() => PathProviderPlatform.instance = originalPathProvider);
+    final workspace = Workspace(
+      id: 'workspace-a',
+      displayName: 'Workspace',
+      alias: 'workspace',
+      customHostPath: root.path,
+    );
+    final workspaces = WorkspaceProvider();
+    await workspaces.init();
+
+    await expectLater(
+      loadWorkspaceAgentsMdInstructions(
+        context: WorkspaceExecutionContext(
+          workspace: workspace,
+          workingDirectory: '/workspace/missing',
+        ),
+        workspaces: workspaces,
+      ),
+      throwsA(isA<WorkspaceAgentsMdLoadException>()),
+    );
+
+    await Directory('${root.path}/AGENTS.md').create();
+    await expectLater(
+      loadWorkspaceAgentsMdInstructions(
+        context: WorkspaceExecutionContext(
+          workspace: workspace,
+          workingDirectory: '/workspace',
+        ),
+        workspaces: workspaces,
+      ),
+      throwsA(isA<WorkspaceAgentsMdLoadException>()),
     );
   });
 }

--- a/test/core/services/workspace/workspace_path_presentation_test.dart
+++ b/test/core/services/workspace/workspace_path_presentation_test.dart
@@ -5,9 +5,33 @@ void main() {
   const safAliases = <String>{'notes', 'assets'};
 
   group('parseModelPath', () {
-    test('translates the bound workspace', () {
+    test('translates workspace absolute and relative paths', () {
       expect(parseModelPath('/workspace', 'default'), '@default');
       expect(parseModelPath('/workspace/a/b.md', 'default'), '@default/a/b.md');
+      expect(
+        parseModelPath(
+          'notes.md',
+          'default',
+          workingDirectory: '/workspace/project',
+        ),
+        '@default/project/notes.md',
+      );
+      expect(
+        parseModelPath(
+          '../shared/file.txt',
+          'default',
+          workingDirectory: '/workspace/project/src',
+        ),
+        '@default/project/shared/file.txt',
+      );
+      expect(
+        parseModelPath(
+          '/workspace/root.txt',
+          'default',
+          workingDirectory: '/workspace/project',
+        ),
+        '@default/root.txt',
+      );
     });
 
     test('translates SAF mounts under /workspace/.mounts/<alias>', () {
@@ -23,13 +47,35 @@ void main() {
         parseModelPath(
           '/workspace/.mounts/notes/a.md',
           'default',
+          workingDirectory: '/workspace/project',
           safAliases: safAliases,
         ),
         '@notes/a.md',
       );
     });
 
-    test('rejects an unknown SAF alias', () {
+    test('rejects escaping and foreign paths', () {
+      for (final bad in [
+        '../../outside.txt',
+        '/etc/passwd',
+        '/tmp/x',
+        '/workspace2/x',
+        'C:/x',
+        '@default/x',
+      ]) {
+        expect(
+          () => parseModelPath(
+            bad,
+            'default',
+            workingDirectory: '/workspace/project',
+          ),
+          throwsA(isA<ModelPathException>()),
+          reason: 'should reject: $bad',
+        );
+      }
+    });
+
+    test('rejects unknown or missing SAF aliases', () {
       expect(
         () => parseModelPath(
           '/workspace/.mounts/nope/a.md',
@@ -38,9 +84,6 @@ void main() {
         ),
         throwsA(isA<ModelPathException>()),
       );
-    });
-
-    test('rejects .mounts without an alias', () {
       expect(
         () => parseModelPath(
           '/workspace/.mounts',
@@ -51,31 +94,20 @@ void main() {
       );
     });
 
-    test('a literal .mounts workspace folder is shadowed', () {
-      // /workspace/.mounts/notes resolves as the SAF mount when the alias is
-      // known — a real folder named .mounts cannot be addressed (ADR-0037).
+    test('preserves trailing slash for engine validation parity', () {
+      expect(parseModelPath('/workspace/', 'default'), '@default/');
+      expect(parseModelPath('/workspace/dir/', 'default'), '@default/dir/');
       expect(
         parseModelPath(
-          '/workspace/.mounts/notes',
+          '/workspace/.mounts/notes/',
           'default',
           safAliases: safAliases,
         ),
-        '@notes',
+        '@notes/',
       );
     });
 
-    test('still rejects canonical wire and absolute paths', () {
-      expect(
-        () => parseModelPath('@notes/a.md', 'default', safAliases: safAliases),
-        throwsA(isA<ModelPathException>()),
-      );
-      expect(
-        () => parseModelPath('/etc/passwd', 'default'),
-        throwsA(isA<ModelPathException>()),
-      );
-    });
-
-    test('passes the root listing through', () {
+    test('passes the mount listing root through', () {
       expect(parseModelPath('/', 'default', safAliases: safAliases), '/');
     });
   });

--- a/test/core/services/workspace/workspace_tools_service_test.dart
+++ b/test/core/services/workspace/workspace_tools_service_test.dart
@@ -1,109 +1,204 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/models/workspace.dart';
+import 'package:Cuplivo/core/providers/workspace_provider.dart';
 import 'package:Cuplivo/core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart';
+import 'package:Cuplivo/core/services/workspace/workspace_execution_context.dart';
 import 'package:Cuplivo/core/services/workspace/workspace_tools_service.dart';
 import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$root/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$root/tmp';
+}
 
 void main() {
-  group('WorkspaceToolsService.dedupeMounts', () {
-    test('keeps workspace mounts first and drops colliding SAF mounts', () {
-      final wsMounts = [
-        const FilesystemMount(
-          alias: 'default',
-          path: '/ws/default',
-          readOnly: false,
-        ),
-      ];
-      final safMounts = [
-        const FilesystemMount(
-          alias: 'default',
-          path: '/mirror/default',
-          uri: 'content://tree/1',
-        ),
-        const FilesystemMount(
-          alias: 'notes',
-          path: '/mirror/notes',
-          uri: 'content://tree/2',
-        ),
-      ];
+  TestWidgetsFlutterBinding.ensureInitialized();
 
-      final out = WorkspaceToolsService.dedupeMounts(wsMounts, safMounts);
+  group('SAF mount composition', () {
+    test('keeps workspace mounts first and drops colliding SAF mounts', () {
+      final out = WorkspaceToolsService.dedupeMounts(
+        const [
+          FilesystemMount(
+            alias: 'default',
+            path: '/ws/default',
+            readOnly: false,
+          ),
+        ],
+        const [
+          FilesystemMount(
+            alias: 'default',
+            path: '/mirror/default',
+            uri: 'content://tree/1',
+          ),
+          FilesystemMount(
+            alias: 'notes',
+            path: '/mirror/notes',
+            uri: 'content://tree/2',
+          ),
+        ],
+      );
 
       expect(out.map((m) => m.alias), ['default', 'notes']);
-      // The workspace mount wins the alias; the SAF mirror is shadowed.
       expect(out.first.uri, isNull);
       expect(out.first.path, '/ws/default');
-      // The non-colliding SAF mount stays.
       expect(out[1].uri, 'content://tree/2');
       expect(out.where((m) => m.isSafMount), hasLength(1));
     });
 
-    test('an empty SAF list is a pass-through', () {
-      final wsMounts = [
-        const FilesystemMount(alias: 'default', path: '/ws/default'),
-      ];
-      final out = WorkspaceToolsService.dedupeMounts(wsMounts, const []);
-      expect(out, hasLength(1));
-      expect(out.single.alias, 'default');
-    });
+    test('empty SAF mounts pass through and aliases use deduped mounts', () {
+      const workspaceMount = FilesystemMount(alias: 'notes', path: '/ws/notes');
+      expect(
+        WorkspaceToolsService.dedupeMounts(const [workspaceMount], const []),
+        hasLength(1),
+      );
 
-    test('a restored custom workspace alias shadows a SAF mount', () {
-      // Backup restore can bring a workspace whose alias matches a SAF mount
-      // added after that backup was made.
-      final wsMounts = [
-        const FilesystemMount(
-          alias: 'notes',
-          path: '/ws/notes',
-          readOnly: false,
-        ),
-      ];
-      final safMounts = [
-        const FilesystemMount(
-          alias: 'notes',
-          path: '/mirror/notes',
-          uri: 'content://tree/9',
-        ),
-      ];
-
-      final out = WorkspaceToolsService.dedupeMounts(wsMounts, safMounts);
-      expect(out, hasLength(1));
-      expect(out.single.uri, isNull);
-    });
-  });
-
-  group('WorkspaceToolsService.safAliasesFrom', () {
-    test('derives aliases from the deduped composition only', () {
       final combined = WorkspaceToolsService.dedupeMounts(
-        [
-          const FilesystemMount(
-            alias: 'notes',
-            path: '/ws/notes',
-            readOnly: false,
-          ),
-        ],
-        [
-          const FilesystemMount(
+        const [workspaceMount],
+        const [
+          FilesystemMount(
             alias: 'notes',
             path: '/mirror/notes',
             uri: 'content://tree/9',
           ),
-          const FilesystemMount(
+          FilesystemMount(
             alias: 'assets',
             path: '/mirror/assets',
             uri: 'content://tree/8',
           ),
         ],
       );
-      // The shadowed "notes" alias must NOT be addressable — parse-time
-      // rejection beats silent routing to the workspace mount.
       expect(WorkspaceToolsService.safAliasesFrom(combined), {'assets'});
     });
+  });
 
-    test('empty when there are no SAF mounts', () {
-      expect(
-        WorkspaceToolsService.safAliasesFrom(const [
-          FilesystemMount(alias: 'default', path: '/ws/default'),
-        ]),
-        isEmpty,
+  group('working-directory execution', () {
+    late Directory temp;
+    late WorkspaceProvider workspaces;
+    late Workspace workspace;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      originalPathProvider = PathProviderPlatform.instance;
+      temp = await Directory.systemTemp.createTemp('cuplivo_tools_cwd_');
+      PathProviderPlatform.instance = _FakePathProvider(temp.path);
+      SharedPreferences.setMockInitialValues({});
+      workspaces = WorkspaceProvider();
+      await workspaces.init();
+      workspace = workspaces.defaultWorkspace!;
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      if (await temp.exists()) await temp.delete(recursive: true);
+    });
+
+    test('filesystem paths resolve from the assistant directory', () async {
+      final host = workspaces.hostPathFor(workspace)!;
+      await Directory('$host/project').create(recursive: true);
+      await File('$host/project/note.txt').writeAsString('cwd-data');
+      await File('$host/root.txt').writeAsString('root-data');
+      final assistant = Assistant(
+        id: 'a1',
+        name: 'Assistant',
+        workspaceEnabled: true,
+        workspaceId: workspace.id,
+        workspaceDefaultDirectories: {workspace.id: '/workspace/project'},
       );
+      final executionContext = WorkspaceExecutionContext(
+        workspace: workspace,
+        workingDirectory: '/workspace/project',
+      );
+
+      final definitions = WorkspaceToolsService.buildToolDefinitions(
+        assistant: assistant,
+        workspaces: workspaces,
+        supportsTools: true,
+        executionContext: executionContext,
+      );
+      final reminder = WorkspaceToolsService.buildPromptReminder(
+        assistant: assistant,
+        workspaces: workspaces,
+        executionContext: executionContext,
+      );
+      final relative = await WorkspaceToolsService.tryHandleToolCall(
+        name: WorkspaceToolNames.read,
+        args: const {'path': 'note.txt'},
+        assistant: assistant,
+        workspaces: workspaces,
+        executionContext: executionContext,
+      );
+      final absolute = await WorkspaceToolsService.tryHandleToolCall(
+        name: WorkspaceToolNames.read,
+        args: const {'path': '/workspace/root.txt'},
+        assistant: assistant,
+        workspaces: workspaces,
+      );
+
+      expect(relative, contains('cwd-data'));
+      expect(absolute, contains('root-data'));
+      expect(definitions.first.toString(), contains('/workspace/project'));
+      expect(
+        reminder,
+        contains('Current working directory: /workspace/project'),
+      );
+    });
+
+    test('conversation override wins and escaping paths fail', () async {
+      final host = workspaces.hostPathFor(workspace)!;
+      await Directory('$host/assistant').create(recursive: true);
+      await Directory('$host/conversation').create(recursive: true);
+      await File('$host/assistant/note.txt').writeAsString('assistant-data');
+      await File(
+        '$host/conversation/note.txt',
+      ).writeAsString('conversation-data');
+      final assistant = Assistant(
+        id: 'a1',
+        name: 'Assistant',
+        workspaceEnabled: true,
+        workspaceId: workspace.id,
+        workspaceDefaultDirectories: {workspace.id: '/workspace/assistant'},
+      );
+      final conversation = Conversation(
+        title: 'Conversation',
+        workspaceDirectoryOverrides: {workspace.id: '/workspace/conversation'},
+      );
+
+      final result = await WorkspaceToolsService.tryHandleToolCall(
+        name: WorkspaceToolNames.read,
+        args: const {'path': 'note.txt'},
+        assistant: assistant,
+        conversation: conversation,
+        workspaces: workspaces,
+      );
+      final escaped = await WorkspaceToolsService.tryHandleToolCall(
+        name: WorkspaceToolNames.read,
+        args: const {'path': '../../outside.txt'},
+        assistant: assistant,
+        conversation: conversation,
+        workspaces: workspaces,
+      );
+
+      expect(result, contains('conversation-data'));
+      expect(escaped, contains('invalid_path'));
     });
   });
 

--- a/test/features/assistant/pages/assistant_settings_edit_page_mcp_test.dart
+++ b/test/features/assistant/pages/assistant_settings_edit_page_mcp_test.dart
@@ -88,6 +88,10 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(find.text('Time Info'), findsOneWidget);
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(AssistantSettingsEditPage)),
+    )!;
+    expect(find.text(l10n.workspaceDefaultDirectoryTitle), findsOneWidget);
     expect(
       find.byWidgetPredicate(
         (widget) => widget is Icon && widget.icon == Lucide.clock,

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/models/chat_message.dart';
 import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/models/workspace.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/services/workspace/workspace_execution_context.dart';
 import 'package:Cuplivo/features/home/services/message_builder_service.dart';
 
 class _FakeBuildContext implements BuildContext {
@@ -781,4 +783,32 @@ void main() {
       );
     });
   });
+
+  test(
+    'skips AGENTS.md loading before accessing the workspace when disabled',
+    () async {
+      final service = MessageBuilderService(
+        chatService: _FakeChatService(const {}),
+        contextProvider: _FakeBuildContext(),
+      );
+      final apiMessages = <Map<String, dynamic>>[
+        {'role': 'system', 'content': 'assistant instructions'},
+      ];
+
+      await service.injectWorkspaceAgentsMdInstructions(
+        apiMessages,
+        assistant: Assistant(
+          id: 'assistant-1',
+          name: 'Assistant',
+          autoLoadAgentsMd: false,
+        ),
+        workspaceExecutionContext: WorkspaceExecutionContext(
+          workspace: Workspace.createDefault(),
+          workingDirectory: '/workspace',
+        ),
+      );
+
+      expect(apiMessages.single['content'], 'assistant instructions');
+    },
+  );
 }

--- a/test/features/home/widgets/tools_hub_content_test.dart
+++ b/test/features/home/widgets/tools_hub_content_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/mcp_provider.dart';
+import 'package:Cuplivo/core/providers/workspace_provider.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/features/home/widgets/tools_hub_content.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
+
+class _FakeChatService extends ChatService {
+  _FakeChatService(this.conversation);
+
+  final Conversation conversation;
+
+  @override
+  bool get initialized => true;
+
+  @override
+  Conversation? getConversation(String id) =>
+      id == conversation.id ? conversation : null;
+
+  @override
+  Future<void> setConversationWorkspaceDirectoryOverride(
+    String conversationId,
+    String workspaceId,
+    String directory,
+  ) async {
+    conversation.workspaceDirectoryOverrides = {
+      ...conversation.workspaceDirectoryOverrides,
+      workspaceId: directory,
+    };
+    notifyListeners();
+  }
+
+  @override
+  Future<void> clearConversationWorkspaceDirectoryOverride(
+    String conversationId,
+    String workspaceId,
+  ) async {
+    conversation.workspaceDirectoryOverrides = {
+      for (final entry in conversation.workspaceDirectoryOverrides.entries)
+        if (entry.key != workspaceId) entry.key: entry.value,
+    };
+    notifyListeners();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory temp;
+  late PathProviderPlatform originalPathProvider;
+  late WorkspaceProvider workspaces;
+
+  setUp(() async {
+    originalPathProvider = PathProviderPlatform.instance;
+    temp = await Directory.systemTemp.createTemp('tools_hub_directory_');
+    PathProviderPlatform.instance = _FakePathProvider(temp.path);
+    SharedPreferences.setMockInitialValues({});
+    workspaces = WorkspaceProvider();
+    await workspaces.init();
+  });
+
+  tearDown(() async {
+    PathProviderPlatform.instance = originalPathProvider;
+    if (await temp.exists()) await temp.delete(recursive: true);
+  });
+
+  Future<AssistantProvider> assistantProvider(Assistant assistant) async {
+    SharedPreferences.setMockInitialValues({
+      'assistants_v1': Assistant.encodeList([assistant]),
+    });
+    final provider = AssistantProvider();
+    await provider.loadFromPrefs();
+    return provider;
+  }
+
+  Future<void> pumpHub(
+    WidgetTester tester, {
+    required Assistant assistant,
+    required Conversation conversation,
+    required String? conversationId,
+  }) async {
+    late BuildContext providerContext;
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(
+            value: await assistantProvider(assistant),
+          ),
+          ChangeNotifierProvider.value(value: workspaces),
+          ChangeNotifierProvider<ChatService>.value(
+            value: _FakeChatService(conversation),
+          ),
+          ChangeNotifierProvider(
+            create: (context) {
+              providerContext = context;
+              return McpProvider(contextProvider: () => providerContext);
+            },
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: ToolsHubContent(
+                assistantId: assistant.id,
+                conversationId: conversationId,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  testWidgets('working-directory row follows bind and stays disabled unbound', (
+    tester,
+  ) async {
+    final assistant = Assistant(id: 'a1', name: 'Assistant');
+    final conversation = Conversation(id: 'c1', title: 'Conversation');
+    await pumpHub(
+      tester,
+      assistant: assistant,
+      conversation: conversation,
+      conversationId: conversation.id,
+    );
+    final context = tester.element(find.byType(ToolsHubContent));
+    final l10n = AppLocalizations.of(context)!;
+    final bind = find.text(l10n.workspaceBindTitle);
+    final directory = find.text(l10n.workspaceDirectoryPickerTitle);
+
+    expect(bind, findsOneWidget);
+    expect(directory, findsOneWidget);
+    expect(
+      tester.getTopLeft(bind).dy,
+      lessThan(tester.getTopLeft(directory).dy),
+    );
+    final gestures = tester.widgetList<GestureDetector>(
+      find.ancestor(of: directory, matching: find.byType(GestureDetector)),
+    );
+    expect(gestures.any((gesture) => gesture.onTap != null), isFalse);
+  });
+
+  testWidgets('bound row opens the conversation-only directory editor', (
+    tester,
+  ) async {
+    final workspace = workspaces.defaultWorkspace!;
+    final assistant = Assistant(
+      id: 'a1',
+      name: 'Assistant',
+      workspaceEnabled: true,
+      workspaceId: workspace.id,
+      workspaceDefaultDirectories: {
+        workspace.id: '/workspace/assistant-default',
+      },
+    );
+    final conversation = Conversation(
+      id: 'c1',
+      title: 'Conversation',
+      workspaceDirectoryOverrides: {workspace.id: '/workspace/conversation'},
+    );
+    await pumpHub(
+      tester,
+      assistant: assistant,
+      conversation: conversation,
+      conversationId: conversation.id,
+    );
+    final context = tester.element(find.byType(ToolsHubContent));
+    final l10n = AppLocalizations.of(context)!;
+
+    expect(find.text('/workspace/conversation'), findsOneWidget);
+    await tester.tap(find.text(l10n.workspaceDirectoryPickerTitle));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text(l10n.workspaceDirectoryPickerTitle), findsNWidgets(2));
+    expect(find.text(l10n.workspaceConversationDirectoryTitle), findsOneWidget);
+    expect(find.text(l10n.workspaceDirectoryBrowse), findsOneWidget);
+    expect(find.text(l10n.workspaceDirectorySave), findsOneWidget);
+    expect(find.text(l10n.workspaceEnableTitle), findsNothing);
+  });
+}

--- a/test/features/home/widgets/tools_hub_content_test.dart
+++ b/test/features/home/widgets/tools_hub_content_test.dart
@@ -4,10 +4,13 @@ import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/providers/assistant_provider.dart';
 import 'package:Cuplivo/core/providers/mcp_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/providers/workspace_provider.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/features/home/widgets/tools_hub_content.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_form_text_field.dart';
+import 'package:Cuplivo/shared/widgets/ios_switch.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 // ignore: depend_on_referenced_packages
@@ -31,6 +34,8 @@ class _FakeChatService extends ChatService {
   _FakeChatService(this.conversation);
 
   final Conversation conversation;
+  int setDirectoryOverrideCalls = 0;
+  int clearDirectoryOverrideCalls = 0;
 
   @override
   bool get initialized => true;
@@ -45,6 +50,7 @@ class _FakeChatService extends ChatService {
     String workspaceId,
     String directory,
   ) async {
+    setDirectoryOverrideCalls++;
     conversation.workspaceDirectoryOverrides = {
       ...conversation.workspaceDirectoryOverrides,
       workspaceId: directory,
@@ -57,6 +63,7 @@ class _FakeChatService extends ChatService {
     String conversationId,
     String workspaceId,
   ) async {
+    clearDirectoryOverrideCalls++;
     conversation.workspaceDirectoryOverrides = {
       for (final entry in conversation.workspaceDirectoryOverrides.entries)
         if (entry.key != workspaceId) entry.key: entry.value,
@@ -95,23 +102,23 @@ void main() {
     return provider;
   }
 
-  Future<void> pumpHub(
+  Future<_FakeChatService> pumpHub(
     WidgetTester tester, {
     required Assistant assistant,
     required Conversation conversation,
     required String? conversationId,
   }) async {
     late BuildContext providerContext;
+    final chatService = _FakeChatService(conversation);
     await tester.pumpWidget(
       MultiProvider(
         providers: [
           ChangeNotifierProvider.value(
             value: await assistantProvider(assistant),
           ),
+          ChangeNotifierProvider.value(value: SettingsProvider()),
           ChangeNotifierProvider.value(value: workspaces),
-          ChangeNotifierProvider<ChatService>.value(
-            value: _FakeChatService(conversation),
-          ),
+          ChangeNotifierProvider<ChatService>.value(value: chatService),
           ChangeNotifierProvider(
             create: (context) {
               providerContext = context;
@@ -135,6 +142,7 @@ void main() {
     );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
+    return chatService;
   }
 
   testWidgets('working-directory row follows bind and stays disabled unbound', (
@@ -199,8 +207,203 @@ void main() {
 
     expect(find.text(l10n.workspaceDirectoryPickerTitle), findsNWidgets(2));
     expect(find.text(l10n.workspaceConversationDirectoryTitle), findsOneWidget);
+    expect(find.text(l10n.workspaceAutoLoadAgentsMdTitle), findsOneWidget);
     expect(find.text(l10n.workspaceDirectoryBrowse), findsOneWidget);
     expect(find.text(l10n.workspaceDirectorySave), findsOneWidget);
     expect(find.text(l10n.workspaceEnableTitle), findsNothing);
   });
+
+  testWidgets('AGENTS.md loading switch saves the assistant setting', (
+    tester,
+  ) async {
+    final workspace = workspaces.defaultWorkspace!;
+    final assistant = Assistant(
+      id: 'a1',
+      name: 'Assistant',
+      workspaceEnabled: true,
+      workspaceId: workspace.id,
+    );
+    final conversation = Conversation(id: 'c1', title: 'Conversation');
+    await pumpHub(
+      tester,
+      assistant: assistant,
+      conversation: conversation,
+      conversationId: conversation.id,
+    );
+    final context = tester.element(find.byType(ToolsHubContent));
+    final l10n = AppLocalizations.of(context)!;
+
+    await tester.tap(find.text(l10n.workspaceDirectoryPickerTitle));
+    await tester.pumpAndSettle();
+
+    final agentsSwitch = find.byWidgetPredicate(
+      (widget) =>
+          widget is IosSwitch &&
+          widget.semanticLabel == l10n.workspaceAutoLoadAgentsMdTitle,
+    );
+    expect(agentsSwitch, findsOneWidget);
+    expect(tester.widget<IosSwitch>(agentsSwitch).value, isTrue);
+
+    await tester.tap(agentsSwitch);
+    await tester.pumpAndSettle();
+
+    expect(
+      context.read<AssistantProvider>().getById(assistant.id)!.autoLoadAgentsMd,
+      isFalse,
+    );
+    final prefs = await SharedPreferences.getInstance();
+    expect(
+      Assistant.decodeList(
+        prefs.getString('assistants_v1')!,
+      ).single.autoLoadAgentsMd,
+      isFalse,
+    );
+  });
+
+  for (final override in <String>[
+    '/workspace/project',
+    '/workspace/project/./src/..',
+  ]) {
+    testWidgets(
+      'equivalent conversation directory $override is inherited and pruned',
+      (tester) async {
+        final workspace = workspaces.defaultWorkspace!;
+        final assistant = Assistant(
+          id: 'a1',
+          name: 'Assistant',
+          workspaceEnabled: true,
+          workspaceId: workspace.id,
+          workspaceDefaultDirectories: {workspace.id: '/workspace/project'},
+        );
+        final conversation = Conversation(
+          id: 'c1',
+          title: 'Conversation',
+          workspaceDirectoryOverrides: {workspace.id: override},
+        );
+        await pumpHub(
+          tester,
+          assistant: assistant,
+          conversation: conversation,
+          conversationId: conversation.id,
+        );
+        final context = tester.element(find.byType(ToolsHubContent));
+        final l10n = AppLocalizations.of(context)!;
+
+        await tester.tap(find.text(l10n.workspaceDirectoryPickerTitle));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text(l10n.workspaceDirectoryInherited), findsOneWidget);
+        expect(find.text(l10n.workspaceDirectoryOverride), findsNothing);
+        expect(
+          find.text(l10n.workspaceDirectoryUseAssistantDefault),
+          findsNothing,
+        );
+        expect(
+          conversation.workspaceDirectoryOverrides.containsKey(workspace.id),
+          isFalse,
+        );
+      },
+    );
+  }
+
+  testWidgets('invalid conversation directory remains an explicit override', (
+    tester,
+  ) async {
+    final workspace = workspaces.defaultWorkspace!;
+    final assistant = Assistant(
+      id: 'a1',
+      name: 'Assistant',
+      workspaceEnabled: true,
+      workspaceId: workspace.id,
+      workspaceDefaultDirectories: {workspace.id: '/workspace/project'},
+    );
+    final conversation = Conversation(
+      id: 'c1',
+      title: 'Conversation',
+      workspaceDirectoryOverrides: {workspace.id: '/tmp/outside'},
+    );
+    await pumpHub(
+      tester,
+      assistant: assistant,
+      conversation: conversation,
+      conversationId: conversation.id,
+    );
+    final context = tester.element(find.byType(ToolsHubContent));
+    final l10n = AppLocalizations.of(context)!;
+
+    await tester.tap(find.text(l10n.workspaceDirectoryPickerTitle));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text(l10n.workspaceDirectoryOverride), findsOneWidget);
+    expect(
+      find.text(l10n.workspaceDirectoryUseAssistantDefault),
+      findsOneWidget,
+    );
+    expect(
+      conversation.workspaceDirectoryOverrides[workspace.id],
+      '/tmp/outside',
+    );
+  });
+
+  testWidgets(
+    'saving the assistant default clears a different conversation override',
+    (tester) async {
+      final workspace = workspaces.defaultWorkspace!;
+      final assistant = Assistant(
+        id: 'a1',
+        name: 'Assistant',
+        workspaceEnabled: true,
+        workspaceId: workspace.id,
+        workspaceDefaultDirectories: {workspace.id: '/workspace/project'},
+      );
+      final conversation = Conversation(
+        id: 'c1',
+        title: 'Conversation',
+        workspaceDirectoryOverrides: {workspace.id: '/workspace/other'},
+      );
+      final chatService = await pumpHub(
+        tester,
+        assistant: assistant,
+        conversation: conversation,
+        conversationId: conversation.id,
+      );
+      final context = tester.element(find.byType(ToolsHubContent));
+      final l10n = AppLocalizations.of(context)!;
+
+      await tester.tap(find.text(l10n.workspaceDirectoryPickerTitle));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(
+        find.text(l10n.workspaceDirectoryUseAssistantDefault),
+        findsOneWidget,
+      );
+
+      final directoryField = find.descendant(
+        of: find.byType(IosFormTextField),
+        matching: find.byType(TextField),
+      );
+      expect(directoryField, findsOneWidget);
+      await tester.enterText(directoryField, '/workspace/project/./src/..');
+      expect(
+        tester.widget<TextField>(directoryField).controller!.text,
+        '/workspace/project/./src/..',
+      );
+      await tester.tap(find.text(l10n.workspaceDirectorySave));
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+
+      expect(chatService.clearDirectoryOverrideCalls, 1);
+      expect(
+        conversation.workspaceDirectoryOverrides.containsKey(workspace.id),
+        isFalse,
+      );
+      expect(find.text(l10n.workspaceDirectoryInherited), findsOneWidget);
+      expect(
+        find.text(l10n.workspaceDirectoryUseAssistantDefault),
+        findsNothing,
+      );
+    },
+  );
 }

--- a/test/features/settings/pages/mount_files_page_test.dart
+++ b/test/features/settings/pages/mount_files_page_test.dart
@@ -183,4 +183,67 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     }
   });
+
+  testWidgets('directory selection hides files and returns canonical path', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final tmp = Directory.systemTemp.createTempSync('mount_picker_test_');
+    addTearDown(() {
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+    Directory('${tmp.path}/project').createSync();
+    File('${tmp.path}/ignored.txt').writeAsStringSync('ignored');
+    final mount = FilesystemMount(
+      alias: 'default',
+      path: tmp.path,
+      readOnly: false,
+    );
+    String? selected;
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => SettingsProvider(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                onPressed: () async {
+                  selected = await Navigator.of(context).push<String>(
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          MountFilesPage(mount: mount, selectDirectory: true),
+                    ),
+                  );
+                },
+                child: const Text('open picker'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open picker'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+    await pumpUntilFound(tester, find.text('project'));
+    expect(find.text('ignored.txt'), findsNothing);
+    expect(find.text('/workspace'), findsOneWidget);
+    await tester.tap(find.text('project'));
+    await tester.pump();
+    final pageL10n = AppLocalizations.of(
+      tester.element(find.byType(MountFilesPage)),
+    )!;
+    await pumpUntilFound(tester, find.text(pageL10n.mountFilesEmptyDir));
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(MountFilesPage)),
+    )!;
+    await tester.tap(find.text(l10n.workspaceDirectorySelectCurrent));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(selected, '/workspace/project');
+  });
 }

--- a/test/features/workspace/widgets/workspace_directory_picker_test.dart
+++ b/test/features/workspace/widgets/workspace_directory_picker_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/models/workspace.dart';
+import 'package:Cuplivo/core/providers/workspace_provider.dart';
+import 'package:Cuplivo/features/settings/pages/mount_files_page.dart';
+import 'package:Cuplivo/features/workspace/widgets/workspace_directory_picker.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('tablet opens the directory picker in a constrained dialog', (
+    tester,
+  ) async {
+    final temp = Directory.systemTemp.createTempSync('cuplivo_picker_');
+    final originalPlatform = debugDefaultTargetPlatformOverride;
+    final originalPathProvider = PathProviderPlatform.instance;
+    addTearDown(() {
+      debugDefaultTargetPlatformOverride = originalPlatform;
+      PathProviderPlatform.instance = originalPathProvider;
+      if (temp.existsSync()) temp.deleteSync(recursive: true);
+    });
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    PathProviderPlatform.instance = _FakePathProvider(temp.path);
+    SharedPreferences.setMockInitialValues({});
+    tester.view.physicalSize = const Size(1000, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final workspaces = WorkspaceProvider();
+    final workspace = Workspace(
+      id: 'tablet-workspace',
+      displayName: 'Tablet',
+      alias: 'tablet',
+      customHostPath: temp.path,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showWorkspaceDirectoryPicker(
+              context,
+              workspace: workspace,
+              workspaces: workspaces,
+              initialDirectory: '/workspace',
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(find.byType(MountFilesPage), findsOneWidget);
+
+    Navigator.of(tester.element(find.byType(MountFilesPage))).pop();
+    await tester.pumpAndSettle();
+    debugDefaultTargetPlatformOverride = originalPlatform;
+  });
+}


### PR DESCRIPTION
## 变更概述

- 为助手新增按工作区 ID 独立保存的默认工作目录，切换工作区时恢复各自配置。
- 为一对一会话新增按工作区保存的目录覆盖，并支持恢复为动态继承助手默认目录。
- 为每个助手新增默认开启的“自动加载 AGENTS.md”开关；在工作目录设置面板中复用 IosSwitch，切换立即持久化且不受会话目录覆盖影响。
- 每次生成从有效工作目录向工作区根逐层读取精确命名的 AGENTS.md，按近到远顺序在助手 system prompt 后注入；常规生成与 handoff 子助手生成均覆盖。
- 在助手本地工具设置和聊天输入区加入可复用的工作区设置面板；手机入口位于加号菜单，平板与桌面显示文件夹入口。
- 复用 MountFilesPage 的目录浏览能力：手机全屏选择，平板与桌面使用受限尺寸对话框，仅显示目录。
- 为文件工具与 Shell 统一 cwd 语义：相对路径基于有效工作目录，绝对 /workspace 路径仍基于工作区根目录。
- 新增 WorkspaceExecutionContext 快照，保证单次生成中的工具定义、提示词和执行处理器使用同一工作区及目录。
- Drift schema 由 v19 升至 v20；在同一迁移中加入工作目录字段与 auto_load_agents_md，补齐自愈、SQLite mapper、主动关怀后台 mapper、模型 JSON 与备份往返。

## 审核修复

- 逐级检查真实文件系统条目并拒绝符号链接工作目录，避免递归创建沿链接逃逸到工作区外。
- AGENTS.md 仅允许读取解析后仍位于工作区内的常规文件；缺失目录、目录项、不可读文件或安全校验失败会中止生成，记录完整 debugPrint 上下文，并以本地化通用提示报错，不发送部分项目指令。
- 主动关怀后台读取旧数据库时安全兼容缺失的新助手列。
- 损坏的会话工作目录 JSON 会记录上下文并显式失败，不再静默回退到工作区根目录。
- 工作区切换时立即同步对应目录，并在持久化期间禁用保存/再次切换，避免快速操作写入错误工作区。
- 平板目录选择器改为与桌面一致的受限尺寸模态框。

## 验证

- dart run build_runner build --delete-conflicting-outputs
- flutter gen-l10n；无未翻译条目
- dart format（全部变更 Dart 与测试文件）
- 工作区路径、AGENTS.md 递归加载与越界拒绝、助手模型/备份、SQLite v19 → v20 升级与 schema self-heal、工具中心开关持久化等相关测试通过
- dart analyze --fatal-infos lib test：无问题

按需求未执行本地平台构建或应用启动。尚未覆盖的验证边界为 Linux 桌面实际构建，以及 Android/iOS 真机或模拟器上的手动交互；这些部分由 CI 和后续平台验收覆盖。

## 手动验收建议

1. 在助手设置中分别为工作区 A/B 设置不同默认目录，来回切换确认各自恢复。
2. 在一对一会话中设置目录覆盖，切换 A/B 后确认覆盖独立，并测试恢复助手默认目录。
3. 在嵌套工作目录放置多份 AGENTS.md，发送消息后确认按最近目录至工作区根的顺序注入；关闭开关后确认不读取。
4. 将 AGENTS.md 设为工作区外文件的链接、目录或不可读文件，确认显示通用加载失败提示且不发起请求。
5. 手机确认入口仅位于加号菜单；平板/桌面确认显示文件夹按钮；群聊确认不显示入口。
6. 验证相对路径、绝对 /workspace 路径、Shell 默认 cwd、目录删除后重建及只读工作区失败提示。
7. 在工作区内放置指向外部的符号链接，确认不能将其保存或执行为工作目录。

## Pre-launch Checklist

- [x] 用户可见文本已加入四份 ARB 并重新生成本地化代码
- [x] 数据库 v20 迁移、自愈和旧数据兼容已覆盖
- [x] 相关自动化测试与 fatal-infos 静态分析已通过
- [x] 已完成维护性、性能、安全、风格一致性和兼容性自审
- [x] 按需求未执行本地平台构建或应用启动