### PR TITLE
fix: strip additionalProperties from Gemini tool schemas (issue #425)

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -1558,6 +1558,31 @@ class ChatApiService {
 
     return result;
   }
+
+  /// Recursively remove `additionalProperties` from every JSON Schema node.
+  ///
+  /// The Gemini API rejects this key with HTTP 400 (issue #425). Unlike
+  /// [_cleanSchemaForGemini], this walks every nested map/list (properties,
+  /// items, anyOf/oneOf/allOf, tuple-form items, $defs, ...) and only strips
+  /// that one key, leaving the rest of the schema byte-identical. MCP tool
+  /// schemas are already stripped by
+  /// `ToolHandlerService.sanitizeToolParametersForProvider`; this is
+  /// defense-in-depth for built-in tools (search/memory/workspace/local) that
+  /// bypass that sanitizer.
+  static dynamic _stripAdditionalProperties(dynamic node) {
+    if (node is Map) {
+      final m = <String, dynamic>{};
+      for (final entry in node.entries) {
+        if (entry.key == 'additionalProperties') continue;
+        m[entry.key] = _stripAdditionalProperties(entry.value);
+      }
+      return m;
+    }
+    if (node is List) {
+      return node.map(_stripAdditionalProperties).toList();
+    }
+    return node;
+  }
 }
 
 class _ImageRef {

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -521,7 +521,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
           'name': name,
           if (desc.isNotEmpty) 'description': desc,
         };
-        if (params != null) d['parameters'] = _cleanSchemaForGemini(params);
+        if (params != null) {
+          // Gemini validation + drop additionalProperties (rejected with
+          // HTTP 400, issue #425). MCP tools are already sanitized by
+          // ToolHandlerService; this covers built-in tools too.
+          d['parameters'] = ChatApiService._stripAdditionalProperties(
+            _cleanSchemaForGemini(params),
+          );
+        }
         decls.add(d);
       }
       if (decls.isNotEmpty) {
@@ -992,7 +999,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       if (params != null) {
         // Google Gemini requires strict JSON Schema compliance
         // Fix array properties that are missing 'items' field
-        final cleanedParams = _cleanSchemaForGemini(params);
+        final cleanedParams = ChatApiService._stripAdditionalProperties(
+          _cleanSchemaForGemini(params),
+        );
         d['parameters'] = cleanedParams;
       }
       decls.add(d);

--- a/test/gemini_tool_schema_strip_test.dart
+++ b/test/gemini_tool_schema_strip_test.dart
@@ -1,0 +1,212 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiToolSchemaStripTest',
+    enabled: true,
+    name: 'GeminiToolSchemaStripTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+Future<HttpServer> _startGeminiServer(
+  void Function(Map<String, dynamic> body) onBody,
+) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) async {
+    final bodyText = await utf8.decoder.bind(request).join();
+    onBody(jsonDecode(bodyText) as Map<String, dynamic>);
+
+    request.response.statusCode = HttpStatus.ok;
+    if (request.uri.path.endsWith(':streamGenerateContent')) {
+      request.response.headers.contentType = ContentType(
+        'text',
+        'event-stream',
+      );
+      request.response.write(
+        'data: ${jsonEncode({
+          'candidates': [
+            {
+              'content': {
+                'parts': [
+                  {'text': 'ok'},
+                ],
+              },
+              'finishReason': 'STOP',
+            },
+          ],
+          'usageMetadata': {'promptTokenCount': 1, 'candidatesTokenCount': 1, 'totalTokenCount': 2},
+        })}\n\n',
+      );
+      request.response.write('data: [DONE]');
+    } else {
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode({
+          'candidates': [
+            {
+              'content': {
+                'parts': [
+                  {'text': 'ok'},
+                ],
+              },
+            },
+          ],
+          'usageMetadata': {
+            'promptTokenCount': 1,
+            'candidatesTokenCount': 1,
+            'totalTokenCount': 2,
+          },
+        }),
+      );
+    }
+    await request.response.close();
+  });
+  return server;
+}
+
+void _expectNoAdditionalProperties(dynamic node) {
+  if (node is Map) {
+    expect(
+      node.containsKey('additionalProperties'),
+      isFalse,
+      reason: 'Gemini rejects additionalProperties (issue #425): $node',
+    );
+    for (final v in node.values) {
+      _expectNoAdditionalProperties(v);
+    }
+  } else if (node is List) {
+    for (final v in node) {
+      _expectNoAdditionalProperties(v);
+    }
+  }
+}
+
+List<Map<String, dynamic>> _toolWithAdditionalProperties() {
+  return [
+    {
+      'type': 'function',
+      'function': {
+        'name': 'fetch_page',
+        'description': 'Fetch a page',
+        'parameters': {
+          'type': 'object',
+          'additionalProperties': true,
+          'properties': {
+            'url': {'type': 'string'},
+            'headers': {
+              'type': 'object',
+              'additionalProperties': {'type': 'string'},
+            },
+            'nested': {
+              'type': 'object',
+              'properties': {
+                'config': {'type': 'object', 'additionalProperties': true},
+              },
+            },
+            'rows': {
+              'type': 'array',
+              'items': {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'},
+              },
+            },
+            'choice': {
+              'anyOf': [
+                {'type': 'string'},
+                {
+                  'type': 'object',
+                  'additionalProperties': {'type': 'number'},
+                },
+              ],
+            },
+            'tuple': {
+              'type': 'array',
+              'items': [
+                {'type': 'string'},
+                {
+                  'type': 'object',
+                  'additionalProperties': {'type': 'boolean'},
+                },
+              ],
+            },
+          },
+          'required': ['url'],
+        },
+      },
+    },
+  ];
+}
+
+void _verifyStripped(Map<String, dynamic> capturedBody) {
+  final tools = capturedBody['tools'] as List;
+  expect(tools, hasLength(1));
+  final decls = (tools.first as Map)['function_declarations'] as List;
+  expect(decls, hasLength(1));
+  final parameters = ((decls.first as Map)['parameters'] as Map)
+      .cast<String, dynamic>();
+  expect(parameters['type'], 'object');
+  _expectNoAdditionalProperties(parameters);
+
+  // Stripping must not reshape object schemas: array-item / property objects
+  // stay bare {type: object}, matching the sanitized MCP path.
+  final props = parameters['properties'] as Map<String, dynamic>;
+  expect(props['headers'], {'type': 'object'});
+  expect(props['rows'], {
+    'type': 'array',
+    'items': {'type': 'object'},
+  });
+  expect(props['choice'], {
+    'anyOf': [
+      {'type': 'string'},
+      {'type': 'object'},
+    ],
+  });
+  expect(props['tuple'], {
+    'type': 'array',
+    'items': [
+      {'type': 'string'},
+      {'type': 'object'},
+    ],
+  });
+}
+
+void main() {
+  group('Gemini tool schema stripping', () {
+    for (final stream in const [false, true]) {
+      test('strips additionalProperties in ${stream ? 'stream' : 'non-stream'} '
+          'requests', () async {
+        late Map<String, dynamic> capturedBody;
+        final server = await _startGeminiServer((body) {
+          capturedBody = body;
+        });
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _geminiConfig(
+            'http://${server.address.address}:${server.port}/v1beta',
+          ),
+          modelId: 'google/gemini-3.5-flash-lite',
+          messages: const [
+            {'role': 'user', 'content': 'hello'},
+          ],
+          tools: _toolWithAdditionalProperties(),
+          stream: stream,
+        ).toList();
+
+        expect(chunks.last.isDone, isTrue);
+        _verifyStripped(capturedBody);
+      });
+    }
+  });
+}

--- a/test/openai_zhipu_glm_compat_test.dart
+++ b/test/openai_zhipu_glm_compat_test.dart
@@ -93,6 +93,80 @@ void main() {
       expect(requests[1].containsKey('reasoning_effort'), isFalse);
     });
 
+    test('glm-5.2 preserves additionalProperties in tool schema', () async {
+      final requests = <Map<String, dynamic>>[];
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requests.add(
+          jsonDecode(await utf8.decoder.bind(request).join())
+              as Map<String, dynamic>,
+        );
+
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'id': 'cmpl-glm52',
+            'object': 'chat.completion.chunk',
+            'created': 0,
+            'model': 'glm-5.2',
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _zhipuConfig(baseUrl),
+        modelId: 'glm-5.2',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        tools: [
+          {
+            'type': 'function',
+            'function': {
+              'name': 'store_note',
+              'description': 'Store a note',
+              'parameters': {
+                'type': 'object',
+                'properties': {
+                  'meta': {
+                    'type': 'object',
+                    'additionalProperties': {'type': 'string'},
+                  },
+                },
+                'required': ['meta'],
+              },
+            },
+          },
+        ],
+      ).toList();
+
+      expect(requests, hasLength(1));
+      final tools = requests[0]['tools'] as List;
+      final params = (tools.first as Map)['function']['parameters'] as Map;
+      expect(params['properties']['meta']['additionalProperties'], {
+        'type': 'string',
+      }, reason: 'GLM needs additionalProperties to fill undeclared params');
+    });
+
     test('glm-5.2 tool continuation preserves reasoning_content', () async {
       final secondRequestCompleter = Completer<Map<String, dynamic>>();
       var requestCount = 0;


### PR DESCRIPTION
Fixes #425.

Gemini tool calls with MCP/built-in tools now strip `additionalProperties` (rejected with HTTP 400) at every schema level, while the OpenAI-compatible path (GLM) keeps it.
