### PR TITLE
feat(world_book): support batch keyword input split by comma and newline

### DIFF
--- a/lib/desktop/setting/world_book_pane.dart
+++ b/lib/desktop/setting/world_book_pane.dart
@@ -1015,10 +1015,15 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
   }
 
   void _addKeywordsFromInput() {
-    final text = _keywordInputController.text.trim();
-    if (text.isEmpty) return;
+    final raw = _keywordInputController.text.trim();
+    if (raw.isEmpty) return;
+    final parts = raw
+        .split(RegExp(r'[,，\n\r\t]+'))
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty);
+    if (parts.isEmpty) return;
     final set = _keywords.toSet();
-    set.add(text);
+    set.addAll(parts);
     setState(() {
       _keywords = set.toList(growable: false);
       _keywordInputController.clear();

--- a/lib/features/world_book/pages/world_book_page.dart
+++ b/lib/features/world_book/pages/world_book_page.dart
@@ -1319,9 +1319,12 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
   }
 
   List<String> _parseKeywordInput(String raw) {
-    final k = raw.trim();
-    if (k.isEmpty) return const <String>[];
-    return <String>[k];
+    if (raw.trim().isEmpty) return const <String>[];
+    return raw
+        .split(RegExp(r'[,，\n\r\t]+'))
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
   }
 
   @override


### PR DESCRIPTION
## Summary

Allows adding multiple trigger keywords in one go in WorldBook entry editing by separating them with commas (both `,` and `，`), newlines, or tabs.

For example, entering `本体，皮下，限定修改, 小克` and pressing enter/Add will split and add 4 individual keyword chips automatically with deduplication.

## Changes

- `lib/features/world_book/pages/world_book_page.dart`: Update `_parseKeywordInput` to split by regex `[,，\n\r\t]+`
- `lib/desktop/setting/world_book_pane.dart`: Update `_addKeywordsFromInput` to split by regex `[,，\n\r\t]+`

Fixes #503