### PR TITLE
fix(world-book): keep keyboard open after adding keyword

### DIFF
--- a/lib/desktop/setting/world_book_pane.dart
+++ b/lib/desktop/setting/world_book_pane.dart
@@ -968,6 +968,7 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
   late final TextEditingController _scanDepthController;
   late final TextEditingController _injectDepthController;
   late final TextEditingController _keywordInputController;
+  final FocusNode _keywordFocusNode = FocusNode();
 
   late bool _enabled;
   late bool _useRegex;
@@ -1011,6 +1012,7 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
     _scanDepthController.dispose();
     _injectDepthController.dispose();
     _keywordInputController.dispose();
+    _keywordFocusNode.dispose();
     super.dispose();
   }
 
@@ -1299,6 +1301,7 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
                                             child: TextField(
                                               controller:
                                                   _keywordInputController,
+                                              focusNode: _keywordFocusNode,
                                               decoration:
                                                   _deskInputDecoration(
                                                     context,
@@ -1306,8 +1309,11 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
                                                     hintText: l10n
                                                         .worldBookEntryKeywordInputHint,
                                                   ),
-                                              onSubmitted: (_) =>
-                                                  _addKeywordsFromInput(),
+                                              onSubmitted: (_) {
+                                                _addKeywordsFromInput();
+                                                _keywordFocusNode
+                                                    .requestFocus();
+                                              },
                                             ),
                                           ),
                                           const SizedBox(width: 8),

--- a/lib/features/world_book/pages/world_book_page.dart
+++ b/lib/features/world_book/pages/world_book_page.dart
@@ -1258,6 +1258,7 @@ class _WorldBookEntryEditSheet extends StatefulWidget {
 class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
   late final TextEditingController _nameController;
   late final TextEditingController _keywordInputController;
+  final FocusNode _keywordFocusNode = FocusNode();
   late final TextEditingController _contentController;
   late final TextEditingController _priorityController;
   late final TextEditingController _scanDepthController;
@@ -1300,6 +1301,7 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
   void dispose() {
     _nameController.dispose();
     _keywordInputController.dispose();
+    _keywordFocusNode.dispose();
     _contentController.dispose();
     _priorityController.dispose();
     _scanDepthController.dispose();
@@ -1822,10 +1824,13 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
                                         ),
                                         child: TextField(
                                           controller: _keywordInputController,
+                                          focusNode: _keywordFocusNode,
                                           onChanged: (_) => setState(() {}),
                                           textInputAction: TextInputAction.done,
-                                          onSubmitted: (_) =>
-                                              addKeywordsFromInput(),
+                                          onSubmitted: (_) {
+                                            addKeywordsFromInput();
+                                            _keywordFocusNode.requestFocus();
+                                          },
                                           textAlignVertical:
                                               TextAlignVertical.center,
                                           style: TextStyle(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2963,7 +2963,7 @@
   "worldBookEntryEnabledLabel": "Entry enabled",
   "worldBookEntryPriorityLabel": "Priority",
   "worldBookEntryKeywordsLabel": "Keywords",
-  "worldBookEntryKeywordsHint": "Type a keyword and tap + to add.",
+  "worldBookEntryKeywordsHint": "Type a keyword and press Enter or tap + to add.",
   "worldBookEntryKeywordInputHint": "Type a keyword",
   "worldBookEntryKeywordAddTooltip": "Add keyword",
   "worldBookEntryUseRegexLabel": "Use regex",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13004,7 +13004,7 @@ abstract class AppLocalizations {
   /// No description provided for @worldBookEntryKeywordsHint.
   ///
   /// In en, this message translates to:
-  /// **'Type a keyword and tap + to add.'**
+  /// **'Type a keyword and press Enter or tap + to add.'**
   String get worldBookEntryKeywordsHint;
 
   /// No description provided for @worldBookEntryKeywordInputHint.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7161,7 +7161,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get worldBookEntryKeywordsLabel => 'Keywords';
 
   @override
-  String get worldBookEntryKeywordsHint => 'Type a keyword and tap + to add.';
+  String get worldBookEntryKeywordsHint =>
+      'Type a keyword and press Enter or tap + to add.';
 
   @override
   String get worldBookEntryKeywordInputHint => 'Type a keyword';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6866,7 +6866,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get worldBookEntryKeywordsLabel => '关键词';
 
   @override
-  String get worldBookEntryKeywordsHint => '输入关键词后点 + 添加。';
+  String get worldBookEntryKeywordsHint => '输入关键词后点 + 或按回车添加。';
 
   @override
   String get worldBookEntryKeywordInputHint => '输入关键词';
@@ -15288,7 +15288,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get worldBookEntryKeywordsLabel => '关键词';
 
   @override
-  String get worldBookEntryKeywordsHint => '输入关键词后点 + 添加。';
+  String get worldBookEntryKeywordsHint => '输入关键词后点 + 或按回车添加。';
 
   @override
   String get worldBookEntryKeywordInputHint => '输入关键词';
@@ -23710,7 +23710,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get worldBookEntryKeywordsLabel => '關鍵詞';
 
   @override
-  String get worldBookEntryKeywordsHint => '輸入關鍵詞後點 + 新增。';
+  String get worldBookEntryKeywordsHint => '輸入關鍵詞後點 + 或按 Enter 新增。';
 
   @override
   String get worldBookEntryKeywordInputHint => '輸入關鍵詞';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2447,7 +2447,7 @@
   "worldBookEntryEnabledLabel": "启用条目",
   "worldBookEntryPriorityLabel": "优先级",
   "worldBookEntryKeywordsLabel": "关键词",
-  "worldBookEntryKeywordsHint": "输入关键词后点 + 添加。",
+  "worldBookEntryKeywordsHint": "输入关键词后点 + 或按回车添加。",
   "worldBookEntryKeywordInputHint": "输入关键词",
   "worldBookEntryKeywordAddTooltip": "添加关键词",
   "worldBookEntryUseRegexLabel": "使用正则",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2448,7 +2448,7 @@
   "worldBookEntryEnabledLabel": "启用条目",
   "worldBookEntryPriorityLabel": "优先级",
   "worldBookEntryKeywordsLabel": "关键词",
-  "worldBookEntryKeywordsHint": "输入关键词后点 + 添加。",
+  "worldBookEntryKeywordsHint": "输入关键词后点 + 或按回车添加。",
   "worldBookEntryKeywordInputHint": "输入关键词",
   "worldBookEntryKeywordAddTooltip": "添加关键词",
   "worldBookEntryUseRegexLabel": "使用正则",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2448,7 +2448,7 @@
   "worldBookEntryEnabledLabel": "啟用條目",
   "worldBookEntryPriorityLabel": "優先級",
   "worldBookEntryKeywordsLabel": "關鍵詞",
-  "worldBookEntryKeywordsHint": "輸入關鍵詞後點 + 新增。",
+  "worldBookEntryKeywordsHint": "輸入關鍵詞後點 + 或按 Enter 新增。",
   "worldBookEntryKeywordInputHint": "輸入關鍵詞",
   "worldBookEntryKeywordAddTooltip": "新增關鍵詞",
   "worldBookEntryUseRegexLabel": "使用正則",


### PR DESCRIPTION
Keep the world book keyword input focused (and mobile keyboard open) after pressing Enter so multiple keywords can be added quickly.
