### PR TITLE
feat(chat): add per-line bubble split toggles for assistant and user messages

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -95,6 +95,10 @@ class AssistantRows extends Table {
       boolean().withDefault(const Constant(false))();
   BoolColumn get useAssistantName =>
       boolean().withDefault(const Constant(false))();
+  BoolColumn get splitBubbleByLine =>
+      boolean().withDefault(const Constant(false))();
+  BoolColumn get splitUserBubbleByLine =>
+      boolean().withDefault(const Constant(false))();
   TextColumn get background => text().nullable()();
 
   // --- Model Selection ---
@@ -378,7 +382,7 @@ class AppDatabase extends _$AppDatabase {
   // self-heal below repairs such gaps on every open; without it the gap is
   // permanent because later upgrades skip the failed step's `from < N` block.
   // See docs/adr/0019-schema-self-heal.md.
-  int get schemaVersion => 19;
+  int get schemaVersion => 20;
 
   /// Whether [table] has a physical column named [column] (sqlite name).
   Future<bool> _hasColumn(String table, String column) async {
@@ -525,6 +529,16 @@ class AppDatabase extends _$AppDatabase {
       'assistant_rows',
       'workspace_id',
       'ALTER TABLE assistant_rows ADD COLUMN workspace_id TEXT NULL',
+    );
+    await _ensureColumn(
+      'assistant_rows',
+      'split_bubble_by_line',
+      'ALTER TABLE assistant_rows ADD COLUMN split_bubble_by_line INTEGER NOT NULL DEFAULT 0',
+    );
+    await _ensureColumn(
+      'assistant_rows',
+      'split_user_bubble_by_line',
+      'ALTER TABLE assistant_rows ADD COLUMN split_user_bubble_by_line INTEGER NOT NULL DEFAULT 0',
     );
 
     // --- message_rows ---
@@ -826,6 +840,18 @@ class AppDatabase extends _$AppDatabase {
         try {
           await migrator.addColumn(assistantRows, assistantRows.workspaceId);
         } catch (_) {}
+      }
+      if (from < 20) {
+        await _ensureColumn(
+          'assistant_rows',
+          'split_bubble_by_line',
+          'ALTER TABLE assistant_rows ADD COLUMN split_bubble_by_line INTEGER NOT NULL DEFAULT 0',
+        );
+        await _ensureColumn(
+          'assistant_rows',
+          'split_user_bubble_by_line',
+          'ALTER TABLE assistant_rows ADD COLUMN split_user_bubble_by_line INTEGER NOT NULL DEFAULT 0',
+        );
       }
       // Final pass: heal any column/table that still did not land.
       await _healSchemaIfNeeded();

--- a/lib/core/models/assistant.dart
+++ b/lib/core/models/assistant.dart
@@ -43,6 +43,8 @@ Do **not** store sensitive information, including:
   final bool
   useAssistantAvatar; // replace model icon in chat with assistant avatar
   final bool useAssistantName; // replace model name in chat with assistant name
+  final bool splitBubbleByLine; // split assistant reply into per-line bubbles
+  final bool splitUserBubbleByLine; // split user message into per-line bubbles
   final String? chatModelProvider; // null -> use global default
   final String? chatModelId; // null -> use global default
   final double? temperature; // null to disable; else 0.0 - 2.0
@@ -109,6 +111,8 @@ Do **not** store sensitive information, including:
     this.avatar,
     this.useAssistantAvatar = false,
     this.useAssistantName = false,
+    this.splitBubbleByLine = false,
+    this.splitUserBubbleByLine = false,
     this.chatModelProvider,
     this.chatModelId,
     this.temperature,
@@ -159,6 +163,8 @@ Do **not** store sensitive information, including:
     String? avatar,
     bool? useAssistantAvatar,
     bool? useAssistantName,
+    bool? splitBubbleByLine,
+    bool? splitUserBubbleByLine,
     String? chatModelProvider,
     String? chatModelId,
     double? temperature,
@@ -218,6 +224,8 @@ Do **not** store sensitive information, including:
       avatar: clearAvatar ? null : (avatar ?? this.avatar),
       useAssistantAvatar: useAssistantAvatar ?? this.useAssistantAvatar,
       useAssistantName: useAssistantName ?? this.useAssistantName,
+      splitBubbleByLine: splitBubbleByLine ?? this.splitBubbleByLine,
+      splitUserBubbleByLine: splitUserBubbleByLine ?? this.splitUserBubbleByLine,
       chatModelProvider: clearChatModel
           ? null
           : (chatModelProvider ?? this.chatModelProvider),
@@ -279,6 +287,8 @@ Do **not** store sensitive information, including:
     'avatar': avatar,
     'useAssistantAvatar': useAssistantAvatar,
     'useAssistantName': useAssistantName,
+    'splitBubbleByLine': splitBubbleByLine,
+    'splitUserBubbleByLine': splitUserBubbleByLine,
     'chatModelProvider': chatModelProvider,
     'chatModelId': chatModelId,
     'temperature': temperature,
@@ -328,6 +338,8 @@ Do **not** store sensitive information, including:
     avatar: json['avatar'] as String?,
     useAssistantAvatar: json['useAssistantAvatar'] as bool? ?? false,
     useAssistantName: json['useAssistantName'] as bool? ?? false,
+    splitBubbleByLine: json['splitBubbleByLine'] as bool? ?? false,
+    splitUserBubbleByLine: json['splitUserBubbleByLine'] as bool? ?? false,
     chatModelProvider: json['chatModelProvider'] as String?,
     chatModelId: json['chatModelId'] as String?,
     temperature: (json['temperature'] as num?)?.toDouble(),

--- a/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
@@ -270,6 +270,28 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                     .updateAssistant(a.copyWith(useAssistantName: v)),
               ),
               _iosDivider(context),
+              // Split assistant reply into per-line bubbles
+              _iosSwitchRow(
+                context,
+                icon: Lucide.SplitSquareVertical,
+                label: 'Split reply by line',
+                value: a.splitBubbleByLine,
+                onChanged: (v) => context
+                    .read<AssistantProvider>()
+                    .updateAssistant(a.copyWith(splitBubbleByLine: v)),
+              ),
+              _iosDivider(context),
+              // Split user message into per-line bubbles
+              _iosSwitchRow(
+                context,
+                icon: Lucide.SplitSquareVertical,
+                label: 'Split user message by line',
+                value: a.splitUserBubbleByLine,
+                onChanged: (v) => context
+                    .read<AssistantProvider>()
+                    .updateAssistant(a.copyWith(splitUserBubbleByLine: v)),
+              ),
+              _iosDivider(context),
               // Stream output
               _iosSwitchRow(
                 context,

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -984,6 +984,67 @@ class _MessageListViewState extends State<MessageListView> {
                 widget.onRecoveredAskUserAnswer!(message, part, result),
     );
 
+    // --- Split-by-line bubble rendering ---
+    final bool shouldSplit;
+    if (message.role == 'assistant') {
+      shouldSplit = assistant?.splitBubbleByLine == true;
+    } else if (message.role == 'user') {
+      shouldSplit = assistant?.splitUserBubbleByLine == true;
+    } else {
+      shouldSplit = false;
+    }
+
+    Widget result = chatWidget;
+
+    if (shouldSplit && !message.isStreaming) {
+      final lines =
+          message.content.split('\n').where((l) => l.trim().isNotEmpty).toList();
+      if (lines.length > 1) {
+        result = Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (int i = 0; i < lines.length; i++)
+              Padding(
+                padding: EdgeInsets.only(bottom: i < lines.length - 1 ? 2 : 0),
+                child: ChatMessageWidget(
+                  message: message.copyWith(content: lines[i]),
+                  versionIndex: i == lines.length - 1 ? selectedIdx : 0,
+                  versionCount: i == lines.length - 1 ? (total > 0 ? total : 1) : 1,
+                  onPrevVersion: i == lines.length - 1
+                      ? (selectedIdx > 0
+                          ? () => widget.onVersionChange?.call(gid, selectedIdx - 1)
+                          : null)
+                      : null,
+                  onNextVersion: i == lines.length - 1
+                      ? (selectedIdx < total - 1
+                          ? () => widget.onVersionChange?.call(gid, selectedIdx + 1)
+                          : null)
+                      : null,
+                  modelIcon: i == 0 ? chatWidget.modelIcon : null,
+                  showModelIcon: i == 0 ? chatWidget.showModelIcon : false,
+                  useAssistantAvatar: i == 0 && chatWidget.useAssistantAvatar,
+                  useAssistantName: i == 0 && chatWidget.useAssistantName,
+                  assistantName: i == 0 ? chatWidget.assistantName : null,
+                  assistantAvatar: i == 0 ? chatWidget.assistantAvatar : null,
+                  showUserAvatar: i == 0 && chatWidget.showUserAvatar,
+                  showTokenStats: i == lines.length - 1 && chatWidget.showTokenStats,
+                  onRegenerate: i == lines.length - 1 ? chatWidget.onRegenerate : null,
+                  onResend: i == lines.length - 1 ? chatWidget.onResend : null,
+                  onEdit: i == lines.length - 1 ? chatWidget.onEdit : null,
+                  onDelete: i == lines.length - 1 ? chatWidget.onDelete : null,
+                  onMore: i == lines.length - 1 ? chatWidget.onMore : null,
+                  onTranslate: null,
+                  onSpeak: null,
+                  suggestions: i == lines.length - 1 ? suggestions : const [],
+                  onSuggestionTap: i == lines.length - 1 ? widget.onSuggestionTap : null,
+                  onQuoteSelection: i == lines.length - 1 ? widget.onQuoteSelection : null,
+                ),
+              ),
+          ],
+        );
+      }
+    }
+
     // Backward bar for handoff-spawned conversations
     if (message.role == 'user' && index == 0) {
       final backwardChip = _buildHandoffBackwardChip(context, message);
@@ -991,11 +1052,11 @@ class _MessageListViewState extends State<MessageListView> {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
-          children: [backwardChip, const SizedBox(height: 8), chatWidget],
+          children: [backwardChip, const SizedBox(height: 8), result],
         );
       }
     }
-    return chatWidget;
+    return result;
   }
 
   Widget? _buildHandoffBackwardChip(BuildContext context, ChatMessage message) {

--- a/lib/icons/lucide_adapter.dart
+++ b/lib/icons/lucide_adapter.dart
@@ -6,6 +6,8 @@ import 'package:lucide_icons_flutter/lucide_icons.dart' as lucide;
 // Adapter to use `Lucide.*` style as requested.
 class Lucide {
   static const IconData ListTree = lucide.LucideIcons.listTree;
+  static const IconData SplitSquareVertical =
+      lucide.LucideIcons.squareSplitVertical;
   static const IconData ListChecks = lucide.LucideIcons.listChecks;
   static const IconData Menu = lucide.LucideIcons.menu;
   static const IconData MessageCirclePlus =


### PR DESCRIPTION
## Summary

Add two new assistant-level settings in **Assistant Settings → Basic**:

1. **Split reply by line** (`splitBubbleByLine`): Split assistant replies into separate bubbles per newline.
2. **Split user message by line** (`splitUserBubbleByLine`): Split user messages into separate bubbles per newline.

Both toggles default to **off** and are configured per assistant.

## Changes

| File | Change |
|---|---|
| `app_database.dart` | +2 BoolColumns on `AssistantRows`, schema 19→20, migration + self-heal |
| `assistant.dart` | +2 fields with `copyWith` / `toJson` / `fromJson` |
| `assistant_settings_edit_basic_tab.dart` | +2 toggle switches below "Use assistant name" |
| `message_list_view.dart` | Rendering: split content by `\n` into independent `ChatMessageWidget`s |
| `lucide_adapter.dart` | Add `SplitSquareVertical` icon mapping |

## Rendering behavior

- Only splits when **not streaming** (avoids flicker during generation)
- Empty lines do not produce empty bubbles
- Avatar / username shown on **first** bubble only
- Version switcher, edit/delete/more menu, token stats on **last** bubble only
- Does not change message storage — purely a display-layer split

## Use case

RP (role-play) scenarios where AI replies contain multi-line dialogue and action descriptions. Splitting into per-line bubbles creates an IM-like visual flow with stronger immersion.

## Note

The generated file `app_database.g.dart` needs to be regenerated via `dart run build_runner build`. This PR does not include the regenerated file to keep the diff minimal and avoid merge conflicts with other pending schema changes.

Fixes #498