### PR TITLE
feat(theme): migrate hardcoded colors to semantic tokens

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -794,8 +794,16 @@
 - **Custom Palette (自定义色板)**: 由激活的 Custom Theme 运行时构建的色板(`ThemePalettes.customPaletteId = 'custom'`)。不是 `ThemePalettes.all` 的成员——仅在 palette id 为 'custom' 时存在。
 - **Dynamic Color (系统动态色)**: Android 12+ 系统配色跟随(`useDynamicColor`)。与 Custom Theme 运行时互斥:激活 Custom Theme 时忽略 Dynamic Color(自定义主题优先)。仅移动端。
 - **Legacy seed (旧种子色)**: 被 Custom Theme 取代的单色相种子功能(`dynamic_color_seed_v1` + `custom_dynamic` 占位色板)。首次加载时迁移为 Custom Theme(primary = seed,无次/三级色);若当时它是激活色板,则迁移后选中该主题并置 palette = 'custom'。
+- **AppSemanticColors (语义色扩展)**: 提供 `ColorScheme` 没有专属角色的语义色 token 的 `ThemeExtension`——`surfaceFill`、`surfaceCard`、`success`/`warning`(+ container)、`searchHighlight`、`chartSeries`——全部从激活 scheme 推导或 harmonize,因此 Custom Theme 自动获得合理取值。经 `context.appColors` 读取(未挂载 extension 时回退为从环境 scheme 推导)。
+- **surfaceFill (浅填充)**: 文本输入框/chips/小卡片/标签容器的细微填充,替代旧 `white10/12` + `F2F3F5/F7F7F9` 惯例;暗色 alpha 0.16(#300 的「暗色 surfaceFill 调亮」)。
+- **surfaceCard (卡片面)**: iOS 风格分区卡片背景,替代旧 `white10`+`white@0.96` 与 `1C1C1E`/`141414` 凸起面。
+- **surfaceContainer 推导**: M3 `surfaceContainerLowest→Highest` 从 scheme surface 推导(静态色板不再用紫色调的 M3 默认值);浅色 `surfaceContainerHigh` = white@0.85,保证气泡/卡片/弹层保持 ≈白。
+- **searchHighlight / chartSeries**: 金色搜索高亮(alpha 0.55);唯一的分类色阶——统计图表与请求日志角色色(system/user/assistant/tool = 索引 6/0/5/3)共用。
+- **color-gate marker (`color-gate: ignore`)**: 逐行标记刻意保留的固定色(色板定义、Cupertino 灰、头像 tint、彩色面上的对比色)。`tool/check_colors.py` 一次性校验脚本以此白名单;不接入 CI。
 
 关系:
 - **Custom Theme** 被选中时解析为 **Custom Palette**(运行时)
 - **Dynamic Color** 与 **Custom Theme** 运行时互斥,Custom Theme 优先
 - **Custom Palette** 永不进入预设列表;预设只能是静态 **ThemePalette**
+- **AppSemanticColors** 的 **surfaceCard** 是 app 级分区卡片 token,与 M3 **surfaceContainer** 角色不同——前者用于自定义 iOS 风格组件,后者用于 Material 组件,二者不混用
+- **surfaceFill**/**surfaceCard** 从 **ColorScheme** 的 surface/onSurface 推导,因此随 **Custom Theme** 自动适配

--- a/docs/adr/0038-semantic-color-migration.md
+++ b/docs/adr/0038-semantic-color-migration.md
@@ -1,0 +1,64 @@
+# ADR-0038: Semantic Color Migration (Phase 2 of the Theme System)
+
+Phase 2 of #300 lands `AppSemanticColors`, derives the M3 `surfaceContainer*` roles from the
+active scheme, and migrates the hardcoded surface-fill / card / status / text-muted colors
+across the app to semantic tokens. It completes the phase-2 scope deferred by ADR-0037.
+
+## Context
+
+ADR-0037 shipped custom themes but deliberately deferred `AppSemanticColors` (a ~100-file
+migration) and the derived `surfaceContainer*` roles. The app still scattered hardcoded color
+literals — `Colors.white10/white12` + `Color(0xFFF2F3F5/F7F7F9)` for subtle fills,
+`Colors.white`@0.96 / `Color(0xFF1C1C1E/141414)` for cards, `Colors.black54/white70` for muted
+text, `Colors.green/orange/red` for status — so custom themes did not fully recolor the UI. M3
+`surfaceContainer*` roles sat at their static purple-tinted defaults, clashing with non-purple
+palettes.
+
+## Decisions
+
+- **Port `AppSemanticColors` verbatim from upstream Kelivo.** A `ThemeExtension` with
+  `surfaceFill`, `surfaceCard`, `success`/`warning` (+ containers), `searchHighlight`, and
+  `chartSeries`, all derived from or harmonized with the active `ColorScheme`; read via
+  `context.appColors` (falls back to deriving from the ambient scheme when the extension is
+  absent, e.g. plain-`MaterialApp` widget tests).
+- **Dark `surfaceFill` alpha is 0.16** — the actual upstream code value (#300's "暗色 surfaceFill
+  调亮"). Upstream's doc comment says 0.14 but the code says 0.16; we port behavior, not the stale
+  comment.
+- **Derive `surfaceContainerLowest → Highest` from the scheme surface** in all four theme
+  builders (`_withDerivedSurfaceContainers`), including the post-fix upstream values (light
+  `surfaceContainerHigh` = white@0.85 so chat bubbles/cards/menus stay ≈white). This changes ~46
+  existing `surfaceContainer*` usages from purple-tinted M3 defaults to palette-derived neutrals
+  — the widest single visual change in this phase, and the point of the ADR-0037 "surfaceContainer
+  推导" item.
+- **Migrate the idiom families to tokens.** `F2F3F5`/`F7F7F9`/`white10`/`white12` →
+  `surfaceFill` (the two near-identical light grays collapse into one derived value — deliberate
+  value drift); `white@0.96` + `1C1C1E`/`141414` raised surfaces → `surfaceCard`; `black54`/
+  `white70`/`grey.shade600` → `onSurfaceVariant`, `black87`/white text → `onSurface`; hover/state
+  overlays → `onSurface` alpha; `barrierColor` black → `cs.scrim`; **red danger → `cs.error`**
+  (accepted: `cs.error` is pure black in the monochrome palette, matching upstream); green/orange
+  status → `success`/`warning` + containers; gold search tint → `searchHighlight`; stats chart
+  ramps and the request-log role colors → `chartSeries`.
+- **AppBarTheme foreground/title/icon → `scheme.onSurface`** (was hardcoded black/white), and
+  `dialogTheme: DialogThemeData(surface)` added to the two non-`ForScheme` builders for parity.
+- **No permanent CI color gate.** Upstream added `tool/check_colors.sh`, then removed it two
+  commits later as "one-off migration verification tooling" after zero-hardcoded-color strictness
+  caused regressions (grayish bubbles, monochrome black/white checkbox borders). We ship
+  `tool/check_colors.py` as a one-off local verification script and keep the
+  `color-gate: ignore` inline-marker convention for deliberate fixed colors (Cupertino greys,
+  avatar tints, contrast-on-primary, `lib/theme/**`). It is NOT wired into CI.
+- **`log_viewer` role colors centralize into `chartSeries`** (system/user/assistant/tool =
+  indices 6/0/5/3) — the values were already byte-identical; one categorical ramp now serves both
+  stats charts and request-log roles.
+
+## Consequences
+
+- Custom themes now recolor the surfaces/cards/status the phase-1 system could not reach; the
+  remaining deliberate fixed colors are explicit via `color-gate: ignore` markers.
+- Dark-mode subtle fills render lighter (0.16 alpha) than the historical `white10` — the #300
+  "调亮" item.
+- Red destructive text follows `cs.error`, which is pure black in the monochrome palette
+  (accepted, upstream parity).
+- The static-palette `surfaceContainer*` rendering changes from purple-tinted to neutral
+  palette-derived; the `_withDerivedSurfaceContainers` comment documents the bubble ≈white rule.
+- Phase 2 is complete; ADR-0037's "Phase 2 remains a standalone, independently reviewable change"
+  note is resolved.

--- a/lib/desktop/add_provider_dialog.dart
+++ b/lib/desktop/add_provider_dialog.dart
@@ -9,14 +9,16 @@ import '../l10n/app_localizations.dart';
 import '../icons/lucide_adapter.dart' as lucide;
 import '../core/providers/settings_provider.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<String?> showDesktopAddProviderDialog(BuildContext context) async {
+  final cs = Theme.of(context).colorScheme;
   String? result;
   await showGeneralDialog<String?>(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'add-provider-dialog',
-    barrierColor: Colors.black.withValues(alpha: 0.25),
+    barrierColor: cs.scrim.withValues(alpha: 0.25),
     pageBuilder: (ctx, _, __) => const _AddProviderDialogBody(),
     transitionBuilder: (ctx, anim, _, child) {
       final curved = CurvedAnimation(parent: anim, curve: Curves.easeOutCubic);
@@ -102,13 +104,12 @@ class _AddProviderDialogBodyState extends State<_AddProviderDialogBody>
   }
 
   InputDecoration _deskInputDecoration(BuildContext context, {String? hint}) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return InputDecoration(
       isDense: true,
       hintText: hint,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(10),
         borderSide: BorderSide(
@@ -152,9 +153,7 @@ class _AddProviderDialogBodyState extends State<_AddProviderDialogBody>
   }) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).brightness == Brightness.dark
-            ? Colors.white10
-            : const Color(0xFFF7F7F9),
+        color: context.appColors.surfaceFill,
         borderRadius: BorderRadius.circular(10),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/desktop/chat_history_dialog.dart
+++ b/lib/desktop/chat_history_dialog.dart
@@ -9,6 +9,7 @@ import '../shared/widgets/snackbar.dart';
 import '../core/services/chat/chat_service.dart';
 import '../core/models/conversation.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<String?> showChatHistoryDesktopDialog(
   BuildContext context, {
@@ -46,7 +47,6 @@ class _ChatHistoryDesktopDialogState extends State<_ChatHistoryDesktopDialog> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     final chatService = context.watch<ChatService>();
     final List<Conversation> all = chatService
@@ -134,7 +134,7 @@ class _ChatHistoryDesktopDialogState extends State<_ChatHistoryDesktopDialog> {
                                   onPressed: () => Navigator.of(ctx).pop(true),
                                   child: Text(
                                     l10n.chatHistoryPageDelete,
-                                    style: TextStyle(color: Colors.red),
+                                    style: TextStyle(color: cs.error),
                                   ),
                                 ),
                               ],
@@ -188,9 +188,7 @@ class _ChatHistoryDesktopDialogState extends State<_ChatHistoryDesktopDialog> {
                             decoration: InputDecoration(
                               hintText: l10n.chatHistoryPageSearchHint,
                               filled: true,
-                              fillColor: isDark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: context.appColors.surfaceFill,
                               isDense: true,
                               isCollapsed: true,
                               contentPadding: const EdgeInsets.symmetric(
@@ -318,10 +316,11 @@ class _ConversationTileDesktopState extends State<_ConversationTileDesktop> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark ? Colors.white12 : const Color(0xFFF7F7F9);
+    final bg = context.appColors.surfaceFill;
     final border = cs.outlineVariant.withValues(alpha: 0.16);
     final hoveredBg = isDark
-        ? Colors.white24
+        ? Colors
+              .white24 // color-gate: ignore
         : cs.primary.withValues(alpha: 0.06);
 
     return Padding(

--- a/lib/desktop/desktop_context_menu.dart
+++ b/lib/desktop/desktop_context_menu.dart
@@ -69,7 +69,7 @@ Future<void> showDesktopContextMenuAt(
     context: context,
     barrierLabel: 'context-menu',
     barrierDismissible: true,
-    barrierColor: Colors.black.withValues(alpha: 0.06),
+    barrierColor: cs.scrim.withValues(alpha: 0.06),
     pageBuilder: (ctx, _, __) {
       return Material(
         type: MaterialType.transparency,
@@ -91,7 +91,7 @@ Future<void> showDesktopContextMenuAt(
                           borderRadius: BorderRadius.circular(16),
                           side: BorderSide(
                             color: isDark
-                                ? Colors.white.withValues(alpha: 0.08)
+                                ? cs.onSurface.withValues(alpha: 0.08)
                                 : cs.outlineVariant.withValues(alpha: 0.2),
                             width: 1,
                           ),
@@ -104,6 +104,7 @@ Future<void> showDesktopContextMenuAt(
                           child: DecoratedBox(
                             decoration: BoxDecoration(
                               color: isDark
+                                  // color-gate: ignore
                                   ? const Color(
                                       0xFF1C1C1E,
                                     ).withValues(alpha: 0.66)
@@ -259,14 +260,10 @@ class _GlassMenuItemState extends State<_GlassMenuItem> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fg = widget.danger ? Colors.red.shade600 : cs.onSurface;
-    final ic = widget.danger
-        ? Colors.red.shade600
-        : cs.onSurface.withValues(alpha: 0.9);
+    final fg = widget.danger ? cs.error : cs.onSurface;
+    final ic = widget.danger ? cs.error : cs.onSurface.withValues(alpha: 0.9);
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 import '../icons/lucide_adapter.dart' as lucide;
 import '../l10n/app_localizations.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 import '../theme/palettes.dart';
 import '../theme/custom_theme.dart';
 import '../features/settings/widgets/custom_theme_widgets.dart';
@@ -367,9 +368,7 @@ class _SettingsMenu extends StatelessWidget {
               onTap: () => onSelect(items[i].$1),
               color: cs.onSurface.withValues(alpha: 0.9),
               selectedColor: cs.primary,
-              hoverBg: isDark
-                  ? Colors.white.withValues(alpha: 0.06)
-                  : Colors.black.withValues(alpha: 0.04),
+              hoverBg: cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04),
             ),
             if (i != items.length - 1) const SizedBox(height: 8),
           ],

--- a/lib/desktop/desktop_translate_page.dart
+++ b/lib/desktop/desktop_translate_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import '../icons/lucide_adapter.dart' as lucide;
 import '../l10n/app_localizations.dart';
@@ -431,7 +432,7 @@ class _LanguageDropdownState extends State<_LanguageDropdown> {
         ).usePureBackground;
         final bgColor = usePure
             ? (isDark ? Colors.black : Colors.white)
-            : (isDark ? const Color(0xFF1C1C1E) : Colors.white);
+            : ctx.appColors.surfaceCard;
 
         return Stack(
           children: [
@@ -469,7 +470,6 @@ class _LanguageDropdownState extends State<_LanguageDropdown> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
     final hoverBorder = cs.primary; // hover/focus border
@@ -493,7 +493,7 @@ class _LanguageDropdownState extends State<_LanguageDropdown> {
             padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
             constraints: const BoxConstraints(minWidth: 150, minHeight: 40),
             decoration: BoxDecoration(
-              color: isDark ? const Color(0xFF141414) : Colors.white,
+              color: context.appColors.surfaceCard,
               borderRadius: BorderRadius.circular(10),
               border: Border.all(color: borderColor, width: 1),
               boxShadow: _open
@@ -721,9 +721,7 @@ class _LangOptionTileState extends State<_LangOptionTile> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.12)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04)
               : Colors.transparent);
 
     return MouseRegion(
@@ -920,9 +918,7 @@ class _ModelPickerButton extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = enabled
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
@@ -990,9 +986,7 @@ class _PaneActionButtonState extends State<_PaneActionButton> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.black.withValues(alpha: 0.06))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.06)
         : Colors.transparent;
     final fg = cs.onSurface.withValues(alpha: 0.9);
     return MouseRegion(

--- a/lib/desktop/html_preview_dialog.dart
+++ b/lib/desktop/html_preview_dialog.dart
@@ -277,7 +277,7 @@ extension _ConsoleDialogExt on _HtmlPreviewDialogState {
     showGeneralDialog<void>(
       context: context,
       barrierDismissible: true,
-      barrierColor: Colors.black.withValues(alpha: 0.25),
+      barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.25),
       barrierLabel: 'console-logs',
       pageBuilder: (ctx, _, __) => _ConsoleDialog(
         title: l10n.messageWebViewConsoleLogs,

--- a/lib/desktop/message_edit_dialog.dart
+++ b/lib/desktop/message_edit_dialog.dart
@@ -4,6 +4,7 @@ import '../features/chat/models/message_edit_result.dart';
 import '../l10n/app_localizations.dart';
 import '../icons/lucide_adapter.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<MessageEditResult?> showMessageEditDesktopDialog(
   BuildContext context, {
@@ -43,7 +44,6 @@ class _MessageEditDesktopDialogState extends State<_MessageEditDesktopDialog> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     return Dialog(
       elevation: 12,
@@ -138,9 +138,7 @@ class _MessageEditDesktopDialogState extends State<_MessageEditDesktopDialog> {
                       decoration: InputDecoration(
                         hintText: l10n.messageEditPageHint,
                         filled: true,
-                        fillColor: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: context.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(

--- a/lib/desktop/mini_map_popover.dart
+++ b/lib/desktop/mini_map_popover.dart
@@ -9,6 +9,7 @@ import '../icons/lucide_adapter.dart';
 import '../l10n/app_localizations.dart';
 import '../shared/widgets/mini_map/mini_map_shared.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<String?> showDesktopMiniMapPopover(
   BuildContext context, {
@@ -426,9 +427,7 @@ class _MiniMapListState extends State<_MiniMapList> {
     final l10n = AppLocalizations.of(context)!;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final textBase = isDark ? Colors.white : Colors.black;
-    final highlightColor = isDark
-        ? const Color(0xFFB8860B).withValues(alpha: 0.55)
-        : const Color(0xFFFFD700).withValues(alpha: 0.55);
+    final highlightColor = context.appColors.searchHighlight;
 
     if (_tokens.isEmpty) {
       // Debounce window: query entered but no result set computed yet.

--- a/lib/desktop/model_edit_dialog.dart
+++ b/lib/desktop/model_edit_dialog.dart
@@ -13,6 +13,7 @@ import '../shared/widgets/ios_switch.dart';
 import '../shared/widgets/snackbar.dart';
 import '../features/model/widgets/model_edit_state_helper.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<bool?> showDesktopModelEditDialog(
   BuildContext context, {
@@ -49,7 +50,7 @@ Future<bool?> _openDialog(
   await showGeneralDialog<bool>(
     context: context,
     barrierDismissible: true,
-    barrierColor: Colors.black.withValues(alpha: 0.25),
+    barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.25),
     barrierLabel: 'model-edit-dialog',
     pageBuilder: (ctx, _, __) => _ModelEditDialogBody(
       providerKey: providerKey,
@@ -276,12 +277,11 @@ class _ModelEditDialogBodyState extends State<_ModelEditDialogBody>
 
   // Desktop input decoration matching provider settings inputs
   InputDecoration _deskInputDecoration(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return InputDecoration(
       isDense: true,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(10),
         borderSide: BorderSide(
@@ -340,7 +340,7 @@ class _ModelEditDialogBodyState extends State<_ModelEditDialogBody>
             borderRadius: BorderRadius.circular(16),
             side: BorderSide(
               color: Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white.withValues(alpha: 0.08)
+                  ? cs.onSurface.withValues(alpha: 0.08)
                   : cs.outlineVariant.withValues(alpha: 0.25),
             ),
           ),
@@ -1005,7 +1005,7 @@ class _SegmentedSingle extends StatelessWidget {
     final selBg = isDark
         ? cs.primary.withValues(alpha: 0.20)
         : cs.primary.withValues(alpha: 0.12);
-    final baseBg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final baseBg = context.appColors.surfaceFill;
     final children = <Widget>[];
     for (int i = 0; i < options.length; i++) {
       final selected = i == value;
@@ -1067,7 +1067,7 @@ class _SegmentedMulti extends StatelessWidget {
     final selBg = isDark
         ? cs.primary.withValues(alpha: 0.20)
         : cs.primary.withValues(alpha: 0.12);
-    final baseBg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final baseBg = context.appColors.surfaceFill;
     final children = <Widget>[];
     for (int i = 0; i < options.length; i++) {
       final selected = isSelected[i];
@@ -1174,7 +1174,6 @@ class _HeaderRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -1186,7 +1185,7 @@ class _HeaderRow extends StatelessWidget {
               decoration: InputDecoration(
                 hintText: l10n.modelDetailSheetHeaderKeyHint,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(10),
                   borderSide: BorderSide(
@@ -1223,7 +1222,7 @@ class _HeaderRow extends StatelessWidget {
               decoration: InputDecoration(
                 hintText: l10n.modelDetailSheetHeaderValueHint,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(10),
                   borderSide: BorderSide(
@@ -1274,7 +1273,6 @@ class _BodyRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -1288,9 +1286,7 @@ class _BodyRow extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.modelDetailSheetBodyKeyHint,
                     filled: true,
-                    fillColor: isDark
-                        ? Colors.white10
-                        : const Color(0xFFF7F7F9),
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(10),
                       borderSide: BorderSide(
@@ -1338,7 +1334,7 @@ class _BodyRow extends StatelessWidget {
             decoration: InputDecoration(
               hintText: l10n.modelDetailSheetBodyJsonHint,
               filled: true,
-              fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+              fillColor: context.appColors.surfaceFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(10),
                 borderSide: BorderSide(
@@ -1396,7 +1392,7 @@ class _ToolTileState extends State<_ToolTile> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     final bool isDisabled = widget.onChanged == null;
-    final baseBg = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
+    final baseBg = context.appColors.surfaceFill;
     final hoverBg = Color.alphaBlend(
       cs.primary.withValues(alpha: isDark ? 0.10 : 0.06),
       baseBg,
@@ -1489,9 +1485,7 @@ class _DeskCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : const Color(0xFFF2F3F5);
+    final bg = context.appColors.surfaceFill;
     return Container(
       decoration: BoxDecoration(
         color: bg,

--- a/lib/desktop/model_fetch_dialog.dart
+++ b/lib/desktop/model_fetch_dialog.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-
 import '../core/providers/settings_provider.dart';
 import '../core/providers/model_provider.dart';
 import '../l10n/app_localizations.dart';
@@ -10,17 +9,19 @@ import '../utils/brand_assets.dart';
 import '../utils/model_grouping.dart';
 import '../shared/widgets/model_tag_wrap.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<void> showModelFetchDialog(
   BuildContext context, {
   required String providerKey,
   required String providerDisplayName,
 }) async {
+  final cs = Theme.of(context).colorScheme;
   await showGeneralDialog<void>(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'model-fetch-dialog',
-    barrierColor: Colors.black.withValues(alpha: 0.25),
+    barrierColor: cs.scrim.withValues(alpha: 0.25),
     pageBuilder: (ctx, _, __) {
       return _ModelFetchDialogBody(
         providerKey: providerKey,
@@ -47,7 +48,6 @@ class _ModelFetchDialogBody extends StatefulWidget {
   });
   final String providerKey;
   final String providerDisplayName;
-
   @override
   State<_ModelFetchDialogBody> createState() => _ModelFetchDialogBodyState();
 }
@@ -58,7 +58,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
   String _error = '';
   List<ModelInfo> _items = const [];
   final Map<String, bool> _collapsed = <String, bool>{};
-
   @override
   void initState() {
     super.initState();
@@ -135,7 +134,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     final settingsWatch = context.watch<SettingsProvider>();
-
     // Compute header filtered list and selection state for toggle icon
     final headerQuery = _searchCtrl.text.trim().toLowerCase();
     final headerFiltered = <ModelInfo>[
@@ -155,7 +153,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
     final bool allHeaderFilteredSelected =
         headerFiltered.isNotEmpty &&
         headerFiltered.every((m) => headerSelectedSet.contains(m.id));
-
     final dialog = Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(
@@ -170,7 +167,7 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
             borderRadius: BorderRadius.circular(16),
             side: BorderSide(
               color: isDark
-                  ? Colors.white.withValues(alpha: 0.08)
+                  ? cs.onSurface.withValues(alpha: 0.08)
                   : cs.outlineVariant.withValues(alpha: 0.25),
               width: 1,
             ),
@@ -228,9 +225,7 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
                               hintText: l10n.providerDetailPageFilterHint,
                               isDense: true,
                               filled: true,
-                              fillColor: isDark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: context.appColors.surfaceFill,
                               prefixIcon: Icon(
                                 lucide.Lucide.Search,
                                 size: 18,
@@ -442,7 +437,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
         ),
       ),
     );
-
     return Material(type: MaterialType.transparency, child: dialog);
   }
 
@@ -456,7 +450,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
         )
         .models
         .toSet();
-
     final q = _searchCtrl.text.trim().toLowerCase();
     final filtered = <ModelInfo>[
       for (final m in _items)
@@ -465,7 +458,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
             m.displayName.toLowerCase().contains(q))
           m,
     ];
-
     final Map<String, List<ModelInfo>> grouped = {};
     for (final m in filtered) {
       final g = _groupFor(context, m);
@@ -473,11 +465,9 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
     }
     final groupKeys = grouped.keys.toList()
       ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
-
     if (groupKeys.isEmpty) {
       return const Center(child: Text(''));
     }
-
     return ListView(
       padding: const EdgeInsets.fromLTRB(8, 0, 8, 12),
       children: [
@@ -494,9 +484,7 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
                 );
                 return Container(
                   decoration: BoxDecoration(
-                    color: Theme.of(context).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    color: context.appColors.surfaceFill,
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Padding(
@@ -624,7 +612,6 @@ class _ModelFetchDialogBodyState extends State<_ModelFetchDialogBody> {
         .models
         .toSet();
     final added = selected.contains(m.id);
-
     return Padding(
       padding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
       child: _TactileRow(
@@ -709,17 +696,14 @@ class _TactileRowState extends State<_TactileRow> {
   bool _hovered = false;
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final overlay = () {
       if (_pressed) {
-        return isDark
-            ? Colors.white.withValues(alpha: 0.08)
-            : Colors.black.withValues(alpha: 0.06);
+        return cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.06);
       }
       if (_hovered) {
-        return isDark
-            ? Colors.white.withValues(alpha: 0.04)
-            : Colors.black.withValues(alpha: 0.03);
+        return cs.onSurface.withValues(alpha: isDark ? 0.04 : 0.03);
       }
       return Colors.transparent;
     }();
@@ -803,6 +787,7 @@ class _BrandAvatar extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
         shape: BoxShape.circle,
       ),

--- a/lib/desktop/select_copy_dialog.dart
+++ b/lib/desktop/select_copy_dialog.dart
@@ -5,6 +5,7 @@ import '../icons/lucide_adapter.dart';
 import '../shared/widgets/snackbar.dart';
 import 'package:flutter/services.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<void> showSelectCopyDesktopDialog(
   BuildContext context, {
@@ -60,7 +61,6 @@ class _SelectCopyDesktopDialogState extends State<_SelectCopyDesktopDialog> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     return Dialog(
       elevation: 12,
@@ -120,9 +120,7 @@ class _SelectCopyDesktopDialogState extends State<_SelectCopyDesktopDialog> {
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                     child: DecoratedBox(
                       decoration: BoxDecoration(
-                        color: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        color: context.appColors.surfaceFill,
                         borderRadius: BorderRadius.circular(12),
                         border: Border.all(
                           color: cs.outlineVariant.withValues(alpha: 0.18),

--- a/lib/desktop/setting/about_pane.dart
+++ b/lib/desktop/setting/about_pane.dart
@@ -10,6 +10,7 @@ import '../../l10n/app_localizations.dart';
 import '../../features/settings/pages/debug_page.dart';
 import '../../shared/widgets/qq_group_join_sheet.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopAboutPane extends StatefulWidget {
   const DesktopAboutPane({super.key});
@@ -224,10 +225,8 @@ class _AppHeaderCardState extends State<_AppHeaderCard> {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark ? const Color(0xFF1C1C1E) : Colors.white;
-    final hoverBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.04);
+    final baseBg = context.appColors.surfaceCard;
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04);
     final overlay = _hover ? hoverBg : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -250,7 +249,7 @@ class _AppHeaderCardState extends State<_AppHeaderCard> {
                 side: BorderSide(
                   width: 0.5,
                   color: isDark
-                      ? Colors.white.withValues(alpha: 0.06)
+                      ? cs.onSurface.withValues(alpha: 0.06)
                       : cs.outlineVariant.withValues(alpha: 0.12),
                 ),
               ),
@@ -320,13 +319,13 @@ class _DeskCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Material(
-      color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+      color: context.appColors.surfaceCard,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(14),
         side: BorderSide(
           width: 0.5,
           color: isDark
-              ? Colors.white.withValues(alpha: 0.06)
+              ? cs.onSurface.withValues(alpha: 0.06)
               : cs.outlineVariant.withValues(alpha: 0.12),
         ),
       ),
@@ -439,9 +438,7 @@ class _DeskNavRowState extends State<_DeskNavRow> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final hoverBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final bg = _hover ? hoverBg : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -510,9 +507,7 @@ class _DeskNavRowSvgState extends State<_DeskNavRowSvg> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final hoverBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final bg = _hover ? hoverBg : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/setting/assistants_pane.dart
+++ b/lib/desktop/setting/assistants_pane.dart
@@ -1,10 +1,8 @@
 part of '../desktop_settings_page.dart';
 
 // ===== Assistants (Desktop right content) =====
-
 class _DesktopAssistantsBody extends StatefulWidget {
   const _DesktopAssistantsBody({super.key});
-
   @override
   State<_DesktopAssistantsBody> createState() => _DesktopAssistantsBodyState();
 }
@@ -120,7 +118,6 @@ class _DesktopAssistantsBodyState extends State<_DesktopAssistantsBody> {
                           ),
                         );
                       }
-
                       final group = groupChats[index - assistants.length];
                       return KeyedSubtree(
                         key: ValueKey('desktop-group-chat-${group.id}'),
@@ -261,9 +258,7 @@ Future<String?> _showAddGroupChatDesktopDialog(BuildContext context) async {
                       decoration: InputDecoration(
                         hintText: l10n.groupChatNameHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(
@@ -369,9 +364,7 @@ Future<String?> _showAddAssistantDesktopDialog(BuildContext context) async {
                       decoration: InputDecoration(
                         hintText: l10n.assistantSettingsAddSheetHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(
@@ -503,7 +496,7 @@ Future<bool?> _confirmDeleteDesktop(BuildContext context) async {
     context: context,
     barrierDismissible: true,
     barrierLabel: 'assistant-delete',
-    barrierColor: Colors.black.withValues(alpha: 0.15),
+    barrierColor: cs.scrim.withValues(alpha: 0.15),
     transitionDuration: const Duration(milliseconds: 160),
     pageBuilder: (ctx, _, __) {
       final dialog = Material(
@@ -518,7 +511,7 @@ Future<bool?> _confirmDeleteDesktop(BuildContext context) async {
                   borderRadius: BorderRadius.circular(14),
                   side: BorderSide(
                     color: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white.withValues(alpha: 0.08)
+                        ? cs.onSurface.withValues(alpha: 0.08)
                         : cs.outlineVariant.withValues(alpha: 0.25),
                   ),
                 ),
@@ -647,12 +640,11 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
         : baseColor;
     final baseBg = widget.filled
         ? baseColor
+        // color-gate: ignore
         : (isDark ? Colors.white10 : Colors.transparent);
     final hoverBg = widget.filled
         ? baseColor.withValues(alpha: 0.92)
-        : (isDark
-              ? Colors.white.withValues(alpha: 0.08)
-              : Colors.black.withValues(alpha: 0.04));
+        : cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04);
     final bg = _hover ? hoverBg : baseBg;
     final borderColor = widget.filled
         ? Colors.transparent
@@ -711,9 +703,7 @@ class _DesktopAssistantCardState extends State<_DesktopAssistantCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);

--- a/lib/desktop/setting/backup_pane.dart
+++ b/lib/desktop/setting/backup_pane.dart
@@ -27,6 +27,7 @@ import '../../features/backup/widgets/backup_reminder_helpers.dart';
 import '../../shared/widgets/lan_sync_section.dart';
 import '../widgets/desktop_select_dropdown.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopBackupPane extends StatefulWidget {
   const DesktopBackupPane({super.key});
@@ -1335,9 +1336,7 @@ class _RemoteItemCardState extends State<_RemoteItemCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -1805,9 +1804,7 @@ class _RestoreModeTileState extends State<_RestoreModeTile> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1871,9 +1868,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1924,9 +1919,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -1976,9 +1969,7 @@ Widget _sectionCard({required List<Widget> children}) {
     builder: (context) {
       final cs = Theme.of(context).colorScheme;
       final isDark = Theme.of(context).brightness == Brightness.dark;
-      final baseBg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final baseBg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: baseBg,
@@ -2000,12 +1991,11 @@ Widget _sectionCard({required List<Widget> children}) {
 
 InputDecoration _deskInputDecoration(BuildContext context) {
   // Match provider dialog style (compact), but slightly shorter height and 14px font hint
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: true,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     hintStyle: TextStyle(
       fontSize: 14,
       color: cs.onSurface.withValues(alpha: 0.5),

--- a/lib/desktop/setting/default_model_pane.dart
+++ b/lib/desktop/setting/default_model_pane.dart
@@ -14,10 +14,10 @@ import '../../features/model/utils/ocr_model_capability.dart';
 import '../../utils/brand_assets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopDefaultModelPane extends StatelessWidget {
   const DesktopDefaultModelPane({super.key});
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -60,7 +60,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 8),
-
                   _ModelCard(
                     icon: lucide.Lucide.MessageCircle,
                     title: l10n.defaultModelPageChatModelTitle,
@@ -86,7 +85,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                       }
                     },
                   ),
-
                   const SizedBox(height: 16),
                   _ModelCard(
                     icon: lucide.Lucide.NotebookTabs,
@@ -114,7 +112,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                     },
                     configAction: () => _showTitlePromptDialog(context),
                   ),
-
                   const SizedBox(height: 16),
                   _ModelCard(
                     icon: lucide.Lucide.FileText,
@@ -147,7 +144,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                     },
                     configAction: () => _showSummaryPromptDialog(context),
                   ),
-
                   const SizedBox(height: 16),
                   _ModelCard(
                     icon: lucide.Lucide.MessagesSquare,
@@ -176,7 +172,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                     },
                     configAction: () => _showSuggestionPromptDialog(context),
                   ),
-
                   const SizedBox(height: 16),
                   _ModelCard(
                     icon: lucide.Lucide.package2,
@@ -212,7 +207,6 @@ class DesktopDefaultModelPane extends StatelessWidget {
                     },
                     configAction: () => _showCompressPromptDialog(context),
                   ),
-
                   const SizedBox(height: 16),
                   _ModelCard(
                     icon: lucide.Lucide.Languages,
@@ -943,7 +937,6 @@ class _ModelCard extends StatefulWidget {
     this.onReset,
     this.configAction,
   });
-
   final IconData icon;
   final String title;
   final String subtitle;
@@ -955,7 +948,6 @@ class _ModelCard extends StatefulWidget {
   final VoidCallback? onReset;
   final VoidCallback onPick;
   final VoidCallback? configAction;
-
   @override
   State<_ModelCard> createState() => _ModelCardState();
 }
@@ -968,12 +960,10 @@ class _ModelCardState extends State<_ModelCard> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final settings = context.read<SettingsProvider>();
     final l10n = AppLocalizations.of(context)!;
-
     final usingFallback =
         widget.modelProvider == null || widget.modelId == null;
     final effectiveProvider = widget.modelProvider ?? widget.fallbackProvider;
     final effectiveModelId = widget.modelId ?? widget.fallbackModelId;
-
     String? providerName;
     String? modelDisplay;
     if (effectiveProvider != null && effectiveModelId != null) {
@@ -1001,18 +991,12 @@ class _ModelCardState extends State<_ModelCard> {
           ? l10n.defaultModelPageNotEnabled
           : l10n.defaultModelPageUseCurrentModel;
     }
-
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.08 : 0.06,
     );
-    final rowBase = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
-    final hoverOverlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
-
+    final rowBase = context.appColors.surfaceFill;
+    final hoverOverlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     return Container(
       decoration: BoxDecoration(
         color: baseBg,
@@ -1063,7 +1047,6 @@ class _ModelCardState extends State<_ModelCard> {
               ),
             ),
             const SizedBox(height: 8),
-
             MouseRegion(
               cursor: SystemMouseCursors.click,
               onEnter: (_) => setState(() => _hover = true),
@@ -1122,14 +1105,12 @@ class _ModelThinkingSwitchRow extends StatelessWidget {
     required this.cs,
     required this.trailing,
   });
-
   final bool value;
   final ValueChanged<bool> onChanged;
   final String label;
   final String semanticLabel;
   final ColorScheme cs;
   final Widget trailing;
-
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -1207,9 +1188,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -1269,9 +1248,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1332,6 +1309,7 @@ class _BrandCircle extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.10),
         shape: BoxShape.circle,
       ),
@@ -1365,12 +1343,11 @@ Widget _promptEditor(
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: false,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(12),
       borderSide: BorderSide(

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -1,7 +1,6 @@
 part of '../desktop_settings_page.dart';
 
 // ===== Display Settings Body =====
-
 class _DisplaySettingsBody extends StatelessWidget {
   const _DisplaySettingsBody({super.key});
   @override
@@ -179,7 +178,6 @@ class _SettingsCard extends StatelessWidget {
   const _SettingsCard({required this.title, required this.children});
   final String title;
   final List<Widget> children;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -188,13 +186,13 @@ class _SettingsCard extends StatelessWidget {
     return Material(
       color: sp.usePureBackground
           ? (isDark ? Colors.black : Colors.white)
-          : (isDark ? const Color(0xFF1C1C1E) : Colors.white),
+          : context.appColors.surfaceCard,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(14),
         side: BorderSide(
           width: 0.5,
           color: isDark
-              ? Colors.white.withValues(alpha: 0.06)
+              ? cs.onSurface.withValues(alpha: 0.06)
               : cs.outlineVariant.withValues(alpha: 0.12),
         ),
       ),
@@ -312,16 +310,12 @@ class _ThemeModeSegmentedState extends State<_ThemeModeSegmented> {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-
     final items = [
       (ThemeMode.light, l10n.settingsPageLightMode, lucide.Lucide.Sun),
       (ThemeMode.dark, l10n.settingsPageDarkMode, lucide.Lucide.Moon),
       (ThemeMode.system, l10n.settingsPageSystemMode, lucide.Lucide.Monitor),
     ];
-
-    final trackBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.04);
+    final trackBg = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04);
     return Container(
       decoration: BoxDecoration(
         color: trackBg,
@@ -355,9 +349,9 @@ class _ThemeModeSegmentedState extends State<_ThemeModeSegmented> {
                         );
                       }
                       if (_hover == i) {
-                        return isDark
-                            ? Colors.white.withValues(alpha: 0.10)
-                            : Colors.black.withValues(alpha: 0.06);
+                        return cs.onSurface.withValues(
+                          alpha: isDark ? 0.10 : 0.06,
+                        );
                       }
                       return Colors.transparent;
                     }(),
@@ -745,7 +739,6 @@ class _TopicPositionDropdownState extends State<_TopicPositionDropdown> {
         label: l10n.desktopDisplaySettingsTopicPositionRight,
       ),
     ];
-
     return DesktopSelectDropdown<DesktopTopicPosition>(
       value: sp.desktopTopicPosition,
       options: options,
@@ -781,7 +774,6 @@ class _BackgroundStyleDropdownState extends State<_BackgroundStyleDropdown> {
         label: l10n.displaySettingsPageChatMessageBackgroundSolid,
       ),
     ];
-
     return DesktopSelectDropdown<ChatMessageBackgroundStyle>(
       value: sp.chatMessageBackgroundStyle,
       options: options,
@@ -814,9 +806,7 @@ class _SimpleOptionTileState extends State<_SimpleOptionTile> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.12)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -884,7 +874,6 @@ class _AppLanguageRowState extends State<_AppLanguageRow> {
   final GlobalKey _key = GlobalKey();
   OverlayEntry? _entry;
   final LayerLink _link = LayerLink();
-
   void _openDropdownOverlay() {
     if (_entry != null) return;
     final rb = _key.currentContext?.findRenderObject() as RenderBox?;
@@ -1027,9 +1016,7 @@ class _HoverDropdownButton extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = hovered || open
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     final angle = open ? 3.1415926 : 0.0;
     return MouseRegion(
@@ -1132,9 +1119,7 @@ class _OverlayMenuItemState extends State<_OverlayMenuItem> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.08)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1184,7 +1169,6 @@ class _OverlayItem extends StatefulWidget {
   final Color background;
   final bool selected;
   final VoidCallback onTap;
-
   @override
   State<_OverlayItem> createState() => _OverlayItemState();
 }
@@ -1197,9 +1181,7 @@ class _OverlayItemState extends State<_OverlayItem> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
         ? Color.alphaBlend(
-            (isDark
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.black.withValues(alpha: 0.04)),
+            cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04),
             widget.background,
           )
         : widget.background;
@@ -1323,9 +1305,7 @@ class _LanguageDropdownState extends State<_LanguageDropdown> {
           color: Colors.transparent,
           child: Container(
             decoration: BoxDecoration(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? const Color(0xFF1C1C1E)
-                  : Colors.white,
+              color: context.appColors.surfaceCard,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: cs.outlineVariant.withValues(alpha: 0.12),
@@ -1432,9 +1412,7 @@ class _LanguageDropdownItemState extends State<_LanguageDropdownItem> {
           padding: const EdgeInsets.symmetric(horizontal: 12),
           decoration: BoxDecoration(
             color: _hover
-                ? (isDark
-                      ? Colors.white.withValues(alpha: 0.06)
-                      : Colors.black.withValues(alpha: 0.04))
+                ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
                 : Colors.transparent,
             borderRadius: BorderRadius.circular(10),
           ),
@@ -1571,7 +1549,6 @@ class _BorderInputState extends State<_BorderInput> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     // hover to change border color (not background)
     final baseBorder = OutlineInputBorder(
       borderRadius: BorderRadius.circular(10),
@@ -1603,7 +1580,7 @@ class _BorderInputState extends State<_BorderInput> {
         decoration: InputDecoration(
           isDense: true,
           filled: true,
-          fillColor: isDark ? Colors.white10 : Colors.white,
+          fillColor: context.appColors.surfaceFill,
           contentPadding: const EdgeInsets.symmetric(
             horizontal: 6,
             vertical: 8,
@@ -1736,9 +1713,7 @@ class _DesktopFontDropdownButtonState
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1798,7 +1773,6 @@ Future<String?> _showDesktopFontChooserDialog(
   final rootNavigator = Navigator.of(context, rootNavigator: true);
   final ctrl = TextEditingController();
   String? result;
-
   Future<List<String>> fetchSystemFonts() async {
     try {
       final sf = SystemFonts();
@@ -1840,8 +1814,7 @@ Future<String?> _showDesktopFontChooserDialog(
       context: context,
       barrierDismissible: false,
       builder: (ctx) {
-        final isDark = Theme.of(ctx).brightness == Brightness.dark;
-        final bg = isDark ? const Color(0xFF1C1C1E) : Colors.white;
+        final bg = ctx.appColors.surfaceCard;
         final cs2 = Theme.of(ctx).colorScheme;
         return Dialog(
           elevation: 0,
@@ -1931,10 +1904,7 @@ Future<String?> _showDesktopFontChooserDialog(
                         isDense: true,
                         filled: true,
                         hintText: l10n.desktopFontFilterHint,
-                        fillColor:
-                            Theme.of(context).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: context.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(10),
                           borderSide: BorderSide(
@@ -1972,6 +1942,7 @@ Future<String?> _showDesktopFontChooserDialog(
                       child: DecoratedBox(
                         decoration: BoxDecoration(
                           color: Theme.of(context).brightness == Brightness.dark
+                              // color-gate: ignore
                               ? Colors.white10
                               : Colors.black.withValues(alpha: 0.03),
                           borderRadius: BorderRadius.circular(10),
@@ -2049,9 +2020,7 @@ class _FontRowItemState extends State<_FontRowItem> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     final sample = 'Aa字';
     return MouseRegion(
@@ -2711,7 +2680,6 @@ class _ToggleRowMsgNavButtons extends StatelessWidget {
         label: l10n.displaySettingsPageMessageNavButtonsModeNever,
       ),
     ];
-
     return _LabeledRow(
       label: l10n.displaySettingsPageMessageNavButtonsTitle,
       trailing: DesktopSelectDropdown<DesktopMessageNavButtonsMode>(
@@ -3146,7 +3114,6 @@ class _OpacityInputGroup extends StatelessWidget {
   final String label;
   final TextEditingController controller;
   final VoidCallback onCommit;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -3211,7 +3178,6 @@ class _SendShortcutDropdownState extends State<_SendShortcutDropdown> {
   final LayerLink _link = LayerLink();
   final GlobalKey _triggerKey = GlobalKey();
   OverlayEntry? _entry;
-
   void _toggle() {
     if (_open) {
       _close();
@@ -3244,7 +3210,6 @@ class _SendShortcutDropdownState extends State<_SendShortcutDropdown> {
     if (rb == null) return;
     final triggerSize = rb.size;
     final triggerWidth = triggerSize.width;
-
     _entry = OverlayEntry(
       builder: (ctx) {
         final isDark = Theme.of(ctx).brightness == Brightness.dark;
@@ -3254,9 +3219,8 @@ class _SendShortcutDropdownState extends State<_SendShortcutDropdown> {
         ).usePureBackground;
         final bgColor = usePure
             ? (isDark ? Colors.black : Colors.white)
-            : (isDark ? const Color(0xFF1C1C1E) : Colors.white);
+            : ctx.appColors.surfaceCard;
         final sp = Provider.of<SettingsProvider>(ctx, listen: false);
-
         return Stack(
           children: [
             Positioned.fill(
@@ -3291,14 +3255,11 @@ class _SendShortcutDropdownState extends State<_SendShortcutDropdown> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final sp = context.watch<SettingsProvider>();
     final label = _labelFor(context, sp.desktopSendShortcut);
-
     final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
     final hoverBorder = cs.primary;
     final borderColor = _open || _hover ? hoverBorder : baseBorder;
-
     return CompositedTransformTarget(
       link: _link,
       child: MouseRegion(
@@ -3314,7 +3275,7 @@ class _SendShortcutDropdownState extends State<_SendShortcutDropdown> {
             padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 6),
             constraints: const BoxConstraints(minWidth: 130, minHeight: 34),
             decoration: BoxDecoration(
-              color: isDark ? const Color(0xFF141414) : Colors.white,
+              color: context.appColors.surfaceCard,
               borderRadius: BorderRadius.circular(10),
               border: Border.all(color: borderColor, width: 1),
               boxShadow: _open
@@ -3379,7 +3340,6 @@ class _SendShortcutOverlayState extends State<_SendShortcutOverlay>
   late final AnimationController _ctrl;
   late final Animation<double> _opacity;
   late final Animation<Offset> _slide;
-
   @override
   void initState() {
     super.initState();
@@ -3406,7 +3366,6 @@ class _SendShortcutOverlayState extends State<_SendShortcutOverlay>
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final borderColor = cs.outlineVariant.withValues(alpha: 0.12);
-
     // Platform-specific modifier key
     final modifier = Platform.isMacOS ? '⌘' : 'Ctrl';
     final items = <(DesktopSendShortcut, String)>[
@@ -3416,7 +3375,6 @@ class _SendShortcutOverlayState extends State<_SendShortcutOverlay>
       ),
       (DesktopSendShortcut.ctrlEnter, '$modifier + Enter'),
     ];
-
     return FadeTransition(
       opacity: _opacity,
       child: SlideTransition(

--- a/lib/desktop/setting/hotkeys_pane.dart
+++ b/lib/desktop/setting/hotkeys_pane.dart
@@ -428,9 +428,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/setting/instruction_injection_pane.dart
+++ b/lib/desktop/setting/instruction_injection_pane.dart
@@ -13,6 +13,7 @@ import '../../core/providers/instruction_injection_group_provider.dart';
 import '../../core/providers/instruction_injection_provider.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopInstructionInjectionPane extends StatefulWidget {
   const DesktopInstructionInjectionPane({super.key});
@@ -344,9 +345,7 @@ class _InstructionInjectionCardState extends State<_InstructionInjectionCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.5 : 0.7)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -553,9 +552,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     final btn = MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -610,9 +607,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -658,12 +653,11 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: false,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(12),
       borderSide: BorderSide(
@@ -711,9 +705,7 @@ class _GroupHeaderState extends State<_GroupHeader> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final hoverBg = (isDark ? Colors.white : Colors.black).withValues(
-      alpha: isDark ? 0.08 : 0.05,
-    );
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.05);
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,

--- a/lib/desktop/setting/mcp_edit_dialog.dart
+++ b/lib/desktop/setting/mcp_edit_dialog.dart
@@ -15,6 +15,7 @@ import '../../features/mcp/widgets/mcp_oauth_section_controller.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 Future<void> showDesktopMcpEditDialog(
   BuildContext context, {
@@ -471,7 +472,9 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
                       ? lucide.Lucide.TriangleAlert
                       : lucide.Lucide.circleCheckBig,
                   size: 14,
-                  color: token == null || expired ? cs.error : Colors.green,
+                  color: token == null || expired
+                      ? cs.error
+                      : context.appColors.success,
                 ),
                 const SizedBox(width: 6),
                 Expanded(
@@ -860,9 +863,9 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
                           states,
                         ) {
                           if (states.contains(WidgetState.hovered)) {
-                            return isDark
-                                ? Colors.white.withValues(alpha: 0.06)
-                                : Colors.black.withValues(alpha: 0.05);
+                            return cs.onSurface.withValues(
+                              alpha: isDark ? 0.06 : 0.05,
+                            );
                           }
                           return Colors.transparent;
                         }),
@@ -1027,9 +1030,9 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
                               states,
                             ) {
                               if (states.contains(WidgetState.hovered)) {
-                                return isDark
-                                    ? Colors.white.withValues(alpha: 0.06)
-                                    : Colors.black.withValues(alpha: 0.05);
+                                return cs.onSurface.withValues(
+                                  alpha: isDark ? 0.06 : 0.05,
+                                );
                               }
                               return Colors.transparent;
                             }),
@@ -1308,7 +1311,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
     bool bold = false,
   }) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1331,7 +1333,7 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           decoration: InputDecoration(
             hintText: hint,
             filled: true,
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
@@ -1363,7 +1365,7 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -1402,9 +1404,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     final btn = Container(
       width: 28,

--- a/lib/desktop/setting/mcp_json_edit_dialog.dart
+++ b/lib/desktop/setting/mcp_json_edit_dialog.dart
@@ -10,6 +10,7 @@ import '../../shared/widgets/snackbar.dart';
 import '../../l10n/app_localizations.dart';
 import '../../core/providers/settings_provider.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 Future<void> showDesktopMcpJsonEditDialog(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
@@ -83,7 +84,6 @@ class _DesktopMcpJsonEditDialogState extends State<_DesktopMcpJsonEditDialog> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     // Resolve user-preferred code font family (Google/local/system)
     final settings = context.watch<SettingsProvider>();
     String resolveCodeFont() {
@@ -140,7 +140,7 @@ class _DesktopMcpJsonEditDialogState extends State<_DesktopMcpJsonEditDialog> {
                 padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: isDark ? Colors.white10 : Colors.white,
+                    color: context.appColors.surfaceFill,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: cs.outlineVariant.withValues(alpha: 0.3),
@@ -173,7 +173,10 @@ class _DesktopMcpJsonEditDialogState extends State<_DesktopMcpJsonEditDialog> {
                   alignment: Alignment.centerLeft,
                   child: Text(
                     _error!,
-                    style: TextStyle(color: Colors.redAccent, fontSize: 12),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                      fontSize: 12,
+                    ),
                   ),
                 ),
               ),
@@ -232,9 +235,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     final btn = Container(
       width: 28,
@@ -275,9 +276,7 @@ class _TextBtnState extends State<_TextBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/setting/mcp_pane.dart
+++ b/lib/desktop/setting/mcp_pane.dart
@@ -9,6 +9,7 @@ import 'mcp_edit_dialog.dart' show showDesktopMcpEditDialog;
 import 'mcp_json_edit_dialog.dart' show showDesktopMcpJsonEditDialog;
 import 'mcp_timeout_dialog.dart' show showDesktopMcpTimeoutDialog;
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopMcpPane extends StatelessWidget {
   const DesktopMcpPane({super.key});
@@ -201,9 +202,7 @@ class _ServerCardState extends State<_ServerCard> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
 
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -212,7 +211,7 @@ class _ServerCardState extends State<_ServerCard> {
     String statusText;
     switch (widget.status) {
       case McpStatus.connected:
-        statusColor = Colors.green;
+        statusColor = context.appColors.success;
         statusText = l10n.mcpPageStatusConnected;
         break;
       case McpStatus.connecting:
@@ -221,7 +220,7 @@ class _ServerCardState extends State<_ServerCard> {
         break;
       case McpStatus.error:
       case McpStatus.idle:
-        statusColor = Colors.redAccent;
+        statusColor = Theme.of(context).colorScheme.error;
         statusText = l10n.mcpPageStatusDisconnected;
         break;
     }
@@ -286,7 +285,7 @@ class _ServerCardState extends State<_ServerCard> {
                     width: 40,
                     height: 40,
                     decoration: BoxDecoration(
-                      color: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                      color: context.appColors.surfaceFill,
                       borderRadius: BorderRadius.circular(10),
                     ),
                     alignment: Alignment.center,
@@ -368,13 +367,13 @@ class _ServerCardState extends State<_ServerCard> {
                           Icon(
                             lucide.Lucide.MessageCircleWarning,
                             size: 14,
-                            color: Colors.red,
+                            color: cs.error,
                           ),
                           const SizedBox(width: 6),
                           Expanded(
                             child: Text(
                               l10n.mcpPageConnectionFailed,
-                              style: TextStyle(fontSize: 12, color: Colors.red),
+                              style: TextStyle(fontSize: 12, color: cs.error),
                             ),
                           ),
                           TextButton(
@@ -425,9 +424,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -507,9 +504,7 @@ Future<void> _showErrorDetails(
                   width: double.infinity,
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF7F7F9),
+                    color: context.appColors.surfaceFill,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -605,9 +600,9 @@ Future<bool?> _confirmDelete(BuildContext context) async {
                               states,
                             ) {
                               if (states.contains(WidgetState.hovered)) {
-                                return isDark
-                                    ? Colors.white.withValues(alpha: 0.06)
-                                    : Colors.black.withValues(alpha: 0.05);
+                                return cs.onSurface.withValues(
+                                  alpha: isDark ? 0.06 : 0.05,
+                                );
                               }
                               return Colors.transparent;
                             }),

--- a/lib/desktop/setting/mcp_timeout_dialog.dart
+++ b/lib/desktop/setting/mcp_timeout_dialog.dart
@@ -7,6 +7,7 @@ import '../../icons/lucide_adapter.dart' as lucide;
 import '../../l10n/app_localizations.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 Future<void> showDesktopMcpTimeoutDialog(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
@@ -104,7 +105,7 @@ class _DesktopMcpTimeoutDialogState extends State<_DesktopMcpTimeoutDialog> {
               decoration: InputDecoration(
                 suffixText: 's',
                 filled: true,
-                fillColor: isDark ? Colors.white10 : Colors.white,
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -139,9 +140,9 @@ class _DesktopMcpTimeoutDialogState extends State<_DesktopMcpTimeoutDialog> {
                   onTap: () => Navigator.of(context).maybePop(),
                   background: Colors.transparent,
                   foreground: cs.onSurface,
-                  hoverBackground: isDark
-                      ? Colors.white.withValues(alpha: 0.06)
-                      : Colors.black.withValues(alpha: 0.05),
+                  hoverBackground: cs.onSurface.withValues(
+                    alpha: isDark ? 0.06 : 0.05,
+                  ),
                 ),
                 const SizedBox(width: 8),
                 _ActionBtn(
@@ -176,9 +177,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     final btn = Container(
       width: 28,
@@ -219,9 +218,7 @@ class _TextBtnState extends State<_TextBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/setting/network_proxy_pane.dart
+++ b/lib/desktop/setting/network_proxy_pane.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import 'package:flutter/material.dart';
 import 'package:http/io_client.dart';
@@ -311,7 +312,7 @@ class _DesktopNetworkProxyPaneState extends State<DesktopNetworkProxyPane> {
                       child: Text(
                         l10n.networkProxyTestSuccess,
                         style: TextStyle(
-                          color: Colors.green.shade600,
+                          color: context.appColors.success,
                           fontWeight: AppFontWeights.semibold,
                         ),
                       ),
@@ -463,9 +464,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -515,9 +514,7 @@ Widget _sectionCard({required List<Widget> children}) {
     builder: (context) {
       final cs = Theme.of(context).colorScheme;
       final isDark = Theme.of(context).brightness == Brightness.dark;
-      final baseBg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final baseBg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: baseBg,
@@ -538,12 +535,11 @@ Widget _sectionCard({required List<Widget> children}) {
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: true,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     hintStyle: TextStyle(
       fontSize: 14,
       color: cs.onSurface.withValues(alpha: 0.5),
@@ -602,8 +598,7 @@ class _ProxyTypeDropdownState extends State<_ProxyTypeDropdown> {
     final size = rb.size;
     _entry = OverlayEntry(
       builder: (ctx) {
-        final isDark = Theme.of(ctx).brightness == Brightness.dark;
-        final bgColor = isDark ? const Color(0xFF1C1C1E) : Colors.white;
+        final bgColor = ctx.appColors.surfaceCard;
         return Stack(
           children: [
             Positioned.fill(
@@ -639,7 +634,6 @@ class _ProxyTypeDropdownState extends State<_ProxyTypeDropdown> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
     final hoverBorder = cs.primary;
     final borderColor = _open || _hover ? hoverBorder : baseBorder;
@@ -673,7 +667,7 @@ class _ProxyTypeDropdownState extends State<_ProxyTypeDropdown> {
             padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
             constraints: const BoxConstraints(minWidth: 150, minHeight: 40),
             decoration: BoxDecoration(
-              color: isDark ? const Color(0xFF141414) : Colors.white,
+              color: context.appColors.surfaceCard,
               borderRadius: BorderRadius.circular(10),
               border: Border.all(color: borderColor, width: 1),
               boxShadow: _open
@@ -810,9 +804,7 @@ class _ProxyTypeTileState extends State<_ProxyTypeTile> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.12)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/setting/providers_pane.dart
+++ b/lib/desktop/setting/providers_pane.dart
@@ -1,7 +1,6 @@
 part of '../desktop_settings_page.dart';
 
 // ===== Providers (Desktop right content) =====
-
 class _DesktopProvidersBody extends StatefulWidget {
   const _DesktopProvidersBody({super.key, this.initialSelectedKey});
   final String? initialSelectedKey;
@@ -12,7 +11,6 @@ class _DesktopProvidersBody extends StatefulWidget {
 class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
   static const Duration _groupReorderRestoreDelay = Duration(milliseconds: 300);
   static const Duration _groupReorderCollapseDelay = Duration(milliseconds: 32);
-
   String? _selectedKey;
   final GlobalKey<_DesktopProviderDetailPaneState> _detailKey =
       GlobalKey<_DesktopProviderDetailPaneState>();
@@ -24,7 +22,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
   bool _temporarilyCollapseGroupedProviders = false;
   bool _groupHeaderDragActive = false;
   bool _groupHeaderRestorePending = false;
-
   @override
   void dispose() {
     _groupReorderRestoreTimer?.cancel();
@@ -37,7 +34,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
   bool _effectiveGroupCollapsed(SettingsProvider settings, String groupKey) =>
       _temporarilyCollapseGroupedProviders ||
       settings.isGroupCollapsed(groupKey);
-
   void _startTemporaryGroupCollapse() {
     _groupReorderRestoreTimer?.cancel();
     setState(() {
@@ -72,7 +68,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
   }
 
   String _normalizeSearchQuery(String value) => value.trim().toLowerCase();
-
   bool _matchesQuery(String value, String normalizedQuery) {
     if (normalizedQuery.isEmpty) return true;
     return value.toLowerCase().contains(normalizedQuery);
@@ -120,7 +115,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
       for (final g in groups) g.id: <({String name, String key})>[],
       ungroupedKey: <({String name, String key})>[],
     };
-
     for (final p in items) {
       final gid = settings.groupIdForProvider(p.key);
       final groupKey = (gid != null && groupById.containsKey(gid))
@@ -130,10 +124,8 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
         p,
       );
     }
-
     final rows = <_DesktopProviderGroupingRowVM>[];
     final searching = normalizedQuery.isNotEmpty;
-
     List<({String name, String key})> providersForGroup(
       String groupKey,
       String title,
@@ -159,7 +151,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
       groups: groups,
       ungroupedIndex: settings.providerUngroupedDisplayIndex,
     );
-
     for (final groupKey in displayKeys) {
       final isUngrouped = groupKey == ungroupedKey;
       final title = isUngrouped
@@ -251,7 +242,7 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                       onPressed: () => Navigator.of(ctx).pop(true),
                       child: Text(
                         l10n.providerDetailPageDeleteButton,
-                        style: TextStyle(color: Colors.red),
+                        style: TextStyle(color: colorScheme.error),
                       ),
                     ),
                   ],
@@ -283,7 +274,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final settings = context.watch<SettingsProvider>();
-
     // Base providers (same as mobile list)
     List<({String name, String key})> base() => [
       (name: 'OpenAI', key: 'OpenAI'),
@@ -299,7 +289,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
       (name: 'Grok', key: 'Grok'),
       (name: l10n.providersPageByteDanceName, key: 'ByteDance'),
     ];
-
     final cfgs = settings.providerConfigs;
     final baseKeys = {for (final p in base()) p.key};
     final dynamicItems = <({String name, String key})>[];
@@ -337,7 +326,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
             normalizedQuery: _searchQuery,
           )
         : const <_DesktopProviderGroupingRowVM>[];
-
     _selectedKey ??=
         (widget.initialSelectedKey ??
         (ordered.isNotEmpty ? ordered.first.key : null));
@@ -351,7 +339,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                 ? settings.getProviderConfig(selectedKey).name
                 : selectedKey,
           );
-
     return Container(
       alignment: Alignment.topCenter,
       child: Padding(
@@ -415,7 +402,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                 }
                                 if (groupingRows.isEmpty) return;
                                 final sp = context.read<SettingsProvider>();
-
                                 final logicRows = <ProviderGroupingRowVM>[
                                   for (final r in groupingRows)
                                     if (r is _DesktopProviderGroupingHeaderVM)
@@ -429,7 +415,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                         groupKey: r.groupKey,
                                       ),
                                 ];
-
                                 if (logicRows[oldIndex]
                                     is ProviderGroupingHeaderVM) {
                                   final intent =
@@ -439,7 +424,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                         newIndex: newIndex,
                                       );
                                   if (intent == null) return;
-
                                   final visibleHeaderKeys = [
                                     for (final row in groupingRows)
                                       if (row
@@ -455,7 +439,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                   final oldActualIndex = fullDisplayKeys
                                       .indexOf(intent.groupKey);
                                   if (oldActualIndex < 0) return;
-
                                   final targetInsertIndex =
                                       mapVisibleGroupTargetToActualInsertIndex(
                                         fullDisplayKeys: fullDisplayKeys,
@@ -468,7 +451,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                       targetInsertIndex > oldActualIndex
                                       ? targetInsertIndex + 1
                                       : targetInsertIndex;
-
                                   try {
                                     await sp.reorderProviderGroupsWithUngrouped(
                                       oldActualIndex,
@@ -481,14 +463,12 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                   }
                                   return;
                                 }
-
                                 final analysis = analyzeProviderGroupingReorder(
                                   rows: logicRows,
                                   oldIndex: oldIndex,
                                   newIndex: newIndex,
                                   isGroupCollapsed: sp.isGroupCollapsed,
                                 );
-
                                 if (analysis.blockedReason ==
                                     ProviderGroupingReorderBlockedReason
                                         .targetGroupCollapsed) {
@@ -501,7 +481,6 @@ class _DesktopProvidersBodyState extends State<_DesktopProvidersBody> {
                                   if (mounted) setState(() {});
                                   return;
                                 }
-
                                 final intent = analysis.intent;
                                 if (intent == null) return;
                                 final targetGroupId =
@@ -723,7 +702,6 @@ class _DesktopProviderGroupingHeaderVM extends _DesktopProviderGroupingRowVM {
     required this.count,
     required this.collapsed,
   });
-
   final String groupKey;
   final String title;
   final int count;
@@ -735,7 +713,6 @@ class _DesktopProviderGroupingProviderVM extends _DesktopProviderGroupingRowVM {
     required this.item,
     required this.groupKey,
   });
-
   final ({String name, String key}) item;
   final String groupKey;
 }
@@ -747,26 +724,19 @@ class _DesktopProvidersSearchField extends StatelessWidget {
     required this.onChanged,
     required this.onClear,
   });
-
   final TextEditingController controller;
   final String hintText;
   final ValueChanged<String> onChanged;
   final VoidCallback onClear;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    final isDark = theme.brightness == Brightness.dark;
     final hasText = controller.text.trim().isNotEmpty;
-
     return TextField(
       controller: controller,
       onChanged: onChanged,
-      style: TextStyle(
-        color: isDark ? Colors.white : Colors.black87,
-        fontSize: 14,
-      ),
+      style: TextStyle(color: cs.onSurface, fontSize: 14),
       cursorColor: cs.primary,
       decoration: InputDecoration(
         hintText: hintText,
@@ -804,9 +774,7 @@ class _DesktopProvidersSearchField extends StatelessWidget {
           minHeight: 34,
         ),
         filled: true,
-        fillColor: isDark
-            ? Colors.white.withValues(alpha: 0.12)
-            : const Color(0xFFEBEBEB),
+        fillColor: context.appColors.surfaceFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: BorderSide.none,
@@ -831,12 +799,10 @@ class _DesktopProviderGroupHeaderRow extends StatefulWidget {
     required this.collapsed,
     this.onToggle,
   });
-
   final String title;
   final int count;
   final bool collapsed;
   final VoidCallback? onToggle;
-
   @override
   State<_DesktopProviderGroupHeaderRow> createState() =>
       _DesktopProviderGroupHeaderRowState();
@@ -845,17 +811,13 @@ class _DesktopProviderGroupHeaderRow extends StatefulWidget {
 class _DesktopProviderGroupHeaderRowState
     extends State<_DesktopProviderGroupHeaderRow> {
   bool _hover = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
-
     return MouseRegion(
       cursor: widget.onToggle == null
           ? SystemMouseCursors.basic
@@ -928,7 +890,6 @@ class _DesktopProviderDetailPaneState
   final FocusNode _searchFocus = FocusNode();
   bool _showApiKey = false;
   bool _eyeHover = false;
-
   // 批量选择模式相关
   bool _isSelectionMode = false;
   final Set<String> _selectedModels = {};
@@ -939,10 +900,8 @@ class _DesktopProviderDetailPaneState
   String? _currentDetectingModel;
   final Set<String> _pendingModels = {};
   int _providerScopedStateEpoch = 0;
-
   // Connection test state for inline dialog
   // Keep local to this file to avoid cross-file coupling
-
   // Persistent controllers for provider top inputs (desktop)
   // Avoid rebuilding controllers each frame which breaks focus/IME
   final TextEditingController _apiKeyCtrl = TextEditingController();
@@ -961,7 +920,6 @@ class _DesktopProviderDetailPaneState
   final TextEditingController _proxyPassCtrl = TextEditingController();
   bool _balanceLoading = false;
   bool _customRequestExpanded = false;
-
   void _syncCtrl(TextEditingController c, String newText) {
     final v = c.value;
     // Do not disturb ongoing IME composition
@@ -1139,14 +1097,12 @@ class _DesktopProviderDetailPaneState
       widget.providerKey,
       explicitType: cfg.providerType,
     );
-
     final models = List<String>.from(cfg.models);
     final allSelected =
         _selectedModels.length == models.length && models.isNotEmpty;
     final hasFailedDetectedModels = _failedDetectedModels(models).isNotEmpty;
     final filtered = _applyFilter(models, _filterCtrl.text.trim());
     final groups = _groupModels(filtered);
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -1305,7 +1261,6 @@ class _DesktopProviderDetailPaneState
                 ),
                 const SizedBox(height: 12),
               ],
-
               if (widget.providerKey.toLowerCase() == 'siliconflow') ...[
                 Container(
                   padding: const EdgeInsets.symmetric(
@@ -1368,7 +1323,6 @@ class _DesktopProviderDetailPaneState
                 ),
                 const SizedBox(height: 12),
               ],
-
               // API Key (hidden when Google Vertex)
               if (!(kind == ProviderKind.google && (cfg.vertexAI == true))) ...[
                 Row(
@@ -1451,10 +1405,13 @@ class _DesktopProviderDetailPaneState
                             padding: const EdgeInsets.all(4),
                             decoration: BoxDecoration(
                               color: _eyeHover
-                                  ? (Theme.of(context).brightness ==
-                                            Brightness.dark
-                                        ? Colors.white.withValues(alpha: 0.06)
-                                        : Colors.black.withValues(alpha: 0.04))
+                                  ? cs.onSurface.withValues(
+                                      alpha:
+                                          Theme.of(context).brightness ==
+                                              Brightness.dark
+                                          ? 0.06
+                                          : 0.04,
+                                    )
                                   : Colors.transparent,
                               borderRadius: BorderRadius.circular(8),
                             ),
@@ -1500,7 +1457,6 @@ class _DesktopProviderDetailPaneState
                 ],
                 const SizedBox(height: 14),
               ],
-
               // API Base URL or Vertex AI fields
               if (!(kind == ProviderKind.google && (cfg.vertexAI == true))) ...[
                 _sectionLabel(
@@ -1754,7 +1710,6 @@ class _DesktopProviderDetailPaneState
                         withData: true,
                       );
                       if (res == null || res.files.isEmpty) return;
-
                       final file = res.files.first;
                       // Desktop FilePicker may not include bytes unless withData is true; fall back to disk read.
                       String? content;
@@ -1775,7 +1730,6 @@ class _DesktopProviderDetailPaneState
                         );
                         return;
                       }
-
                       String projectId = cfg.projectId ?? '';
                       try {
                         final obj = jsonDecode(content);
@@ -1796,7 +1750,6 @@ class _DesktopProviderDetailPaneState
                   ),
                 ),
               ],
-
               // API Path (OpenAI chat)
               if (kind == ProviderKind.openai &&
                   (cfg.useResponseApi != true)) ...[
@@ -1864,7 +1817,6 @@ class _DesktopProviderDetailPaneState
                   ),
                 ),
               ],
-
               const SizedBox(height: 18),
               // Models header with count + search + actions (test / add / fetch)
               Row(
@@ -2108,7 +2060,6 @@ class _DesktopProviderDetailPaneState
                   ],
                 ],
               ),
-
               const SizedBox(height: 6),
               // Accordion groups
               for (final entry in groups.entries)
@@ -2168,12 +2119,11 @@ class _DesktopProviderDetailPaneState
   }
 
   InputDecoration _inputDecoration(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return InputDecoration(
       isDense: true,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(10),
         borderSide: BorderSide(
@@ -2249,12 +2199,11 @@ class _DesktopProviderDetailPaneState
   }
 
   InputDecoration _proxyInputDecoration(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return InputDecoration(
       isDense: true,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+      fillColor: context.appColors.surfaceFill,
       hintStyle: TextStyle(
         fontSize: 14,
         color: cs.onSurface.withValues(alpha: 0.5),
@@ -2637,10 +2586,7 @@ class _DesktopProviderDetailPaneState
                                       options: groupOptions,
                                       maxLabelWidth: 150,
                                       triggerFillColor:
-                                          Theme.of(ctx).brightness ==
-                                              Brightness.dark
-                                          ? Colors.white10
-                                          : const Color(0xFFF7F7F9),
+                                          ctx.appColors.surfaceFill,
                                       onSelected: (v) async {
                                         if (v ==
                                             SettingsProvider
@@ -2666,7 +2612,7 @@ class _DesktopProviderDetailPaneState
                                           TextEditingController();
                                       final ok = await showDialog<bool>(
                                         context: ctx,
-                                        barrierColor: Colors.black.withValues(
+                                        barrierColor: cs.scrim.withValues(
                                           alpha: 0.12,
                                         ),
                                         builder: (dctx) => AlertDialog(
@@ -2719,7 +2665,7 @@ class _DesktopProviderDetailPaneState
                                       showDialog<void>(
                                         context: ctx,
                                         barrierDismissible: true,
-                                        barrierColor: Colors.black.withValues(
+                                        barrierColor: cs.scrim.withValues(
                                           alpha: 0.12,
                                         ),
                                         builder: (_) =>
@@ -2837,10 +2783,7 @@ class _DesktopProviderDetailPaneState
                                               ],
                                               maxLabelWidth: 150,
                                               triggerFillColor:
-                                                  Theme.of(ctx).brightness ==
-                                                      Brightness.dark
-                                                  ? Colors.white10
-                                                  : const Color(0xFFF7F7F9),
+                                                  ctx.appColors.surfaceFill,
                                               onSelected: (v) async {
                                                 final old = spWatch
                                                     .getProviderConfig(
@@ -3231,10 +3174,7 @@ class _DesktopProviderDetailPaneState
                                             ),
                                           ],
                                           triggerFillColor:
-                                              Theme.of(ctx).brightness ==
-                                                  Brightness.dark
-                                              ? Colors.white10
-                                              : const Color(0xFFF7F7F9),
+                                              ctx.appColors.surfaceFill,
                                           onSelected: (value) async {
                                             final old = spWatch
                                                 .getProviderConfig(
@@ -3296,10 +3236,7 @@ class _DesktopProviderDetailPaneState
                                         value: proxyTypeNow,
                                         options: proxyTypeOptions,
                                         triggerFillColor:
-                                            Theme.of(ctx).brightness ==
-                                                Brightness.dark
-                                            ? Colors.white10
-                                            : const Color(0xFFF7F7F9),
+                                            ctx.appColors.surfaceFill,
                                         onSelected: (value) async {
                                           final old = spWatch.getProviderConfig(
                                             widget.providerKey,
@@ -3608,9 +3545,7 @@ class _DesktopProviderDetailPaneState
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerImageUrlDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx2).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx2.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: const BorderSide(color: Colors.transparent),
@@ -3669,12 +3604,13 @@ class _DesktopProviderDetailPaneState
     String providerKey,
   ) async {
     final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
     final settings = context.read<SettingsProvider>();
     final controller = TextEditingController();
     String value = '';
     final ok = await showDialog<bool>(
       context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.16),
+      barrierColor: cs.scrim.withValues(alpha: 0.16),
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
         bool valid(String s) => s.trim().isNotEmpty;
@@ -3788,7 +3724,6 @@ class _DesktopProviderDetailPaneState
     final icons = BrandAssets.selectableIcons;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final cfg = settings.getProviderConfig(providerKey);
-
     await showDialog<void>(
       context: context,
       builder: (ctx) {
@@ -3835,6 +3770,7 @@ class _DesktopProviderDetailPaneState
                             child: Container(
                               decoration: BoxDecoration(
                                 color: isDark
+                                    // color-gate: ignore
                                     ? Colors.white10
                                     : cs.primary.withValues(alpha: 0.1),
                                 shape: BoxShape.circle,
@@ -3932,7 +3868,6 @@ class _DesktopProviderDetailPaneState
         bool detecting = false;
         String? testingKeyId;
         StateSetter? setDRef;
-
         Future<void> pickDetectModel(BuildContext dctx) async {
           final sel = await showModelSelector(
             dctx,
@@ -4588,12 +4523,10 @@ class _DesktopProviderDetailPaneState
   }
 
   // Replaced with desktop centered dialog: showModelFetchDialog
-
   // Future<void> _showGetModelsDialog(BuildContext context) async {
   //   // For now this acts similar to Detect, but kept separate per spec.
   //   return _showDetectModelsDialog(context);
   // }
-
   Future<void> _createModel(BuildContext context) async {
     final res = await showDesktopCreateModelDialog(
       context,
@@ -4680,7 +4613,7 @@ class _DesktopProviderDetailPaneState
             break;
           case _TestState.success:
             message = l10n.providerDetailPageTestSuccessMessage;
-            color = Colors.green;
+            color = context.appColors.success;
             break;
           case _TestState.error:
             message = errorMessage.isNotEmpty ? errorMessage : 'Error';
@@ -4749,9 +4682,7 @@ class _DesktopProviderDetailPaneState
                               vertical: 10,
                             ),
                             decoration: BoxDecoration(
-                              color: Theme.of(ctx).brightness == Brightness.dark
-                                  ? Colors.white10
-                                  : const Color(0xFFF7F7F9),
+                              color: ctx.appColors.surfaceFill,
                               borderRadius: BorderRadius.circular(12),
                               border: Border.all(
                                 color: cs.outlineVariant.withValues(
@@ -5024,7 +4955,6 @@ class _DesktopProviderDetailPaneState
     );
     if (ok != true) return;
     if (!mounted) return;
-
     final sp = context.read<SettingsProvider>();
     final assistantProvider = context.read<AssistantProvider>();
     final deletedCount = await sp.deleteModels(
@@ -5160,10 +5090,8 @@ class _DesktopProviderDetailPaneState
 
   Future<void> _startDetection() async {
     if (_selectedModels.isEmpty || _isDetecting) return;
-
     final modelsToTest = Set<String>.from(_selectedModels);
     final detectionEpoch = _providerScopedStateEpoch;
-
     setState(() {
       _isDetecting = true;
       _detectionResults.removeWhere((id, _) => modelsToTest.contains(id));
@@ -5172,13 +5100,11 @@ class _DesktopProviderDetailPaneState
       _pendingModels.addAll(modelsToTest);
       _currentDetectingModel = null;
     });
-
     final sp = context.read<SettingsProvider>();
     final cfg = sp.getProviderConfig(
       widget.providerKey,
       defaultName: widget.displayName,
     );
-
     for (final modelId in modelsToTest) {
       if (!mounted || detectionEpoch != _providerScopedStateEpoch) return;
       if (mounted) {
@@ -5187,7 +5113,6 @@ class _DesktopProviderDetailPaneState
           _pendingModels.remove(modelId);
         });
       }
-
       try {
         await ProviderManager.testConnection(
           cfg,
@@ -5210,7 +5135,6 @@ class _DesktopProviderDetailPaneState
       }
       await Future.delayed(const Duration(milliseconds: 500));
     }
-
     if (mounted && detectionEpoch == _providerScopedStateEpoch) {
       setState(() {
         _isDetecting = false;
@@ -5237,7 +5161,6 @@ class _ProviderTypeDropdownState extends State<_ProviderTypeDropdown> {
   final GlobalKey _key = GlobalKey();
   final LayerLink _link = LayerLink();
   OverlayEntry? _entry;
-
   void _close() {
     _entry?.remove();
     _entry = null;
@@ -5271,7 +5194,7 @@ class _ProviderTypeDropdownState extends State<_ProviderTypeDropdown> {
                     listen: false,
                   ).usePureBackground)
                   ? (isDark ? Colors.black : Colors.white)
-                  : (isDark ? const Color(0xFF1C1C1E) : Colors.white),
+                  : ctx.appColors.surfaceCard,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: cs.outlineVariant.withValues(alpha: 0.12),
@@ -5373,7 +5296,6 @@ class _StrategyDropdownState extends State<_StrategyDropdown> {
   final GlobalKey _key = GlobalKey();
   final LayerLink _link = LayerLink();
   OverlayEntry? _entry;
-
   void _close() {
     _entry?.remove();
     _entry = null;
@@ -5425,7 +5347,7 @@ class _StrategyDropdownState extends State<_StrategyDropdown> {
                           listen: false,
                         ).usePureBackground)
                         ? (isDark ? Colors.black : Colors.white)
-                        : (isDark ? const Color(0xFF1C1C1E) : Colors.white),
+                        : ctx.appColors.surfaceCard,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: cs.outlineVariant.withValues(alpha: 0.12),
@@ -5511,10 +5433,7 @@ class _GreyCapsule extends StatelessWidget {
   final String label;
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : const Color(0xFFF2F3F5);
+    final bg = context.appColors.surfaceFill;
     final fg = Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.85);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
@@ -5557,9 +5476,7 @@ class _IconBtnState extends State<_IconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -5609,9 +5526,7 @@ class _IconTextBtnState extends State<_IconTextBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -5648,7 +5563,6 @@ class _IconTextBtnState extends State<_IconTextBtn> {
 
 class _DesktopProviderGroupsDialog extends StatefulWidget {
   const _DesktopProviderGroupsDialog();
-
   @override
   State<_DesktopProviderGroupsDialog> createState() =>
       _DesktopProviderGroupsDialogState();
@@ -5666,7 +5580,7 @@ class _DesktopProviderGroupsDialogState
     final controller = TextEditingController(text: initialText);
     final ok = await showDialog<bool>(
       context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.12),
+      barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.12),
       builder: (ctx) => AlertDialog(
         title: Text(title),
         content: TextField(
@@ -5731,9 +5645,10 @@ class _DesktopProviderGroupsDialogState
   Future<void> _deleteGroup(BuildContext context, String groupId) async {
     final sp = context.read<SettingsProvider>();
     final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
     final ok = await showDialog<bool>(
       context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.12),
+      barrierColor: cs.scrim.withValues(alpha: 0.12),
       builder: (ctx) => AlertDialog(
         title: Text(l10n.providerGroupsDeleteConfirmTitle),
         content: Text(l10n.providerGroupsDeleteConfirmContent),
@@ -5746,7 +5661,7 @@ class _DesktopProviderGroupsDialogState
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(
               l10n.providerGroupsDeleteConfirmOk,
-              style: TextStyle(color: Colors.red),
+              style: TextStyle(color: cs.error),
             ),
           ),
         ],
@@ -5768,7 +5683,6 @@ class _DesktopProviderGroupsDialogState
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final groups = sp.providerGroups;
-
     final counts = <String, int>{};
     int ungroupedCount = 0;
     for (final k in sp.providersOrder) {
@@ -5796,7 +5710,6 @@ class _DesktopProviderGroupsDialogState
           isUngrouped: key == SettingsProvider.providerUngroupedGroupKey,
         ),
     ];
-
     return Dialog(
       backgroundColor: cs.surface,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
@@ -5916,18 +5829,16 @@ class _DesktopProviderGroupCard extends StatelessWidget {
     this.onDelete,
     required this.dragHandle,
   });
-
   final String title;
   final int count;
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
   final Widget dragHandle;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final bg = context.appColors.surfaceFill;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.12 : 0.10,
     );
@@ -5977,7 +5888,6 @@ class _DesktopProviderGroupCard extends StatelessWidget {
 class _DesktopCountPill extends StatelessWidget {
   const _DesktopCountPill({required this.count});
   final int count;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -6002,22 +5912,18 @@ class _DesktopCountPill extends StatelessWidget {
 
 class _DesktopDragHandle extends StatefulWidget {
   const _DesktopDragHandle();
-
   @override
   State<_DesktopDragHandle> createState() => _DesktopDragHandleState();
 }
 
 class _DesktopDragHandleState extends State<_DesktopDragHandle> {
   bool _hover = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       cursor: SystemMouseCursors.grab,
@@ -6048,7 +5954,6 @@ class _DesktopProviderShareDialog extends StatefulWidget {
   });
   final String providerKey;
   final String displayName;
-
   @override
   State<_DesktopProviderShareDialog> createState() =>
       _DesktopProviderShareDialogState();
@@ -6059,7 +5964,6 @@ class _DesktopProviderShareDialogState
   late final String _code;
   final GlobalKey _qrKey = GlobalKey();
   bool _copyingQr = false;
-
   @override
   void initState() {
     super.initState();
@@ -6106,7 +6010,6 @@ class _DesktopProviderShareDialogState
         return true;
       }
     } catch (_) {}
-
     try {
       final file = File(
         p.join(Directory.systemTemp.path, 'kelivo-provider-qr.png'),
@@ -6280,7 +6183,6 @@ class _DialogActionButton extends StatefulWidget {
   final String label;
   final VoidCallback? onTap;
   final bool filled;
-
   @override
   State<_DialogActionButton> createState() => _DialogActionButtonState();
 }
@@ -6288,7 +6190,6 @@ class _DialogActionButton extends StatefulWidget {
 class _DialogActionButtonState extends State<_DialogActionButton> {
   bool _hover = false;
   bool _pressed = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -6306,7 +6207,6 @@ class _DialogActionButtonState extends State<_DialogActionButton> {
         ? cs.primary.withValues(alpha: isDark ? 0.30 : 0.25)
         : cs.primary.withValues(alpha: 0.35);
     final fg = widget.filled ? cs.onPrimary : cs.primary;
-
     return MouseRegion(
       cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
       onEnter: (_) => setState(() => _hover = true),
@@ -6396,6 +6296,7 @@ class _BrandCircle extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.10),
         shape: BoxShape.circle,
       ),
@@ -6434,10 +6335,13 @@ class _ProviderListRowState extends State<_ProviderListRow> {
   bool _hover = false;
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final hoverBg = _hover && !widget.selected
-        ? Theme.of(context).brightness == Brightness.dark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04)
+        ? cs.onSurface.withValues(
+            alpha: Theme.of(context).brightness == Brightness.dark
+                ? 0.06
+                : 0.04,
+          )
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -6508,8 +6412,9 @@ class _ProviderListRowState extends State<_ProviderListRow> {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                 decoration: BoxDecoration(
-                  color: (widget.enabled ? Colors.green : Colors.orange)
-                      .withValues(alpha: 0.12),
+                  color: widget.enabled
+                      ? context.appColors.successContainer
+                      : context.appColors.warningContainer,
                   borderRadius: BorderRadius.circular(999),
                   // No border for left list status
                 ),
@@ -6521,7 +6426,9 @@ class _ProviderListRowState extends State<_ProviderListRow> {
                         )!.providersPageDisabledStatus,
                   style: TextStyle(
                     fontSize: 11,
-                    color: widget.enabled ? Colors.green : Colors.orange,
+                    color: widget.enabled
+                        ? context.appColors.success
+                        : context.appColors.warning,
                     fontWeight: AppFontWeights.emphasis,
                   ),
                 ),
@@ -6554,12 +6461,8 @@ class _AddFullWidthButtonState extends State<_AddFullWidthButton> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.04);
-    final hoverBg = isDark
-        ? Colors.white.withValues(alpha: 0.10)
-        : Colors.black.withValues(alpha: 0.06);
+    final baseBg = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04);
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.10 : 0.06);
     final bg = _hover ? hoverBg : baseBg;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -6615,10 +6518,7 @@ class _DesktopIosSectionCard extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final Color base = cs.surface;
-    final Color bg = isDark
-        ? Color.lerp(base, Colors.white, 0.06)!
-        : const Color(0xFFF7F7F9);
+    final Color bg = context.appColors.surfaceFill;
     return Container(
       decoration: BoxDecoration(
         color: bg,
@@ -6667,7 +6567,7 @@ class _DesktopKeyRow extends StatelessWidget {
     Color statusColor(ApiKeyStatus st) {
       switch (st) {
         case ApiKeyStatus.active:
-          return Colors.green;
+          return context.appColors.success;
         case ApiKeyStatus.disabled:
           return cs.onSurface.withValues(alpha: 0.6);
         case ApiKeyStatus.error:
@@ -6948,7 +6848,6 @@ class _ModelRow extends StatelessWidget {
         baseId = apiId;
       }
     }
-
     ModelInfo effective() {
       final base = infer(baseId);
       if (ov == null) return base;
@@ -6968,7 +6867,6 @@ class _ModelRow extends StatelessWidget {
     } else {
       displayName = baseId;
     }
-
     return GestureDetector(
       onTap: isSelectionMode
           ? () => onSelectionChanged?.call(!isSelected)
@@ -7034,7 +6932,9 @@ class _ModelRow extends StatelessWidget {
                         ? lucide.Lucide.CheckCircle
                         : lucide.Lucide.XCircle,
                     size: 16,
-                    color: detectionResult! ? Colors.green : cs.error,
+                    color: detectionResult!
+                        ? context.appColors.success
+                        : cs.error,
                   ),
                 ),
               ),
@@ -7091,10 +6991,8 @@ class _ModelRow extends StatelessWidget {
 /// Desktop collapsible header row for the custom request section.
 class _CustomRequestHeaderRow extends StatelessWidget {
   const _CustomRequestHeaderRow({required this.expanded, required this.onTap});
-
   final bool expanded;
   final VoidCallback onTap;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -7132,12 +7030,10 @@ class _DesktopCustomRequestSection extends StatelessWidget {
     required this.mode,
     required this.entries,
   });
-
   final String providerKey;
   final String displayName;
   final KeyMode mode;
   final List<Map<String, String>> entries;
-
   Future<void> _save(
     BuildContext context,
     List<Map<String, String>> updated,
@@ -7206,11 +7102,10 @@ class _CardPressState extends State<_CardPress> {
   bool _pressed = false;
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final overlay = _pressed
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -7237,11 +7132,7 @@ class _CardPressState extends State<_CardPress> {
     );
   }
 }
-
 // Removed embedded default model pane; now in setting/default_model_pane.dart
-
 // Removed default model prompt dialogs; migrated to setting/default_model_pane.dart
-
 // Removed embedded default model card; now in setting/default_model_pane.dart
-
 // ===== Display Settings Body =====

--- a/lib/desktop/setting/quick_phrases_pane.dart
+++ b/lib/desktop/setting/quick_phrases_pane.dart
@@ -7,6 +7,7 @@ import '../../l10n/app_localizations.dart';
 import '../../core/models/quick_phrase.dart';
 import '../../core/providers/quick_phrase_provider.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopQuickPhrasesPane extends StatefulWidget {
   const DesktopQuickPhrasesPane({super.key});
@@ -194,9 +195,7 @@ class _QuickPhraseCardState extends State<_QuickPhraseCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -382,9 +381,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -435,9 +432,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -483,12 +478,11 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: false,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(12),
       borderSide: BorderSide(

--- a/lib/desktop/setting/search_services_pane.dart
+++ b/lib/desktop/setting/search_services_pane.dart
@@ -12,6 +12,7 @@ import 'package:intl/intl.dart';
 import 'package:uuid/uuid.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopSearchServicesPane extends StatefulWidget {
   const DesktopSearchServicesPane({super.key});
@@ -22,7 +23,6 @@ class DesktopSearchServicesPane extends StatefulWidget {
 
 class _DesktopSearchServicesPaneState extends State<DesktopSearchServicesPane> {
   final Map<String, bool> _testing = <String, bool>{};
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -34,7 +34,6 @@ class _DesktopSearchServicesPaneState extends State<DesktopSearchServicesPane> {
       services.isNotEmpty ? services.length - 1 : 0,
     );
     final common = settings.searchCommonOptions;
-
     return Container(
       alignment: Alignment.topCenter,
       child: Padding(
@@ -81,7 +80,6 @@ class _DesktopSearchServicesPaneState extends State<DesktopSearchServicesPane> {
                 ),
               ),
               const SliverToBoxAdapter(child: SizedBox(height: 8)),
-
               SliverReorderableList(
                 itemCount: services.length,
                 itemBuilder: (context, index) {
@@ -161,7 +159,6 @@ class _DesktopSearchServicesPaneState extends State<DesktopSearchServicesPane> {
                   }
                 },
               ),
-
               const SliverToBoxAdapter(child: SizedBox(height: 16)),
               SliverToBoxAdapter(
                 child: _sectionCard(
@@ -246,7 +243,6 @@ class _DesktopSearchServicesPaneState extends State<DesktopSearchServicesPane> {
   }
 
   // list height helper removed after switching to sliver-based list
-
   Future<void> _testConnection(
     BuildContext context,
     SearchServiceOptions s,
@@ -297,13 +293,10 @@ class _ServiceCardState extends State<_ServiceCard> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final name = SearchService.getService(widget.service).name;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover || widget.selected
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
-
     // Connection/testing status capsule
     final l10n = AppLocalizations.of(context)!;
     final conn = context
@@ -318,18 +311,17 @@ class _ServiceCardState extends State<_ServiceCard> {
       statusFg = cs.primary;
     } else if (conn == true) {
       statusText = l10n.searchServicesPageConnectedStatus;
-      statusBg = Colors.green.withValues(alpha: 0.12);
-      statusFg = Colors.green;
+      statusBg = context.appColors.successContainer;
+      statusFg = context.appColors.success;
     } else if (conn == false) {
       statusText = l10n.searchServicesPageFailedStatus;
-      statusBg = Colors.orange.withValues(alpha: 0.12);
-      statusFg = Colors.orange;
+      statusBg = context.appColors.warningContainer;
+      statusFg = context.appColors.warning;
     } else {
       statusText = l10n.searchServicesPageNotTestedStatus;
       statusBg = cs.onSurface.withValues(alpha: 0.06);
       statusFg = cs.onSurface.withValues(alpha: 0.7);
     }
-
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
       onExit: (_) => setState(() => _hover = false),
@@ -423,7 +415,6 @@ class _ToggleRow extends StatelessWidget {
   final String label;
   final bool value;
   final ValueChanged<bool> onChanged;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -546,9 +537,7 @@ class _StepperButtonState extends State<_StepperButton> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final base = Colors.transparent;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.10)
-              : Colors.black.withValues(alpha: 0.07))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.10 : 0.07)
         : base;
     final c = widget.enabled
         ? cs.onSurface
@@ -628,6 +617,7 @@ class _BrandBadge extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final asset = BrandAssets.assetForName(name);
+    // color-gate: ignore
     final bg = isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1);
     if (asset != null) {
       if (asset.endsWith('.svg')) {
@@ -689,9 +679,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -719,9 +707,7 @@ Widget _sectionCard({required List<Widget> children}) {
     builder: (context) {
       final cs = Theme.of(context).colorScheme;
       final isDark = Theme.of(context).brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -753,7 +739,6 @@ Widget _divider(BuildContext context) {
 }
 
 // ===== Dialogs =====
-
 Future<SearchServiceOptions?> _showAddServiceDialog(
   BuildContext context,
 ) async {
@@ -816,7 +801,6 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
     'includeDomains': TextEditingController(),
     'excludeDomains': TextEditingController(),
   };
-
   @override
   void dispose() {
     for (final c in _controllers.values) {
@@ -1199,7 +1183,6 @@ class _AddServiceDialogState extends State<_AddServiceDialog> {
 
   SearchServiceOptions _createService() {
     final id = const Uuid().v4().substring(0, 8);
-
     List<ApiKeyConfig> makeKeys() {
       final key = _controllers['apiKey']?.text;
       if (key == null || key.isEmpty) return [];
@@ -1323,7 +1306,6 @@ class _EditServiceDialog extends StatefulWidget {
 class _EditServiceDialogState extends State<_EditServiceDialog> {
   final Map<String, TextEditingController> _controllers = {};
   late List<ApiKeyConfig> _editKeys;
-
   @override
   void initState() {
     super.initState();
@@ -1478,9 +1460,7 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
     final s = widget.service;
     InputDecoration deco(String hint) =>
         _deskInputDecoration(context).copyWith(hintText: hint);
-
     final fields = <Widget>[];
-
     if (s is TavilyOptions) {
       fields.addAll([
         TextField(
@@ -1697,7 +1677,6 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
         ),
       ]);
     }
-
     if (SearchService.serviceUsesKeys(s)) {
       if (fields.isNotEmpty) fields.add(const SizedBox(height: 12));
       fields.addAll(_buildKeyManagement());
@@ -1723,7 +1702,6 @@ class _EditServiceDialogState extends State<_EditServiceDialog> {
   List<Widget> _buildKeyManagement() {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-
     final rows = <Widget>[];
     for (int i = 0; i < _editKeys.length; i++) {
       final k = _editKeys[i];
@@ -2321,7 +2299,7 @@ class _ServiceTypeChipsState extends State<_ServiceTypeChips> {
         final name = _serviceTypeName(context, it.type);
         final bg = selected
             ? cs.primary.withValues(alpha: isDark ? 0.18 : 0.12)
-            : (isDark ? Colors.white12 : const Color(0xFFF7F7F9));
+            : context.appColors.surfaceFill;
         final fg = selected ? cs.primary : cs.onSurface.withValues(alpha: 0.85);
         return GestureDetector(
           onTap: () => widget.onChanged(it.type),
@@ -2423,7 +2401,6 @@ class _ServiceTypeDropdownState extends State<_ServiceTypeDropdown> {
   final GlobalKey _key = GlobalKey();
   static const List<({String type, String brand})> _types =
       _ServiceTypeChipsState._types;
-
   void _toggle() {
     _open ? _close() : _openOverlay();
   }
@@ -2468,9 +2445,7 @@ class _ServiceTypeDropdownState extends State<_ServiceTypeDropdown> {
                     borderRadius: BorderRadius.circular(12),
                     child: Container(
                       decoration: BoxDecoration(
-                        color: Theme.of(ctx).brightness == Brightness.dark
-                            ? const Color(0xFF1C1C1E)
-                            : Colors.white,
+                        color: ctx.appColors.surfaceCard,
                         border: Border.all(
                           color: cs.outlineVariant.withValues(alpha: 0.12),
                           width: 0.5,
@@ -2542,15 +2517,12 @@ class _ServiceTypeDropdownState extends State<_ServiceTypeDropdown> {
         orElse: () => _types.first,
       )
       .brand;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover || _open
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     return CompositedTransformTarget(
       link: _link,
@@ -2629,9 +2601,7 @@ class _DropdownItemState extends State<_DropdownItem> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.08)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -2701,9 +2671,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -2749,12 +2717,11 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: false,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(12),
       borderSide: BorderSide(

--- a/lib/desktop/setting/tts_services_pane.dart
+++ b/lib/desktop/setting/tts_services_pane.dart
@@ -15,6 +15,7 @@ import '../../features/settings/widgets/voice_service_widgets.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 /// Desktop: TTS (语音服务) right-side pane
 /// Adapts mobile TTS page to desktop with hoverable list card style
@@ -168,7 +169,7 @@ class _NetworkServiceCardState extends State<_NetworkServiceCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = _appSurfaceCard(cs);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover || widget.selected
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -469,7 +470,7 @@ class _SystemTtsCardState extends State<_SystemTtsCard> {
     final l10n = AppLocalizations.of(context)!;
     final tts = context.watch<TtsProvider>();
 
-    final baseBg = _appSurfaceCard(cs);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -2062,17 +2063,4 @@ class _InputRow extends StatelessWidget {
       ),
     );
   }
-}
-
-Color _appSurfaceCard(ColorScheme cs) {
-  final isDark = cs.brightness == Brightness.dark;
-  return isDark
-      ? Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.10),
-          cs.surface,
-        )
-      : Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.96),
-          cs.surface,
-        );
 }

--- a/lib/desktop/setting/world_book_pane.dart
+++ b/lib/desktop/setting/world_book_pane.dart
@@ -15,6 +15,7 @@ import '../../shared/widgets/ios_switch.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../widgets/desktop_select_dropdown.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 class DesktopWorldBookPane extends StatefulWidget {
   const DesktopWorldBookPane({super.key});
@@ -254,7 +255,7 @@ class _DesktopWorldBookPaneState extends State<DesktopWorldBookPane> {
               onPressed: () => Navigator.of(ctx).pop(true),
               child: Text(
                 l10n.worldBookDelete,
-                style: TextStyle(color: Colors.red),
+                style: TextStyle(color: Theme.of(ctx).colorScheme.error),
               ),
             ),
           ],
@@ -466,9 +467,7 @@ class _WorldBookCardState extends State<_WorldBookCard> {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -630,9 +629,7 @@ class _EntriesPanel extends StatelessWidget {
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.16 : 0.12,
     );
-    final bg = isDark
-        ? Colors.white.withValues(alpha: 0.04)
-        : const Color(0xFFF8F8FA);
+    final bg = context.appColors.surfaceFill;
 
     if (entries.isEmpty) {
       return Container(
@@ -699,9 +696,7 @@ class _EntryRowState extends State<_EntryRow> {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final hoverBg = (isDark ? Colors.white : Colors.black).withValues(
-      alpha: isDark ? 0.08 : 0.04,
-    );
+    final hoverBg = cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04);
 
     final title = widget.entry.name.trim().isEmpty
         ? l10n.worldBookUnnamedEntry
@@ -1175,12 +1170,11 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
   }
 
   DesktopSelectDropdown<T> _formDropdown<T>({
-    required bool isDark,
     required T value,
     required List<DesktopSelectOption<T>> options,
     required ValueChanged<T> onSelected,
   }) {
-    final fillColor = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final fillColor = context.appColors.surfaceFill;
     return DesktopSelectDropdown<T>(
       value: value,
       options: options,
@@ -1404,7 +1398,6 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
                                   label:
                                       l10n.worldBookEntryInjectionPositionLabel,
                                   child: _formDropdown(
-                                    isDark: isDark,
                                     value: _position,
                                     options: positionOptions,
                                     onSelected: (v) =>
@@ -1429,7 +1422,6 @@ class _WorldBookEntryEditDialogState extends State<_WorldBookEntryEditDialog> {
                                   cs: cs,
                                   label: l10n.worldBookEntryInjectionRoleLabel,
                                   child: _formDropdown(
-                                    isDark: isDark,
                                     value: _role,
                                     options: roleOptions,
                                     onSelected: (v) =>
@@ -1557,9 +1549,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     final btn = MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -1614,9 +1604,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
     final bg = widget.filled
         ? (_hover ? cs.primary.withValues(alpha: 0.92) : cs.primary)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
               : Colors.transparent);
     final borderColor = widget.filled
         ? Colors.transparent
@@ -1662,12 +1650,11 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
 }
 
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: false,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     border: OutlineInputBorder(
       borderRadius: BorderRadius.circular(12),
       borderSide: BorderSide(

--- a/lib/desktop/user_profile_dialog.dart
+++ b/lib/desktop/user_profile_dialog.dart
@@ -14,13 +14,15 @@ import '../shared/widgets/emoji_picker_dialog.dart';
 import '../shared/widgets/snackbar.dart';
 import '../utils/sandbox_path_resolver.dart';
 import '../theme/app_font_weights.dart';
+import '../theme/app_semantic_colors.dart';
 
 Future<void> showUserProfileDialog(BuildContext context) async {
+  final cs = Theme.of(context).colorScheme;
   await showGeneralDialog<void>(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'user-profile-dialog',
-    barrierColor: Colors.black.withValues(alpha: 0.25),
+    barrierColor: cs.scrim.withValues(alpha: 0.25),
     pageBuilder: (ctx, _, __) {
       return const _UserProfileDialogBody();
     },
@@ -119,13 +121,13 @@ class _UserProfileDialogBodyState extends State<_UserProfileDialogBody> {
       child: ConstrainedBox(
         constraints: const BoxConstraints(minWidth: 320, maxWidth: 420),
         child: Material(
-          color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+          color: context.appColors.surfaceCard,
           elevation: 0,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20),
             side: BorderSide(
               color: isDark
-                  ? Colors.white.withValues(alpha: 0.08)
+                  ? cs.onSurface.withValues(alpha: 0.08)
                   : cs.outlineVariant.withValues(alpha: 0.25),
               width: 1,
             ),
@@ -163,9 +165,7 @@ class _UserProfileDialogBodyState extends State<_UserProfileDialogBody> {
                             color: cs.primary,
                             shape: BoxShape.circle,
                             border: Border.all(
-                              color: isDark
-                                  ? const Color(0xFF1C1C1E)
-                                  : Colors.white,
+                              color: context.appColors.surfaceCard,
                               width: 2,
                             ),
                           ),
@@ -340,9 +340,7 @@ class _UserProfileDialogBodyState extends State<_UserProfileDialogBody> {
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerImageUrlDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),
@@ -464,9 +462,7 @@ class _UserProfileDialogBodyState extends State<_UserProfileDialogBody> {
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerQQAvatarInputHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),

--- a/lib/desktop/widgets/desktop_select_dropdown.dart
+++ b/lib/desktop/widgets/desktop_select_dropdown.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -94,7 +95,7 @@ class _DesktopSelectDropdownState<T> extends State<DesktopSelectDropdown<T>> {
     }
     final usePure = sp?.usePureBackground ?? false;
     if (usePure) return isDark ? Colors.black : Colors.white;
-    return isDark ? const Color(0xFF1C1C1E) : Colors.white;
+    return context.appColors.surfaceCard;
   }
 
   void _openMenu() {
@@ -143,16 +144,13 @@ class _DesktopSelectDropdownState<T> extends State<DesktopSelectDropdown<T>> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final label = _labelForValue(widget.value);
 
     final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
     final hoverBorder = cs.primary;
     final borderColor = _open || _hover ? hoverBorder : baseBorder;
 
-    final fillColor =
-        widget.triggerFillColor ??
-        (isDark ? const Color(0xFF141414) : Colors.white);
+    final fillColor = widget.triggerFillColor ?? context.appColors.surfaceCard;
 
     return CompositedTransformTarget(
       link: _link,
@@ -362,9 +360,7 @@ class _DesktopSelectOptionTileState extends State<_DesktopSelectOptionTile> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.12)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/desktop/widgets/preset_dropdown.dart
+++ b/lib/desktop/widgets/preset_dropdown.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -101,7 +102,7 @@ class _PresetDropdownState<T> extends State<PresetDropdown<T>> {
     }
     final usePure = sp?.usePureBackground ?? false;
     if (usePure) return isDark ? Colors.black : Colors.white;
-    return isDark ? const Color(0xFF1C1C1E) : Colors.white;
+    return context.appColors.surfaceCard;
   }
 
   void _openMenu() {
@@ -150,16 +151,13 @@ class _PresetDropdownState<T> extends State<PresetDropdown<T>> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final label = _labelForValue(widget.value);
 
     final baseBorder = cs.outlineVariant.withValues(alpha: 0.18);
     final hoverBorder = cs.primary;
     final borderColor = _open || _hover ? hoverBorder : baseBorder;
 
-    final fillColor =
-        widget.triggerFillColor ??
-        (isDark ? const Color(0xFF141414) : Colors.white);
+    final fillColor = widget.triggerFillColor ?? context.appColors.surfaceCard;
 
     return CompositedTransformTarget(
       link: _link,
@@ -357,9 +355,7 @@ class _DesktopSelectOptionTileState extends State<_DesktopSelectOptionTile> {
     final bg = widget.selected
         ? cs.primary.withValues(alpha: 0.12)
         : (_hover
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.04))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.04)
               : Colors.transparent);
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/features/assistant/pages/assistant_regex_tab.dart
+++ b/lib/features/assistant/pages/assistant_regex_tab.dart
@@ -1,9 +1,7 @@
 import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
-
 import '../../../core/models/assistant_regex.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -13,11 +11,11 @@ import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../core/services/haptics.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class AssistantRegexTab extends StatefulWidget {
   const AssistantRegexTab({super.key, required this.assistantId});
   final String assistantId;
-
   @override
   State<AssistantRegexTab> createState() => _AssistantRegexTabState();
 }
@@ -103,7 +101,6 @@ class _AssistantRegexTabState extends State<AssistantRegexTab> {
     );
     if (assistant == null) return const SizedBox.shrink();
     final rules = assistant.regexRules;
-
     if (rules.isEmpty) {
       return Center(
         child: Padding(
@@ -132,6 +129,7 @@ class _AssistantRegexTabState extends State<AssistantRegexTab> {
                   onTap: () => _addOrEdit(),
                   borderRadius: BorderRadius.circular(12),
                   baseColor: isDark
+                      // color-gate: ignore
                       ? Colors.white10
                       : cs.primary.withValues(alpha: 0.12),
                   pressedBlendStrength: 0.18,
@@ -161,7 +159,6 @@ class _AssistantRegexTabState extends State<AssistantRegexTab> {
         ),
       );
     }
-
     return Stack(
       children: [
         ReorderableListView.builder(
@@ -218,7 +215,6 @@ class _AssistantRegexTabState extends State<AssistantRegexTab> {
 class AssistantRegexDesktopPane extends StatefulWidget {
   const AssistantRegexDesktopPane({super.key, required this.assistantId});
   final String assistantId;
-
   @override
   State<AssistantRegexDesktopPane> createState() =>
       _AssistantRegexDesktopPaneState();
@@ -305,7 +301,6 @@ class _AssistantRegexDesktopPaneState extends State<AssistantRegexDesktopPane> {
     );
     if (assistant == null) return const SizedBox.shrink();
     final rules = assistant.regexRules;
-
     return Container(
       alignment: Alignment.topCenter,
       child: Column(
@@ -341,6 +336,7 @@ class _AssistantRegexDesktopPaneState extends State<AssistantRegexDesktopPane> {
                   onTap: () => _addOrEdit(),
                   borderRadius: BorderRadius.circular(12),
                   baseColor: isDark
+                      // color-gate: ignore
                       ? Colors.white10
                       : cs.primary.withValues(alpha: 0.12),
                   padding: const EdgeInsets.symmetric(
@@ -430,33 +426,29 @@ class _RegexRuleCard extends StatefulWidget {
     required this.onToggle,
     required this.desktop,
   });
-
   final AssistantRegex rule;
   final VoidCallback onTap;
   final VoidCallback onDelete;
   final ValueChanged<bool> onToggle;
   final bool desktop;
-
   @override
   State<_RegexRuleCard> createState() => _RegexRuleCardState();
 }
 
 class _RegexRuleCardState extends State<_RegexRuleCard> {
   bool _hovered = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
     final borderBase = cs.outlineVariant.withValues(
       alpha: isDark ? 0.08 : 0.06,
     );
     final borderColor = widget.desktop && _hovered
         ? cs.primary.withValues(alpha: 0.55)
         : borderBase;
-
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
       onExit: (_) => setState(() => _hovered = false),
@@ -594,7 +586,6 @@ class _GlassCircleButton extends StatefulWidget {
   final IconData icon;
   final Color color;
   final VoidCallback onTap;
-
   @override
   State<_GlassCircleButton> createState() => _GlassCircleButtonState();
 }
@@ -609,20 +600,16 @@ class _GlassCircleButtonState extends State<_GlassCircleButton> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;
     final borderColor = cs.outlineVariant.withValues(alpha: 0.10);
-
     final child = SizedBox(
       width: 48,
       height: 48,
       child: Center(child: Icon(widget.icon, size: 18, color: widget.color)),
     );
-
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown: (_) => setState(() => _pressed = true),
@@ -698,7 +685,6 @@ Future<_RegexFormData?> _showRegexBottomSheet(
   };
   bool visualOnly = rule?.visualOnly ?? false;
   bool replaceOnly = rule?.replaceOnly ?? false;
-
   final result = await showModalBottomSheet<_RegexFormData>(
     context: context,
     isScrollControlled: true,
@@ -932,7 +918,6 @@ Future<_RegexFormData?> _showRegexDialog(
   };
   bool visualOnly = rule?.visualOnly ?? false;
   bool replaceOnly = rule?.replaceOnly ?? false;
-
   final result = await showDialog<_RegexFormData>(
     context: context,
     barrierDismissible: true,
@@ -1166,7 +1151,6 @@ Future<_RegexFormData?> _showRegexDialog(
       );
     },
   );
-
   nameCtrl.dispose();
   patternCtrl.dispose();
   replacementCtrl.dispose();
@@ -1180,16 +1164,13 @@ class _RegexTextField extends StatelessWidget {
     this.autofocus = false,
     this.multiline = false,
   });
-
   final TextEditingController controller;
   final String label;
   final bool autofocus;
   final bool multiline;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return TextField(
       controller: controller,
       autofocus: autofocus,
@@ -1202,7 +1183,7 @@ class _RegexTextField extends StatelessWidget {
       decoration: InputDecoration(
         labelText: label,
         filled: true,
-        fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+        fillColor: context.appColors.surfaceFill,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(12),
           borderSide: BorderSide(
@@ -1225,26 +1206,23 @@ class _ScopeChoiceCard extends StatefulWidget {
     required this.onTap,
     required this.desktop,
   });
-
   final String label;
   final bool selected;
   final VoidCallback onTap;
   final bool desktop;
-
   @override
   State<_ScopeChoiceCard> createState() => _ScopeChoiceCardState();
 }
 
 class _ScopeChoiceCardState extends State<_ScopeChoiceCard> {
   bool _hovered = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final base = widget.selected
         ? cs.primary.withValues(alpha: 0.16)
-        : (isDark ? Colors.white10 : const Color(0xFFF2F3F5));
+        : context.appColors.surfaceFill;
     final borderBase = widget.selected
         ? cs.primary.withValues(alpha: 0.55)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.14 : 0.12);
@@ -1252,7 +1230,6 @@ class _ScopeChoiceCardState extends State<_ScopeChoiceCard> {
     final fg = widget.selected
         ? cs.primary
         : cs.onSurface.withValues(alpha: 0.8);
-
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       onEnter: (_) => setState(() => _hovered = true),

--- a/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_basic_tab.dart
@@ -3,7 +3,6 @@ part of 'assistant_settings_edit_page.dart';
 class _BasicSettingsTab extends StatefulWidget {
   const _BasicSettingsTab({required this.assistantId});
   final String assistantId;
-
   @override
   State<_BasicSettingsTab> createState() => _BasicSettingsTabState();
 }
@@ -16,7 +15,6 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
   late final TextEditingController _handoffIdCtrl;
   late final TextEditingController _handoffDescCtrl;
   String? _handoffIdError;
-
   @override
   void initState() {
     super.initState();
@@ -65,7 +63,6 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final ap = context.watch<AssistantProvider>();
     final a = ap.getById(widget.assistantId)!;
-
     Widget avatarWidget({double size = 56}) {
       final bg = cs.primary.withValues(alpha: isDark ? 0.18 : 0.12);
       Widget inner;
@@ -145,9 +142,7 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
         // Identity card (avatar + name) - iOS style
         Container(
           decoration: BoxDecoration(
-            color: isDark
-                ? Colors.white10
-                : Colors.white.withValues(alpha: 0.96),
+            color: context.appColors.surfaceCard,
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
               color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -174,7 +169,6 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
           ),
         ),
         const SizedBox(height: 16),
-
         // iOS section card with all settings (without Use Assistant Avatar and Stream Output)
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 0),
@@ -284,13 +278,10 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
           ),
         ),
         const SizedBox(height: 16),
-
         // Chat model card (moved down, styled like DefaultModelPage)
         Container(
           decoration: BoxDecoration(
-            color: isDark
-                ? Colors.white10
-                : Colors.white.withValues(alpha: 0.96),
+            color: context.appColors.surfaceCard,
             borderRadius: BorderRadius.circular(16),
             border: Border.all(
               color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -362,12 +353,10 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                   },
                   pressedScale: 0.98,
                   builder: (pressed) {
-                    final bg = isDark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5);
-                    final overlay = isDark
-                        ? Colors.white.withValues(alpha: 0.06)
-                        : Colors.black.withValues(alpha: 0.05);
+                    final bg = context.appColors.surfaceFill;
+                    final overlay = cs.onSurface.withValues(
+                      alpha: isDark ? 0.06 : 0.05,
+                    );
                     final pressedBg = Color.alphaBlend(overlay, bg);
                     final l10n = AppLocalizations.of(context)!;
                     final settings = context.read<SettingsProvider>();
@@ -424,13 +413,10 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
           ),
         ),
         const SizedBox(height: 16),
-
         // Chat background (separate iOS card)
         Container(
           decoration: BoxDecoration(
-            color: isDark
-                ? Colors.white10
-                : Colors.white.withValues(alpha: 0.96),
+            color: context.appColors.surfaceCard,
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
               color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -472,12 +458,10 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                     onTap: () => _pickBackground(context, a),
                     pressedScale: 0.98,
                     builder: (pressed) {
-                      final bg = isDark
-                          ? Colors.white10
-                          : const Color(0xFFF2F3F5);
-                      final overlay = isDark
-                          ? Colors.white.withValues(alpha: 0.06)
-                          : Colors.black.withValues(alpha: 0.05);
+                      final bg = context.appColors.surfaceFill;
+                      final overlay = cs.onSurface.withValues(
+                        alpha: isDark ? 0.06 : 0.05,
+                      );
                       final pressedBg = Color.alphaBlend(overlay, bg);
                       final iconColor = cs.onSurface.withValues(alpha: 0.75);
                       final textColor = cs.onSurface.withValues(alpha: 0.9);
@@ -596,9 +580,7 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                         hintText: 'research-bot',
                         errorText: _handoffIdError,
                         filled: true,
-                        fillColor: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: context.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(
@@ -665,9 +647,7 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                       decoration: InputDecoration(
                         hintText: l10n.assistantEditHandoffDescription,
                         filled: true,
-                        fillColor: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: context.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(
@@ -1266,9 +1246,7 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
                   decoration: InputDecoration(
                     hintText: l10n.assistantEditMaxTokensHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
@@ -1309,14 +1287,12 @@ class _BasicSettingsTabState extends State<_BasicSettingsTab> {
 class _BackgroundPreview extends StatefulWidget {
   const _BackgroundPreview({required this.path});
   final String path;
-
   @override
   State<_BackgroundPreview> createState() => _BackgroundPreviewState();
 }
 
 class _BackgroundPreviewState extends State<_BackgroundPreview> {
   Size? _size;
-
   @override
   void initState() {
     super.initState();
@@ -1401,7 +1377,6 @@ class _SliderTileNew extends StatelessWidget {
     this.customLabelStops,
     this.onLabelTap,
   });
-
   final double value;
   final double min;
   final double max;
@@ -1410,7 +1385,6 @@ class _SliderTileNew extends StatelessWidget {
   final ValueChanged<double> onChanged;
   final List<double>? customLabelStops;
   final VoidCallback? onLabelTap;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -1422,7 +1396,6 @@ class _SliderTileNew extends StatelessWidget {
         ? (customLabelStops!.where((v) => v >= min && v <= max).toSet().toList()
             ..sort())
         : const <double>[];
-
     final active = cs.primary;
     final inactive = cs.onSurface.withValues(alpha: isDark ? 0.25 : 0.20);
     final double clamped = value.clamp(min, max);
@@ -1449,7 +1422,6 @@ class _SliderTileNew extends StatelessWidget {
       if (minor < 0) minor = 0;
       if (minor > 8) minor = 8;
     }
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1591,6 +1563,7 @@ class _ValuePill extends StatelessWidget {
           : HitTestBehavior.deferToChild,
       child: DecoratedBox(
         decoration: BoxDecoration(
+          // color-gate: ignore
           color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.10),
           borderRadius: BorderRadius.circular(10),
           border: Border.all(
@@ -1792,9 +1765,7 @@ extension _AssistantAvatarActions on _BasicSettingsTabState {
                       decoration: InputDecoration(
                         hintText: l10n.assistantEditEmojiDialogHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(color: Colors.transparent),
@@ -1903,9 +1874,7 @@ extension _AssistantAvatarActions on _BasicSettingsTabState {
                 decoration: InputDecoration(
                   hintText: l10n.assistantEditImageUrlDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),
@@ -2027,9 +1996,7 @@ extension _AssistantAvatarActions on _BasicSettingsTabState {
                 decoration: InputDecoration(
                   hintText: l10n.assistantEditQQAvatarDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),

--- a/lib/features/assistant/pages/assistant_settings_edit_custom_request_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_custom_request_tab.dart
@@ -3,7 +3,6 @@ part of 'assistant_settings_edit_page.dart';
 class _CustomRequestTab extends StatelessWidget {
   const _CustomRequestTab({required this.assistantId});
   final String assistantId;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -11,7 +10,6 @@ class _CustomRequestTab extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final ap = context.watch<AssistantProvider>();
     final a = ap.getById(assistantId)!;
-
     Widget card({required Widget child}) => Padding(
       padding: const EdgeInsets.fromLTRB(
         16,
@@ -21,6 +19,7 @@ class _CustomRequestTab extends StatelessWidget {
       ), // Increased right padding
       child: Container(
         decoration: BoxDecoration(
+          // color-gate: ignore
           color: isDark ? Colors.white10 : cs.surface,
           borderRadius: BorderRadius.circular(14),
           border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.25)),
@@ -29,7 +28,6 @@ class _CustomRequestTab extends StatelessWidget {
         child: Padding(padding: const EdgeInsets.all(12), child: child),
       ),
     );
-
     void addHeader() {
       final list = List<Map<String, String>>.of(a.customHeaders);
       list.add({'name': '', 'value': ''});
@@ -161,7 +159,6 @@ class _CustomRequestTab extends StatelessWidget {
             ],
           ),
         ),
-
         // Body
         card(
           child: Column(
@@ -246,7 +243,6 @@ class _HeaderRow extends StatefulWidget {
   final String value;
   final void Function(String name, String value) onChanged;
   final VoidCallback onDelete;
-
   @override
   State<_HeaderRow> createState() => _HeaderRowState();
 }
@@ -256,7 +252,6 @@ class _HeaderRowState extends State<_HeaderRow> {
   late final TextEditingController _valCtrl;
   late final FocusNode _nameFocus;
   late final FocusNode _valFocus;
-
   @override
   void initState() {
     super.initState();
@@ -289,11 +284,10 @@ class _HeaderRowState extends State<_HeaderRow> {
 
   InputDecoration _dec(BuildContext context, String label) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return InputDecoration(
       labelText: label,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide.none,
@@ -360,7 +354,6 @@ class _BodyRow extends StatefulWidget {
   final String value;
   final void Function(String key, String value) onChanged;
   final VoidCallback onDelete;
-
   @override
   State<_BodyRow> createState() => _BodyRowState();
 }
@@ -370,7 +363,6 @@ class _BodyRowState extends State<_BodyRow> {
   late final TextEditingController _valCtrl;
   late final FocusNode _keyFocus;
   late final FocusNode _valFocus;
-
   @override
   void initState() {
     super.initState();
@@ -403,11 +395,10 @@ class _BodyRowState extends State<_BodyRow> {
 
   InputDecoration _dec(BuildContext context, String label) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return InputDecoration(
       labelText: label,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide.none,

--- a/lib/features/assistant/pages/assistant_settings_edit_memory_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_memory_tab.dart
@@ -128,10 +128,7 @@ class _MemoryTabState extends State<_MemoryTab> {
                           decoration: InputDecoration(
                             hintText: l10n.assistantEditMemoryDialogHint,
                             filled: true,
-                            fillColor:
-                                Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF7F7F9),
+                            fillColor: ctx.appColors.surfaceFill,
                             border: OutlineInputBorder(
                               borderSide: BorderSide(
                                 color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -261,9 +258,7 @@ class _MemoryTabState extends State<_MemoryTab> {
                       decoration: InputDecoration(
                         hintText: l10n.assistantEditMemoryDialogHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderSide: BorderSide(
                             color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -350,7 +345,7 @@ class _MemoryTabState extends State<_MemoryTab> {
       child: Container(
         decoration: BoxDecoration(
           // Match Settings page: Light uses translucent white; Dark uses subtle white10
-          color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+          color: context.appColors.surfaceCard,
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
             color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -603,9 +598,7 @@ class _MemoryTabState extends State<_MemoryTab> {
             padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
             child: Container(
               decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white10
-                    : Colors.white.withValues(alpha: 0.96),
+                color: context.appColors.surfaceCard,
                 borderRadius: BorderRadius.circular(14),
                 border: Border.all(
                   color: cs.outlineVariant.withValues(
@@ -700,9 +693,7 @@ class _MemoryTabState extends State<_MemoryTab> {
                   padding: const EdgeInsets.fromLTRB(16, 6, 16, 6),
                   child: Container(
                     decoration: BoxDecoration(
-                      color: isDark
-                          ? Colors.white10
-                          : Colors.white.withValues(alpha: 0.96),
+                      color: context.appColors.surfaceCard,
                       borderRadius: BorderRadius.circular(14),
                       border: Border.all(
                         color: cs.outlineVariant.withValues(
@@ -874,10 +865,7 @@ class _MemoryTabState extends State<_MemoryTab> {
                           decoration: InputDecoration(
                             hintText: l10n.assistantEditSummaryDialogHint,
                             filled: true,
-                            fillColor:
-                                Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF7F7F9),
+                            fillColor: ctx.appColors.surfaceFill,
                             border: OutlineInputBorder(
                               borderSide: BorderSide(
                                 color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -991,9 +979,7 @@ class _MemoryTabState extends State<_MemoryTab> {
                   decoration: InputDecoration(
                     hintText: l10n.assistantEditSummaryDialogHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF7F7F9),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderSide: BorderSide(
                         color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -1250,9 +1236,7 @@ class _RecentChatsSummaryFrequencySection extends StatelessWidget {
                         hintText: l10n
                             .assistantEditRecentChatsSummaryFrequencyCustomHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderSide: BorderSide(
                             color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -1397,7 +1381,7 @@ class _FrequencyChipButton extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final baseBackground = selected
         ? cs.primary.withValues(alpha: isDark ? 0.22 : 0.12)
-        : (isDark ? Colors.white10 : const Color(0xFFF2F3F5));
+        : context.appColors.surfaceFill;
     final borderColor = selected
         ? cs.primary.withValues(alpha: 0.38)
         : (emphasized
@@ -1597,7 +1581,7 @@ class _ModeOption extends StatelessWidget {
           decoration: BoxDecoration(
             color: selected
                 ? cs.primary.withValues(alpha: isDark ? 0.22 : 0.12)
-                : (isDark ? Colors.white10 : const Color(0xFFF2F3F5)),
+                : context.appColors.surfaceFill,
             borderRadius: BorderRadius.circular(10),
             border: Border.all(
               color: selected

--- a/lib/features/assistant/pages/assistant_settings_edit_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_page.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io' show File, Platform;
 import 'dart:math' as math;
 import 'dart:ui';
-
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/material.dart';
@@ -17,7 +16,6 @@ import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
 import 'package:syncfusion_flutter_sliders/sliders.dart';
 import 'package:uuid/uuid.dart';
-
 import '../../chat/widgets/chat_message_widget.dart';
 import '../../home/widgets/assistant_avatar.dart';
 import '../../chat/widgets/reasoning_budget_sheet.dart';
@@ -47,6 +45,7 @@ import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../theme/design_tokens.dart';
 import '../../../utils/avatar_cache.dart';
 import '../../../utils/brand_assets.dart';
@@ -56,7 +55,6 @@ import '../utils/assistant_edit_tab_layout.dart';
 import '../widgets/proactive_care_datetime_picker.dart';
 import '../../workspace/widgets/workspace_bind_sheet.dart';
 import 'assistant_regex_tab.dart';
-
 part 'assistant_settings_edit_basic_tab.dart';
 part 'assistant_settings_edit_prompt_tab.dart';
 part 'assistant_settings_edit_memory_tab.dart';
@@ -77,7 +75,6 @@ class _AssistantEditTabSpec {
     required this.icon,
     required this.child,
   });
-
   final String id;
   final String label;
   final IconData icon;
@@ -187,7 +184,6 @@ List<_AssistantEditTabSpec> _visibleAssistantEditTabs(
 
 int _clampContextMessages(num value) =>
     value.clamp(_contextMessageMin, _contextMessageMax).toInt();
-
 Future<int?> _showContextMessageInputDialog(
   BuildContext context, {
   required int initialValue,
@@ -197,9 +193,7 @@ Future<int?> _showContextMessageInputDialog(
   final controller = TextEditingController(
     text: _clampContextMessages(initialValue).toString(),
   );
-
   int? parseValue() => int.tryParse(controller.text);
-
   try {
     return await showDialog<int>(
       context: context,
@@ -270,7 +264,6 @@ Future<int?> _showContextMessageInputDialog(
 class AssistantSettingsEditPage extends StatefulWidget {
   const AssistantSettingsEditPage({super.key, required this.assistantId});
   final String assistantId;
-
   @override
   State<AssistantSettingsEditPage> createState() =>
       _AssistantSettingsEditPageState();
@@ -279,7 +272,6 @@ class AssistantSettingsEditPage extends StatefulWidget {
 class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
     with TickerProviderStateMixin {
   late TabController _tabController;
-
   @override
   void initState() {
     super.initState();
@@ -320,7 +312,6 @@ class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
     final provider = context.watch<AssistantProvider>();
     final settings = context.watch<SettingsProvider>();
     final assistant = provider.getById(widget.assistantId);
-
     if (assistant == null) {
       return Scaffold(
         appBar: AppBar(
@@ -339,14 +330,12 @@ class _AssistantSettingsEditPageState extends State<AssistantSettingsEditPage>
         body: Center(child: Text(l10n.assistantEditPageNotFound)),
       );
     }
-
     final allTabs = _assistantEditTabSpecs(context, assistant.id);
     final visibleTabs = _visibleAssistantEditTabs(allTabs, settings);
     final useOutline = settings.mobileAssistantDetailOutlineEnabled;
     if (!useOutline) {
       _syncTabController(visibleTabs.length);
     }
-
     return Scaffold(
       appBar: AppBar(
         leading: Tooltip(
@@ -424,14 +413,11 @@ class _AssistantDetailOutlinePage extends StatelessWidget {
     required this.assistant,
     required this.tabs,
   });
-
   final Assistant assistant;
   final List<_AssistantEditTabSpec> tabs;
-
   @override
   Widget build(BuildContext context) {
     final prompt = assistant.systemPrompt.trim();
-
     return ListView(
       padding: const EdgeInsets.fromLTRB(16, 10, 16, 28),
       children: [
@@ -455,10 +441,8 @@ class _AssistantOutlineHeader extends StatelessWidget {
     required this.assistant,
     required this.prompt,
   });
-
   final Assistant assistant;
   final String prompt;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -468,11 +452,10 @@ class _AssistantOutlineHeader extends StatelessWidget {
     final name = assistant.name.trim().isNotEmpty
         ? assistant.name.trim()
         : l10n.assistantEditPageTitle;
-
     return Container(
       padding: const EdgeInsets.fromLTRB(18, 20, 18, 18),
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.1 : 0.08),
@@ -517,10 +500,8 @@ class _AssistantOutlineHeader extends StatelessWidget {
 
 class _AssistantOutlineItem extends StatelessWidget {
   const _AssistantOutlineItem({required this.tab, required this.assistantId});
-
   final _AssistantEditTabSpec tab;
   final String assistantId;
-
   @override
   Widget build(BuildContext context) {
     return _iosNavRow(
@@ -546,17 +527,14 @@ class _AssistantDetailSectionPage extends StatelessWidget {
     required this.assistantId,
     required this.tabId,
   });
-
   final String assistantId;
   final String tabId;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final provider = context.watch<AssistantProvider>();
     final assistant = provider.getById(assistantId);
-
     if (assistant == null) {
       return Scaffold(
         appBar: AppBar(
@@ -577,13 +555,11 @@ class _AssistantDetailSectionPage extends StatelessWidget {
         body: Center(child: Text(l10n.assistantEditPageNotFound)),
       );
     }
-
     final tabs = _assistantEditTabSpecs(context, assistant.id);
     final tab = tabs.firstWhere(
       (candidate) => candidate.id == tabId,
       orElse: () => tabs.first,
     );
-
     return Scaffold(
       appBar: AppBar(
         leading: Tooltip(
@@ -611,7 +587,6 @@ class _AssistantDetailSectionPage extends StatelessWidget {
 
 class _AssistantTabLayoutPage extends StatelessWidget {
   const _AssistantTabLayoutPage();
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -623,7 +598,6 @@ class _AssistantTabLayoutPage extends StatelessWidget {
     );
     final hidden = settings.hiddenMobileAssistantEditTabs;
     final visibleCount = tabs.where((tab) => !hidden.contains(tab.id)).length;
-
     return Scaffold(
       appBar: AppBar(
         leading: Tooltip(
@@ -748,9 +722,7 @@ class _AssistantTabLayoutPage extends StatelessWidget {
 
 class _AssistantOutlineModeSwitch extends StatelessWidget {
   const _AssistantOutlineModeSwitch({required this.settings});
-
   final SettingsProvider settings;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -791,23 +763,20 @@ class _AssistantTabLayoutTile extends StatelessWidget {
     required this.visible,
     required this.onVisibleChanged,
   });
-
   final _AssistantEditTabSpec tab;
   final int index;
   final bool visible;
   final ValueChanged<bool> onVisibleChanged;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
     final fg = visible
         ? cs.onSurface.withValues(alpha: 0.9)
         : cs.onSurface.withValues(alpha: 0.42);
-
     return Container(
       decoration: BoxDecoration(
         color: bg,
@@ -865,13 +834,11 @@ class _SegTabBar extends StatelessWidget {
   const _SegTabBar({required this.controller, required this.tabs});
   final TabController controller;
   final List<String> tabs;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-
     const double outerHeight = 44;
     const double innerPadding = 4; // gap between shell and selected block
     const double gap = 6; // spacing between segments
@@ -881,7 +848,6 @@ class _SegTabBar extends StatelessWidget {
       0.0,
       pillRadius,
     )).toDouble();
-
     return AnimatedBuilder(
       animation: controller.animation ?? controller,
       builder: (context, _) {
@@ -891,7 +857,6 @@ class _SegTabBar extends StatelessWidget {
           animationValue: rawIndex,
           tabCount: tabs.length,
         );
-
         return LayoutBuilder(
           builder: (context, constraints) {
             final double availWidth = constraints.maxWidth;
@@ -902,11 +867,9 @@ class _SegTabBar extends StatelessWidget {
             );
             final double rowWidth =
                 segWidth * tabs.length + gap * (tabs.length - 1);
-
             final Color shellBg = isDark
                 ? Colors.white.withValues(alpha: 0.08)
                 : Colors.white; // 白底胶囊，无边框阴影
-
             List<Widget> children = [];
             for (int index = 0; index < tabs.length; index++) {
               final bool selected = selectedIndex == index;
@@ -922,7 +885,6 @@ class _SegTabBar extends StatelessWidget {
                           ? cs.primary.withValues(alpha: 0.14)
                           : Colors.transparent;
                       final Color bg = baseBg; // 不叠加遮罩，不改变底色
-
                       // 仅文字在按压时变浅并有渐变
                       final Color baseTextColor = selected
                           ? cs
@@ -932,7 +894,6 @@ class _SegTabBar extends StatelessWidget {
                           ? Color.lerp(baseTextColor, Colors.white, 0.22) ??
                                 baseTextColor
                           : baseTextColor;
-
                       return AnimatedContainer(
                         duration: const Duration(milliseconds: 180),
                         curve: Curves.easeOutCubic,
@@ -971,7 +932,6 @@ class _SegTabBar extends StatelessWidget {
                 children.add(const SizedBox(width: gap));
               }
             }
-
             return Container(
               height: outerHeight,
               decoration: BoxDecoration(
@@ -1010,11 +970,9 @@ class _InputRow extends StatelessWidget {
   final String label;
   final TextEditingController controller;
   final ValueChanged<String>? onChanged;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1025,7 +983,7 @@ class _InputRow extends StatelessWidget {
         const SizedBox(height: 6),
         Container(
           decoration: BoxDecoration(
-            color: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+            color: context.appColors.surfaceFill,
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
               color: cs.outlineVariant.withValues(alpha: 0.35),
@@ -1058,7 +1016,6 @@ class _BrandAvatarLike extends StatelessWidget {
   const _BrandAvatarLike({required this.name, this.size = 20});
   final String name;
   final double size;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -1075,6 +1032,7 @@ class _BrandAvatarLike extends StatelessWidget {
           width: size,
           height: size,
           decoration: BoxDecoration(
+            // color-gate: ignore
             color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
             shape: BoxShape.circle,
           ),
@@ -1091,6 +1049,7 @@ class _BrandAvatarLike extends StatelessWidget {
           width: size,
           height: size,
           decoration: BoxDecoration(
+            // color-gate: ignore
             color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
             shape: BoxShape.circle,
           ),
@@ -1108,6 +1067,7 @@ class _BrandAvatarLike extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
         shape: BoxShape.circle,
       ),
@@ -1125,7 +1085,6 @@ class _BrandAvatarLike extends StatelessWidget {
 }
 
 // --- iOS-style helpers ---
-
 class _TactileIconButton extends StatefulWidget {
   const _TactileIconButton({
     required this.icon,
@@ -1137,14 +1096,12 @@ class _TactileIconButton extends StatefulWidget {
   final Color color;
   final VoidCallback onTap;
   final double size;
-
   @override
   State<_TactileIconButton> createState() => _TactileIconButtonState();
 }
 
 class _TactileIconButtonState extends State<_TactileIconButton> {
   bool _pressed = false;
-
   @override
   Widget build(BuildContext context) {
     final base = widget.color;
@@ -1182,9 +1139,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -1224,7 +1179,6 @@ class _AnimatedPressColor extends StatelessWidget {
   final bool pressed;
   final Color base;
   final Widget Function(Color color) builder;
-
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -1253,14 +1207,12 @@ class _TactileRow extends StatefulWidget {
   final bool haptics;
   final double pressedScale;
   final int releaseDelayMs;
-
   @override
   State<_TactileRow> createState() => _TactileRowState();
 }
 
 class _TactileRowState extends State<_TactileRow> {
   bool _pressed = false;
-
   void _setPressed(bool v) {
     if (_pressed != v) setState(() => _pressed = v);
   }
@@ -1413,37 +1365,29 @@ class _IosButton extends StatefulWidget {
   final bool filled;
   final bool neutral; // If true, use neutral colors instead of primary
   final bool dense;
-
   @override
   State<_IosButton> createState() => _IosButtonState();
 }
 
 class _IosButtonState extends State<_IosButton> {
   bool _pressed = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
     // Determine if this is a Material icon (needs more spacing)
     final isMaterialIcon =
         widget.icon != null &&
         (widget.icon == Icons.image ||
             widget.icon.runtimeType.toString().contains('MaterialIcons'));
-
     final iconColor = widget.filled
         ? cs.onPrimary
         : (widget.neutral ? cs.onSurface.withValues(alpha: 0.75) : cs.primary);
-
     final textColor = widget.filled
         ? cs.onPrimary
         : (widget.neutral ? cs.onSurface.withValues(alpha: 0.9) : cs.primary);
-
     final borderColor = widget.neutral
         ? cs.outlineVariant.withValues(alpha: 0.35)
         : cs.primary.withValues(alpha: 0.45);
-
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown: (_) => setState(() => _pressed = true),
@@ -1459,9 +1403,7 @@ class _IosButtonState extends State<_IosButton> {
         curve: Curves.easeOutCubic,
         child: Container(
           decoration: BoxDecoration(
-            color: widget.filled
-                ? cs.primary
-                : (isDark ? Colors.white10 : const Color(0xFFF2F3F5)),
+            color: widget.filled ? cs.primary : context.appColors.surfaceFill,
             borderRadius: BorderRadius.circular(12),
             border: widget.filled ? null : Border.all(color: borderColor),
           ),
@@ -1497,7 +1439,6 @@ class _IosButtonState extends State<_IosButton> {
 }
 
 // ===== Desktop Assistant Dialog (reuses mobile tabs) =====
-
 enum _AssistantDesktopMenu {
   basic,
   prompts,
@@ -1543,7 +1484,6 @@ class _DesktopAssistantDialogShell extends StatefulWidget {
 class _DesktopAssistantDialogShellState
     extends State<_DesktopAssistantDialogShell> {
   _AssistantDesktopMenu _menu = _AssistantDesktopMenu.basic;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -1687,9 +1627,7 @@ class _DesktopAssistantMenuState extends State<_DesktopAssistantMenu> {
           final bg = selected
               ? cs.primary.withValues(alpha: 0.10)
               : (_hover == i
-                    ? (isDark
-                          ? Colors.white.withValues(alpha: 0.06)
-                          : Colors.black.withValues(alpha: 0.04))
+                    ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
                     : Colors.transparent);
           final fg = selected
               ? cs.primary
@@ -1750,7 +1688,6 @@ class _DesktopAssistantBasicPaneState
   bool _hoverChatModel = false;
   bool _hoverBgChooser = false;
   final GlobalKey _avatarKey = GlobalKey();
-
   @override
   void initState() {
     super.initState();
@@ -1789,7 +1726,6 @@ class _DesktopAssistantBasicPaneState
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final ap = context.watch<AssistantProvider>();
     final a = ap.getById(widget.assistantId)!;
-
     Widget header() {
       return Padding(
         padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
@@ -1900,9 +1836,7 @@ class _DesktopAssistantBasicPaneState
                     labelText: l10n.assistantEditAssistantNameLabel,
                     isDense: true,
                     filled: true,
-                    fillColor: isDark
-                        ? Colors.white10
-                        : const Color(0xFFF7F7F9),
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(10),
                       borderSide: BorderSide(
@@ -1975,7 +1909,6 @@ class _DesktopAssistantBasicPaneState
         color: cs.outlineVariant.withValues(alpha: 0.12),
       ),
     );
-
     Widget headerWithSwitch({
       required Widget title,
       required bool value,
@@ -2236,9 +2169,7 @@ class _DesktopAssistantBasicPaneState
                           vertical: 20,
                         ),
                         filled: true,
-                        fillColor: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        fillColor: context.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(10),
                           borderSide: BorderSide(
@@ -2360,15 +2291,11 @@ class _DesktopAssistantBasicPaneState
                       },
                       pressedScale: 0.98,
                       builder: (pressed) {
-                        final base = isDark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5);
-                        final pressOv = isDark
-                            ? Colors.white.withValues(alpha: 0.06)
-                            : Colors.black.withValues(alpha: 0.05);
-                        final hoverOv = isDark
-                            ? Colors.white.withValues(alpha: 0.04)
-                            : Colors.black.withValues(alpha: 0.04);
+                        final base = context.appColors.surfaceFill;
+                        final pressOv = cs.onSurface.withValues(
+                          alpha: isDark ? 0.06 : 0.05,
+                        );
+                        final hoverOv = cs.onSurface.withValues(alpha: 0.04);
                         final bgColor = pressed
                             ? Color.alphaBlend(pressOv, base)
                             : (_hoverChatModel
@@ -2453,15 +2380,11 @@ class _DesktopAssistantBasicPaneState
                         onTap: () => _pickBackground(context, a),
                         pressedScale: 0.98,
                         builder: (pressed) {
-                          final base = isDark
-                              ? Colors.white10
-                              : const Color(0xFFF2F3F5);
-                          final pressOv = isDark
-                              ? Colors.white.withValues(alpha: 0.06)
-                              : Colors.black.withValues(alpha: 0.05);
-                          final hoverOv = isDark
-                              ? Colors.white.withValues(alpha: 0.04)
-                              : Colors.black.withValues(alpha: 0.04);
+                          final base = context.appColors.surfaceFill;
+                          final pressOv = cs.onSurface.withValues(
+                            alpha: isDark ? 0.06 : 0.05,
+                          );
+                          final hoverOv = cs.onSurface.withValues(alpha: 0.04);
                           final bg = pressed
                               ? Color.alphaBlend(pressOv, base)
                               : (_hoverBgChooser
@@ -2589,9 +2512,7 @@ class _DesktopAssistantBasicPaneState
                               hintText: 'research-bot',
                               errorText: _handoffIdError,
                               filled: true,
-                              fillColor: isDark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: context.appColors.surfaceFill,
                               border: OutlineInputBorder(
                                 borderRadius: BorderRadius.circular(12),
                                 borderSide: BorderSide(
@@ -2644,9 +2565,7 @@ class _DesktopAssistantBasicPaneState
                             decoration: InputDecoration(
                               hintText: l10n.assistantEditHandoffDescription,
                               filled: true,
-                              fillColor: isDark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: context.appColors.surfaceFill,
                               border: OutlineInputBorder(
                                 borderRadius: BorderRadius.circular(12),
                                 borderSide: BorderSide(
@@ -2797,9 +2716,7 @@ class _DesktopAssistantBasicPaneState
             decoration: InputDecoration(
               hintText: l10n.assistantEditImageUrlDialogHint,
               filled: true,
-              fillColor: Theme.of(ctx).brightness == Brightness.dark
-                  ? Colors.white10
-                  : const Color(0xFFF2F3F5),
+              fillColor: ctx.appColors.surfaceFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: BorderSide(color: Colors.transparent),
@@ -2904,9 +2821,7 @@ class _DesktopAssistantBasicPaneState
                 decoration: InputDecoration(
                   hintText: l10n.assistantEditQQAvatarDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),

--- a/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_prompt_tab.dart
@@ -165,7 +165,7 @@ class _PromptTabState extends State<_PromptTab> {
       context: context,
       barrierDismissible: true,
       barrierLabel: 'system-prompt-editor',
-      barrierColor: Colors.black.withValues(alpha: 0.12),
+      barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.12),
       pageBuilder: (ctx, _, __) {
         return _SystemPromptDesktopDialog(initial: initial);
       },
@@ -303,10 +303,9 @@ class _PromptTabState extends State<_PromptTab> {
     }
 
     // System Prompt Card (no border, iOS style)
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final sysCard = Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(14),
       ),
       child: Padding(
@@ -417,7 +416,7 @@ class _PromptTabState extends State<_PromptTab> {
     // Time Injection Card
     final timeInjectionCard = Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(14),
       ),
       child: Padding(
@@ -469,7 +468,7 @@ class _PromptTabState extends State<_PromptTab> {
     // Template Card with preview (no border, iOS style)
     final tmplCard = Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(14),
       ),
       child: Padding(
@@ -608,7 +607,6 @@ class _PromptTabState extends State<_PromptTab> {
     // Preset conversation card
     Widget presetCard() {
       final a = ap.getById(widget.assistantId)!;
-      final isDark = Theme.of(context).brightness == Brightness.dark;
       final items = a.presetMessages;
       final isDesktop =
           Theme.of(context).platform == TargetPlatform.macOS ||
@@ -716,9 +714,7 @@ class _PromptTabState extends State<_PromptTab> {
         );
       }
 
-      final baseBg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final baseBg = context.appColors.surfaceCard;
 
       return Container(
         decoration: BoxDecoration(
@@ -956,9 +952,7 @@ class _PresetMessageCardState extends State<_PresetMessageCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -1083,9 +1077,9 @@ class _HoverTextButtonState extends State<_HoverTextButton> {
         ? const EdgeInsets.symmetric(horizontal: 10, vertical: 8)
         : const EdgeInsets.symmetric(horizontal: 12, vertical: 10);
     final Color bg = (_hover || _press)
-        ? (isDark
-              ? Colors.white.withValues(alpha: _press ? 0.12 : 0.08)
-              : Colors.black.withValues(alpha: _press ? 0.08 : 0.06))
+        ? cs.onSurface.withValues(
+            alpha: isDark ? (_press ? 0.12 : 0.08) : (_press ? 0.08 : 0.06),
+          )
         : Colors.transparent;
 
     return MouseRegion(
@@ -1144,7 +1138,6 @@ class _SystemPromptMobileSheetState extends State<_SystemPromptMobileSheet> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final bottom = MediaQuery.of(context).viewInsets.bottom;
     return SizedBox(
       height: MediaQuery.of(context).size.height * 0.96,
@@ -1176,7 +1169,7 @@ class _SystemPromptMobileSheetState extends State<_SystemPromptMobileSheet> {
             Expanded(
               child: DecoratedBox(
                 decoration: BoxDecoration(
-                  color: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+                  color: context.appColors.surfaceFill,
                   borderRadius: BorderRadius.circular(14),
                   border: Border.all(
                     color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -1288,9 +1281,7 @@ class _SystemPromptDesktopDialogState
                       padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
                       child: DecoratedBox(
                         decoration: BoxDecoration(
-                          color: isDark
-                              ? Colors.white10
-                              : const Color(0xFFF7F7F9),
+                          color: context.appColors.surfaceFill,
                           borderRadius: BorderRadius.circular(14),
                           border: Border.all(
                             color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -1558,9 +1549,7 @@ Future<void> _showEditPresetDialog(
                       ? l10n.assistantEditPresetInputHintAssistant
                       : l10n.assistantEditPresetInputHintUser,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF7F7F9),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(10),
                     borderSide: BorderSide(

--- a/lib/features/assistant/pages/assistant_settings_edit_quick_phrase_tab.dart
+++ b/lib/features/assistant/pages/assistant_settings_edit_quick_phrase_tab.dart
@@ -80,10 +80,7 @@ class _QuickPhraseTab extends StatelessWidget {
                           decoration: InputDecoration(
                             labelText: l10n.quickPhraseTitleLabel,
                             filled: true,
-                            fillColor:
-                                Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF2F3F5),
+                            fillColor: ctx.appColors.surfaceFill,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
                               borderSide: BorderSide(
@@ -107,10 +104,7 @@ class _QuickPhraseTab extends StatelessWidget {
                             labelText: l10n.quickPhraseContentLabel,
                             alignLabelWithHint: true,
                             filled: true,
-                            fillColor:
-                                Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF2F3F5),
+                            fillColor: ctx.appColors.surfaceFill,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
                               borderSide: BorderSide(
@@ -361,12 +355,10 @@ class _QuickPhraseTab extends StatelessWidget {
                       onTap: () => _showAddEditSheet(context, phrase: phrase),
                       pressedScale: 0.98,
                       builder: (pressed) {
-                        final bg = isDark
-                            ? Colors.white10
-                            : Colors.white.withValues(alpha: 0.96);
-                        final overlay = isDark
-                            ? Colors.white.withValues(alpha: 0.06)
-                            : Colors.black.withValues(alpha: 0.05);
+                        final bg = context.appColors.surfaceCard;
+                        final overlay = cs.onSurface.withValues(
+                          alpha: isDark ? 0.06 : 0.05,
+                        );
                         final pressedBg = Color.alphaBlend(overlay, bg);
                         return Container(
                           decoration: BoxDecoration(
@@ -478,9 +470,7 @@ class _GlassCircleButtonQPState extends State<_GlassCircleButtonQP> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;
@@ -562,7 +552,6 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return SafeArea(
       top: false,
@@ -606,7 +595,7 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
               decoration: InputDecoration(
                 labelText: l10n.quickPhraseTitleLabel,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -635,7 +624,7 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
                 labelText: l10n.quickPhraseContentLabel,
                 alignLabelWithHint: true,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(

--- a/lib/features/assistant/pages/assistant_settings_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_page.dart
@@ -18,6 +18,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../shared/widgets/create_action_icon_button.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class AssistantSettingsPage extends StatefulWidget {
   const AssistantSettingsPage({super.key});
@@ -160,9 +161,7 @@ class _AssistantCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final content = _TactileCard(
       onTap: () {
         Navigator.of(context).push(
@@ -427,11 +426,10 @@ class _TactileCardState extends State<_TactileCard> {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final overlay = _pressed
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.04))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.04)
         : Colors.transparent;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -511,7 +509,6 @@ Future<String?> _showAddAssistantSheet(BuildContext context) async {
     ),
     builder: (ctx) {
       final cs = Theme.of(ctx).colorScheme;
-      final isDark = Theme.of(ctx).brightness == Brightness.dark;
       final bottomInset = MediaQuery.of(ctx).viewInsets.bottom;
       return SafeArea(
         top: false,
@@ -553,7 +550,7 @@ Future<String?> _showAddAssistantSheet(BuildContext context) async {
                 decoration: InputDecoration(
                   hintText: l10n.assistantSettingsAddSheetHint,
                   filled: true,
-                  fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(

--- a/lib/features/assistant/pages/tags_manager_page.dart
+++ b/lib/features/assistant/pages/tags_manager_page.dart
@@ -5,6 +5,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 class TagsManagerPage extends StatefulWidget {
   const TagsManagerPage({super.key, required this.assistantId});
@@ -199,7 +200,7 @@ class _MobileTagCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final bg = context.appColors.surfaceFill;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.12 : 0.10,
     );

--- a/lib/features/assistant/widgets/assistant_select_sheet.dart
+++ b/lib/features/assistant/widgets/assistant_select_sheet.dart
@@ -95,7 +95,7 @@ Future<String?> showAssistantMoveSelector(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'assistant-move-selector',
-    barrierColor: Colors.black.withValues(alpha: 0.15),
+    barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.15),
     pageBuilder: (ctx, _, __) {
       final l10n = AppLocalizations.of(ctx)!;
       final cs = Theme.of(ctx).colorScheme;
@@ -329,9 +329,7 @@ class _SmallIconBtn2State extends State<_SmallIconBtn2> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -366,11 +364,10 @@ class _DeskAssistantRowState extends State<_DeskAssistantRow> {
   bool _hover = false;
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),

--- a/lib/features/assistant/widgets/proactive_care_datetime_picker.dart
+++ b/lib/features/assistant/widgets/proactive_care_datetime_picker.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 String proactiveCareNextMessageLabel(BuildContext context, DateTime? value) {
   final l10n = AppLocalizations.of(context)!;
@@ -369,9 +370,7 @@ class _ProactiveCareDateTimePanelState
               onTap: _save,
               haptics: false,
               borderRadius: BorderRadius.circular(13),
-              baseColor: isDark
-                  ? Colors.white.withValues(alpha: 0.16)
-                  : const Color(0xFFDADDE2),
+              baseColor: context.appColors.surfaceFill,
               padding: const EdgeInsets.symmetric(vertical: 11),
               child: Center(
                 child: Text(

--- a/lib/features/assistant/widgets/tags_manager_dialog.dart
+++ b/lib/features/assistant/widgets/tags_manager_dialog.dart
@@ -4,6 +4,7 @@ import '../../../core/providers/tag_provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<void> showAssistantTagsManagerDialog(
   BuildContext context, {
@@ -14,7 +15,7 @@ Future<void> showAssistantTagsManagerDialog(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'tags-manager',
-    barrierColor: Colors.black.withValues(alpha: 0.15),
+    barrierColor: cs.scrim.withValues(alpha: 0.15),
     pageBuilder: (ctx, _, __) {
       // Use a full-screen tap area to allow closing by tapping outside the dialog.
       return GestureDetector(
@@ -277,9 +278,7 @@ class _SmallIconBtnState extends State<_SmallIconBtn> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final bg = _hover
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return MouseRegion(
       onEnter: (_) => setState(() => _hover = true),
@@ -323,9 +322,7 @@ class _TagCardState extends State<_TagCard> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     final borderColor = _hover
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);

--- a/lib/features/backup/pages/backup_page.dart
+++ b/lib/features/backup/pages/backup_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -142,8 +143,7 @@ class _BackupPageState extends State<BackupPage> {
 
   Future<RestoreMode?> _chooseImportModeDialog(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final cardColor = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final cardColor = context.appColors.surfaceFill;
 
     return showDialog<RestoreMode>(
       context: context,
@@ -1710,9 +1710,8 @@ class _InputRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
-    final fieldBg = isDark ? Colors.white12 : const Color(0xFFF2F3F5);
+    final fieldBg = context.appColors.surfaceFill;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1895,9 +1894,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -2226,11 +2223,7 @@ class _RemoteListSheet extends StatelessWidget {
                             padding: const EdgeInsets.symmetric(vertical: 6),
                             child: Container(
                               decoration: BoxDecoration(
-                                color:
-                                    Theme.of(context).brightness ==
-                                        Brightness.dark
-                                    ? Colors.white10
-                                    : const Color(0xFFF7F7F9),
+                                color: context.appColors.surfaceFill,
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
                                   color: cs.outlineVariant.withValues(
@@ -2318,9 +2311,7 @@ class _ActionCard extends StatelessWidget {
       builder: (pressed) {
         final isDark = Theme.of(context).brightness == Brightness.dark;
         final overlay = pressed
-            ? (isDark
-                  ? Colors.black.withValues(alpha: 0.06)
-                  : Colors.white.withValues(alpha: 0.05))
+            ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
             : Colors.transparent;
         return AnimatedContainer(
           duration: const Duration(milliseconds: 160),
@@ -2601,7 +2592,6 @@ class _S3SettingsPageState extends State<_S3SettingsPage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
       backgroundColor: cs.surface,
@@ -2700,9 +2690,7 @@ class _S3SettingsPageState extends State<_S3SettingsPage> {
                             const SizedBox(height: 12),
                             Container(
                               decoration: BoxDecoration(
-                                color: isDark
-                                    ? Colors.white10
-                                    : const Color(0xFFF2F3F5),
+                                color: context.appColors.surfaceFill,
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
                                   color: cs.outlineVariant.withValues(

--- a/lib/features/backup/widgets/backup_reminder_helpers.dart
+++ b/lib/features/backup/widgets/backup_reminder_helpers.dart
@@ -9,6 +9,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 String backupReminderFrequencyLabel(AppLocalizations l10n, int days) {
   return switch (days) {
@@ -460,7 +461,7 @@ class _BackupReminderTimeWheelPanelState
               haptics: false,
               borderRadius: BorderRadius.circular(13),
               baseColor: isDark
-                  ? Colors.white.withValues(alpha: 0.08)
+                  ? cs.onSurface.withValues(alpha: 0.08)
                   : const Color(0xFFE7E9EC),
               padding: const EdgeInsets.symmetric(vertical: 11),
               child: Center(
@@ -481,9 +482,7 @@ class _BackupReminderTimeWheelPanelState
               onTap: _save,
               haptics: false,
               borderRadius: BorderRadius.circular(13),
-              baseColor: isDark
-                  ? Colors.white.withValues(alpha: 0.16)
-                  : const Color(0xFFDADDE2),
+              baseColor: context.appColors.surfaceFill,
               padding: const EdgeInsets.symmetric(vertical: 11),
               child: Center(
                 child: Text(
@@ -568,9 +567,7 @@ class _BackupReminderCustomDaysDialogState
               decoration: InputDecoration(
                 labelText: l10n.backupReminderCustomDaysLabel,
                 filled: true,
-                fillColor: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white10
-                    : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(

--- a/lib/features/chat/pages/chat_history_page.dart
+++ b/lib/features/chat/pages/chat_history_page.dart
@@ -10,6 +10,7 @@ import '../../../core/services/chat/chat_service.dart';
 import '../../../core/models/conversation.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ChatHistoryPage extends StatefulWidget {
   const ChatHistoryPage({super.key, this.assistantId});
@@ -34,7 +35,6 @@ class _ChatHistoryPageState extends State<ChatHistoryPage>
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final chatService = context.watch<ChatService>();
     final List<Conversation> all = chatService
         .getAllConversations()
@@ -94,7 +94,7 @@ class _ChatHistoryPageState extends State<ChatHistoryPage>
                       onPressed: () => Navigator.of(ctx).pop(true),
                       child: Text(
                         l10n.chatHistoryPageDelete,
-                        style: TextStyle(color: Colors.red),
+                        style: TextStyle(color: cs.error),
                       ),
                     ),
                   ],
@@ -153,9 +153,7 @@ class _ChatHistoryPageState extends State<ChatHistoryPage>
                           decoration: InputDecoration(
                             hintText: l10n.chatHistoryPageSearchHint,
                             filled: true,
-                            fillColor: isDark
-                                ? Colors.white10
-                                : const Color(0xFFF2F3F5),
+                            fillColor: context.appColors.surfaceFill,
                             contentPadding: const EdgeInsets.symmetric(
                               horizontal: 16,
                               vertical: 12,
@@ -308,8 +306,7 @@ class _ConversationCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark ? Colors.white12 : const Color(0xFFF7F7F9);
+    final bg = context.appColors.surfaceFill;
     final border = cs.outlineVariant.withValues(alpha: 0.16);
 
     return Padding(

--- a/lib/features/chat/pages/message_edit_page.dart
+++ b/lib/features/chat/pages/message_edit_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class MessageEditPage extends StatefulWidget {
   const MessageEditPage({super.key, required this.message});
@@ -61,9 +62,7 @@ class _MessageEditPageState extends State<MessageEditPage> {
             decoration: InputDecoration(
               hintText: l10n.messageEditPageHint,
               filled: true,
-              fillColor: Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white10
-                  : const Color(0xFFF2F3F5),
+              fillColor: context.appColors.surfaceFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
                 borderSide: const BorderSide(color: Colors.transparent),

--- a/lib/features/chat/widgets/bottom_tools_sheet.dart
+++ b/lib/features/chat/widgets/bottom_tools_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/world_book_provider.dart';
@@ -48,8 +49,7 @@ class BottomToolsSheet extends StatelessWidget {
       required String label,
       VoidCallback? onTap,
     }) {
-      final isDark = Theme.of(context).brightness == Brightness.dark;
-      final cardColor = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
+      final cardColor = context.appColors.surfaceFill;
       return Expanded(
         child: SizedBox(
           height: 72,

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -51,6 +51,7 @@ import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
 import 'token_display_widget.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 final RegExp _urlSchemeRe = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:');
 
@@ -466,11 +467,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                                 width: double.infinity,
                                 padding: const EdgeInsets.all(10),
                                 decoration: BoxDecoration(
-                                  color:
-                                      Theme.of(ctx).brightness ==
-                                          Brightness.dark
-                                      ? Colors.white10
-                                      : const Color(0xFFF7F7F9),
+                                  color: ctx.appColors.surfaceFill,
                                   borderRadius: BorderRadius.circular(10),
                                   border: Border.all(
                                     color: cs.outlineVariant.withValues(
@@ -496,11 +493,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                                 width: double.infinity,
                                 padding: const EdgeInsets.all(10),
                                 decoration: BoxDecoration(
-                                  color:
-                                      Theme.of(ctx).brightness ==
-                                          Brightness.dark
-                                      ? Colors.white10
-                                      : const Color(0xFFF7F7F9),
+                                  color: ctx.appColors.surfaceFill,
                                   borderRadius: BorderRadius.circular(10),
                                   border: Border.all(
                                     color: cs.outlineVariant.withValues(
@@ -613,9 +606,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                     width: double.infinity,
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: Theme.of(ctx).brightness == Brightness.dark
-                          ? Colors.white10
-                          : const Color(0xFFF7F7F9),
+                      color: ctx.appColors.surfaceFill,
                       borderRadius: BorderRadius.circular(10),
                       border: Border.all(
                         color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -639,9 +630,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                     width: double.infinity,
                     padding: const EdgeInsets.all(10),
                     decoration: BoxDecoration(
-                      color: Theme.of(ctx).brightness == Brightness.dark
-                          ? Colors.white10
-                          : const Color(0xFFF7F7F9),
+                      color: ctx.appColors.surfaceFill,
                       borderRadius: BorderRadius.circular(10),
                       border: Border.all(
                         color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -1127,7 +1116,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
       context: context,
       barrierDismissible: true,
       barrierLabel: 'context-menu',
-      barrierColor: Colors.black.withValues(alpha: 0.08),
+      barrierColor: cs.scrim.withValues(alpha: 0.08),
       pageBuilder: (ctx, _, __) {
         return Stack(
           children: [
@@ -1157,6 +1146,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
                       child: DecoratedBox(
                         decoration: BoxDecoration(
                           color: isDark
+                              // color-gate: ignore
                               ? const Color(0xFF1C1C1E).withValues(alpha: 0.66)
                               : Colors.white.withValues(alpha: 0.66),
                         ),
@@ -1725,9 +1715,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
                   errorBuilder: (_, __, ___) => Container(
                     width: 112,
                     height: 112,
-                    color: isDark
-                        ? Colors.white.withValues(alpha: 0.08)
-                        : Colors.black.withValues(alpha: 0.06),
+                    color: cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.06),
                     child: Icon(
                       Icons.broken_image,
                       color: cs.onSurface.withValues(alpha: 0.45),
@@ -1746,7 +1734,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
         parsed.docs.map((d) {
           return IosCardPress(
             baseColor: isDark
-                ? Colors.white.withValues(alpha: 0.08)
+                ? cs.onSurface.withValues(alpha: 0.08)
                 : cs.surface.withValues(alpha: 0.92),
             pressedScale: 0.99,
             borderRadius: BorderRadius.circular(10),
@@ -3236,6 +3224,7 @@ Widget _buildSharedChatSurface(
           child: DecoratedBox(
             decoration: BoxDecoration(
               color: isDark
+                  // color-gate: ignore
                   ? const Color(0xFF1C1C1E).withValues(alpha: 0.66)
                   : Colors.white.withValues(alpha: 0.66),
               borderRadius: borderRadius,
@@ -3251,7 +3240,7 @@ Widget _buildSharedChatSurface(
     case ChatMessageBackgroundStyle.solid:
       return DecoratedBox(
         decoration: BoxDecoration(
-          color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+          color: context.appColors.surfaceCard,
           borderRadius: borderRadius,
           border: Border.all(
             color: cs.outlineVariant.withValues(alpha: 0.16),
@@ -3341,10 +3330,8 @@ class _MenuItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final fg = danger ? Colors.red.shade600 : cs.onSurface;
-    final ic = danger
-        ? Colors.red.shade600
-        : cs.onSurface.withValues(alpha: 0.9);
+    final fg = danger ? cs.error : cs.onSurface;
+    final ic = danger ? cs.error : cs.onSurface.withValues(alpha: 0.9);
     // iOS-style press effect: no ripple. Use transparent base and a subtle
     // pressed blend inside the blurred/glass menu container.
     return IosCardPress(
@@ -4881,11 +4868,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                   width: double.infinity,
                                   padding: const EdgeInsets.all(10),
                                   decoration: BoxDecoration(
-                                    color:
-                                        Theme.of(ctx).brightness ==
-                                            Brightness.dark
-                                        ? Colors.white10
-                                        : const Color(0xFFF7F7F9),
+                                    color: ctx.appColors.surfaceFill,
                                     borderRadius: BorderRadius.circular(10),
                                     border: Border.all(
                                       color: cs.outlineVariant.withValues(
@@ -4911,11 +4894,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                   width: double.infinity,
                                   padding: const EdgeInsets.all(10),
                                   decoration: BoxDecoration(
-                                    color:
-                                        Theme.of(ctx).brightness ==
-                                            Brightness.dark
-                                        ? Colors.white10
-                                        : const Color(0xFFF7F7F9),
+                                    color: ctx.appColors.surfaceFill,
                                     borderRadius: BorderRadius.circular(10),
                                     border: Border.all(
                                       color: cs.outlineVariant.withValues(
@@ -5032,9 +5011,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        color: ctx.appColors.surfaceFill,
                         borderRadius: BorderRadius.circular(10),
                         border: Border.all(
                           color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -5058,9 +5035,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF7F7F9),
+                        color: ctx.appColors.surfaceFill,
                         borderRadius: BorderRadius.circular(10),
                         border: Border.all(
                           color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -5963,9 +5938,7 @@ class _SourcesSummaryCard extends StatelessWidget {
     return IosCardPress(
       borderRadius: BorderRadius.circular(20),
       border: Border.all(
-        color: isDark
-            ? Colors.white.withValues(alpha: 0.16)
-            : Colors.black.withValues(alpha: 0.10),
+        color: cs.onSurface.withValues(alpha: isDark ? 0.16 : 0.10),
         width: 0.8,
       ),
       baseColor: Colors.transparent,
@@ -6060,9 +6033,7 @@ class _SourceFavicon extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final borderColor = isDark
-        ? Colors.white.withValues(alpha: 0.14)
-        : Colors.black.withValues(alpha: 0.06);
+    final borderColor = cs.onSurface.withValues(alpha: isDark ? 0.14 : 0.06);
 
     return Container(
       width: _SourceFaviconStack._iconSize,

--- a/lib/features/chat/widgets/chat_suggestion_bubbles.dart
+++ b/lib/features/chat/widgets/chat_suggestion_bubbles.dart
@@ -26,7 +26,7 @@ class ChatSuggestionBubbles extends StatelessWidget {
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
     final baseColor = isDark
-        ? Colors.white.withValues(alpha: 0.08)
+        ? cs.onSurface.withValues(alpha: 0.08)
         : cs.primaryContainer.withValues(alpha: 0.42);
     final textColor = isDark
         ? cs.onSurface.withValues(alpha: 0.92)

--- a/lib/features/chat/widgets/context_management_sheet.dart
+++ b/lib/features/chat/widgets/context_management_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import '../../../core/services/haptics.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -96,8 +97,7 @@ class _OptionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final cardColor = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
+    final cardColor = context.appColors.surfaceFill;
     final radius = BorderRadius.circular(14);
 
     return IosCardPress(

--- a/lib/features/chat/widgets/message_edit_sheet.dart
+++ b/lib/features/chat/widgets/message_edit_sheet.dart
@@ -5,6 +5,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../core/services/haptics.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<MessageEditResult?> showMessageEditSheet(
   BuildContext context, {
@@ -161,9 +162,7 @@ class _MessageEditSheetState extends State<_MessageEditSheet> {
                     decoration: InputDecoration(
                       hintText: l10n.messageEditPageHint,
                       filled: true,
-                      fillColor: Theme.of(context).brightness == Brightness.dark
-                          ? Colors.white10
-                          : const Color(0xFFF2F3F5),
+                      fillColor: context.appColors.surfaceFill,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(20),
                         borderSide: const BorderSide(color: Colors.transparent),

--- a/lib/features/chat/widgets/message_more_sheet.dart
+++ b/lib/features/chat/widgets/message_more_sheet.dart
@@ -215,7 +215,7 @@ class _MessageMoreSheetState extends State<_MessageMoreSheet> {
     VoidCallback? onTap,
   }) {
     final cs = Theme.of(context).colorScheme;
-    final fg = danger ? Colors.red.shade600 : cs.onSurface;
+    final fg = danger ? cs.error : cs.onSurface;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: SizedBox(

--- a/lib/features/group_chat/widgets/group_avatar.dart
+++ b/lib/features/group_chat/widgets/group_avatar.dart
@@ -86,7 +86,9 @@ class GroupAvatar extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: isDark ? Colors.white24 : Colors.black12,
+          color: Theme.of(
+            context,
+          ).colorScheme.onSurface.withValues(alpha: isDark ? 0.24 : 0.12),
           width: 0.5,
         ),
       ),

--- a/lib/features/group_chat/widgets/group_chat_settings_card.dart
+++ b/lib/features/group_chat/widgets/group_chat_settings_card.dart
@@ -6,6 +6,7 @@ import '../../../core/providers/group_chat_provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../pages/group_chat_settings_page.dart';
 import 'group_avatar.dart';
 
@@ -34,9 +35,7 @@ class GroupChatSettingsCard extends StatelessWidget {
     final preview = context.watch<GroupChatProvider>().latestMessagePreview(
       group.id,
     );
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
 
     return IosCardPress(
       onTap: () {

--- a/lib/features/home/pages/home_desktop_layout.dart
+++ b/lib/features/home/pages/home_desktop_layout.dart
@@ -791,6 +791,7 @@ class _DesktopScrollButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     return ClipOval(
       child: BackdropFilter(
         filter: ui.ImageFilter.blur(sigmaX: 14, sigmaY: 14),
@@ -817,11 +818,7 @@ class _DesktopScrollButton extends StatelessWidget {
               onTap: onTap,
               child: Padding(
                 padding: const EdgeInsets.all(8),
-                child: Icon(
-                  icon,
-                  size: 18,
-                  color: isDark ? Colors.white : Colors.black87,
-                ),
+                child: Icon(icon, size: 18, color: cs.onSurface),
               ),
             ),
           ),
@@ -921,9 +918,7 @@ class _DesktopGlassCircleButtonState extends State<_DesktopGlassCircleButton> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;

--- a/lib/features/home/pages/home_mobile_layout.dart
+++ b/lib/features/home/pages/home_mobile_layout.dart
@@ -509,6 +509,7 @@ class _ScrollButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     return ClipOval(
       child: BackdropFilter(
         filter: ui.ImageFilter.blur(sigmaX: 14, sigmaY: 14),
@@ -535,11 +536,7 @@ class _ScrollButton extends StatelessWidget {
               onTap: onTap,
               child: Padding(
                 padding: const EdgeInsets.all(6),
-                child: Icon(
-                  icon,
-                  size: 16,
-                  color: isDark ? Colors.white : Colors.black87,
-                ),
+                child: Icon(icon, size: 16, color: cs.onSurface),
               ),
             ),
           ),
@@ -638,9 +635,7 @@ class _GlassCircleButtonState extends State<_GlassCircleButton> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/loading_dialog_card.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
 import '../../../theme/design_tokens.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/quick_phrase_provider.dart';
@@ -239,8 +240,7 @@ class _CompressContextOptionsDialogState
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final panelColor = isDark ? const Color(0xFF1C1C1E) : cs.surface;
+    final panelColor = context.appColors.surfaceCard;
     final constrainedWidth = MediaQuery.of(
       context,
     ).size.width.clamp(0.0, 420.0).toDouble();
@@ -465,10 +465,9 @@ class _KeepCountButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final enabled = onTap != null;
     return IosCardPress(
-      baseColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+      baseColor: context.appColors.surfaceFill,
       borderRadius: BorderRadius.circular(10),
       pressedScale: 0.98,
       onTap: onTap,
@@ -505,7 +504,7 @@ class _SegmentButton extends StatelessWidget {
     final selectedBg = isDark
         ? cs.primary.withValues(alpha: 0.22)
         : cs.primary.withValues(alpha: 0.12);
-    final baseBg = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
+    final baseBg = context.appColors.surfaceFill;
 
     return IosCardPress(
       baseColor: selected ? selectedBg : baseBg,
@@ -548,10 +547,7 @@ class _DialogActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final base = primary
-        ? cs.primary
-        : (isDark ? Colors.white10 : const Color(0xFFF2F3F5));
+    final base = primary ? cs.primary : context.appColors.surfaceFill;
 
     return IosCardPress(
       baseColor: base,
@@ -2064,6 +2060,7 @@ class _HomePageState extends State<HomePage>
     bool deleteAllVersions = false,
   }) async {
     final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
     final confirm = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
@@ -2084,10 +2081,7 @@ class _HomePageState extends State<HomePage>
           ),
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              l10n.homePageDelete,
-              style: TextStyle(color: Colors.red),
-            ),
+            child: Text(l10n.homePageDelete, style: TextStyle(color: cs.error)),
           ),
         ],
       ),
@@ -2110,6 +2104,7 @@ class _HomePageState extends State<HomePage>
     required bool deleteAllVersions,
   }) async {
     final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
     if (_controller.selectedItems.isEmpty) {
       showAppSnackBar(
         context,
@@ -2143,10 +2138,7 @@ class _HomePageState extends State<HomePage>
           ),
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(
-              l10n.homePageDelete,
-              style: TextStyle(color: Colors.red),
-            ),
+            child: Text(l10n.homePageDelete, style: TextStyle(color: cs.error)),
           ),
         ],
       ),

--- a/lib/features/home/widgets/assistant_avatar.dart
+++ b/lib/features/home/widgets/assistant_avatar.dart
@@ -86,7 +86,9 @@ class AssistantAvatar extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: isDark ? Colors.white24 : Colors.black12,
+          color: Theme.of(
+            context,
+          ).colorScheme.onSurface.withValues(alpha: isDark ? 0.24 : 0.12),
           width: 0.5,
         ),
       ),

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -42,6 +42,7 @@ import '../../../shared/dialogs/image_compression_dialog.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 import '../../../desktop/desktop_context_menu.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import '../../group_chat/models/chat_input_mode.dart';
 
 class ChatInputBarController {
@@ -2433,10 +2434,10 @@ class _ChatInputBarState extends State<ChatInputBar>
   Widget _buildInlineAttachmentPreviews(BuildContext context, bool isDark) {
     final theme = Theme.of(context);
     final previewFill = isDark
-        ? Colors.white.withValues(alpha: 0.08)
+        ? theme.colorScheme.onSurface.withValues(alpha: 0.08)
         : theme.colorScheme.onSurface.withValues(alpha: 0.045);
     final previewBorder = isDark
-        ? Colors.white.withValues(alpha: 0.10)
+        ? theme.colorScheme.onSurface.withValues(alpha: 0.10)
         : theme.colorScheme.outline.withValues(alpha: 0.13);
 
     return Padding(
@@ -2688,7 +2689,7 @@ class _ChatInputBarState extends State<ChatInputBar>
           borderRadius: BorderRadius.circular(10),
           border: Border.all(
             color: isDark
-                ? Colors.white.withValues(alpha: 0.10)
+                ? theme.colorScheme.onSurface.withValues(alpha: 0.10)
                 : theme.colorScheme.outline.withValues(alpha: 0.13),
             width: 1,
           ),
@@ -2706,7 +2707,7 @@ class _ChatInputBarState extends State<ChatInputBar>
             borderRadius: BorderRadius.circular(10),
             border: Border.all(
               color: isDark
-                  ? Colors.white.withValues(alpha: 0.10)
+                  ? theme.colorScheme.onSurface.withValues(alpha: 0.10)
                   : theme.colorScheme.outline.withValues(alpha: 0.13),
               width: 1,
             ),
@@ -2745,7 +2746,7 @@ class _ChatInputBarState extends State<ChatInputBar>
             borderRadius: BorderRadius.circular(10),
             border: Border.all(
               color: isDark
-                  ? Colors.white.withValues(alpha: 0.10)
+                  ? theme.colorScheme.onSurface.withValues(alpha: 0.10)
                   : theme.colorScheme.outline.withValues(alpha: 0.13),
               width: 1,
             ),
@@ -2855,7 +2856,9 @@ class _ChatInputBarState extends State<ChatInputBar>
                         // Use previous gray border for better contrast on white
                         border: Border.all(
                           color: isDark
-                              ? Colors.white.withValues(alpha: 0.10)
+                              ? theme.colorScheme.onSurface.withValues(
+                                  alpha: 0.10,
+                                )
                               : theme.colorScheme.outline.withValues(
                                   alpha: 0.20,
                                 ),
@@ -3198,7 +3201,7 @@ class _QueuedInputBanner extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: isDark
-            ? Colors.white.withValues(alpha: 0.08)
+            ? theme.colorScheme.onSurface.withValues(alpha: 0.08)
             : Colors.white.withValues(alpha: 0.84),
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
@@ -3309,10 +3312,9 @@ class _CompactIconButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
     final fgColor = active
         ? theme.colorScheme.primary
-        : (isDark ? Colors.white70 : Colors.black54);
+        : theme.colorScheme.onSurfaceVariant;
     final bool isDesktop =
         Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
@@ -3388,11 +3390,12 @@ class _CompactSendButton extends StatelessWidget {
     final bg = (enabled || loading)
         ? color
         : (isDark
-              ? Colors.white12
+              ? context.appColors.surfaceFill
+              // color-gate: ignore
               : Colors.grey.shade300.withValues(alpha: 0.84));
     final fg = (enabled || loading)
         ? (isDark ? Colors.black : Colors.white)
-        : (isDark ? Colors.white70 : Colors.grey.shade600);
+        : Theme.of(context).colorScheme.onSurfaceVariant;
 
     final button = Material(
       color: bg,

--- a/lib/features/home/widgets/image_generation_options.dart
+++ b/lib/features/home/widgets/image_generation_options.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 /// Holds the state of image generation options (quality / size / aspect
 /// ratio / format / compression / count). Values are emitted into the API
@@ -841,11 +842,7 @@ class _OptionChip extends StatelessWidget {
       onTap: onTap,
       haptics: false,
       borderRadius: BorderRadius.circular(999),
-      baseColor: selected
-          ? selectedBg
-          : isDark
-          ? Colors.white10
-          : cs.surface,
+      baseColor: selected ? selectedBg : context.appColors.surfaceFill,
       pressedBlendStrength: 0.18,
       border: Border.all(
         color: selected

--- a/lib/features/home/widgets/learning_prompt_sheet.dart
+++ b/lib/features/home/widgets/learning_prompt_sheet.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../../core/providers/instruction_injection_provider.dart';
 import '../../../core/models/instruction_injection.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../theme/app_semantic_colors.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
 
 /// Bottom sheet for editing the active instruction injection prompt.
@@ -77,9 +78,7 @@ class _LearningPromptSheetState extends State<LearningPromptSheet> {
               decoration: InputDecoration(
                 hintText: l10n.bottomToolsSheetPromptHint,
                 filled: true,
-                fillColor: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white10
-                    : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(

--- a/lib/features/home/widgets/mini_map_sheet.dart
+++ b/lib/features/home/widgets/mini_map_sheet.dart
@@ -7,6 +7,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/mini_map/mini_map_shared.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<String?> showMiniMapSheet(
   BuildContext context,
@@ -270,11 +271,8 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
     ScrollController controller,
   ) {
     final l10n = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final textBase = isDark ? Colors.white : Colors.black;
-    final highlightColor = isDark
-        ? const Color(0xFFB8860B).withValues(alpha: 0.55)
-        : const Color(0xFFFFD700).withValues(alpha: 0.55);
+    final cs = Theme.of(context).colorScheme;
+    final highlightColor = context.appColors.searchHighlight;
 
     if (_tokens.isEmpty) {
       // Debounce window: query entered but no result set computed yet.
@@ -288,7 +286,7 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
           l10n.miniMapSearchNoResults,
           style: TextStyle(
             fontSize: 13,
-            color: textBase.withValues(alpha: 0.45),
+            color: cs.onSurface.withValues(alpha: 0.45),
           ),
         ),
       );
@@ -303,7 +301,7 @@ class _MiniMapSheetState extends State<_MiniMapSheet>
             l10n.miniMapSearchResultCount(_searchResults.length),
             style: TextStyle(
               fontSize: 12,
-              color: textBase.withValues(alpha: 0.5),
+              color: cs.onSurface.withValues(alpha: 0.5),
               fontWeight: AppFontWeights.medium,
             ),
           ),

--- a/lib/features/home/widgets/model_icon.dart
+++ b/lib/features/home/widgets/model_icon.dart
@@ -17,22 +17,18 @@ class CurrentModelIcon extends StatelessWidget {
     this.withBackground = true,
     this.backgroundColor,
   });
-
   final String? providerKey;
   final String? modelId;
   final double size; // outer diameter
   final bool withBackground; // whether to draw circular background
   final Color? backgroundColor; // override background color if provided
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     if (providerKey == null || modelId == null) return const SizedBox.shrink();
-
     String? asset = BrandAssets.assetForName(modelId!);
     asset ??= BrandAssets.assetForName(providerKey!);
-
     Widget inner;
     if (asset != null) {
       if (asset.endsWith('.svg')) {
@@ -65,13 +61,13 @@ class CurrentModelIcon extends StatelessWidget {
         ),
       );
     }
-
     return Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
         color: withBackground
             ? (backgroundColor ??
+                  // color-gate: ignore
                   (isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1)))
             : Colors.transparent,
         shape: BoxShape.circle,

--- a/lib/features/home/widgets/multi_ai_comparison_view.dart
+++ b/lib/features/home/widgets/multi_ai_comparison_view.dart
@@ -3,6 +3,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../utils/platform_utils.dart';
 import '../../chat/pages/reading_mode_page.dart';
 import '../../chat/widgets/chat_message_widget.dart'
@@ -529,7 +530,7 @@ class _ModeButtonState extends State<_ModeButton> {
             decoration: BoxDecoration(
               color: widget.active
                   ? cs.primary.withValues(alpha: isDark ? 0.22 : 0.12)
-                  : (isDark ? Colors.white10 : const Color(0xFFF2F3F5)),
+                  : context.appColors.surfaceFill,
               borderRadius: BorderRadius.circular(10),
               border: Border.all(
                 color: widget.active

--- a/lib/features/home/widgets/scroll_nav_buttons.dart
+++ b/lib/features/home/widgets/scroll_nav_buttons.dart
@@ -43,8 +43,9 @@ class ScrollNavButtonsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final iconColor = isDark ? Colors.white : Colors.black87;
+    final cs = Theme.of(context).colorScheme;
+    final iconColor = cs.onSurface;
+    final isDark = cs.brightness == Brightness.dark;
     final buttonDiameter = iconSize + buttonPadding * 2;
     final hoverHeight = buttonDiameter * 4 + buttonSpacing * 3 + 24;
     final hoverWidth = buttonDiameter + 24;

--- a/lib/features/home/widgets/selection_toolbar.dart
+++ b/lib/features/home/widgets/selection_toolbar.dart
@@ -99,9 +99,7 @@ class _GlassCapsuleButtonState extends State<GlassCapsuleButton> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.65);
-    final overlay = isDark
-        ? Colors.black.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;
@@ -189,9 +187,7 @@ class _GlassCircleButtonSmallState extends State<GlassCircleButtonSmall> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;

--- a/lib/features/home/widgets/side_drawer.dart
+++ b/lib/features/home/widgets/side_drawer.dart
@@ -45,6 +45,7 @@ import '../../../desktop/desktop_context_menu.dart';
 import '../../../desktop/menu_anchor.dart';
 import '../../../shared/widgets/emoji_text.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../core/providers/tag_provider.dart';
 import '../../assistant/widgets/assistant_select_sheet.dart';
 import '../../../desktop/hotkeys/sidebar_tab_bus.dart';
@@ -509,7 +510,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                     row(
                       icon: Lucide.Trash,
                       label: l10n.sideDrawerMenuDelete,
-                      color: Colors.redAccent,
+                      color: Theme.of(context).colorScheme.error,
                       action: () async {
                         final confirmed = await _confirmDeleteConversation(
                           context,
@@ -569,7 +570,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
               onPressed: () => Navigator.of(ctx).pop(true),
               child: Text(
                 l10n.sideDrawerMenuDelete,
-                style: TextStyle(color: Colors.red),
+                style: TextStyle(color: Theme.of(ctx).colorScheme.error),
               ),
             ),
           ],
@@ -697,7 +698,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(
               l10n.sideDrawerMenuDelete,
-              style: TextStyle(color: Colors.red),
+              style: TextStyle(color: Theme.of(ctx).colorScheme.error),
             ),
           ),
         ],
@@ -1042,7 +1043,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                               Icon(
                                 Lucide.Trash2,
                                 size: 20,
-                                color: Colors.redAccent,
+                                color: Theme.of(context).colorScheme.error,
                               ),
                               const SizedBox(width: 10),
                               Text(
@@ -1050,7 +1051,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                                 style: TextStyle(
                                   fontSize: 15,
                                   fontWeight: AppFontWeights.medium,
-                                  color: Colors.redAccent,
+                                  color: Theme.of(context).colorScheme.error,
                                 ),
                               ),
                             ],
@@ -1164,7 +1165,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                     row(
                       icon: Lucide.Trash2,
                       label: l10n.sideDrawerMenuDelete,
-                      color: Colors.redAccent,
+                      color: Theme.of(context).colorScheme.error,
                       action: _batchDelete,
                     ),
                     const SizedBox(height: 4),
@@ -1443,9 +1444,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
         .split(RegExp(r'\s+'))
         .where((e) => e.isNotEmpty)
         .toList();
-    final highlightColor = isDark
-        ? const Color(0xFFB8860B).withValues(alpha: 0.55)
-        : const Color(0xFFFFD700).withValues(alpha: 0.55);
+    final highlightColor = context.appColors.searchHighlight;
 
     if (!_globalSearchHasRun) {
       if (!_isDesktop) {
@@ -2000,11 +1999,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                                       return l10n.sideDrawerSearchHint;
                                     })(),
                                     filled: true,
-                                    fillColor: isDark
-                                        ? Colors.white10
-                                        : Colors.grey.shade200.withValues(
-                                            alpha: 0.80,
-                                          ),
+                                    fillColor: context.appColors.surfaceFill,
                                     isDense: true,
                                     isCollapsed: true,
                                     prefixIcon: Padding(
@@ -2254,12 +2249,8 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                                                   ? ''
                                                   : _mobileSearchHint(),
                                               filled: true,
-                                              fillColor: isDark
-                                                  ? Colors.white10
-                                                  : Colors.grey.shade200
-                                                        .withValues(
-                                                          alpha: 0.80,
-                                                        ),
+                                              fillColor:
+                                                  context.appColors.surfaceFill,
                                               isDense: true,
                                               isCollapsed: true,
                                               prefixIcon: Padding(
@@ -3205,9 +3196,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                       decoration: InputDecoration(
                         hintText: l10n.sideDrawerEmojiDialogHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(color: Colors.transparent),
@@ -3317,9 +3306,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerImageUrlDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),
@@ -3444,9 +3431,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerQQAvatarInputHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(color: Colors.transparent),
@@ -3597,7 +3582,6 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
       context: context,
       builder: (ctx) {
         final cs = Theme.of(ctx).colorScheme;
-        final isDark = Theme.of(ctx).brightness == Brightness.dark;
         String value = controller.text;
         bool valid(String v) => v.trim().isNotEmpty && v.trim() != initial;
         return StatefulBuilder(
@@ -3626,9 +3610,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
                       labelText: l10n.sideDrawerNicknameLabel,
                       hintText: l10n.sideDrawerNicknameHint,
                       filled: true,
-                      fillColor: isDark
-                          ? Colors.white10
-                          : const Color(0xFFF2F3F5),
+                      fillColor: context.appColors.surfaceFill,
                       counterText: '',
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -3921,7 +3903,6 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
         if (url == null || url.isEmpty) return const SizedBox.shrink();
         final l10n = AppLocalizations.of(context)!;
         final cs = Theme.of(context).colorScheme;
-        final isDark = Theme.of(context).brightness == Brightness.dark;
         final version = info.build != null
             ? l10n.sideDrawerUpdateTitleWithBuild(info.version, info.build!)
             : l10n.sideDrawerUpdateTitle(info.version);
@@ -3929,7 +3910,7 @@ class _SideDrawerState extends State<SideDrawer> with TickerProviderStateMixin {
           padding: const EdgeInsets.only(bottom: 8),
           child: IosCardPress(
             borderRadius: BorderRadius.circular(12),
-            baseColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+            baseColor: context.appColors.surfaceFill,
             padding: const EdgeInsets.fromLTRB(10, 8, 4, 8),
             onTap: () {
               if (_isDesktop) {
@@ -4528,9 +4509,7 @@ class _DesktopSidebarTabsState extends State<_DesktopSidebarTabs> {
             final double segW = (constraints.maxWidth - pad * 2) / 2;
             return Container(
               decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white10
-                    : Colors.grey.shade200.withValues(alpha: 0.80),
+                color: context.appColors.surfaceFill.withValues(alpha: 0.80),
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Stack(

--- a/lib/features/instruction_injection/pages/instruction_injection_page.dart
+++ b/lib/features/instruction_injection/pages/instruction_injection_page.dart
@@ -15,6 +15,7 @@ import 'package:uuid/uuid.dart';
 import '../../../core/services/haptics.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class InstructionInjectionPage extends StatefulWidget {
   const InstructionInjectionPage({super.key});
@@ -373,11 +374,8 @@ class _InstructionInjectionPageState extends State<InstructionInjectionPage> {
                                         onTap: () =>
                                             _showAddEditSheet(item: item),
                                         builder: (pressed, overlay) {
-                                          final baseBg = isDark
-                                              ? Colors.white10
-                                              : Colors.white.withValues(
-                                                  alpha: 0.96,
-                                                );
+                                          final baseBg =
+                                              context.appColors.surfaceCard;
                                           return Container(
                                             decoration: BoxDecoration(
                                               color: Color.alphaBlend(
@@ -585,7 +583,6 @@ class _InstructionInjectionEditSheetState
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return SafeArea(
       top: false,
@@ -629,7 +626,7 @@ class _InstructionInjectionEditSheetState
               decoration: InputDecoration(
                 labelText: l10n.instructionInjectionNameLabel,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -657,7 +654,7 @@ class _InstructionInjectionEditSheetState
                 labelText: l10n.instructionInjectionGroupLabel,
                 hintText: l10n.instructionInjectionGroupHint,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -686,7 +683,7 @@ class _InstructionInjectionEditSheetState
                 labelText: l10n.instructionInjectionPromptLabel,
                 alignLabelWithHint: true,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -805,11 +802,10 @@ class _TactileCardState extends State<_TactileCard> {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final overlay = _pressed
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/lib/features/mcp/pages/mcp_page.dart
+++ b/lib/features/mcp/pages/mcp_page.dart
@@ -11,6 +11,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../core/services/haptics.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class McpPage extends StatelessWidget {
   const McpPage({super.key});
@@ -19,12 +20,12 @@ class McpPage extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     switch (s) {
       case McpStatus.connected:
-        return Colors.green;
+        return context.appColors.success;
       case McpStatus.connecting:
         return cs.primary;
       case McpStatus.error:
       case McpStatus.idle:
-        return Colors.red;
+        return cs.error;
     }
   }
 
@@ -75,9 +76,7 @@ class McpPage extends StatelessWidget {
                     width: double.infinity,
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.dark
-                          ? Colors.white10
-                          : const Color(0xFFF7F7F9),
+                      color: context.appColors.surfaceFill,
                       borderRadius: BorderRadius.circular(12),
                       border: Border.all(
                         color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -102,10 +101,7 @@ class McpPage extends StatelessWidget {
                           ),
                           style: OutlinedButton.styleFrom(
                             minimumSize: const Size.fromHeight(44),
-                            backgroundColor:
-                                Theme.of(context).brightness == Brightness.dark
-                                ? Colors.white10
-                                : const Color(0xFFF2F3F5),
+                            backgroundColor: context.appColors.surfaceFill,
                             side: BorderSide(
                               color: cs.outlineVariant.withValues(alpha: 0.35),
                             ),
@@ -250,15 +246,13 @@ class McpPage extends StatelessWidget {
                       base: base,
                       builder: (c) {
                         final overlay = pressed
-                            ? (isDark
-                                  ? Colors.black.withValues(alpha: 0.06)
-                                  : Colors.white.withValues(alpha: 0.05))
+                            ? cs.onSurface.withValues(
+                                alpha: isDark ? 0.06 : 0.05,
+                              )
                             : Colors.transparent;
                         return Container(
                           decoration: BoxDecoration(
-                            color: isDark
-                                ? Colors.white10
-                                : Colors.white.withValues(alpha: 0.96),
+                            color: context.appColors.surfaceCard,
                             // Soften the list card corners a bit
                             borderRadius: BorderRadius.circular(14),
                             border: Border.all(
@@ -283,9 +277,7 @@ class McpPage extends StatelessWidget {
                                       width: 42,
                                       height: 42,
                                       decoration: BoxDecoration(
-                                        color: isDark
-                                            ? Colors.white10
-                                            : const Color(0xFFF2F3F5),
+                                        color: context.appColors.surfaceFill,
                                         borderRadius: BorderRadius.circular(10),
                                       ),
                                       alignment: Alignment.center,
@@ -365,10 +357,12 @@ class McpPage extends StatelessWidget {
                                                       ? l10n.mcpPageStatusConnecting
                                                       : l10n.mcpPageStatusDisconnected),
                                             color: st == McpStatus.connected
-                                                ? Colors.green
+                                                ? context.appColors.success
                                                 : (st == McpStatus.connecting
                                                       ? cs.primary
-                                                      : Colors.redAccent),
+                                                      : Theme.of(
+                                                          context,
+                                                        ).colorScheme.error),
                                           ),
                                           tagStyled(
                                             s.transport ==
@@ -404,7 +398,7 @@ class McpPage extends StatelessWidget {
                                             Icon(
                                               Lucide.MessageCircleWarning,
                                               size: 14,
-                                              color: Colors.red,
+                                              color: cs.error,
                                             ),
                                             const SizedBox(width: 6),
                                             Expanded(
@@ -412,7 +406,7 @@ class McpPage extends StatelessWidget {
                                                 l10n.mcpPageConnectionFailed,
                                                 style: TextStyle(
                                                   fontSize: 12,
-                                                  color: Colors.red,
+                                                  color: cs.error,
                                                 ),
                                               ),
                                             ),

--- a/lib/features/mcp/widgets/mcp_conversation_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_conversation_sheet.dart
@@ -7,6 +7,7 @@ import '../../../theme/design_tokens.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<void> showConversationMcpSheet(
   BuildContext context, {
@@ -27,19 +28,16 @@ Future<void> showConversationMcpSheet(
 class _ConversationMcpSheet extends StatelessWidget {
   const _ConversationMcpSheet({required this.conversationId});
   final String conversationId;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final mcp = context.watch<McpProvider>();
     final chat = context.watch<ChatService>();
-
     final selected = chat.getConversationMcpServers(conversationId).toSet();
     final servers = mcp.servers
         .where((s) => mcp.statusFor(s.id) == McpStatus.connected)
         .toList();
-
     Widget tag(String text) => Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(
@@ -56,7 +54,6 @@ class _ConversationMcpSheet extends StatelessWidget {
         ),
       ),
     );
-
     return SafeArea(
       top: false,
       child: DraggableScrollableSheet(
@@ -163,12 +160,12 @@ class _ConversationMcpSheet extends StatelessWidget {
                                       : 0.10,
                                 )
                               : (Theme.of(context).brightness == Brightness.dark
+                                    // color-gate: ignore
                                     ? Colors.white10
                                     : cs.surface);
                           final borderColor = isSelected
                               ? cs.primary.withValues(alpha: 0.45)
                               : cs.outlineVariant.withValues(alpha: 0.25);
-
                           return Material(
                             color: Colors.transparent,
                             shape: RoundedRectangleBorder(
@@ -209,11 +206,7 @@ class _ConversationMcpSheet extends StatelessWidget {
                                         width: 42,
                                         height: 42,
                                         decoration: BoxDecoration(
-                                          color:
-                                              Theme.of(context).brightness ==
-                                                  Brightness.dark
-                                              ? Colors.white10
-                                              : const Color(0xFFF2F3F5),
+                                          color: context.appColors.surfaceFill,
                                           borderRadius: BorderRadius.circular(
                                             10,
                                           ),

--- a/lib/features/mcp/widgets/mcp_json_edit_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_json_edit_sheet.dart
@@ -10,6 +10,7 @@ import '../../../shared/widgets/snackbar.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<void> showMcpJsonEditSheet(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
@@ -79,7 +80,6 @@ class _McpJsonEditSheetState extends State<_McpJsonEditSheet> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     // Resolve user-preferred code font family (Google/local/system)
     final settings = context.watch<SettingsProvider>();
     String resolveCodeFont() {
@@ -160,7 +160,7 @@ class _McpJsonEditSheetState extends State<_McpJsonEditSheet> {
                 ),
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: isDark ? Colors.white10 : Colors.white,
+                    color: context.appColors.surfaceFill,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
                       color: cs.outlineVariant.withValues(alpha: 0.3),
@@ -191,7 +191,10 @@ class _McpJsonEditSheetState extends State<_McpJsonEditSheet> {
                 padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                 child: Text(
                   _error!,
-                  style: TextStyle(color: Colors.redAccent, fontSize: 12),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.error,
+                    fontSize: 12,
+                  ),
                 ),
               ),
             ],

--- a/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/snackbar.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import 'mcp_oauth_section_controller.dart';
 
 class _HeaderEntry {
@@ -242,7 +243,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -273,7 +274,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
     required TextEditingController controller,
     String? hint,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -292,7 +292,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
             hintText: hint,
             filled: true,
             // Match provider sheet input background
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             // Match provider sheet border styles
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
@@ -502,9 +502,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
             margin: const EdgeInsets.only(bottom: 10),
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: Theme.of(context).brightness == Brightness.dark
-                  ? Colors.white10
-                  : const Color(0xFFF7F7F9),
+              color: context.appColors.surfaceFill,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: cs.outlineVariant.withValues(alpha: 0.2),
@@ -700,7 +698,9 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
                       ? Lucide.TriangleAlert
                       : Lucide.circleCheckBig,
                   size: 14,
-                  color: token == null || expired ? cs.error : Colors.green,
+                  color: token == null || expired
+                      ? cs.error
+                      : context.appColors.success,
                 ),
                 const SizedBox(width: 6),
                 Expanded(
@@ -982,11 +982,7 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
                                       margin: const EdgeInsets.only(bottom: 10),
                                       padding: const EdgeInsets.all(12),
                                       decoration: BoxDecoration(
-                                        color:
-                                            Theme.of(context).brightness ==
-                                                Brightness.dark
-                                            ? Colors.white10
-                                            : const Color(0xFFF7F7F9),
+                                        color: context.appColors.surfaceFill,
                                         borderRadius: BorderRadius.circular(12),
                                         border: Border.all(
                                           color: cs.outlineVariant.withValues(
@@ -1323,7 +1319,7 @@ class _SegChoiceBar extends StatelessWidget {
             segWidth * labels.length + gap * (labels.length - 1);
 
         final Color shellBg = isDark
-            ? Colors.white.withValues(alpha: 0.08)
+            ? cs.onSurface.withValues(alpha: 0.08)
             : Colors.white;
 
         List<Widget> children = [];
@@ -1446,7 +1442,7 @@ class _SegTabBar extends StatelessWidget {
             segWidth * tabs.length + gap * (tabs.length - 1);
 
         final Color shellBg = isDark
-            ? Colors.white.withValues(alpha: 0.08)
+            ? cs.onSurface.withValues(alpha: 0.08)
             : Colors.white;
 
         List<Widget> children = [];

--- a/lib/features/mcp/widgets/mcp_timeout_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_timeout_sheet.dart
@@ -2,11 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-
 import '../../../core/providers/mcp_provider.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<void> showMcpTimeoutSheet(BuildContext context) async {
   final l10n = AppLocalizations.of(context)!;
@@ -14,7 +14,6 @@ Future<void> showMcpTimeoutSheet(BuildContext context) async {
   final controller = TextEditingController(
     text: mcp.requestTimeoutSeconds.toString(),
   );
-
   await showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
@@ -26,7 +25,6 @@ Future<void> showMcpTimeoutSheet(BuildContext context) async {
       final cs = Theme.of(ctx).colorScheme;
       final isDark = Theme.of(ctx).brightness == Brightness.dark;
       final bottom = MediaQuery.of(ctx).viewInsets.bottom;
-
       Future<void> handleSave() async {
         FocusScope.of(ctx).unfocus();
         final raw = controller.text.trim();
@@ -87,7 +85,7 @@ Future<void> showMcpTimeoutSheet(BuildContext context) async {
                 hintText: l10n.mcpTimeoutSecondsLabel,
                 suffixText: 's',
                 filled: true,
-                fillColor: isDark ? Colors.white10 : Colors.white,
+                fillColor: ctx.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -120,6 +118,7 @@ Future<void> showMcpTimeoutSheet(BuildContext context) async {
                   child: CupertinoButton(
                     padding: const EdgeInsets.symmetric(vertical: 12),
                     color: isDark
+                        // color-gate: ignore
                         ? Colors.white10
                         : cs.surfaceContainerHighest.withValues(alpha: 0.85),
                     borderRadius: BorderRadius.circular(12),

--- a/lib/features/model/pages/default_model_page.dart
+++ b/lib/features/model/pages/default_model_page.dart
@@ -1,5 +1,4 @@
 import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../core/providers/settings_provider.dart';
@@ -18,10 +17,10 @@ import '../../../l10n/app_localizations.dart';
 import '../../../utils/brand_assets.dart';
 import '../../../core/services/haptics.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class DefaultModelPage extends StatelessWidget {
   const DefaultModelPage({super.key});
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -376,9 +375,7 @@ class DefaultModelPage extends StatelessWidget {
                       decoration: InputDecoration(
                         hintText: l10n.defaultModelPageTitlePromptHint,
                         filled: true,
-                        fillColor: Theme.of(ctx).brightness == Brightness.dark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: BorderSide(
@@ -604,9 +601,7 @@ class DefaultModelPage extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.defaultModelPageTranslatePromptHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
@@ -728,9 +723,7 @@ class DefaultModelPage extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.defaultModelPageSummaryPromptHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
@@ -866,9 +859,7 @@ class DefaultModelPage extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.defaultModelPageCompressPromptHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
@@ -987,9 +978,7 @@ class DefaultModelPage extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.defaultModelPageSuggestionPromptHint,
                     filled: true,
-                    fillColor: Theme.of(ctx).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: BorderSide(
@@ -1064,7 +1053,6 @@ class _ModelCard extends StatelessWidget {
     this.disabledWhenUnset = false,
     this.configAction,
   });
-
   final IconData icon;
   final String title;
   final String subtitle;
@@ -1076,21 +1064,17 @@ class _ModelCard extends StatelessWidget {
   final VoidCallback onPick;
   final VoidCallback? onReset;
   final VoidCallback? configAction;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final settings = context.read<SettingsProvider>();
     final l10n = AppLocalizations.of(context)!;
-
     // Check if using fallback (not explicitly set)
     final usingFallback = modelProvider == null || modelId == null;
-
     // Use fallback values if needed
     final effectiveProvider = modelProvider ?? fallbackProvider;
     final effectiveModelId = modelId ?? fallbackModelId;
-
     String? providerName;
     String? modelDisplay;
     if (effectiveProvider != null && effectiveModelId != null) {
@@ -1113,16 +1097,13 @@ class _ModelCard extends StatelessWidget {
         modelDisplay = effectiveModelId;
       }
     }
-
     // Override display text if using fallback
     if (usingFallback) {
       modelDisplay = disabledWhenUnset
           ? l10n.defaultModelPageNotEnabled
           : l10n.defaultModelPageUseCurrentModel;
     }
-    final baseBg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final baseBg = context.appColors.surfaceCard;
     return Container(
       decoration: BoxDecoration(
         color: baseBg,
@@ -1185,10 +1166,10 @@ class _ModelCard extends StatelessWidget {
             _TactileRow(
               onTap: onPick,
               builder: (pressed) {
-                final bg = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
-                final overlay = isDark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.black.withValues(alpha: 0.05);
+                final bg = context.appColors.surfaceFill;
+                final overlay = cs.onSurface.withValues(
+                  alpha: isDark ? 0.06 : 0.05,
+                );
                 final pressedBg = Color.alphaBlend(overlay, bg);
                 return AnimatedScale(
                   scale: pressed ? 0.98 : 1.0,
@@ -1240,7 +1221,6 @@ class _BrandAvatar extends StatelessWidget {
   const _BrandAvatar({required this.name, this.size = 20});
   final String name;
   final double size;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -1282,6 +1262,7 @@ class _BrandAvatar extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
         shape: BoxShape.circle,
       ),
@@ -1299,13 +1280,11 @@ class _ModelThinkingSwitchRow extends StatelessWidget {
     required this.semanticLabel,
     required this.cs,
   });
-
   final bool value;
   final ValueChanged<bool> onChanged;
   final String label;
   final String semanticLabel;
   final ColorScheme cs;
-
   @override
   Widget build(BuildContext context) {
     return _TactileRow(

--- a/lib/features/model/widgets/model_detail_sheet.dart
+++ b/lib/features/model/widgets/model_detail_sheet.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import 'model_edit_state_helper.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 Future<bool?> showModelDetailSheet(
   BuildContext context, {
@@ -386,7 +387,6 @@ class _ModelDetailSheetState extends State<_ModelDetailSheet>
   }
 
   List<Widget> _buildBasic(BuildContext context, AppLocalizations l10n) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return [
       Padding(
@@ -415,7 +415,7 @@ class _ModelDetailSheetState extends State<_ModelDetailSheet>
                   : null,
               decoration: InputDecoration(
                 filled: true,
-                fillColor: isDark ? Colors.white10 : Colors.white,
+                fillColor: context.appColors.surfaceFill,
                 hintText: l10n.modelDetailSheetModelIdHint,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(14),
@@ -479,7 +479,7 @@ class _ModelDetailSheetState extends State<_ModelDetailSheet>
               },
               decoration: InputDecoration(
                 filled: true,
-                fillColor: isDark ? Colors.white10 : Colors.white,
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(14),
                   borderSide: BorderSide(
@@ -967,7 +967,7 @@ class _SegmentedSingle extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(12),
-        color: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+        color: context.appColors.surfaceFill,
         border: Border.all(
           color: Theme.of(
             context,
@@ -1042,7 +1042,7 @@ class _SegmentedMulti extends StatelessWidget {
         isSelected.isNotEmpty && isSelected.every((e) => e);
     final int selectedCount = isSelected.where((e) => e).length;
 
-    final base = isDark ? Colors.white10 : const Color(0xFFF2F3F5);
+    final base = context.appColors.surfaceFill;
     final sel = isDark
         ? cs.primary.withValues(alpha: 0.20)
         : cs.primary.withValues(alpha: 0.14);
@@ -1154,7 +1154,6 @@ class _HeaderRow extends StatelessWidget {
   final VoidCallback onDelete;
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
     return Padding(
@@ -1169,7 +1168,7 @@ class _HeaderRow extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.modelDetailSheetHeaderKeyHint,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(
@@ -1207,7 +1206,7 @@ class _HeaderRow extends StatelessWidget {
             decoration: InputDecoration(
               hintText: l10n.modelDetailSheetHeaderValueHint,
               filled: true,
-              fillColor: isDark ? Colors.white10 : Colors.white,
+              fillColor: context.appColors.surfaceFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(14),
                 borderSide: BorderSide(
@@ -1243,7 +1242,6 @@ class _BodyRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
@@ -1257,7 +1255,7 @@ class _BodyRow extends StatelessWidget {
                   decoration: InputDecoration(
                     hintText: l10n.modelDetailSheetBodyKeyHint,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(
@@ -1303,7 +1301,7 @@ class _BodyRow extends StatelessWidget {
             decoration: InputDecoration(
               hintText: l10n.modelDetailSheetBodyJsonHint,
               filled: true,
-              fillColor: isDark ? Colors.white10 : Colors.white,
+              fillColor: context.appColors.surfaceFill,
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(14),
                 borderSide: BorderSide(
@@ -1349,13 +1347,12 @@ class _ToolTile extends StatelessWidget {
   final ValueChanged<bool>? onChanged;
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     final bool isDisabled = onChanged == null;
     return Opacity(
       opacity: isDisabled ? 0.45 : 1.0,
       child: Material(
-        color: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+        color: context.appColors.surfaceFill,
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
@@ -1515,7 +1512,7 @@ class _SegTabBar extends StatelessWidget {
             segWidth * tabs.length + gap * (tabs.length - 1);
 
         final Color shellBg = isDark
-            ? Colors.white.withValues(alpha: 0.08)
+            ? cs.onSurface.withValues(alpha: 0.08)
             : Colors.white;
 
         List<Widget> children = [];

--- a/lib/features/model/widgets/model_select_sheet.dart
+++ b/lib/features/model/widgets/model_select_sheet.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
@@ -21,6 +20,7 @@ import '../../provider/widgets/provider_avatar.dart';
 import '../../provider/widgets/provider_balance_badge.dart';
 import '../../../core/services/model_override_resolver.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ModelSelection {
   final String providerKey;
@@ -39,7 +39,6 @@ class _ModelProcessingData {
   final List<String> providersOrder;
   final String? limitProviderKey;
   final bool disableResolverPlatformLogging;
-
   _ModelProcessingData({
     required this.providerConfigs,
     required this.pinnedModels,
@@ -54,7 +53,6 @@ class _ModelProcessingResult {
   final Map<String, _ProviderGroup> groups;
   final List<_ModelItem> favItems;
   final List<String> orderedKeys;
-
   _ModelProcessingResult({
     required this.groups,
     required this.favItems,
@@ -99,16 +97,13 @@ _ModelProcessingResult _processModelsInBackground(_ModelProcessingData data) {
             data.limitProviderKey!:
                 data.providerConfigs[data.limitProviderKey]!,
         };
-
   // Build data map: providerKey -> (displayName, models)
   final Map<String, _ProviderGroup> groups = {};
-
   providers.forEach((key, cfg) {
     // Skip disabled providers entirely so they can't be selected
     if (!(cfg['enabled'] as bool)) return;
     final models = cfg['models'] as List<dynamic>? ?? [];
     if (models.isEmpty) return;
-
     final name = (cfg['name'] as String?) ?? '';
     final overrides =
         (cfg['overrides'] as Map?)?.map((k, v) => MapEntry(k.toString(), v)) ??
@@ -157,7 +152,6 @@ _ModelProcessingResult _processModelsInBackground(_ModelProcessingData data) {
       items: list,
     );
   });
-
   // Build favorites group (duplicate items)
   final favItems = <_ModelItem>[];
   for (final k in data.pinnedModels) {
@@ -180,7 +174,6 @@ _ModelProcessingResult _processModelsInBackground(_ModelProcessingData data) {
     );
     favItems.add(found.copyWith(pinned: true));
   }
-
   // Provider sections ordered by ProvidersPage order
   final orderedKeys = <String>[];
   for (final k in data.providersOrder) {
@@ -189,7 +182,6 @@ _ModelProcessingResult _processModelsInBackground(_ModelProcessingData data) {
   for (final k in groups.keys) {
     if (!orderedKeys.contains(k)) orderedKeys.add(k);
   }
-
   return _ModelProcessingResult(
     groups: groups,
     favItems: favItems,
@@ -218,7 +210,9 @@ Future<List<ModelSelection>?> showMultiModelSelector(
         context: context,
         barrierDismissible: true,
         barrierLabel: 'multi-model-select-desktop',
-        barrierColor: Colors.black.withValues(alpha: 0.25),
+        barrierColor: Theme.of(
+          context,
+        ).colorScheme.scrim.withValues(alpha: 0.25),
         pageBuilder: (ctx, _, __) => _DesktopModelSelectDialogBody(
           limitProviderKey: limitProviderKey,
           preselectedKeys: preselectedKeys,
@@ -391,7 +385,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
   final ItemScrollController _itemScrollController = ItemScrollController();
   final ItemPositionsListener _itemPositionsListener =
       ItemPositionsListener.create();
-
   // Flattened rows + index maps for precise jumps
   final List<_ListRow> _rows = <_ListRow>[];
   final Map<String, int> _headerIndexMap =
@@ -400,16 +393,13 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       <String, int>{}; // 'pk::modelId' in provider sections -> index
   final Map<String, int> _favModelIndexMap =
       <String, int>{}; // 'pk::modelId' in favorites -> index
-
   // Multi-select state
   final _multiSelect = ModelMultiSelectState();
-
   // Async loading state
   bool _isLoading = true;
   Map<String, _ProviderGroup> _groups = {};
   List<String> _orderedKeys = [];
   bool _autoScrolled = false; // ensure we only auto-scroll once per open
-
   dynamic _sanitizeJsonValue(dynamic value) {
     if (value == null || value is num || value is bool || value is String) {
       return value;
@@ -498,9 +488,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       final settings = context.read<SettingsProvider>();
       final assistantProvider = context.read<AssistantProvider>();
       final providerConfigs = _buildProviderConfigsPayload(settings);
-
       final currentKey = _currentModelKey(settings, assistantProvider);
-
       // Prepare data for background processing
       final processingData = _ModelProcessingData(
         providerConfigs: providerConfigs,
@@ -513,10 +501,8 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         limitProviderKey: widget.limitProviderKey,
         disableResolverPlatformLogging: true,
       );
-
       // Process in background isolate
       final result = await compute(_processModelsInBackground, processingData);
-
       if (mounted) {
         setState(() {
           _groups = result.groups;
@@ -557,9 +543,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     final settings = context.read<SettingsProvider>();
     final assistantProvider = context.read<AssistantProvider>();
     final providerConfigs = _buildProviderConfigsPayload(settings);
-
     final currentKey = _currentModelKey(settings, assistantProvider);
-
     final processingData = _ModelProcessingData(
       providerConfigs: providerConfigs,
       pinnedModels: settings.pinnedModels,
@@ -571,9 +555,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       limitProviderKey: widget.limitProviderKey,
       disableResolverPlatformLogging: false,
     );
-
     final result = _processModelsInBackground(processingData);
-
     setState(() {
       _groups = result.groups;
       _orderedKeys = result.orderedKeys;
@@ -600,13 +582,11 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       await _scrollToFirstSearchGroup(initial: true);
       return;
     }
-
     // Optionally expand a bit for better context
     await _expandSheetIfNeeded(
       _initialSize.clamp(0.0, _maxSize),
       duration: const Duration(milliseconds: 200),
     );
-
     // Ensure the list is attached before attempting to scroll
     if (!_itemScrollController.isAttached) {
       // Try again shortly after the list attaches
@@ -617,9 +597,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       });
       return;
     }
-
     final targetIndex = _currentSelectionTargetIndex();
-
     if (targetIndex != null) {
       final alignment = _currentSelectionScrollAlignment(targetIndex);
       try {
@@ -650,21 +628,17 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
 
   int? _currentSelectionTargetIndex() {
     if (_search.text.trim().isNotEmpty) return null;
-
     final settings = context.read<SettingsProvider>();
-
     final currentKey = _currentModelKey(
       settings,
       context.read<AssistantProvider>(),
     );
     if (currentKey.isEmpty) return null;
-
     if (widget.limitProviderKey == null &&
         settings.pinnedModels.contains(currentKey)) {
       final favIndex = _favModelIndexMap[currentKey];
       if (favIndex != null) return favIndex;
     }
-
     final separator = currentKey.indexOf('::');
     final pk = separator == -1
         ? currentKey
@@ -680,11 +654,9 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         ? (_stickyProviderHeaderHeight / _listViewportHeight).clamp(0.0, 0.3)
         : 0.0;
     if (_rows.length <= 1) return topAlignment;
-
     final remainingExtent = _estimatedRemainingExtentFrom(targetIndex);
     final topAlignedRequiredExtent = _listViewportHeight * (1 - topAlignment);
     if (remainingExtent >= topAlignedRequiredExtent) return topAlignment;
-
     final tailAlignment = 1.0 - (remainingExtent / _listViewportHeight);
     return tailAlignment.clamp(topAlignment, 0.72);
   }
@@ -707,7 +679,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       _initialSize.clamp(0.0, _maxSize),
       duration: const Duration(milliseconds: 200),
     );
-
     if (!_itemScrollController.isAttached) {
       Future.delayed(const Duration(milliseconds: 60), () {
         if (mounted) {
@@ -716,7 +687,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
       });
       return;
     }
-
     int? targetIndex;
     // Prefer favorites section when it exists in current filtered rows
     targetIndex = _headerIndexMap['__fav__'];
@@ -730,9 +700,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         }
       }
     }
-
     if (targetIndex == null) return;
-
     try {
       await _itemScrollController.scrollTo(
         index: targetIndex,
@@ -792,11 +760,9 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
             .toList()
           ..sort((a, b) => a.itemLeadingEdge.compareTo(b.itemLeadingEdge));
     if (positions.isEmpty || _rows.isEmpty) return null;
-
     final topIndex = positions.first.index;
     final directKey = _providerKeyForRow(topIndex);
     if (directKey != null) return directKey;
-
     for (var i = topIndex - 1; i >= 0; i--) {
       final key = _providerKeyForRow(i);
       if (key != null) return key;
@@ -844,16 +810,13 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         !_providerTabsController.hasClients) {
       return;
     }
-
     final tabBox = tabContext.findRenderObject();
     final viewportBox = viewportContext.findRenderObject();
     if (tabBox is! RenderBox || viewportBox is! RenderBox) return;
-
     final tabLeft = tabBox.localToGlobal(Offset.zero).dx;
     final tabRight = tabLeft + tabBox.size.width;
     final viewportLeft = viewportBox.localToGlobal(Offset.zero).dx;
     final viewportRight = viewportLeft + viewportBox.size.width;
-
     var targetOffset = _providerTabsController.offset;
     if (tabLeft < viewportLeft) {
       targetOffset += tabLeft - viewportLeft;
@@ -862,7 +825,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     } else {
       return;
     }
-
     targetOffset = targetOffset.clamp(
       _providerTabsController.position.minScrollExtent,
       _providerTabsController.position.maxScrollExtent,
@@ -880,7 +842,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
-
     return SafeArea(
       top: false,
       child: AnimatedPadding(
@@ -945,12 +906,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
                             _lastQuery = q;
                           },
                           // Ensure high-contrast input text in both themes
-                          style: TextStyle(
-                            color:
-                                Theme.of(context).brightness == Brightness.dark
-                                ? Colors.white
-                                : Colors.black87,
-                          ),
+                          style: TextStyle(color: cs.onSurface),
                           cursorColor: cs.primary,
                           decoration: InputDecoration(
                             hintText: l10n.modelSelectSheetSearchHint,
@@ -1145,9 +1101,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     _headerIndexMap.clear();
     _modelIndexMap.clear();
     _favModelIndexMap.clear();
-
     final Set<String> favMatchedKeys = <String>{};
-
     if (widget.limitProviderKey == null) {
       final pinned = context.watch<SettingsProvider>().pinnedModels;
       if (pinned.isNotEmpty) {
@@ -1190,7 +1144,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         }
       }
     }
-
     for (final pk in _orderedKeys) {
       final g = _groups[pk]!;
       List<_ModelItem> items;
@@ -1217,11 +1170,8 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         _rows.add(_ModelRow(m));
       }
     }
-
     if (_rows.isEmpty) return const SizedBox.shrink();
-
     _scheduleActiveProviderUpdate();
-
     return LayoutBuilder(
       builder: (context, constraints) {
         _listViewportHeight = constraints.maxHeight;
@@ -1345,9 +1295,7 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
         }
       }
     }
-
     if (providerTabs.isEmpty) return const SizedBox.shrink();
-
     return Padding(
       // SafeArea already applies bottom inset; avoid doubling it here.
       padding: const EdgeInsets.only(left: 12, right: 12, top: 8, bottom: 10),
@@ -1366,7 +1314,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     if (providerKey == null) return const SizedBox.shrink();
     final group = _groups[providerKey];
     if (group == null) return const SizedBox.shrink();
-
     final cs = Theme.of(context).colorScheme;
     return Positioned(
       top: -1,
@@ -1658,7 +1605,6 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
   Future<void> _jumpToProvider(String pk) async {
     // Expand sheet first if needed
     await _expandSheetIfNeeded(_maxSize);
-
     // Use precise index jump via ScrollablePositionedList
     final idx = _headerIndexMap[pk];
     if (idx != null) {
@@ -1685,13 +1631,11 @@ class _ModelSelectSheetState extends State<_ModelSelectSheet> {
     if (widget.limitProviderKey != null) return;
     // Expand sheet first to reveal more content
     await _expandSheetIfNeeded(_maxSize);
-
     // If search text hides favorites section, clear it to ensure favorites are visible
     if (_search.text.isNotEmpty) {
       setState(() => _search.clear());
       await Future.delayed(const Duration(milliseconds: 150));
     }
-
     // Jump to favorites header index if present
     final idx = _headerIndexMap['__fav__'];
     if (idx != null) {
@@ -1728,7 +1672,6 @@ class _ProviderChip extends StatefulWidget {
   final VoidCallback? onLongPress;
   final Color? borderColor;
   final bool selected;
-
   @override
   State<_ProviderChip> createState() => _ProviderChipState();
 }
@@ -1746,9 +1689,7 @@ class _ProviderChipState extends State<_ProviderChip> {
               ? cs.primary.withValues(alpha: 0.08)
               : cs.primary.withValues(alpha: 0.05))
         : cs.surface;
-    final Color overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final Color overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final Color bg = _pressed ? Color.alphaBlend(overlay, baseBg) : baseBg;
     // Slightly stronger border when selected; keep label color unchanged for subtlety
     final Color borderColor =
@@ -1840,16 +1781,13 @@ class ModelMultiSelectState {
   bool isActive = false;
   final Set<String> _selected = {};
   Set<String> _locked = {};
-
   static String keyFor(String providerKey, String modelId) =>
       '$providerKey|$modelId';
-
   int get count => _selected.length;
   int get lockedCount => _locked.length;
   bool canConfirm(int minCount) => count >= minCount;
   bool contains(String key) => _selected.contains(key);
   bool isLocked(String key) => _locked.contains(key);
-
   void toggle(String key) {
     if (_locked.contains(key)) return;
     if (_selected.contains(key)) {
@@ -1913,7 +1851,6 @@ class _BrandAvatar extends StatelessWidget {
   final String name;
   final double size;
   final String? assetOverride;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -1955,6 +1892,7 @@ class _BrandAvatar extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1),
         shape: BoxShape.circle,
       ),
@@ -1965,7 +1903,6 @@ class _BrandAvatar extends StatelessWidget {
 }
 
 // ===== Desktop dialog implementation =====
-
 Future<ModelSelection?> _showDesktopModelSelector(
   BuildContext context, {
   String? limitProviderKey,
@@ -1977,7 +1914,7 @@ Future<ModelSelection?> _showDesktopModelSelector(
     context: context,
     barrierDismissible: true,
     barrierLabel: 'model-select-desktop',
-    barrierColor: Colors.black.withValues(alpha: 0.25),
+    barrierColor: Theme.of(context).colorScheme.scrim.withValues(alpha: 0.25),
     pageBuilder: (ctx, _, __) => _DesktopModelSelectDialogBody(
       limitProviderKey: limitProviderKey,
       initialProviderKey: initialProviderKey,
@@ -2037,7 +1974,6 @@ class _DesktopModelSelectDialogBodyState
   final Map<String, int> _favModelIndexMap =
       <String, int>{}; // 'pk::modelId' in favorites -> index
   bool _autoScrolled = false; // auto-scroll once when dialog opens
-
   @override
   void initState() {
     super.initState();
@@ -2125,7 +2061,6 @@ class _DesktopModelSelectDialogBodyState
     final assistantProvider = context.read<AssistantProvider>();
     final providerConfigs = _buildProviderConfigsPayload(settings);
     final currentKey = _currentModelKey(settings, assistantProvider);
-
     final data = _ModelProcessingData(
       providerConfigs: providerConfigs,
       pinnedModels: settings.pinnedModels,
@@ -2190,9 +2125,7 @@ class _DesktopModelSelectDialogBodyState
     _headerIndexMap.clear();
     _modelIndexMap.clear();
     _favModelIndexMap.clear();
-
     final Set<String> favMatchedKeys = <String>{};
-
     if (widget.limitProviderKey == null) {
       final pinned = settings.pinnedModels;
       if (pinned.isNotEmpty) {
@@ -2235,7 +2168,6 @@ class _DesktopModelSelectDialogBodyState
         }
       }
     }
-
     for (final pk in _orderedKeys) {
       final g = _groups[pk];
       if (g == null) continue;
@@ -2273,7 +2205,6 @@ class _DesktopModelSelectDialogBodyState
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
-
     final dialog = Center(
       child: ConstrainedBox(
         constraints: const BoxConstraints(
@@ -2315,9 +2246,7 @@ class _DesktopModelSelectDialogBodyState
                               hintText: l10n.modelSelectSheetSearchHint,
                               isDense: true,
                               filled: true,
-                              fillColor: isDark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: context.appColors.surfaceFill,
                               prefixIcon: Icon(
                                 Lucide.Search,
                                 size: 16,
@@ -2467,7 +2396,6 @@ class _DesktopModelSelectDialogBodyState
         ),
       ),
     );
-
     return Material(type: MaterialType.transparency, child: dialog);
   }
 
@@ -2518,21 +2446,17 @@ class _DesktopModelSelectDialogBodyState
       });
       return;
     }
-
     final settings = context.read<SettingsProvider>();
     final currentKey = _currentModelKey(
       settings,
       context.read<AssistantProvider>(),
     );
     if (currentKey.isEmpty) return;
-
     // Rebuild to ensure index maps are current
     _rebuildRows();
-
     final bool showFavorites =
         widget.limitProviderKey == null && _searchCtrl.text.isEmpty;
     final bool isPinned = settings.pinnedModels.contains(currentKey);
-
     int? targetIndex;
     if (showFavorites && isPinned) {
       targetIndex = _favModelIndexMap[currentKey];
@@ -2546,9 +2470,7 @@ class _DesktopModelSelectDialogBodyState
           : currentKey.substring(0, separator);
       targetIndex ??= _headerIndexMap[pk];
     }
-
     if (targetIndex == null) return;
-
     try {
       await _itemScrollController.scrollTo(
         index: targetIndex,
@@ -2646,7 +2568,6 @@ class _DesktopModelSelectDialogBodyState
               ? cs.primary.withValues(alpha: 0.12)
               : cs.primary.withValues(alpha: 0.08))
         : cs.surface;
-
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
       child: IosCardPress(
@@ -2854,5 +2775,4 @@ class _DesktopModelSelectDialogBodyState
     } catch (_) {}
   }
 }
-
 // (desktop tactile row removed in favor of IosCardPress for consistency)

--- a/lib/features/model/widgets/ocr_prompt_sheet.dart
+++ b/lib/features/model/widgets/ocr_prompt_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import '../../../core/prompts/ocr_presets.dart';
 import '../../../core/providers/settings_provider.dart';
@@ -97,9 +98,7 @@ Future<void> showOcrPromptSheet(BuildContext context) async {
                 decoration: InputDecoration(
                   hintText: l10n.defaultModelPageOcrPromptHint,
                   filled: true,
-                  fillColor: Theme.of(ctx).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: BorderSide(

--- a/lib/features/provider/pages/multi_key_manager_page.dart
+++ b/lib/features/provider/pages/multi_key_manager_page.dart
@@ -11,6 +11,7 @@ import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../core/services/haptics.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class MultiKeyManagerPage extends StatefulWidget {
   const MultiKeyManagerPage({
@@ -247,7 +248,7 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
     Color statusColor(ApiKeyStatus st) {
       switch (st) {
         case ApiKeyStatus.active:
-          return Colors.green;
+          return context.appColors.success;
         case ApiKeyStatus.disabled:
           return cs.onSurface.withValues(alpha: 0.6);
         case ApiKeyStatus.error:
@@ -826,7 +827,6 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
   Future<List<String>?> _showAddKeysSheet() async {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final inputCtrl = TextEditingController();
     final result = await showModalBottomSheet<List<String>?>(
       context: context,
@@ -893,7 +893,7 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
                   decoration: InputDecoration(
                     hintText: l10n.multiKeyPageAddHint,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(
@@ -941,7 +941,6 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
   Future<ApiKeyConfig?> _showEditKeySheet(ApiKeyConfig k) async {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final aliasCtrl = TextEditingController(text: k.name ?? '');
     final keyCtrl = TextEditingController(text: k.key);
     final priCtrl = TextEditingController(text: k.priority.toString());
@@ -1008,7 +1007,7 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
                   decoration: InputDecoration(
                     hintText: l10n.multiKeyPageAlias,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(
@@ -1039,7 +1038,7 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
                   decoration: InputDecoration(
                     hintText: l10n.multiKeyPageKey,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(
@@ -1071,7 +1070,7 @@ class _MultiKeyManagerPageState extends State<MultiKeyManagerPage> {
                   decoration: InputDecoration(
                     hintText: l10n.multiKeyPagePriority,
                     filled: true,
-                    fillColor: isDark ? Colors.white10 : Colors.white,
+                    fillColor: context.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(14),
                       borderSide: BorderSide(

--- a/lib/features/provider/pages/provider_balance_page.dart
+++ b/lib/features/provider/pages/provider_balance_page.dart
@@ -10,6 +10,7 @@ import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../widgets/provider_balance_badge.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ProviderBalancePage extends StatefulWidget {
   const ProviderBalancePage({
@@ -293,12 +294,11 @@ class _ProviderBalancePageState extends State<ProviderBalancePage> {
 }
 
 InputDecoration _balanceInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: true,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     hintStyle: TextStyle(
       fontSize: 14,
       color: cs.onSurface.withValues(alpha: 0.5),

--- a/lib/features/provider/pages/provider_detail_page.dart
+++ b/lib/features/provider/pages/provider_detail_page.dart
@@ -39,6 +39,7 @@ import '../../provider/widgets/provider_balance_badge.dart';
 import '../../provider/widgets/provider_avatar.dart';
 import '../../../utils/model_grouping.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ProviderDetailPage extends StatefulWidget {
   const ProviderDetailPage({
@@ -48,7 +49,6 @@ class ProviderDetailPage extends StatefulWidget {
   });
   final String keyName;
   final String displayName;
-
   @override
   State<ProviderDetailPage> createState() => _ProviderDetailPageState();
 }
@@ -76,7 +76,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
   bool _vertexAI = false; // google
   bool _showApiKey = false; // toggle visibility
   bool _multiKeyEnabled = false; // single/multi key mode
-
   // 模型选择模式相关
   bool _isSelectionMode = false;
   final Set<String> _selectedModels = {};
@@ -89,7 +88,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
   bool _aihubmixAppCodeEnabled = false;
   bool _claudePromptCachingEnabled = false;
   String _claudePromptCachingTtl = ProviderConfig.claudePromptCachingTtl5m;
-
   @override
   void initState() {
     super.initState();
@@ -274,7 +272,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                           onPressed: () => Navigator.of(ctx).pop(true),
                           child: Text(
                             l10n.providerDetailPageDeleteButton,
-                            style: TextStyle(color: Colors.red),
+                            style: TextStyle(color: cs.error),
                           ),
                         ),
                       ],
@@ -291,7 +289,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                         }
                       }
                     } catch (_) {}
-
                     // Remove provider config and related selections/pins
                     await settings.removeProviderConfig(widget.keyName);
                     if (!context.mounted) return;
@@ -473,9 +470,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                 decoration: InputDecoration(
                   hintText: l10n.sideDrawerImageUrlDialogHint,
                   filled: true,
-                  fillColor: Theme.of(ctx2).brightness == Brightness.dark
-                      ? Colors.white10
-                      : const Color(0xFFF2F3F5),
+                  fillColor: ctx2.appColors.surfaceFill,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                     borderSide: const BorderSide(color: Colors.transparent),
@@ -555,9 +550,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                   decoration: InputDecoration(
                     hintText: l10n.providerAvatarLobehubDialogHint,
                     filled: true,
-                    fillColor: Theme.of(ctx2).brightness == Brightness.dark
-                        ? Colors.white10
-                        : const Color(0xFFF2F3F5),
+                    fillColor: ctx2.appColors.surfaceFill,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
                       borderSide: const BorderSide(color: Colors.transparent),
@@ -634,14 +627,12 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final icons = BrandAssets.selectableIcons;
-
     // 若当前头像为 LobeHub 自定义图标，预热缓存，使弹窗与详情页头像无需等待下载。
     final current = settings.getProviderConfig(widget.keyName);
     if (current.avatarType == 'lobehub' &&
         (current.avatarValue ?? '').isNotEmpty) {
       _prewarmLobehubIcon(current.avatarValue!.trim().toLowerCase());
     }
-
     await showDialog<void>(
       context: context,
       builder: (ctx) {
@@ -672,9 +663,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                         prefixIcon: const Icon(Lucide.Search, size: 18),
                         isDense: true,
                         filled: true,
-                        fillColor: isDark
-                            ? Colors.white10
-                            : const Color(0xFFF2F3F5),
+                        fillColor: ctx.appColors.surfaceFill,
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(12),
                           borderSide: const BorderSide(
@@ -750,6 +739,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                                           child: Container(
                                             decoration: BoxDecoration(
                                               color: isDark
+                                                  // color-gate: ignore
                                                   ? Colors.white10
                                                   : cs.primary.withValues(
                                                       alpha: 0.1,
@@ -829,7 +819,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
       widget.keyName,
       defaultName: widget.displayName,
     );
-
     return ListView(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
       children: [
@@ -1555,7 +1544,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                                 modelOverrides: newOverrides,
                               ),
                             );
-
                             // Clear global and assistant-level model selections that reference the deleted model
                             await settings.clearSelectionsForModel(
                               widget.keyName,
@@ -1571,7 +1559,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                                 }
                               }
                             } catch (_) {}
-
                             if (!context.mounted) return;
                             showAppSnackBar(
                               context,
@@ -1670,7 +1657,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
   }
 
   // Legacy network tab removed (replaced by ProviderNetworkPage)
-
   Widget _inputRow(
     BuildContext context, {
     required String label,
@@ -1681,7 +1667,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     Widget? suffix,
     ValueChanged<String>? onChanged,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -1705,7 +1690,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
           decoration: InputDecoration(
             hintText: hint,
             filled: true,
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(14),
               borderSide: BorderSide(
@@ -1813,7 +1798,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
   }
 
   // --- iOS style helpers (consistent with MultiKeyManagerPage) ---
-
   Widget _iosSectionCard({required List<Widget> children}) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
@@ -2326,7 +2310,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
       // preserve models and modelOverrides and proxy fields implicitly via copyWith
     );
     await settings.setProviderConfig(widget.keyName, updated);
-
     // If provider is now disabled but was previously enabled, clear model selections
     if (!_enabled && old.enabled) {
       await settings.clearSelectionsForProvider(widget.keyName);
@@ -2341,7 +2324,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
         }
       } catch (_) {}
     }
-
     if (!mounted) return;
     // Silent auto-save (no snackbar) for immediate-save UX
   }
@@ -2354,7 +2336,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     List<Widget>? actions,
     ValueChanged<String>? onChanged,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -2386,7 +2367,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
             hintText: hint,
             filled: true,
             alignLabelWithHint: true,
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(14),
               borderSide: BorderSide(
@@ -2466,13 +2447,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     required EdgeInsetsGeometry padding,
     required double maxWidth,
   }) {
-    final toolbarColor = Theme.of(context).brightness == Brightness.dark
-        ? Color.alphaBlend(
-            Colors.white.withValues(alpha: 0.12),
-            colorScheme.surface,
-          )
-        : const Color(0xFFF2F3F5);
-
+    final toolbarColor = context.appColors.surfaceFill;
     return Align(
       alignment: Alignment.bottomCenter,
       child: Padding(
@@ -2515,7 +2490,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
           horizontal: compact ? 12 : 18,
           vertical: 10,
         );
-
         return _buildToolbarShell(
           colorScheme: cs,
           horizontalMargin: horizontalMargin,
@@ -2699,7 +2673,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
         final textScaler = MediaQuery.textScalerOf(context);
         final textDirection = Directionality.of(context);
         final locale = Localizations.maybeLocaleOf(context);
-
         double labelWidth(String label) {
           final painter = TextPainter(
             text: TextSpan(text: label, style: buttonTextStyle),
@@ -2793,7 +2766,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
             toolbarTextBudget) {
           showDetectLabel = false;
         }
-
         return _buildToolbarShell(
           colorScheme: cs,
           horizontalMargin: horizontalMargin,
@@ -3236,7 +3208,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     );
     if (ok != true) return;
     if (!mounted) return;
-
     final settings = context.read<SettingsProvider>();
     final assistantProvider = context.read<AssistantProvider>();
     final deletedCount = await settings.deleteModels(
@@ -3271,9 +3242,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
 
   Future<void> _startDetection() async {
     if (_selectedModels.isEmpty || _isDetecting) return;
-
     final modelsToTest = Set<String>.from(_selectedModels);
-
     setState(() {
       _isDetecting = true;
       _detectionResults.removeWhere((id, _) => modelsToTest.contains(id));
@@ -3282,12 +3251,10 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
       _pendingModels.addAll(modelsToTest);
       _currentDetectingModel = null;
     });
-
     final cfg = context.read<SettingsProvider>().getProviderConfig(
       widget.keyName,
       defaultName: widget.displayName,
     );
-
     // 顺序检测,防止并发导致API被封锁
     for (final modelId in modelsToTest) {
       if (mounted) {
@@ -3296,7 +3263,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
           _pendingModels.remove(modelId);
         });
       }
-
       try {
         await ProviderManager.testConnection(
           cfg,
@@ -3319,7 +3285,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
       }
       await Future.delayed(const Duration(milliseconds: 500));
     }
-
     if (mounted) {
       setState(() {
         _isDetecting = false;
@@ -3388,7 +3353,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
   }
 
   // _saveNetwork moved to ProviderNetworkPage
-
   Future<void> _showModelPicker(BuildContext context) async {
     final cs = Theme.of(context).colorScheme;
     final settings = context.read<SettingsProvider>();
@@ -3407,7 +3371,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
     String error = '';
     // Collapsed state per group in the selector dialog
     final Map<String, bool> collapsed = <String, bool>{};
-
     await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -3460,7 +3423,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
               // kick off loading once
               Future.microtask(loadModels);
             }
-
             final selected = settings
                 .getProviderConfig(
                   widget.keyName,
@@ -3477,7 +3439,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                         m.displayName.toLowerCase().contains(query)))
                   m,
             ];
-
             String groupFor(ModelInfo m) {
               return ModelGrouping.groupFor(
                 m,
@@ -3493,7 +3454,6 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
             }
             final groupKeys = grouped.keys.toList()
               ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
-
             return SafeArea(
               top: false,
               child: AnimatedPadding(
@@ -3530,10 +3490,7 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                             decoration: InputDecoration(
                               hintText: l10n.providerDetailPageFilterHint,
                               filled: true,
-                              fillColor:
-                                  Theme.of(ctx).brightness == Brightness.dark
-                                  ? Colors.white10
-                                  : const Color(0xFFF2F3F5),
+                              fillColor: ctx.appColors.surfaceFill,
                               prefixIcon: Icon(
                                 Lucide.Search,
                                 size: 20,
@@ -3722,13 +3679,9 @@ class _ProviderDetailPageState extends State<ProviderDetailPage> {
                                           builder: (_) {
                                             return Container(
                                               decoration: BoxDecoration(
-                                                color:
-                                                    Theme.of(
-                                                          context,
-                                                        ).brightness ==
-                                                        Brightness.dark
-                                                    ? Colors.white10
-                                                    : const Color(0xFFF2F3F5),
+                                                color: context
+                                                    .appColors
+                                                    .surfaceFill,
                                                 borderRadius:
                                                     BorderRadius.circular(12),
                                               ),
@@ -4098,7 +4051,6 @@ class _ModelCard extends StatelessWidget {
   final String? detectionErrorMessage;
   final bool isDetecting;
   final bool isPending;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -4142,7 +4094,7 @@ class _ModelCard extends StatelessWidget {
               child: Icon(
                 detectionResult! ? Lucide.CheckCircle : Lucide.XCircle,
                 size: 16,
-                color: detectionResult! ? Colors.green : cs.error,
+                color: detectionResult! ? context.appColors.success : cs.error,
               ),
             ),
           )
@@ -4249,7 +4201,6 @@ class _ResolvedModelOverride {
     required this.ov,
     required this.baseId,
   });
-
   final ModelInfo base;
   final Map<String, dynamic>? ov;
   final String baseId;
@@ -4262,7 +4213,6 @@ class _ConnectionTestDialog extends StatefulWidget {
   });
   final String providerKey;
   final String providerDisplayName;
-
   @override
   State<_ConnectionTestDialog> createState() => _ConnectionTestDialogState();
 }
@@ -4275,7 +4225,6 @@ class _ConnectionTestDialogState extends State<_ConnectionTestDialog> {
   String _errorMessage = '';
   bool _useStream = false;
   bool _hasModels = true;
-
   @override
   void initState() {
     super.initState();
@@ -4501,7 +4450,7 @@ class _ConnectionTestDialogState extends State<_ConnectionTestDialog> {
     required bool success,
     required String message,
   }) {
-    final color = success ? Colors.green : cs.error;
+    final color = success ? context.appColors.success : cs.error;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -4637,14 +4586,11 @@ ModelInfo _applyModelOverride(
 }
 
 // Using flutter_slidable for reliable swipe actions with confirm + undo.
-
 // Legacy page-based implementations removed in favor of swipeable PageView tabs.
-
 class _BrandAvatar extends StatelessWidget {
   const _BrandAvatar({required this.name, this.size = 20});
   final String name;
   final double size;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -4659,6 +4605,7 @@ class _BrandAvatar extends StatelessWidget {
     return CircleAvatar(
       radius: size / 2,
       backgroundColor: isDark
+          // color-gate: ignore
           ? Colors.white10
           : cs.primary.withValues(alpha: 0.1),
       child: asset == null
@@ -4717,21 +4664,18 @@ class _TactileIconButton extends StatefulWidget {
     this.size = 22,
     this.haptics = true,
   });
-
   final IconData icon;
   final Color color;
   final VoidCallback onTap;
   final String? semanticLabel;
   final double size;
   final bool haptics;
-
   @override
   State<_TactileIconButton> createState() => _TactileIconButtonState();
 }
 
 class _TactileIconButtonState extends State<_TactileIconButton> {
   bool _pressed = false;
-
   @override
   Widget build(BuildContext context) {
     final base = widget.color;
@@ -4742,7 +4686,6 @@ class _TactileIconButtonState extends State<_TactileIconButton> {
       color: _pressed ? pressColor : base,
       semanticLabel: widget.semanticLabel,
     );
-
     return Semantics(
       button: true,
       label: widget.semanticLabel,
@@ -4817,7 +4760,6 @@ class _BottomTabs extends StatelessWidget {
   final IconData rightIcon;
   final String rightLabel;
   final ValueChanged<int> onSelect;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -4867,21 +4809,18 @@ class _BottomTabItem extends StatefulWidget {
   final String label;
   final bool selected;
   final VoidCallback onTap;
-
   @override
   State<_BottomTabItem> createState() => _BottomTabItemState();
 }
 
 class _BottomTabItemState extends State<_BottomTabItem> {
   bool _pressed = false;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final baseColor = cs.onSurface.withValues(alpha: 0.7);
     final selColor = cs.primary;
     final target = widget.selected ? selColor : baseColor;
-
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown: (_) => setState(() => _pressed = true),
@@ -4940,21 +4879,16 @@ class _PromptCachingTtlSegmentedControl extends StatelessWidget {
     required this.semanticLabel,
     required this.onChanged,
   });
-
   final String value;
   final String fiveMinuteLabel;
   final String oneHourLabel;
   final String semanticLabel;
   final ValueChanged<String> onChanged;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final background = isDark
-        ? Colors.white.withValues(alpha: 0.08)
-        : Colors.black.withValues(alpha: 0.05);
-
+    final background = cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.05);
     return Semantics(
       label: semanticLabel,
       child: Container(
@@ -4992,12 +4926,10 @@ class _PromptCachingTtlSegment extends StatelessWidget {
     required this.selectedColor,
     required this.onTap,
   });
-
   final String label;
   final bool selected;
   final Color selectedColor;
   final VoidCallback onTap;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;

--- a/lib/features/provider/pages/provider_groups_page.dart
+++ b/lib/features/provider/pages/provider_groups_page.dart
@@ -8,6 +8,7 @@ import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../utils/provider_grouping_logic.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ProviderGroupsPage extends StatefulWidget {
   const ProviderGroupsPage({super.key});
@@ -105,7 +106,7 @@ class _ProviderGroupsPageState extends State<ProviderGroupsPage> {
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(
               l10n.providerGroupsDeleteConfirmOk,
-              style: TextStyle(color: Colors.red),
+              style: TextStyle(color: Theme.of(ctx).colorScheme.error),
             ),
           ),
         ],
@@ -251,7 +252,7 @@ class _ProviderGroupCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final bg = context.appColors.surfaceFill;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.12 : 0.10,
     );

--- a/lib/features/provider/pages/provider_network_page.dart
+++ b/lib/features/provider/pages/provider_network_page.dart
@@ -6,6 +6,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ProviderNetworkPage extends StatefulWidget {
   const ProviderNetworkPage({
@@ -197,12 +198,11 @@ class _ProviderNetworkPageState extends State<ProviderNetworkPage> {
 }
 
 InputDecoration _proxyInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: true,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     hintStyle: TextStyle(
       fontSize: 14,
       color: cs.onSurface.withValues(alpha: 0.5),
@@ -242,8 +242,7 @@ class _ProxyTypeSheetField extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fillColor = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final fillColor = context.appColors.surfaceFill;
 
     String labelOf(String currentValue) {
       switch (currentValue) {

--- a/lib/features/provider/pages/providers_page.dart
+++ b/lib/features/provider/pages/providers_page.dart
@@ -22,6 +22,7 @@ import '../widgets/provider_avatar.dart';
 import '../widgets/provider_group_select_sheet.dart';
 import '../../../utils/provider_grouping_logic.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class ProvidersPage extends StatefulWidget {
   const ProvidersPage({super.key});
@@ -667,7 +668,7 @@ class _ProvidersPageState extends State<ProvidersPage> {
             onPressed: () => Navigator.of(ctx).pop(true),
             child: Text(
               l10n.providerDetailPageDeleteButton,
-              style: TextStyle(color: Colors.red),
+              style: TextStyle(color: Theme.of(ctx).colorScheme.error),
             ),
           ),
         ],
@@ -754,7 +755,7 @@ class _ProvidersList extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.08 : 0.06,
     );
@@ -878,7 +879,7 @@ class _GroupedProvidersList extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
     final borderColor = cs.outlineVariant.withValues(
       alpha: isDark ? 0.08 : 0.06,
     );
@@ -1052,7 +1053,6 @@ class _ProvidersSearchField extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    final isDark = theme.brightness == Brightness.dark;
     final hasText = controller.text.trim().isNotEmpty;
 
     return Padding(
@@ -1060,10 +1060,7 @@ class _ProvidersSearchField extends StatelessWidget {
       child: TextField(
         controller: controller,
         onChanged: onChanged,
-        style: TextStyle(
-          color: isDark ? Colors.white : Colors.black87,
-          fontSize: 14,
-        ),
+        style: TextStyle(color: cs.onSurface, fontSize: 14),
         cursorColor: cs.primary,
         decoration: InputDecoration(
           hintText: hintText,
@@ -1104,9 +1101,7 @@ class _ProvidersSearchField extends StatelessWidget {
             minHeight: 34,
           ),
           filled: true,
-          fillColor: isDark
-              ? Colors.white.withValues(alpha: 0.12)
-              : const Color(0xFFEBEBEB),
+          fillColor: context.appColors.surfaceFill,
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(12),
             borderSide: BorderSide.none,
@@ -1223,9 +1218,11 @@ class _ProviderRow extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     final statusBg = enabled
-        ? Colors.green.withValues(alpha: 0.12)
-        : Colors.orange.withValues(alpha: 0.15);
-    final statusFg = enabled ? Colors.green : Colors.orange;
+        ? context.appColors.successContainer
+        : context.appColors.warningContainer;
+    final statusFg = enabled
+        ? context.appColors.success
+        : context.appColors.warning;
 
     final row = _TactileRow(
       onTap: () {
@@ -1473,9 +1470,7 @@ class _GlassCircleButtonState extends State<_GlassCircleButton> {
     final glassBase = isDark
         ? Colors.black.withValues(alpha: 0.06)
         : Colors.white.withValues(alpha: 0.06);
-    final overlay = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : Colors.black.withValues(alpha: 0.05);
+    final overlay = cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final tileColor = _pressed
         ? Color.alphaBlend(overlay, glassBase)
         : glassBase;

--- a/lib/features/provider/widgets/add_provider_sheet.dart
+++ b/lib/features/provider/widgets/add_provider_sheet.dart
@@ -11,6 +11,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../core/services/haptics.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 Future<String?> showAddProviderSheet(BuildContext context) async {
   final cs = Theme.of(context).colorScheme;
@@ -99,7 +100,6 @@ class _AddProviderSheetState extends State<_AddProviderSheet>
     bool obscure = false,
     bool enabled = true,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -119,7 +119,7 @@ class _AddProviderSheetState extends State<_AddProviderSheet>
           decoration: InputDecoration(
             hintText: hint,
             filled: true,
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
@@ -169,7 +169,7 @@ class _AddProviderSheetState extends State<_AddProviderSheet>
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),
@@ -572,7 +572,6 @@ class _AddProviderSheetState extends State<_AddProviderSheet>
     String? hint,
     List<Widget>? actions,
   }) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -599,7 +598,7 @@ class _AddProviderSheetState extends State<_AddProviderSheet>
           decoration: InputDecoration(
             hintText: hint,
             filled: true,
-            fillColor: isDark ? Colors.white10 : Colors.white,
+            fillColor: context.appColors.surfaceFill,
             border: const OutlineInputBorder(
               borderRadius: BorderRadius.all(Radius.circular(12)),
               borderSide: BorderSide(color: Colors.transparent),

--- a/lib/features/provider/widgets/import_provider_sheet.dart
+++ b/lib/features/provider/widgets/import_provider_sheet.dart
@@ -11,6 +11,7 @@ import '../../../shared/widgets/snackbar.dart';
 import '../../../core/services/haptics.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class _ImportResult {
   final String key;
@@ -517,10 +518,7 @@ Future<void> showImportProviderSheet(BuildContext context) async {
                           decoration: InputDecoration(
                             hintText: l10n.importProviderSheetDescription,
                             filled: true,
-                            fillColor:
-                                Theme.of(ctx).brightness == Brightness.dark
-                                ? Colors.white10
-                                : Colors.white,
+                            fillColor: ctx.appColors.surfaceFill,
                             border: OutlineInputBorder(
                               borderRadius: BorderRadius.circular(12),
                               borderSide: BorderSide(

--- a/lib/features/provider/widgets/provider_avatar.dart
+++ b/lib/features/provider/widgets/provider_avatar.dart
@@ -2,7 +2,6 @@ import 'dart:io' show File;
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
-
 import '../../../core/providers/settings_provider.dart';
 import '../../../utils/avatar_cache.dart';
 import '../../../utils/sandbox_path_resolver.dart';
@@ -18,12 +17,10 @@ class ProviderAvatar extends StatelessWidget {
     this.size = 28,
     this.onTap,
   });
-
   final String providerKey;
   final String displayName;
   final double size;
   final VoidCallback? onTap;
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -32,11 +29,9 @@ class ProviderAvatar extends StatelessWidget {
       providerKey,
       defaultName: displayName,
     );
-
     Widget avatar;
     final type = cfg.avatarType;
     final value = cfg.avatarValue;
-
     if (type == 'emoji' && value != null && value.isNotEmpty) {
       avatar = Container(
         width: size,
@@ -122,22 +117,21 @@ class ProviderAvatar extends StatelessWidget {
         cfg.name.isNotEmpty ? cfg.name : displayName,
       );
     }
-
     final child = Container(
       width: size,
       height: size,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: isDark ? Colors.white24 : Colors.black12,
+          color: Theme.of(
+            context,
+          ).colorScheme.onSurface.withValues(alpha: isDark ? 0.24 : 0.12),
           width: 0.5,
         ),
       ),
       child: avatar,
     );
-
     if (onTap == null) return child;
-
     return InkWell(
       onTap: onTap,
       customBorder: const CircleBorder(),
@@ -169,6 +163,7 @@ class ProviderAvatar extends StatelessWidget {
     final mono = isDark && BrandAssets.assetNeedsDarkInvert(asset);
     return CircleAvatar(
       backgroundColor: isDark
+          // color-gate: ignore
           ? Colors.white10
           : cs.primary.withValues(alpha: 0.1),
       child: asset.endsWith('.svg')
@@ -224,6 +219,7 @@ class ProviderAvatar extends StatelessWidget {
   ) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    // color-gate: ignore
     final bg = isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1);
     // 缓存命中时同步渲染，避免每次 rebuild 都经历 FutureBuilder 的 loading 态。
     final cached = _peekLobehubPath(iconName);
@@ -270,6 +266,7 @@ class ProviderAvatar extends StatelessWidget {
     final needsMono = isDark && BrandAssets.assetNeedsDarkInvert(asset);
     return CircleAvatar(
       backgroundColor: isDark
+          // color-gate: ignore
           ? Colors.white10
           : cs.primary.withValues(alpha: 0.1),
       child: isSvg

--- a/lib/features/quick_phrase/pages/quick_phrases_page.dart
+++ b/lib/features/quick_phrase/pages/quick_phrases_page.dart
@@ -8,6 +8,7 @@ import '../../../core/providers/quick_phrase_provider.dart';
 import 'package:uuid/uuid.dart';
 import '../../../core/services/haptics.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class QuickPhrasesPage extends StatefulWidget {
   const QuickPhrasesPage({super.key, this.assistantId});
@@ -226,9 +227,7 @@ class _QuickPhrasesPageState extends State<QuickPhrasesPage> {
                           pressedScale: 0.98,
                           onTap: () => _showAddEditSheet(phrase: phrase),
                           builder: (pressed, overlay) {
-                            final baseBg = isDark
-                                ? Colors.white10
-                                : Colors.white.withValues(alpha: 0.96);
+                            final baseBg = context.appColors.surfaceCard;
                             return Container(
                               decoration: BoxDecoration(
                                 color: Color.alphaBlend(overlay, baseBg),
@@ -352,7 +351,6 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     return SafeArea(
       top: false,
@@ -396,7 +394,7 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
               decoration: InputDecoration(
                 labelText: l10n.quickPhraseTitleLabel,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -425,7 +423,7 @@ class _QuickPhraseEditSheetState extends State<_QuickPhraseEditSheet> {
                 labelText: l10n.quickPhraseContentLabel,
                 alignLabelWithHint: true,
                 filled: true,
-                fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+                fillColor: context.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -541,11 +539,10 @@ class _TactileCardState extends State<_TactileCard> {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final overlay = _pressed
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
         : Colors.transparent;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/lib/features/quick_phrase/widgets/quick_phrase_menu.dart
+++ b/lib/features/quick_phrase/widgets/quick_phrase_menu.dart
@@ -63,6 +63,7 @@ class QuickPhraseMenu extends StatelessWidget {
                   constraints: BoxConstraints(maxHeight: maxMenuHeight),
                   decoration: BoxDecoration(
                     color: isDark
+                        // color-gate: ignore
                         ? const Color(0xFF1C1C1E).withValues(alpha: 0.66)
                         : Colors.white.withValues(alpha: 0.66),
                     borderRadius: BorderRadius.circular(16),

--- a/lib/features/search/pages/search_api_keys_page.dart
+++ b/lib/features/search/pages/search_api_keys_page.dart
@@ -6,6 +6,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 /// Full-page manager for a search service's API key rotation pool.
 ///
@@ -390,7 +391,7 @@ Widget _card(BuildContext context, {required Widget child}) {
   final isDark = theme.brightness == Brightness.dark;
   return Container(
     decoration: BoxDecoration(
-      color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+      color: context.appColors.surfaceCard,
       borderRadius: BorderRadius.circular(12),
       border: Border.all(
         color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),

--- a/lib/features/search/pages/search_service_editor_page.dart
+++ b/lib/features/search/pages/search_service_editor_page.dart
@@ -12,6 +12,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../utils/brand_assets.dart';
 import 'search_api_keys_page.dart';
 
@@ -1807,7 +1808,7 @@ class _ProviderTypeChipState extends State<_ProviderTypeChip> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final base = widget.selected
         ? cs.primary.withValues(alpha: isDark ? 0.2 : 0.12)
-        : (isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96));
+        : context.appColors.surfaceCard;
     final overlay = _pressed
         ? cs.onSurface.withValues(alpha: 0.08)
         : (_hovered
@@ -2230,7 +2231,7 @@ Widget _sectionCard(BuildContext context, {required Widget child}) {
   final theme = Theme.of(context);
   final cs = theme.colorScheme;
   final isDark = theme.brightness == Brightness.dark;
-  final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+  final bg = context.appColors.surfaceCard;
   return Container(
     decoration: BoxDecoration(
       color: bg,

--- a/lib/features/search/pages/search_services_page.dart
+++ b/lib/features/search/pages/search_services_page.dart
@@ -11,6 +11,7 @@ import '../../../core/services/haptics.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../theme/app_font_weights.dart';
 import 'search_service_editor_page.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class SearchServicesPage extends StatefulWidget {
   const SearchServicesPage({super.key});
@@ -479,12 +480,12 @@ class _SearchServicesPageState extends State<SearchServicesPage> {
       statusFg = cs.primary;
     } else if (conn == true) {
       statusText = l10n.searchServicesPageConnectedStatus;
-      statusBg = Colors.green.withValues(alpha: 0.12);
-      statusFg = Colors.green;
+      statusBg = context.appColors.successContainer;
+      statusFg = context.appColors.success;
     } else if (conn == false) {
       statusText = l10n.searchServicesPageFailedStatus;
-      statusBg = Colors.orange.withValues(alpha: 0.12);
-      statusFg = Colors.orange;
+      statusBg = context.appColors.warningContainer;
+      statusFg = context.appColors.warning;
     } else {
       statusText = l10n.searchServicesPageNotTestedStatus;
       statusBg = cs.onSurface.withValues(alpha: 0.06);
@@ -648,6 +649,7 @@ class _BrandBadge extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     // Use BrandAssets to get the icon path
     final asset = BrandAssets.assetForName(name);
+    // color-gate: ignore
     final bg = isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1);
     if (asset != null) {
       if (asset.endsWith('.svg')) {
@@ -819,9 +821,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -870,9 +870,7 @@ Widget _sheetOption(
     builder: (pressed) {
       final base = cs.onSurface;
       final bgTarget = (bgOnPress && pressed)
-          ? (isDark
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.black.withValues(alpha: 0.05))
+          ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
           : Colors.transparent;
       return _AnimatedPressColor(
         pressed: pressed,

--- a/lib/features/search/widgets/search_settings_sheet.dart
+++ b/lib/features/search/widgets/search_settings_sheet.dart
@@ -28,7 +28,6 @@ Future<void> showSearchSettingsSheet(BuildContext context) async {
 
 class _SearchSettingsSheet extends StatelessWidget {
   const _SearchSettingsSheet();
-
   String _nameOf(BuildContext context, SearchServiceOptions s) {
     final svc = SearchService.getService(s);
     return svc.name;
@@ -119,7 +118,6 @@ class _SearchSettingsSheet extends StatelessWidget {
       services.isNotEmpty ? services.length - 1 : 0,
     );
     final enabled = ap.currentSearchEnabled;
-
     // Determine if current selected model supports built-in search
     final providerKey = a?.chatModelProvider ?? settings.currentModelProvider;
     final modelId = a?.chatModelId ?? settings.currentModelId;
@@ -136,7 +134,6 @@ class _SearchSettingsSheet extends StatelessWidget {
           cfg: cfg,
           modelId: modelId,
         );
-
     // Read current built-in search toggle from modelOverrides
     final hasBuiltInSearch = BuiltInToolsHelper.isBuiltInSearchEnabled(
       cfg: cfg,
@@ -148,7 +145,6 @@ class _SearchSettingsSheet extends StatelessWidget {
           modelId: modelId,
         );
     final builtInMode = hasBuiltInSearch;
-
     final maxHeight = MediaQuery.of(context).size.height * 0.8;
     return SafeArea(
       top: false,
@@ -345,7 +341,6 @@ class _SearchSettingsSheet extends StatelessWidget {
                       },
                     ),
                 ],
-
                 // Toggle card
                 if (!builtInMode) ...[
                   IosCardPress(
@@ -481,7 +476,6 @@ class _BrandBadge extends StatelessWidget {
   const _BrandBadge({required this.name, this.size = 20});
   final String name;
   final double size;
-
   static Widget forService(SearchServiceOptions s, {double size = 24}) {
     final n = _nameForService(s);
     return _BrandBadge(name: n, size: size);
@@ -516,6 +510,7 @@ class _BrandBadge extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     // Use BrandAssets to get the icon path
     final asset = BrandAssets.assetForName(name);
+    // color-gate: ignore
     final bg = isDark ? Colors.white10 : cs.primary.withValues(alpha: 0.1);
     if (asset != null) {
       if (asset.endsWith('.svg')) {

--- a/lib/features/settings/pages/about_page.dart
+++ b/lib/features/settings/pages/about_page.dart
@@ -14,6 +14,7 @@ import '../../../shared/widgets/ios_labeled_switch_row.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/qq_group_join_sheet.dart';
 import '../../../core/services/haptics.dart';
+import '../../../theme/app_semantic_colors.dart';
 import 'debug_page.dart';
 import 'log_viewer_page.dart';
 
@@ -478,9 +479,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,

--- a/lib/features/settings/pages/debug_page.dart
+++ b/lib/features/settings/pages/debug_page.dart
@@ -9,6 +9,7 @@ import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../services/debug_conversation_factory.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class DebugPage extends StatefulWidget {
   const DebugPage({super.key});
@@ -235,12 +236,12 @@ class _DebugSectionCard extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: isDark ? const Color(0xFF1C1C1E) : Colors.white,
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
           width: 0.5,
           color: isDark
-              ? Colors.white.withValues(alpha: 0.06)
+              ? cs.onSurface.withValues(alpha: 0.06)
               : cs.outlineVariant.withValues(alpha: 0.12),
         ),
       ),

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -12,6 +12,7 @@ import 'package:syncfusion_flutter_core/theme.dart';
 import '../../../core/providers/settings_provider.dart';
 import 'theme_settings_page.dart';
 import '../../../theme/palettes.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../core/services/haptics.dart';
@@ -813,9 +814,7 @@ class _DisplaySettingsPageState extends State<DisplaySettingsPage> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? Colors.white12
-                            : const Color(0xFFF2F3F5),
+                        color: context.appColors.surfaceFill,
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Text(
@@ -1281,9 +1280,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -1639,9 +1636,7 @@ Widget _sheetOption(
                 base)
           : base;
       final bgTarget = pressed
-          ? (isDark
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.black.withValues(alpha: 0.05))
+          ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
           : Colors.transparent;
       return TweenAnimationBuilder<Color?>(
         tween: ColorTween(end: target),
@@ -2044,7 +2039,6 @@ class _AutoCollapseCodeBlockLinesRowState
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final sp = context.watch<SettingsProvider>();
 
     // Keep controller in sync when not editing
@@ -2095,7 +2089,7 @@ class _AutoCollapseCodeBlockLinesRowState
                 decoration: InputDecoration(
                   isDense: true,
                   filled: true,
-                  fillColor: isDark ? Colors.white10 : Colors.white,
+                  fillColor: context.appColors.surfaceFill,
                   contentPadding: const EdgeInsets.symmetric(
                     horizontal: 8,
                     vertical: 8,

--- a/lib/features/settings/pages/google_fonts_picker_page.dart
+++ b/lib/features/settings/pages/google_fonts_picker_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class GoogleFontsPickerPage extends StatefulWidget {
   const GoogleFontsPickerPage({super.key, required this.title});
@@ -48,9 +49,7 @@ class _GoogleFontsPickerPageState extends State<GoogleFontsPickerPage> {
                 hintText: l10n.fontPickerFilterHint,
                 isDense: true,
                 filled: true,
-                fillColor: Theme.of(context).brightness == Brightness.dark
-                    ? Colors.white10
-                    : Colors.white,
+                fillColor: context.appColors.surfaceFill,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 10,

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -24,6 +24,7 @@ import '../logs/request_body_beautifier.dart';
 import '../logs/request_log_ai_analysis.dart';
 import '../logs/request_log_parser.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 /// Mobile log viewer - shows list of log files and allows viewing/exporting
 class LogViewerPage extends StatefulWidget {
@@ -351,7 +352,7 @@ class _LogFilesList extends StatelessWidget {
     }
 
     final Color tileBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color border = cs.outlineVariant.withValues(
       alpha: isDark ? 0.26 : 0.38,
@@ -448,8 +449,8 @@ class _FileIcon extends StatelessWidget {
     final Color bg = isCurrent
         ? cs.primary.withValues(alpha: isDark ? 0.22 : 0.14)
         : (isDark
-              ? Colors.white.withValues(alpha: 0.08)
-              : const Color(0xFFF2F3F5));
+              ? cs.onSurface.withValues(alpha: 0.08)
+              : context.appColors.surfaceFill);
     final Color fg = isCurrent
         ? cs.primary
         : cs.onSurface.withValues(alpha: 0.72);
@@ -800,7 +801,7 @@ class _CategoryChip extends StatelessWidget {
     final Color bg = selected
         ? cs.primary.withValues(alpha: isDark ? 0.85 : 0.90)
         : isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color fg = selected
         ? cs.onPrimary
@@ -852,7 +853,7 @@ class _RequestLogSummaryBar extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     final Color bg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color border = cs.outlineVariant.withValues(
       alpha: isDark ? 0.26 : 0.38,
@@ -860,7 +861,7 @@ class _RequestLogSummaryBar extends StatelessWidget {
 
     final Color errorPillBg = Color.alphaBlend(
       cs.error.withValues(alpha: isDark ? 0.18 : 0.12),
-      isDark ? Colors.white.withValues(alpha: 0.08) : Colors.white,
+      isDark ? cs.onSurface.withValues(alpha: 0.08) : Colors.white,
     );
     final Color errorPillFg = cs.error.withValues(alpha: isDark ? 0.92 : 0.88);
 
@@ -958,7 +959,7 @@ class _RequestLogCard extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
 
     final Color tileBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color border = cs.outlineVariant.withValues(
       alpha: isDark ? 0.26 : 0.38,
@@ -1064,9 +1065,7 @@ class _InlineErrorPreview extends StatelessWidget {
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
 
-    final Color base = isDark
-        ? Colors.white.withValues(alpha: 0.06)
-        : const Color(0xFFF6F7F9);
+    final Color base = context.appColors.surfaceFill;
     final Color bg = Color.alphaBlend(
       cs.error.withValues(alpha: isDark ? 0.12 : 0.07),
       base,
@@ -1183,7 +1182,7 @@ class _StatusPill extends StatelessWidget {
     final Color bg = () {
       if (isError || code >= 400) {
         final Color base = isDark
-            ? Colors.white.withValues(alpha: 0.08)
+            ? cs.onSurface.withValues(alpha: 0.08)
             : Colors.white;
         return Color.alphaBlend(
           cs.error.withValues(alpha: isDark ? 0.18 : 0.12),
@@ -1570,7 +1569,7 @@ class _ErrorHeroCard extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     final Color base = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color bg = Color.alphaBlend(
       cs.error.withValues(alpha: isDark ? 0.14 : 0.08),
@@ -1654,7 +1653,7 @@ class _SectionCard extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
 
     final Color bg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color border = cs.outlineVariant.withValues(
       alpha: isDark ? 0.26 : 0.38,
@@ -1710,8 +1709,9 @@ class _CodeBlock extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
 
     final Color neutralBg = isDark
+        // color-gate: ignore
         ? Colors.black.withValues(alpha: 0.16)
-        : const Color(0xFFF6F7F9);
+        : const Color(0xFFF6F7F9); // color-gate: ignore
     final Color bg = () {
       if (tone == _CodeTone.error) {
         return Color.alphaBlend(
@@ -1839,7 +1839,7 @@ class _SegTabBar extends StatelessWidget {
                 segWidth * tabs.length + gap * (tabs.length - 1);
 
             final Color shellBg = isDark
-                ? Colors.white.withValues(alpha: 0.08)
+                ? cs.onSurface.withValues(alpha: 0.08)
                 : Colors.white;
 
             List<Widget> children = [];
@@ -1978,7 +1978,7 @@ class _LogSettingsSheet extends StatelessWidget {
     final settings = context.watch<SettingsProvider>();
 
     final Color tileBg = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : Colors.white;
     final Color border = cs.outlineVariant.withValues(
       alpha: isDark ? 0.26 : 0.38,
@@ -2155,26 +2155,25 @@ class _LogSettingsSheet extends StatelessWidget {
 // Beautified request body rendering
 // ---------------------------------------------------------------------------
 
-/// Role color pair (light, dark).
-class _RoleColor {
-  const _RoleColor(this.label, this.light, this.dark);
-  final String label;
-  final Color light;
-  final Color dark;
-
-  Color color(bool isDark) => isDark ? dark : light;
+/// Role accent color, derived from the active theme's [AppSemanticColors]
+/// chart series (indices 6/0/5/3 for system/user/assistant/tool).
+Color _roleColor(BuildContext context, TurnRole role) {
+  return context.appColors.chartSeries[switch (role) {
+    TurnRole.system => 6,
+    TurnRole.user => 0,
+    TurnRole.assistant => 5,
+    TurnRole.tool => 3,
+  }];
 }
 
-const _roleColors = <TurnRole, _RoleColor>{
-  TurnRole.system: _RoleColor('SYSTEM', Color(0xFFCA8A04), Color(0xFFFACC15)),
-  TurnRole.user: _RoleColor('USER', Color(0xFF2563EB), Color(0xFF60A5FA)),
-  TurnRole.assistant: _RoleColor(
-    'ASSISTANT',
-    Color(0xFF16A34A),
-    Color(0xFF86EFAC),
-  ),
-  TurnRole.tool: _RoleColor('TOOL', Color(0xFF8B5CF6), Color(0xFFA78BFA)),
-};
+String _roleLabel(TurnRole role) {
+  return switch (role) {
+    TurnRole.system => 'SYSTEM',
+    TurnRole.user => 'USER',
+    TurnRole.assistant => 'ASSISTANT',
+    TurnRole.tool => 'TOOL',
+  };
+}
 
 /// Renders a [BeautifiedBody]: colored turn blocks on top, config JSON below.
 class _BeautifiedBodyView extends StatelessWidget {
@@ -2237,12 +2236,12 @@ class _TurnBlock extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final rc = _roleColors[turn.role]!;
-    final color = rc.color(isDark);
+    final color = _roleColor(context, turn.role);
+    final label = _roleLabel(turn.role);
 
     final children = <Widget>[
       Text(
-        rc.label,
+        label,
         style: TextStyle(
           fontSize: 10.5,
           fontWeight: AppFontWeights.heavy,

--- a/lib/features/settings/pages/network_proxy_page.dart
+++ b/lib/features/settings/pages/network_proxy_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -266,7 +267,7 @@ class _NetworkProxyPageState extends State<NetworkProxyPage> {
               child: Text(
                 l10n.networkProxyTestSuccess,
                 style: TextStyle(
-                  color: Colors.green.shade600,
+                  color: context.appColors.success,
                   fontWeight: AppFontWeights.semibold,
                 ),
               ),
@@ -358,8 +359,7 @@ class _ProxyTypeSheetField extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fillColor = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final fillColor = context.appColors.surfaceFill;
 
     String labelOf(String v) {
       switch (v) {
@@ -543,9 +543,7 @@ Widget _sectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -594,12 +592,11 @@ Widget _labeledField(
 
 // Reuse desktop input styles to keep consistent look
 InputDecoration _deskInputDecoration(BuildContext context) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
   final cs = Theme.of(context).colorScheme;
   return InputDecoration(
     isDense: true,
     filled: true,
-    fillColor: isDark ? Colors.white10 : const Color(0xFFF7F7F9),
+    fillColor: context.appColors.surfaceFill,
     hintStyle: TextStyle(
       fontSize: 14,
       color: cs.onSurface.withValues(alpha: 0.5),
@@ -655,9 +652,7 @@ class _DeskIosButtonState extends State<_DeskIosButton> {
         : cs.onSurface.withValues(alpha: 0.9);
     final bg = widget.filled
         ? cs.primary
-        : (isDark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.black.withValues(alpha: 0.05));
+        : cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05);
     final borderColor = widget.filled
         ? Colors.transparent
         : cs.outlineVariant.withValues(alpha: isDark ? 0.22 : 0.18);

--- a/lib/features/settings/pages/settings_page.dart
+++ b/lib/features/settings/pages/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../utils/format.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../theme/app_semantic_colors.dart';
 import 'package:provider/provider.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../core/providers/settings_provider.dart';
@@ -460,9 +461,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
       // Light: white with slight transparency; Dark: subtle translucent dark
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -744,9 +743,7 @@ Widget _sheetOption(
     builder: (pressed) {
       final base = cs.onSurface;
       final bgTarget = pressed
-          ? (isDark
-                ? Colors.white.withValues(alpha: 0.06)
-                : Colors.black.withValues(alpha: 0.05))
+          ? cs.onSurface.withValues(alpha: isDark ? 0.06 : 0.05)
           : Colors.transparent;
       return _AnimatedPressColor(
         pressed: pressed,

--- a/lib/features/settings/pages/sponsor_page.dart
+++ b/lib/features/settings/pages/sponsor_page.dart
@@ -8,6 +8,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../core/services/haptics.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class SponsorPage extends StatefulWidget {
   const SponsorPage({super.key});
@@ -274,9 +275,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -11,6 +11,7 @@ import '../../../core/models/workspace.dart';
 import '../../../core/providers/workspace_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/haptics.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../workspace/pages/workspace_detail_page.dart';
 import '../../workspace/pages/workspace_list_page.dart';
 import '../../../core/services/storage/message_locate_bus.dart';
@@ -2143,7 +2144,7 @@ class _UploadManagerState extends State<_UploadManager> {
     final selBg = isDark
         ? cs.primary.withValues(alpha: 0.20)
         : cs.primary.withValues(alpha: 0.12);
-    final baseBg = isDark ? Colors.white10 : const Color(0xFFF7F7F9);
+    final baseBg = context.appColors.surfaceFill;
     return GestureDetector(
       onTap: onTap,
       child: AnimatedContainer(
@@ -2802,9 +2803,7 @@ Widget _iosSectionCard({required Widget child}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = isDark
-          ? Colors.white10
-          : Colors.white.withValues(alpha: 0.96);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,

--- a/lib/features/settings/pages/theme_settings_page.dart
+++ b/lib/features/settings/pages/theme_settings_page.dart
@@ -8,6 +8,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../core/services/haptics.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../theme/custom_theme.dart';
 import '../widgets/custom_theme_widgets.dart';
 
@@ -276,7 +277,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final settings = context.watch<SettingsProvider>();
       final Color bg = settings.usePureBackground
           ? (isDark ? Colors.black : const Color(0xFFFFFFFF))
-          : (isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96));
+          : context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,

--- a/lib/features/settings/pages/tts_services_page.dart
+++ b/lib/features/settings/pages/tts_services_page.dart
@@ -16,6 +16,7 @@ import '../widgets/asr_services_section.dart';
 import '../widgets/mimo_reference_audio_picker.dart';
 import '../widgets/voice_service_widgets.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class TtsServicesPage extends StatelessWidget {
   const TtsServicesPage({super.key});
@@ -358,7 +359,7 @@ Widget _iosSectionCard({required List<Widget> children}) {
       final theme = Theme.of(context);
       final cs = theme.colorScheme;
       final isDark = theme.brightness == Brightness.dark;
-      final Color bg = _appSurfaceCard(cs);
+      final Color bg = context.appColors.surfaceCard;
       return Container(
         decoration: BoxDecoration(
           color: bg,
@@ -1718,7 +1719,7 @@ class _TtsEditorTextFieldState extends State<_TtsEditorTextField> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final fieldBg = _appSurfaceFill(cs);
+    final fieldBg = context.appColors.surfaceFill;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       child: Column(
@@ -2315,25 +2316,4 @@ String _voiceLabelFor(NetworkTtsKind k, AppLocalizations l10n) {
     case NetworkTtsKind.fishAudio:
       return l10n.ttsServicesFieldVoiceIdLabel;
   }
-}
-
-Color _appSurfaceCard(ColorScheme cs) {
-  final isDark = cs.brightness == Brightness.dark;
-  return isDark
-      ? Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.10),
-          cs.surface,
-        )
-      : Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.96),
-          cs.surface,
-        );
-}
-
-Color _appSurfaceFill(ColorScheme cs) {
-  final isDark = cs.brightness == Brightness.dark;
-  return Color.alphaBlend(
-    cs.onSurface.withValues(alpha: isDark ? 0.10 : 0.05),
-    cs.surface,
-  );
 }

--- a/lib/features/settings/pages/tts_settings_page.dart
+++ b/lib/features/settings/pages/tts_settings_page.dart
@@ -9,6 +9,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class TtsSettingsPage extends StatelessWidget {
   const TtsSettingsPage({super.key});
@@ -116,7 +117,7 @@ class _SettingsSection extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/settings/widgets/asr_services_section.dart
+++ b/lib/features/settings/widgets/asr_services_section.dart
@@ -15,6 +15,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../utils/brand_assets.dart';
 import 'voice_service_widgets.dart';
 
@@ -261,7 +262,6 @@ class _AsrServiceCardState extends State<_AsrServiceCard> {
 
   Widget _buildMobile(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     final displayName = _serviceDisplayName(l10n, widget.service);
     return VoiceServiceTactileRow(
@@ -270,7 +270,7 @@ class _AsrServiceCardState extends State<_AsrServiceCard> {
         duration: const Duration(milliseconds: 180),
         curve: Curves.easeOutCubic,
         color: pressed
-            ? (isDark ? Colors.white : Colors.black).withValues(alpha: 0.05)
+            ? cs.onSurface.withValues(alpha: 0.05)
             : Colors.transparent,
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 11),
         child: Row(
@@ -330,9 +330,7 @@ class _AsrServiceCardState extends State<_AsrServiceCard> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     final displayName = _serviceDisplayName(l10n, widget.service);
-    final background = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final background = context.appColors.surfaceCard;
     final border = _hovered || widget.selected
         ? cs.primary.withValues(alpha: isDark ? 0.35 : 0.45)
         : cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08);
@@ -1328,7 +1326,7 @@ class _SystemConfiguration extends StatelessWidget {
         : l10n.asrServicesSystemSubtitle;
     final controlColor = desktop
         ? Colors.transparent
-        : (isDark ? Colors.white12 : const Color(0xFFF2F3F5));
+        : context.appColors.surfaceFill;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -1445,11 +1443,10 @@ class _LocalModelPicker extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context)!;
     final listColor = desktop
         ? Colors.transparent
-        : (isDark ? Colors.white12 : const Color(0xFFF2F3F5));
+        : context.appColors.surfaceFill;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -1835,8 +1832,7 @@ class _EditorFieldState extends State<_EditorField> {
       );
     }
 
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fieldBg = isDark ? Colors.white12 : const Color(0xFFF2F3F5);
+    final fieldBg = context.appColors.surfaceFill;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       child: Column(

--- a/lib/features/settings/widgets/custom_theme_widgets.dart
+++ b/lib/features/settings/widgets/custom_theme_widgets.dart
@@ -13,6 +13,7 @@ import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_tile_button.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../../theme/custom_theme.dart';
 import '../../../theme/palettes.dart';
 
@@ -20,23 +21,6 @@ bool get _isDesktop =>
     defaultTargetPlatform == TargetPlatform.macOS ||
     defaultTargetPlatform == TargetPlatform.windows ||
     defaultTargetPlatform == TargetPlatform.linux;
-
-/// iOS-style section card background, matching the app's `_iosSectionCard`
-/// idiom (white overlay over the active scheme's surface). AppSemanticColors
-/// is not ported in phase 1 (see ADR-0037) so this stays local.
-Color _surfaceCardColor(BuildContext context) {
-  final cs = Theme.of(context).colorScheme;
-  final isDark = Theme.of(context).brightness == Brightness.dark;
-  return isDark
-      ? Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.10),
-          cs.surface,
-        )
-      : Color.alphaBlend(
-          const Color(0xFFFFFFFF).withValues(alpha: 0.96),
-          cs.surface,
-        );
-}
 
 // ---------------------------------------------------------------------------
 // Presentation shells (match the app's custom sheet/dialog idioms — no
@@ -302,7 +286,7 @@ InputDecoration _fieldDecoration(
     ),
     isDense: true,
     filled: true,
-    fillColor: _surfaceCardColor(context),
+    fillColor: context.appColors.surfaceCard,
     contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
     border: border(cs.outlineVariant.withValues(alpha: 0.4)),
     enabledBorder: border(cs.outlineVariant.withValues(alpha: 0.4)),

--- a/lib/features/settings/widgets/language_select_sheet.dart
+++ b/lib/features/settings/widgets/language_select_sheet.dart
@@ -234,18 +234,14 @@ class _LanguageSelectSheetState extends State<_LanguageSelectSheet> {
                           padding: const EdgeInsets.symmetric(horizontal: 12),
                           child: Row(
                             children: [
-                              Icon(
-                                Lucide.X,
-                                size: 20,
-                                color: Colors.red.shade600,
-                              ),
+                              Icon(Lucide.X, size: 20, color: cs.error),
                               const SizedBox(width: 10),
                               Text(
                                 l10n.languageSelectSheetClearButton,
                                 style: TextStyle(
                                   fontSize: 15,
                                   fontWeight: AppFontWeights.medium,
-                                  color: Colors.red.shade600,
+                                  color: cs.error,
                                 ),
                               ),
                             ],

--- a/lib/features/stats/pages/stats_page.dart
+++ b/lib/features/stats/pages/stats_page.dart
@@ -328,9 +328,9 @@ class _RangeButton extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final selectedBackground = isDark
         ? Colors.white.withValues(alpha: 0.16)
-        : const Color(0xFFD9DDE2);
+        : const Color(0xFFD9DDE2); // color-gate: ignore
     final idleBackground = isDark
-        ? Colors.white.withValues(alpha: 0.06)
+        ? cs.onSurface.withValues(alpha: 0.06)
         : const Color(0xFFEEF0F3);
     return Semantics(
       button: true,
@@ -465,7 +465,7 @@ class _CustomRangeSheetState extends State<_CustomRangeSheet> {
                   onTap: () => Navigator.of(context).pop(),
                   borderRadius: BorderRadius.circular(13),
                   baseColor: isDark
-                      ? Colors.white.withValues(alpha: 0.08)
+                      ? cs.onSurface.withValues(alpha: 0.08)
                       : const Color(0xFFE7E9EC),
                   padding: const EdgeInsets.symmetric(vertical: 11),
                   child: Center(
@@ -489,7 +489,7 @@ class _CustomRangeSheetState extends State<_CustomRangeSheet> {
                   borderRadius: BorderRadius.circular(13),
                   baseColor: isDark
                       ? Colors.white.withValues(alpha: 0.16)
-                      : const Color(0xFFDADDE2),
+                      : const Color(0xFFDADDE2), // color-gate: ignore
                   padding: const EdgeInsets.symmetric(vertical: 11),
                   child: Center(
                     child: Text(
@@ -641,7 +641,7 @@ class _StatsDatePickerPanelState extends State<_StatsDatePickerPanel> {
                     }),
                     borderRadius: BorderRadius.circular(13),
                     baseColor: isDark
-                        ? Colors.white.withValues(alpha: 0.08)
+                        ? cs.onSurface.withValues(alpha: 0.08)
                         : const Color(0xFFECEEF1),
                     padding: const EdgeInsets.symmetric(
                       horizontal: 14,
@@ -903,9 +903,9 @@ class _MonthCell extends StatelessWidget {
     final background = selected
         ? (isDark
               ? Colors.white.withValues(alpha: 0.18)
-              : const Color(0xFFDADDE2))
+              : const Color(0xFFDADDE2)) // color-gate: ignore
         : (isDark
-              ? Colors.white.withValues(alpha: 0.06)
+              ? cs.onSurface.withValues(alpha: 0.06)
               : const Color(0xFFECEEF1));
     return IosCardPress(
       onTap: enabled ? onTap : null,
@@ -953,7 +953,7 @@ class _DateCell extends StatelessWidget {
     final background = selected
         ? (isDark
               ? Colors.white.withValues(alpha: 0.18)
-              : const Color(0xFFDADDE2))
+              : const Color(0xFFDADDE2)) // color-gate: ignore
         : Colors.transparent;
     final alpha = !enabled
         ? 0.18
@@ -1001,7 +1001,7 @@ class _DateField extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(13),
       baseColor: isDark
-          ? Colors.white.withValues(alpha: 0.07)
+          ? cs.onSurface.withValues(alpha: 0.07)
           : const Color(0xFFECEEF1),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       child: Column(

--- a/lib/features/stats/widgets/stats_heatmap.dart
+++ b/lib/features/stats/widgets/stats_heatmap.dart
@@ -410,6 +410,7 @@ class _HeatCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     final alpha = switch (level) {
       0 => 0.10,
       1 => 0.25,
@@ -417,11 +418,10 @@ class _HeatCell extends StatelessWidget {
       3 => 0.68,
       _ => 0.92,
     };
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final color = level == 0
         ? isDark
               ? Colors.white.withValues(alpha: 0.14)
-              : const Color(0xFFDDE2E8)
+              : const Color(0xFFDDE2E8) // color-gate: ignore
         : cs.primary.withValues(alpha: alpha);
     return Container(
       width: size,

--- a/lib/features/stats/widgets/stats_metric_grid.dart
+++ b/lib/features/stats/widgets/stats_metric_grid.dart
@@ -94,7 +94,7 @@ class _MetricTile extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: isDark
-            ? Colors.white.withValues(alpha: 0.06)
+            ? cs.onSurface.withValues(alpha: 0.06)
             : cs.surfaceContainerHighest.withValues(alpha: 0.38),
         borderRadius: BorderRadius.circular(10),
       ),

--- a/lib/features/stats/widgets/stats_rank_section.dart
+++ b/lib/features/stats/widgets/stats_rank_section.dart
@@ -3,6 +3,7 @@ import 'package:Cuplivo/theme/app_font_weights.dart';
 
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../models/stats_models.dart';
 import 'stats_section_card.dart';
 
@@ -248,12 +249,9 @@ class _RankRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final ratio = maxValue <= 0 ? 0.0 : item.value / maxValue;
     final widthFactor = (0.36 + ratio * 0.64).clamp(0.36, 1.0);
-    final fillColor = isDark
-        ? Colors.white.withValues(alpha: 0.1)
-        : const Color(0xFFF2F3F5);
+    final fillColor = context.appColors.surfaceFill;
     final leading = leadingBuilder?.call(context, item);
 
     return Row(

--- a/lib/features/stats/widgets/stats_section_card.dart
+++ b/lib/features/stats/widgets/stats_section_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class StatsSectionCard extends StatelessWidget {
   const StatsSectionCard({
@@ -20,7 +21,7 @@ class StatsSectionCard extends StatelessWidget {
     final isDark = theme.brightness == Brightness.dark;
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),

--- a/lib/features/stats/widgets/stats_usage_chart.dart
+++ b/lib/features/stats/widgets/stats_usage_chart.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import '../../../l10n/app_localizations.dart';
 import '../models/stats_models.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 const double _usageDetailBubbleWidth = 228;
 const double _usageDetailBubbleTop = 8;
@@ -121,6 +122,7 @@ class _StatsUsageChartState extends State<StatsUsageChart> {
                                     isDark:
                                         Theme.of(context).brightness ==
                                         Brightness.dark,
+                                    chartSeries: context.appColors.chartSeries,
                                   ),
                                 ),
                                 if (selectedIndex != null &&
@@ -306,6 +308,7 @@ class _UsageChartPainter extends CustomPainter {
     required this.gap,
     required this.selectedDayIndex,
     required this.isDark,
+    required this.chartSeries,
   });
 
   final List<StatsTrendDay> days;
@@ -315,6 +318,7 @@ class _UsageChartPainter extends CustomPainter {
   final double gap;
   final int? selectedDayIndex;
   final bool isDark;
+  final List<Color> chartSeries;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -367,7 +371,7 @@ class _UsageChartPainter extends CustomPainter {
         final segmentHeight = barHeight * weight / total;
         final segmentTop = segmentBottom - segmentHeight;
         final paint = Paint()
-          ..color = _providerColorForIndex(isDark, providerIndex);
+          ..color = chartSeries[providerIndex % chartSeries.length];
         canvas.drawRect(
           Rect.fromLTWH(x, segmentTop, barWidth, segmentHeight),
           paint,
@@ -399,7 +403,8 @@ class _UsageChartPainter extends CustomPainter {
         oldDelegate.barWidth != barWidth ||
         oldDelegate.gap != gap ||
         oldDelegate.selectedDayIndex != selectedDayIndex ||
-        oldDelegate.isDark != isDark;
+        oldDelegate.isDark != isDark ||
+        oldDelegate.chartSeries != chartSeries;
   }
 }
 
@@ -564,31 +569,6 @@ int _detailTokenTotal(StatsTokenBucket bucket) {
 }
 
 Color _providerColor(BuildContext context, int index) {
-  final isDark = Theme.of(context).brightness == Brightness.dark;
-  return _providerColorForIndex(isDark, index);
-}
-
-Color _providerColorForIndex(bool isDark, int index) {
-  final palette = isDark
-      ? [
-          const Color(0xFF60A5FA),
-          const Color(0xFF5EEAD4),
-          const Color(0xFFFB923C),
-          const Color(0xFFA78BFA),
-          const Color(0xFFFB7185),
-          const Color(0xFF86EFAC),
-          const Color(0xFFFACC15),
-          const Color(0xFF67E8F9),
-        ]
-      : [
-          const Color(0xFF2563EB),
-          const Color(0xFF0F8F83),
-          const Color(0xFFEA580C),
-          const Color(0xFF8B5CF6),
-          const Color(0xFFE11D48),
-          const Color(0xFF16A34A),
-          const Color(0xFFCA8A04),
-          const Color(0xFF0891B2),
-        ];
-  return palette[index % palette.length];
+  final series = context.appColors.chartSeries;
+  return series[index % series.length];
 }

--- a/lib/features/workspace/pages/workspace_detail_page.dart
+++ b/lib/features/workspace/pages/workspace_detail_page.dart
@@ -16,6 +16,7 @@ import '../../../shared/widgets/ios_expandable_section.dart';
 import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import '../../settings/pages/mount_files_page.dart';
 import '../controllers/dependency_install_controller.dart';
 import 'sandbox_files_page.dart';
@@ -800,11 +801,10 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   };
 
   Widget _sectionCard({required List<Widget> children}) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final cs = Theme.of(context).colorScheme;
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.1)),
       ),

--- a/lib/features/workspace/pages/workspace_list_page.dart
+++ b/lib/features/workspace/pages/workspace_list_page.dart
@@ -7,6 +7,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 import 'workspace_detail_page.dart';
 
 class WorkspaceListPage extends StatelessWidget {
@@ -150,9 +151,8 @@ class _WorkspaceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Material(
-      color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+      color: context.appColors.surfaceCard,
       borderRadius: BorderRadius.circular(14),
       child: InkWell(
         borderRadius: BorderRadius.circular(14),

--- a/lib/features/world_book/pages/world_book_page.dart
+++ b/lib/features/world_book/pages/world_book_page.dart
@@ -17,6 +17,7 @@ import '../../../shared/widgets/ios_switch.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
 import '../../../theme/app_font_weights.dart';
+import '../../../theme/app_semantic_colors.dart';
 
 class WorldBookPage extends StatefulWidget {
   const WorldBookPage({super.key});
@@ -313,7 +314,7 @@ class _WorldBookPageState extends State<WorldBookPage> {
               onPressed: () => Navigator.of(ctx).pop(true),
               child: Text(
                 l10n.worldBookDelete,
-                style: TextStyle(color: Colors.red),
+                style: TextStyle(color: Theme.of(ctx).colorScheme.error),
               ),
             ),
           ],
@@ -967,7 +968,7 @@ class _IosSectionCard extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final bg = isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96);
+    final bg = context.appColors.surfaceCard;
     return Container(
       decoration: BoxDecoration(
         color: bg,
@@ -1810,9 +1811,7 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
                                       height: 40,
                                       child: Container(
                                         decoration: BoxDecoration(
-                                          color: isDark
-                                              ? Colors.white12
-                                              : const Color(0xFFF2F3F5),
+                                          color: context.appColors.surfaceFill,
                                           borderRadius: BorderRadius.circular(
                                             12,
                                           ),
@@ -1869,9 +1868,8 @@ class _WorldBookEntryEditSheetState extends State<_WorldBookEntryEditSheet> {
                                       message:
                                           l10n.worldBookEntryKeywordAddTooltip,
                                       child: IosCardPress(
-                                        baseColor: isDark
-                                            ? Colors.white12
-                                            : const Color(0xFFF2F3F5),
+                                        baseColor:
+                                            context.appColors.surfaceFill,
                                         borderRadius: BorderRadius.circular(12),
                                         pressedScale: 0.98,
                                         haptics: false,
@@ -2037,13 +2035,9 @@ class _IosOutlineButtonState extends State<_IosOutlineButton> {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final bg = Theme.of(context).brightness == Brightness.dark
-        ? Colors.white10
-        : const Color(0xFFF2F3F5);
+    final bg = context.appColors.surfaceFill;
     final overlay = _pressed
-        ? (Theme.of(context).brightness == Brightness.dark
-              ? Colors.white12
-              : Colors.black12)
+        ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.12)
         : Colors.transparent;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,

--- a/lib/shared/dialogs/tool_collision_dialog.dart
+++ b/lib/shared/dialogs/tool_collision_dialog.dart
@@ -267,6 +267,7 @@ class _ToolCollisionDialogBodyState extends State<_ToolCollisionDialogBody> {
   ) {
     final r = _resolutions[idx];
     final isBuiltin = collision.source == CollisionSource.builtin;
+    final cs = Theme.of(context).colorScheme;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -354,7 +355,7 @@ class _ToolCollisionDialogBodyState extends State<_ToolCollisionDialogBody> {
                         : Icons.link,
                     size: 20,
                     color: r.serversToUnbind.contains(server.id)
-                        ? Colors.red
+                        ? cs.error
                         : null,
                   ),
                 ),
@@ -368,7 +369,7 @@ class _ToolCollisionDialogBodyState extends State<_ToolCollisionDialogBody> {
                 l10n.mcpToolCollisionUnbindHint,
                 style: Theme.of(
                   context,
-                ).textTheme.bodySmall?.copyWith(color: Colors.red),
+                ).textTheme.bodySmall?.copyWith(color: cs.error),
               ),
             ),
         ],

--- a/lib/shared/widgets/avatar_picker_sheet.dart
+++ b/lib/shared/widgets/avatar_picker_sheet.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../core/services/haptics.dart';
 import '../../l10n/app_localizations.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 import 'emoji_picker_dialog.dart';
 import 'ios_tactile.dart';
 import 'snackbar.dart';
@@ -156,9 +157,7 @@ Future<void> _inputAvatarUrl(
           decoration: InputDecoration(
             hintText: l10n.assistantEditImageUrlDialogHint,
             filled: true,
-            fillColor: Theme.of(ctx).brightness == Brightness.dark
-                ? Colors.white10
-                : const Color(0xFFF2F3F5),
+            fillColor: ctx.appColors.surfaceFill,
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(color: Colors.transparent),
@@ -261,9 +260,7 @@ Future<void> _inputQQAvatar(
               decoration: InputDecoration(
                 hintText: l10n.assistantEditQQAvatarDialogHint,
                 filled: true,
-                fillColor: Theme.of(ctx).brightness == Brightness.dark
-                    ? Colors.white10
-                    : const Color(0xFFF2F3F5),
+                fillColor: ctx.appColors.surfaceFill,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(color: Colors.transparent),

--- a/lib/shared/widgets/codex_account_entry.dart
+++ b/lib/shared/widgets/codex_account_entry.dart
@@ -1,14 +1,12 @@
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
-
 import 'package:Cuplivo/core/providers/codex_device_code_controller.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
-
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import 'codex_device_code_flow.dart';
 import 'ios_tile_button.dart';
 import 'snackbar.dart';
@@ -18,17 +16,13 @@ import 'snackbar.dart';
 /// device-code flow.
 class CodexAccountEntry extends StatelessWidget {
   const CodexAccountEntry({super.key, required this.cfg});
-
   static final DateFormat _expiryFormat = DateFormat('yyyy-MM-dd HH:mm');
-
   final ProviderConfig cfg;
-
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<CodexDeviceCodeController>();
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-
     final Widget body = switch (controller.status) {
       CodexAuthStatus.signedIn => _buildSignedIn(context, controller, l10n, cs),
       CodexAuthStatus.expired => _buildOutOfDate(
@@ -47,12 +41,12 @@ class CodexAccountEntry extends StatelessWidget {
       CodexAuthStatus.polling => _buildWaiting(controller, l10n, cs),
       CodexAuthStatus.signedOut => _buildSignedOut(context, l10n, cs),
     };
-
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.surface,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.35)),
@@ -134,7 +128,11 @@ class CodexAccountEntry extends StatelessWidget {
       children: [
         Row(
           children: [
-            const Icon(Lucide.CheckCircle, size: 18, color: Color(0xFF34C759)),
+            Icon(
+              Lucide.CheckCircle,
+              size: 18,
+              color: context.appColors.success,
+            ),
             const SizedBox(width: 8),
             Text(
               l10n.codexLoginStatusSignedIn,

--- a/lib/shared/widgets/custom_key_value_editor.dart
+++ b/lib/shared/widgets/custom_key_value_editor.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../icons/lucide_adapter.dart';
 import '../../l10n/app_localizations.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 import '../../theme/design_tokens.dart';
 import 'ios_tactile.dart';
 
@@ -33,7 +34,6 @@ class CustomKeyValueEditor extends StatelessWidget {
     required this.onUpdate,
     this.showCard = true,
   });
-
   final String title;
   final KeyMode keyMode;
   final List<Map<String, String>> entries;
@@ -41,13 +41,11 @@ class CustomKeyValueEditor extends StatelessWidget {
   final void Function(int index) onRemove;
   final void Function(int index, String key, String value) onUpdate;
   final bool showCard;
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-
     final body = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -99,10 +97,10 @@ class CustomKeyValueEditor extends StatelessWidget {
           ),
       ],
     );
-
     if (showCard) {
       return Container(
         decoration: BoxDecoration(
+          // color-gate: ignore
           color: isDark ? Colors.white10 : cs.surface,
           borderRadius: BorderRadius.circular(14),
           border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.25)),
@@ -121,11 +119,9 @@ class _AddButton extends StatelessWidget {
     required this.label,
     required this.cs,
   });
-
   final VoidCallback onTap;
   final String label;
   final ColorScheme cs;
-
   @override
   Widget build(BuildContext context) {
     return IosCardPress(
@@ -159,14 +155,12 @@ class _KeyValueRow extends StatefulWidget {
     required this.onChanged,
     required this.onDelete,
   });
-
   final int index;
   final KeyMode keyMode;
   final String keyName;
   final String value;
   final void Function(String key, String value) onChanged;
   final VoidCallback onDelete;
-
   @override
   State<_KeyValueRow> createState() => _KeyValueRowState();
 }
@@ -176,7 +170,6 @@ class _KeyValueRowState extends State<_KeyValueRow> {
   late final TextEditingController _valCtrl;
   late final FocusNode _keyFocus;
   late final FocusNode _valFocus;
-
   @override
   void initState() {
     super.initState();
@@ -208,11 +201,10 @@ class _KeyValueRowState extends State<_KeyValueRow> {
 
   InputDecoration _dec(BuildContext context, String label) {
     final cs = Theme.of(context).colorScheme;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return InputDecoration(
       labelText: label,
       filled: true,
-      fillColor: isDark ? Colors.white10 : const Color(0xFFF2F3F5),
+      fillColor: context.appColors.surfaceFill,
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
         borderSide: BorderSide.none,
@@ -236,7 +228,6 @@ class _KeyValueRowState extends State<_KeyValueRow> {
     final label = widget.keyMode == KeyMode.header
         ? l10n.assistantEditHeaderNameLabel
         : l10n.assistantEditBodyKeyLabel;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/shared/widgets/emoji_picker_dialog.dart
+++ b/lib/shared/widgets/emoji_picker_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../l10n/app_localizations.dart';
 import 'emoji_text.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 /// A reusable emoji picker dialog used by both mobile and desktop.
 /// Returns the chosen emoji (single grapheme) or null if cancelled.
@@ -188,9 +189,7 @@ Future<String?> showEmojiPickerDialog(
                     decoration: InputDecoration(
                       hintText: hintText ?? l10n.assistantEditEmojiDialogHint,
                       filled: true,
-                      fillColor: Theme.of(ctx).brightness == Brightness.dark
-                          ? Colors.white10
-                          : const Color(0xFFF2F3F5),
+                      fillColor: ctx.appColors.surfaceFill,
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
                         borderSide: const BorderSide(color: Colors.transparent),

--- a/lib/shared/widgets/grok_account_entry.dart
+++ b/lib/shared/widgets/grok_account_entry.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
 import 'package:Cuplivo/core/providers/grok_device_code_controller.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
-
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import 'grok_device_code_flow.dart';
 import 'ios_tile_button.dart';
 import 'snackbar.dart';
@@ -15,15 +13,12 @@ import 'snackbar.dart';
 /// Inline Grok account status card for provider settings pages.
 class GrokAccountEntry extends StatelessWidget {
   const GrokAccountEntry({super.key, required this.cfg});
-
   final ProviderConfig cfg;
-
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<GrokDeviceCodeController>();
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
-
     final Widget body = switch (controller.status) {
       GrokAuthStatus.signedIn => _buildSignedIn(context, controller, l10n, cs),
       GrokAuthStatus.expired => _buildOutOfDate(
@@ -42,12 +37,12 @@ class GrokAccountEntry extends StatelessWidget {
       GrokAuthStatus.polling => _buildWaiting(controller, l10n, cs),
       GrokAuthStatus.signedOut => _buildSignedOut(context, l10n, cs),
     };
-
     final isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
+        // color-gate: ignore
         color: isDark ? Colors.white10 : cs.surface,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.35)),
@@ -123,7 +118,11 @@ class GrokAccountEntry extends StatelessWidget {
       children: [
         Row(
           children: [
-            const Icon(Lucide.CheckCircle, size: 18, color: Color(0xFF34C759)),
+            Icon(
+              Lucide.CheckCircle,
+              size: 18,
+              color: context.appColors.success,
+            ),
             const SizedBox(width: 8),
             Text(
               l10n.grokLoginStatusSignedIn,

--- a/lib/shared/widgets/ios_expandable_section.dart
+++ b/lib/shared/widgets/ios_expandable_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../core/services/haptics.dart';
 import '../../icons/lucide_adapter.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 
 /// iOS-style expandable settings group: one card containing a tappable
 /// header (leading icon + title + rotating chevron) and an
@@ -57,7 +58,7 @@ class _IosExpandableSectionState extends State<IosExpandableSection> {
 
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(color: cs.outlineVariant.withValues(alpha: 0.1)),
       ),

--- a/lib/shared/widgets/ios_form_text_field.dart
+++ b/lib/shared/widgets/ios_form_text_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 class IosFormTextField extends StatelessWidget {
   const IosFormTextField({
@@ -59,7 +60,7 @@ class IosFormTextField extends StatelessWidget {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final fieldBg = isDark ? Colors.white12 : const Color(0xFFF2F3F5);
+    final fieldBg = context.appColors.surfaceFill;
     final labelColor = cs.onSurface.withValues(alpha: 0.85);
     final valueColor = cs.onSurface.withValues(alpha: enabled ? 0.92 : 0.55);
     final hintColor = cs.onSurface.withValues(alpha: isDark ? 0.42 : 0.46);

--- a/lib/shared/widgets/ios_settings_section.dart
+++ b/lib/shared/widgets/ios_settings_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../icons/lucide_adapter.dart';
+import '../../theme/app_semantic_colors.dart';
 import 'ios_switch.dart';
 
 /// An iOS-style settings card: rounded container with a subtle border used by
@@ -15,9 +16,7 @@ class IosSettingsSection extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
-    final Color bg = isDark
-        ? Colors.white10
-        : Colors.white.withValues(alpha: 0.96);
+    final Color bg = context.appColors.surfaceCard;
     return Container(
       decoration: BoxDecoration(
         color: bg,

--- a/lib/shared/widgets/ios_tactile.dart
+++ b/lib/shared/widgets/ios_tactile.dart
@@ -23,7 +23,6 @@ class IosIconButton extends StatefulWidget {
          icon != null || builder != null,
          'Either icon or builder must be provided',
        );
-
   final IconData? icon;
   // Builder receives the current animated color to render custom child (e.g., SVG).
   final Widget Function(Color color)? builder;
@@ -37,7 +36,6 @@ class IosIconButton extends StatefulWidget {
   final double? minSize; // min tap target (e.g., 44 for AppBar)
   final String? semanticLabel;
   final bool enabled;
-
   @override
   State<IosIconButton> createState() => _IosIconButtonState();
 }
@@ -45,10 +43,10 @@ class IosIconButton extends StatefulWidget {
 class _IosIconButtonState extends State<IosIconButton> {
   bool _pressed = false;
   bool _hovered = false;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     // Respect provided color opacity when enabled; only dim when disabled.
     final Color base = () {
       if (widget.color != null) {
@@ -72,7 +70,6 @@ class _IosIconButtonState extends State<IosIconButton> {
     final Color target = _pressed
         ? pressTarget
         : (_hovered ? hoverTarget : base);
-
     final child = TweenAnimationBuilder<Color?>(
       tween: ColorTween(end: target),
       duration: const Duration(milliseconds: 200),
@@ -90,18 +87,12 @@ class _IosIconButtonState extends State<IosIconButton> {
         );
       },
     );
-
     // Subtle hover background for desktop/web
     final Color bgTarget = _pressed
-        ? (isDark
-              ? Colors.white.withValues(alpha: 0.12)
-              : Colors.black.withValues(alpha: 0.08))
+        ? cs.onSurface.withValues(alpha: isDark ? 0.12 : 0.08)
         : (_hovered
-              ? (isDark
-                    ? Colors.white.withValues(alpha: 0.08)
-                    : Colors.black.withValues(alpha: 0.06))
+              ? cs.onSurface.withValues(alpha: isDark ? 0.08 : 0.06)
               : Colors.transparent);
-
     final content = Semantics(
       button: true,
       enabled: widget.enabled,
@@ -144,7 +135,6 @@ class _IosIconButtonState extends State<IosIconButton> {
         ),
       ),
     );
-
     if (widget.minSize != null) {
       return ConstrainedBox(
         constraints: BoxConstraints(
@@ -175,7 +165,6 @@ class IosCardPress extends StatefulWidget {
     this.duration,
     this.haptics = true,
   });
-
   final Widget child;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
@@ -192,7 +181,6 @@ class IosCardPress extends StatefulWidget {
   final Duration? duration;
   // Whether to perform a soft haptic on tap (also gated by settings/global toggles)
   final bool haptics;
-
   @override
   State<IosCardPress> createState() => _IosCardPressState();
 }
@@ -200,13 +188,13 @@ class IosCardPress extends StatefulWidget {
 class _IosCardPressState extends State<IosCardPress> {
   bool _pressed = false;
   bool _hovered = false;
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
     final Color base =
+        // color-gate: ignore
         widget.baseColor ?? (isDark ? Colors.white10 : cs.surface);
     final double k = widget.pressedBlendStrength ?? (isDark ? 0.14 : 0.12);
     final Color pressTarget =
@@ -218,11 +206,9 @@ class _IosCardPressState extends State<IosCardPress> {
         : (_hovered ? hoverTarget : base);
     final double scale = _pressed ? (widget.pressedScale ?? 1.0) : 1.0;
     final Duration dur = widget.duration ?? const Duration(milliseconds: 200);
-
     final content = widget.padding == null
         ? widget.child
         : Padding(padding: widget.padding!, child: widget.child);
-
     return MouseRegion(
       cursor: (widget.onTap != null || widget.onLongPress != null)
           ? SystemMouseCursors.click

--- a/lib/shared/widgets/ios_tile_button.dart
+++ b/lib/shared/widgets/ios_tile_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../core/services/haptics.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 class IosTileButton extends StatefulWidget {
   const IosTileButton({
@@ -43,7 +44,7 @@ class _IosTileButtonState extends State<IosTileButton> {
     // Use a light primary-tinted background when tinted; otherwise the neutral grey tile
     final Color baseBg = tinted
         ? (isDark ? tint.withValues(alpha: 0.20) : tint.withValues(alpha: 0.12))
-        : (isDark ? Colors.white10 : const Color(0xFFF2F3F5));
+        : context.appColors.surfaceFill;
     final overlay = isDark
         ? Colors.white.withValues(alpha: 0.06)
         : Colors.black.withValues(alpha: 0.05);

--- a/lib/shared/widgets/lan_sync_section.dart
+++ b/lib/shared/widgets/lan_sync_section.dart
@@ -16,6 +16,7 @@ import '../../core/services/sync/lan_sync_server.dart';
 import '../../core/services/sync/windows_firewall.dart';
 import '../../l10n/app_localizations.dart';
 import '../../theme/app_font_weights.dart';
+import '../../theme/app_semantic_colors.dart';
 import '../../utils/format.dart';
 import '../dialogs/restart_required_dialog.dart';
 import 'ios_form_text_field.dart';
@@ -293,7 +294,7 @@ class _LanSyncSectionState extends State<LanSyncSection> {
   }) {
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(18),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.12 : 0.08),
@@ -395,7 +396,7 @@ class _LanSyncSectionState extends State<LanSyncSection> {
   }) {
     return Container(
       decoration: BoxDecoration(
-        color: isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96),
+        color: context.appColors.surfaceCard,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: cs.outlineVariant.withValues(alpha: isDark ? 0.08 : 0.06),

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -33,6 +33,7 @@ import 'tabbed_preview_block.dart';
 import 'package:path/path.dart' as p;
 import 'package:Cuplivo/l10n/app_localizations.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import 'package:Cuplivo/theme/theme_factory.dart' show getPlatformFontFallback;
 import 'package:provider/provider.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -458,9 +459,8 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
         // Unmask dollar signs that were protected during preprocessing
         String unmasked = inline.replaceAll(_codeDollarMask, r'$');
         String softened = _softBreakInline(unmasked);
-        final bool isDarkCtx = Theme.of(ctx).brightness == Brightness.dark;
         final csCtx = Theme.of(ctx).colorScheme;
-        final bg = isDarkCtx ? Colors.white12 : const Color(0xFFF1F3F5);
+        final bg = ctx.appColors.surfaceFill;
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(

--- a/lib/shared/widgets/snackbar.dart
+++ b/lib/shared/widgets/snackbar.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import '../../core/services/haptics.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 
 enum NotificationType { success, error, info, warning }
 
@@ -321,16 +322,17 @@ class _NotificationWidgetState extends State<NotificationWidget>
     }
   }
 
-  Color _getIconColor(ColorScheme cs) {
+  Color _getIconColor(BuildContext context) {
+    final appColors = context.appColors;
     switch (widget.notification.type) {
       case NotificationType.success:
-        return const Color(0xFF34C759);
+        return appColors.success;
       case NotificationType.error:
-        return const Color(0xFFFF3B30);
+        return Theme.of(context).colorScheme.error;
       case NotificationType.warning:
-        return const Color(0xFFFF9500);
+        return appColors.warning;
       case NotificationType.info:
-        return cs.primary;
+        return Theme.of(context).colorScheme.primary;
     }
   }
 
@@ -368,9 +370,7 @@ class _NotificationWidgetState extends State<NotificationWidget>
           margin: const EdgeInsets.only(bottom: 8),
           constraints: const BoxConstraints(maxWidth: 400),
           decoration: BoxDecoration(
-            color: isDark
-                ? const Color(0xFF1C1C1E).withValues(alpha: 0.98)
-                : Colors.white.withValues(alpha: 0.98),
+            color: context.appColors.surfaceCard.withValues(alpha: 0.98),
             // color: cs.surface.withValues(alpha: 0.98),
             borderRadius: BorderRadius.circular(14),
             boxShadow: [
@@ -387,7 +387,7 @@ class _NotificationWidgetState extends State<NotificationWidget>
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               child: Row(
                 children: [
-                  Icon(_getIcon(), size: 22, color: _getIconColor(cs)),
+                  Icon(_getIcon(), size: 22, color: _getIconColor(context)),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(

--- a/lib/theme/app_semantic_colors.dart
+++ b/lib/theme/app_semantic_colors.dart
@@ -1,0 +1,191 @@
+import 'package:dynamic_color/dynamic_color.dart';
+import 'package:flutter/material.dart';
+
+/// Semantic colors that have no dedicated role in [ColorScheme].
+///
+/// All values are derived from (or harmonized with) the active [ColorScheme]
+/// so custom/seed-generated themes get sensible values automatically.
+class AppSemanticColors extends ThemeExtension<AppSemanticColors> {
+  final Color surfaceFill;
+  final Color surfaceCard;
+  final Color success;
+  final Color successContainer;
+  final Color onSuccessContainer;
+  final Color warning;
+  final Color warningContainer;
+  final Color onWarningContainer;
+  final Color searchHighlight;
+  final List<Color> chartSeries;
+
+  const AppSemanticColors({
+    required this.surfaceFill,
+    required this.surfaceCard,
+    required this.success,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.warning,
+    required this.warningContainer,
+    required this.onWarningContainer,
+    required this.searchHighlight,
+    required this.chartSeries,
+  });
+
+  /// Subtle fill for text fields, chips, small cards and tag containers.
+  /// Replaces the old `isDark ? Colors.white10 : Color(0xFFF2F3F5/F7F7F9)` idiom.
+  ///
+  /// Dark mode uses a stronger alpha (0.16) than the historical white10/white12
+  /// because these fills most often sit on [surfaceCard] (white@0.10 over
+  /// surface) — at 0.10 the two were indistinguishable (e.g. input fields in
+  /// section cards became invisible).
+  static Color _deriveSurfaceFill(ColorScheme cs) {
+    final alpha = cs.brightness == Brightness.dark ? 0.16 : 0.05;
+    return Color.alphaBlend(cs.onSurface.withValues(alpha: alpha), cs.surface);
+  }
+
+  /// iOS-style section card background.
+  /// Replaces the old `isDark ? Colors.white10 : Colors.white.withValues(alpha: 0.96)`
+  /// idiom.
+  static Color _deriveSurfaceCard(ColorScheme cs) {
+    return cs.brightness == Brightness.dark
+        ? Color.alphaBlend(
+            const Color(0xFFFFFFFF).withValues(alpha: 0.10),
+            cs.surface,
+          )
+        : Color.alphaBlend(
+            const Color(0xFFFFFFFF).withValues(alpha: 0.96),
+            cs.surface,
+          );
+  }
+
+  factory AppSemanticColors.light(ColorScheme cs) {
+    const successBase = Color(0xFF2E7D32);
+    const warningBase = Color(0xFFF57C00);
+    return AppSemanticColors(
+      surfaceFill: _deriveSurfaceFill(cs),
+      surfaceCard: _deriveSurfaceCard(cs),
+      success: successBase.harmonizeWith(cs.primary),
+      successContainer: const Color(0xFFA5D6A7).harmonizeWith(cs.primary),
+      onSuccessContainer: const Color(0xFF1B5E20),
+      warning: warningBase.harmonizeWith(cs.primary),
+      warningContainer: const Color(0xFFFFE0B2).harmonizeWith(cs.primary),
+      onWarningContainer: const Color(0xFF4E2600),
+      searchHighlight: const Color(0xFFFFD700).withValues(alpha: 0.55),
+      chartSeries: const [
+        Color(0xFF2563EB),
+        Color(0xFF0F8F83),
+        Color(0xFFEA580C),
+        Color(0xFF8B5CF6),
+        Color(0xFFE11D48),
+        Color(0xFF16A34A),
+        Color(0xFFCA8A04),
+        Color(0xFF0891B2),
+      ],
+    );
+  }
+
+  factory AppSemanticColors.dark(ColorScheme cs) {
+    const successBase = Color(0xFF81C784);
+    const warningBase = Color(0xFFFFB74D);
+    return AppSemanticColors(
+      surfaceFill: _deriveSurfaceFill(cs),
+      surfaceCard: _deriveSurfaceCard(cs),
+      success: successBase.harmonizeWith(cs.primary),
+      successContainer: const Color(0xFF1B5E20).harmonizeWith(cs.primary),
+      onSuccessContainer: const Color(0xFFC8E6C9),
+      warning: warningBase.harmonizeWith(cs.primary),
+      warningContainer: const Color(0xFF8D4E00).harmonizeWith(cs.primary),
+      onWarningContainer: const Color(0xFFFFE8CC),
+      searchHighlight: const Color(0xFFB8860B).withValues(alpha: 0.55),
+      chartSeries: const [
+        Color(0xFF60A5FA),
+        Color(0xFF5EEAD4),
+        Color(0xFFFB923C),
+        Color(0xFFA78BFA),
+        Color(0xFFFB7185),
+        Color(0xFF86EFAC),
+        Color(0xFFFACC15),
+        Color(0xFF67E8F9),
+      ],
+    );
+  }
+
+  @override
+  AppSemanticColors copyWith({
+    Color? surfaceFill,
+    Color? surfaceCard,
+    Color? success,
+    Color? successContainer,
+    Color? onSuccessContainer,
+    Color? warning,
+    Color? warningContainer,
+    Color? onWarningContainer,
+    Color? searchHighlight,
+    List<Color>? chartSeries,
+  }) {
+    return AppSemanticColors(
+      surfaceFill: surfaceFill ?? this.surfaceFill,
+      surfaceCard: surfaceCard ?? this.surfaceCard,
+      success: success ?? this.success,
+      successContainer: successContainer ?? this.successContainer,
+      onSuccessContainer: onSuccessContainer ?? this.onSuccessContainer,
+      warning: warning ?? this.warning,
+      warningContainer: warningContainer ?? this.warningContainer,
+      onWarningContainer: onWarningContainer ?? this.onWarningContainer,
+      searchHighlight: searchHighlight ?? this.searchHighlight,
+      chartSeries: chartSeries ?? this.chartSeries,
+    );
+  }
+
+  @override
+  AppSemanticColors lerp(ThemeExtension<AppSemanticColors>? other, double t) {
+    if (other is! AppSemanticColors) return this;
+    final len = chartSeries.length < other.chartSeries.length
+        ? chartSeries.length
+        : other.chartSeries.length;
+    return AppSemanticColors(
+      surfaceFill: Color.lerp(surfaceFill, other.surfaceFill, t)!,
+      surfaceCard: Color.lerp(surfaceCard, other.surfaceCard, t)!,
+      success: Color.lerp(success, other.success, t)!,
+      successContainer: Color.lerp(
+        successContainer,
+        other.successContainer,
+        t,
+      )!,
+      onSuccessContainer: Color.lerp(
+        onSuccessContainer,
+        other.onSuccessContainer,
+        t,
+      )!,
+      warning: Color.lerp(warning, other.warning, t)!,
+      warningContainer: Color.lerp(
+        warningContainer,
+        other.warningContainer,
+        t,
+      )!,
+      onWarningContainer: Color.lerp(
+        onWarningContainer,
+        other.onWarningContainer,
+        t,
+      )!,
+      searchHighlight: Color.lerp(searchHighlight, other.searchHighlight, t)!,
+      chartSeries: List.generate(
+        len,
+        (i) => Color.lerp(chartSeries[i], other.chartSeries[i], t)!,
+      ),
+    );
+  }
+}
+
+extension AppSemanticColorsX on BuildContext {
+  /// The ambient [AppSemanticColors]. Falls back to deriving values from the
+  /// ambient [ColorScheme] when the extension is not attached (e.g. in widget
+  /// tests that pump a plain MaterialApp).
+  AppSemanticColors get appColors {
+    final theme = Theme.of(this);
+    final ext = theme.extension<AppSemanticColors>();
+    if (ext != null) return ext;
+    return theme.brightness == Brightness.dark
+        ? AppSemanticColors.dark(theme.colorScheme)
+        : AppSemanticColors.light(theme.colorScheme);
+  }
+}

--- a/lib/theme/theme_factory.dart
+++ b/lib/theme/theme_factory.dart
@@ -2,6 +2,7 @@ import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 
@@ -47,6 +48,29 @@ List<String> getPlatformFontFallback() {
 
 // Internal helper for theme building
 List<String> _getPlatformFontFallback() => getPlatformFontFallback();
+
+/// Derive neutral `surfaceContainer*` roles from the scheme's surface.
+///
+/// Palettes in this app only define the classic ColorScheme roles, leaving the
+/// M3 surface containers at their static (purple-tinted) defaults, which clash
+/// with non-purple palettes. Deriving them here keeps dialogs, menus, cards
+/// and other Material surfaces consistent with the active palette.
+ColorScheme _withDerivedSurfaceContainers(ColorScheme s) {
+  final dark = s.brightness == Brightness.dark;
+  const white = Color(0xFFFFFFFF);
+  const black = Color(0xFF000000);
+  Color over(Color c, double a) =>
+      Color.alphaBlend(c.withValues(alpha: a), s.surface);
+  return s.copyWith(
+    surfaceContainerLowest: dark ? over(black, 0.28) : over(white, 0.72),
+    surfaceContainerLow: dark ? over(white, 0.03) : over(white, 0.55),
+    surfaceContainer: dark ? over(white, 0.045) : over(white, 0.35),
+    // Light "high" containers must stay ≈ white: chat bubbles, cards, menus
+    // and dialogs historically used plain Colors.white in light mode.
+    surfaceContainerHigh: dark ? over(white, 0.06) : over(white, 0.85),
+    surfaceContainerHighest: dark ? over(white, 0.09) : over(s.onSurface, 0.05),
+  );
+}
 
 TextTheme _withFontFallback(TextTheme base, List<String> fallback) {
   TextStyle? f(TextStyle? s) => s?.copyWith(fontFamilyFallback: fallback);
@@ -135,47 +159,49 @@ TextTheme _withFontFallback(TextTheme base, List<String> fallback) {
 
 ThemeData buildLightTheme(ColorScheme? dynamicScheme) {
   final fontFallback = _getPlatformFontFallback();
-  final scheme =
-      (dynamicScheme?.harmonized()) ??
-      const ColorScheme(
-        brightness: Brightness.light,
-        primary: Color(0xFF4D5C92),
-        onPrimary: Color(0xFFFFFFFF),
-        primaryContainer: Color(0xFFDCE1FF),
-        onPrimaryContainer: Color(0xFF03174B),
-        secondary: Color(0xFF595D72),
-        onSecondary: Color(0xFFFFFFFF),
-        secondaryContainer: Color(0xFFDEE1F9),
-        onSecondaryContainer: Color(0xFF161B2C),
-        tertiary: Color(0xFF75546F),
-        onTertiary: Color(0xFFFFFFFF),
-        tertiaryContainer: Color(0xFFFFD7F6),
-        onTertiaryContainer: Color(0xFF2C122A),
-        error: Color(0xFFBB0947),
-        onError: Color(0xFFFFFFFF),
-        errorContainer: Color(0xFFFDDADE),
-        onErrorContainer: Color(0xFF400013),
-        // background: Color(0xFFFEFBFF),
-        // onBackground: Color(0xFF1A1B21),
-        surface: Color(0xFFFEFBFF),
-        onSurface: Color(0xFF1A1B21),
-        // surfaceVariant: Color(0xFFE2E1EC),
-        onSurfaceVariant: Color(0xFF45464F),
-        outline: Color(0xFF75757F),
-        outlineVariant: Color(0xFFC6C6D0),
-        shadow: Color(0xFF000000),
-        scrim: Color(0xFF000000),
-        inverseSurface: Color(0xFF2F3036),
-        onInverseSurface: Color(0xFFF1F0F7),
-        inversePrimary: Color(0xFFB6C4FF),
-        surfaceTint: Color(0xFF4D5C92),
-      );
+  final scheme = _withDerivedSurfaceContainers(
+    (dynamicScheme?.harmonized()) ??
+        const ColorScheme(
+          brightness: Brightness.light,
+          primary: Color(0xFF4D5C92),
+          onPrimary: Color(0xFFFFFFFF),
+          primaryContainer: Color(0xFFDCE1FF),
+          onPrimaryContainer: Color(0xFF03174B),
+          secondary: Color(0xFF595D72),
+          onSecondary: Color(0xFFFFFFFF),
+          secondaryContainer: Color(0xFFDEE1F9),
+          onSecondaryContainer: Color(0xFF161B2C),
+          tertiary: Color(0xFF75546F),
+          onTertiary: Color(0xFFFFFFFF),
+          tertiaryContainer: Color(0xFFFFD7F6),
+          onTertiaryContainer: Color(0xFF2C122A),
+          error: Color(0xFFBB0947),
+          onError: Color(0xFFFFFFFF),
+          errorContainer: Color(0xFFFDDADE),
+          onErrorContainer: Color(0xFF400013),
+          // background: Color(0xFFFEFBFF),
+          // onBackground: Color(0xFF1A1B21),
+          surface: Color(0xFFFEFBFF),
+          onSurface: Color(0xFF1A1B21),
+          // surfaceVariant: Color(0xFFE2E1EC),
+          onSurfaceVariant: Color(0xFF45464F),
+          outline: Color(0xFF75757F),
+          outlineVariant: Color(0xFFC6C6D0),
+          shadow: Color(0xFF000000),
+          scrim: Color(0xFF000000),
+          inverseSurface: Color(0xFF2F3036),
+          onInverseSurface: Color(0xFFF1F0F7),
+          inversePrimary: Color(0xFFB6C4FF),
+          surfaceTint: Color(0xFF4D5C92),
+        ),
+  );
   // _logColorScheme('Light ${dynamicScheme != null ? 'Dynamic' : 'Static'}', scheme);
 
   final theme = ThemeData(
     useMaterial3: true,
     colorScheme: scheme,
     scaffoldBackgroundColor: scheme.surface,
+    extensions: <ThemeExtension<dynamic>>[AppSemanticColors.light(scheme)],
     snackBarTheme: SnackBarThemeData(
       behavior: SnackBarBehavior.floating,
       backgroundColor: scheme.inverseSurface,
@@ -190,20 +216,21 @@ ThemeData buildLightTheme(ColorScheme? dynamicScheme) {
       actionTextColor: scheme.primary,
       disabledActionTextColor: scheme.onInverseSurface.withValues(alpha: 0.5),
     ),
+    dialogTheme: DialogThemeData(backgroundColor: scheme.surface),
     appBarTheme: AppBarTheme(
       backgroundColor: scheme.surface,
       surfaceTintColor: scheme.surface,
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      foregroundColor: Colors.black,
+      foregroundColor: scheme.onSurface,
       titleTextStyle: TextStyle(
-        color: Colors.black,
+        color: scheme.onSurface,
         fontSize: 18,
         fontWeight: AppFontWeights.semibold,
       ).copyWith(fontFamilyFallback: fontFallback),
-      iconTheme: const IconThemeData(color: Colors.black),
-      actionsIconTheme: const IconThemeData(color: Colors.black),
+      iconTheme: IconThemeData(color: scheme.onSurface),
+      actionsIconTheme: IconThemeData(color: scheme.onSurface),
       systemOverlayStyle: const SystemUiOverlayStyle(
         statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.dark,
@@ -234,12 +261,14 @@ ThemeData buildLightThemeForScheme(
       onInverseSurface: const Color(0xFFFFFFFF),
     );
   }
+  scheme = _withDerivedSurfaceContainers(scheme);
   // Align logging behavior with buildLightTheme so diagnostics are consistent.
   // _logColorScheme('Light ${dynamicScheme != null ? 'Dynamic' : 'Static'}', scheme);
   final theme = ThemeData(
     useMaterial3: true,
     colorScheme: scheme,
     scaffoldBackgroundColor: scheme.surface,
+    extensions: <ThemeExtension<dynamic>>[AppSemanticColors.light(scheme)],
     snackBarTheme: SnackBarThemeData(
       behavior: SnackBarBehavior.floating,
       backgroundColor: scheme.inverseSurface,
@@ -261,14 +290,14 @@ ThemeData buildLightThemeForScheme(
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      foregroundColor: Colors.black,
+      foregroundColor: scheme.onSurface,
       titleTextStyle: TextStyle(
-        color: Colors.black,
+        color: scheme.onSurface,
         fontSize: 18,
         fontWeight: AppFontWeights.semibold,
       ).copyWith(fontFamilyFallback: fontFallback),
-      iconTheme: const IconThemeData(color: Colors.black),
-      actionsIconTheme: const IconThemeData(color: Colors.black),
+      iconTheme: IconThemeData(color: scheme.onSurface),
+      actionsIconTheme: IconThemeData(color: scheme.onSurface),
       systemOverlayStyle: SystemUiOverlayStyle(
         statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.dark,
@@ -285,47 +314,49 @@ ThemeData buildLightThemeForScheme(
 
 ThemeData buildDarkTheme(ColorScheme? dynamicScheme) {
   final fontFallback = _getPlatformFontFallback();
-  final scheme =
-      (dynamicScheme?.harmonized()) ??
-      const ColorScheme(
-        brightness: Brightness.dark,
-        primary: Color(0xFFB6C4FF),
-        onPrimary: Color(0xFF1D2D61),
-        primaryContainer: Color(0xFF354479),
-        onPrimaryContainer: Color(0xFFDCE1FF),
-        secondary: Color(0xFFC2C5DD),
-        onSecondary: Color(0xFF2B3042),
-        secondaryContainer: Color(0xFF424659),
-        onSecondaryContainer: Color(0xFFDEE1F9),
-        tertiary: Color(0xFFE3BADA),
-        onTertiary: Color(0xFF432740),
-        tertiaryContainer: Color(0xFF5B3D57),
-        onTertiaryContainer: Color(0xFFFFD7F6),
-        error: Color(0xFFFCB4BD),
-        onError: Color(0xFF670023),
-        errorContainer: Color(0xFF910034),
-        onErrorContainer: Color(0xFFFCB4BD),
-        // background: Color(0xFF1A1B21),
-        // onBackground: Color(0xFFE3E1E9),
-        surface: Color(0xFF1A1B21),
-        onSurface: Color(0xFFE3E1E9),
-        // surfaceVariant: Color(0xFF45464F),
-        onSurfaceVariant: Color(0xFFC6C6D0),
-        outline: Color(0xFF90909A),
-        outlineVariant: Color(0xFF45464F),
-        shadow: Color(0xFF000000),
-        scrim: Color(0xFF000000),
-        inverseSurface: Color(0xFFE3E1E9),
-        onInverseSurface: Color(0xFF2F3036),
-        inversePrimary: Color(0xFF4D5C92),
-        surfaceTint: Color(0xFFB6C4FF),
-      );
+  final scheme = _withDerivedSurfaceContainers(
+    (dynamicScheme?.harmonized()) ??
+        const ColorScheme(
+          brightness: Brightness.dark,
+          primary: Color(0xFFB6C4FF),
+          onPrimary: Color(0xFF1D2D61),
+          primaryContainer: Color(0xFF354479),
+          onPrimaryContainer: Color(0xFFDCE1FF),
+          secondary: Color(0xFFC2C5DD),
+          onSecondary: Color(0xFF2B3042),
+          secondaryContainer: Color(0xFF424659),
+          onSecondaryContainer: Color(0xFFDEE1F9),
+          tertiary: Color(0xFFE3BADA),
+          onTertiary: Color(0xFF432740),
+          tertiaryContainer: Color(0xFF5B3D57),
+          onTertiaryContainer: Color(0xFFFFD7F6),
+          error: Color(0xFFFCB4BD),
+          onError: Color(0xFF670023),
+          errorContainer: Color(0xFF910034),
+          onErrorContainer: Color(0xFFFCB4BD),
+          // background: Color(0xFF1A1B21),
+          // onBackground: Color(0xFFE3E1E9),
+          surface: Color(0xFF1A1B21),
+          onSurface: Color(0xFFE3E1E9),
+          // surfaceVariant: Color(0xFF45464F),
+          onSurfaceVariant: Color(0xFFC6C6D0),
+          outline: Color(0xFF90909A),
+          outlineVariant: Color(0xFF45464F),
+          shadow: Color(0xFF000000),
+          scrim: Color(0xFF000000),
+          inverseSurface: Color(0xFFE3E1E9),
+          onInverseSurface: Color(0xFF2F3036),
+          inversePrimary: Color(0xFF4D5C92),
+          surfaceTint: Color(0xFFB6C4FF),
+        ),
+  );
   // _logColorScheme('Dark ${dynamicScheme != null ? 'Dynamic' : 'Static'}', scheme);
 
   final theme = ThemeData(
     useMaterial3: true,
     colorScheme: scheme,
     scaffoldBackgroundColor: scheme.surface,
+    extensions: <ThemeExtension<dynamic>>[AppSemanticColors.dark(scheme)],
     snackBarTheme: SnackBarThemeData(
       behavior: SnackBarBehavior.floating,
       backgroundColor: scheme.inverseSurface,
@@ -340,20 +371,21 @@ ThemeData buildDarkTheme(ColorScheme? dynamicScheme) {
       actionTextColor: scheme.primary,
       disabledActionTextColor: scheme.onInverseSurface.withValues(alpha: 0.6),
     ),
+    dialogTheme: DialogThemeData(backgroundColor: scheme.surface),
     appBarTheme: AppBarTheme(
       backgroundColor: scheme.surface,
       surfaceTintColor: scheme.surface,
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      foregroundColor: Colors.white,
+      foregroundColor: scheme.onSurface,
       titleTextStyle: TextStyle(
-        color: Colors.white,
+        color: scheme.onSurface,
         fontSize: 18,
         fontWeight: AppFontWeights.semibold,
       ).copyWith(fontFamilyFallback: fontFallback),
-      iconTheme: const IconThemeData(color: Colors.white),
-      actionsIconTheme: const IconThemeData(color: Colors.white),
+      iconTheme: IconThemeData(color: scheme.onSurface),
+      actionsIconTheme: IconThemeData(color: scheme.onSurface),
       systemOverlayStyle: const SystemUiOverlayStyle(
         statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.light,
@@ -383,12 +415,14 @@ ThemeData buildDarkThemeForScheme(
       onInverseSurface: const Color(0xFF000000),
     );
   }
+  scheme = _withDerivedSurfaceContainers(scheme);
   // Align logging behavior with buildDarkTheme so diagnostics are consistent.
   // _logColorScheme('Dark ${dynamicScheme != null ? 'Dynamic' : 'Static'}', scheme);
   final theme = ThemeData(
     useMaterial3: true,
     colorScheme: scheme,
     scaffoldBackgroundColor: scheme.surface,
+    extensions: <ThemeExtension<dynamic>>[AppSemanticColors.dark(scheme)],
     snackBarTheme: SnackBarThemeData(
       behavior: SnackBarBehavior.floating,
       backgroundColor: scheme.inverseSurface,
@@ -410,14 +444,14 @@ ThemeData buildDarkThemeForScheme(
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      foregroundColor: Colors.white,
+      foregroundColor: scheme.onSurface,
       titleTextStyle: TextStyle(
-        color: Colors.white,
+        color: scheme.onSurface,
         fontSize: 18,
         fontWeight: AppFontWeights.semibold,
       ).copyWith(fontFamilyFallback: fontFallback),
-      iconTheme: const IconThemeData(color: Colors.white),
-      actionsIconTheme: const IconThemeData(color: Colors.white),
+      iconTheme: IconThemeData(color: scheme.onSurface),
+      actionsIconTheme: IconThemeData(color: scheme.onSurface),
       systemOverlayStyle: SystemUiOverlayStyle(
         statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.light,

--- a/test/features/chat/widgets/chat_message_widget_background_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_background_test.dart
@@ -130,7 +130,12 @@ void main() {
       expect(capsule.baseColor, Colors.transparent);
       expect(
         capsule.border,
-        Border.all(color: Colors.black.withValues(alpha: 0.10), width: 0.8),
+        Border.all(
+          color: ThemeData.light().colorScheme.onSurface.withValues(
+            alpha: 0.10,
+          ),
+          width: 0.8,
+        ),
       );
       expect(
         capsule.padding,

--- a/test/theme/app_semantic_colors_test.dart
+++ b/test/theme/app_semantic_colors_test.dart
@@ -1,0 +1,171 @@
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const ColorScheme _lightScheme = ColorScheme.light(
+  primary: Color(0xFF4D5C92),
+  onPrimary: Color(0xFFFFFFFF),
+  surface: Color(0xFFFEFBFF),
+  onSurface: Color(0xFF1A1B21),
+  onSurfaceVariant: Color(0xFF45464F),
+);
+
+const ColorScheme _darkScheme = ColorScheme.dark(
+  primary: Color(0xFFB6C4FF),
+  onPrimary: Color(0xFF1D2D61),
+  surface: Color(0xFF1A1B21),
+  onSurface: Color(0xFFE3E1E9),
+  onSurfaceVariant: Color(0xFFC6C6D0),
+);
+
+void main() {
+  group('AppSemanticColors.light', () {
+    final app = AppSemanticColors.light(_lightScheme);
+
+    test('surfaceFill blends onSurface over surface at 0.05', () {
+      expect(
+        app.surfaceFill,
+        Color.alphaBlend(
+          _lightScheme.onSurface.withValues(alpha: 0.05),
+          _lightScheme.surface,
+        ),
+      );
+    });
+
+    test('surfaceCard blends white over surface at 0.96', () {
+      expect(
+        app.surfaceCard,
+        Color.alphaBlend(
+          const Color(0xFFFFFFFF).withValues(alpha: 0.96),
+          _lightScheme.surface,
+        ),
+      );
+    });
+
+    test('searchHighlight is gold at 0.55 alpha', () {
+      expect(
+        app.searchHighlight,
+        const Color(0xFFFFD700).withValues(alpha: 0.55),
+      );
+    });
+
+    test('chartSeries is the 8-color light ramp', () {
+      expect(app.chartSeries, hasLength(8));
+      expect(app.chartSeries.first, const Color(0xFF2563EB));
+      expect(app.chartSeries.last, const Color(0xFF0891B2));
+    });
+  });
+
+  group('AppSemanticColors.dark', () {
+    final app = AppSemanticColors.dark(_darkScheme);
+
+    test('surfaceFill uses the lightened 0.16 dark alpha', () {
+      expect(
+        app.surfaceFill,
+        Color.alphaBlend(
+          _darkScheme.onSurface.withValues(alpha: 0.16),
+          _darkScheme.surface,
+        ),
+      );
+      expect(app.surfaceFill.computeLuminance(), greaterThan(0.03));
+    });
+
+    test('surfaceCard blends white over surface at 0.10', () {
+      expect(
+        app.surfaceCard,
+        Color.alphaBlend(
+          const Color(0xFFFFFFFF).withValues(alpha: 0.10),
+          _darkScheme.surface,
+        ),
+      );
+    });
+
+    test('chartSeries is the 8-color dark ramp', () {
+      expect(app.chartSeries, hasLength(8));
+      expect(app.chartSeries.first, const Color(0xFF60A5FA));
+      expect(app.chartSeries.last, const Color(0xFF67E8F9));
+    });
+  });
+
+  group('status tokens are harmonized with the primary', () {
+    test('light success/warning are opaque derived colors', () {
+      final app = AppSemanticColors.light(_lightScheme);
+      expect(app.success.a, 1.0);
+      expect(app.warning.a, 1.0);
+      expect(app.successContainer, isNot(equals(app.success)));
+      expect(app.warningContainer, isNot(equals(app.warning)));
+    });
+  });
+
+  group('context.appColors fallback', () {
+    testWidgets('derives from the ambient scheme when no extension attached', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final app = context.appColors;
+              final cs = Theme.of(context).colorScheme;
+              expect(
+                app.surfaceFill,
+                Color.alphaBlend(
+                  cs.onSurface.withValues(alpha: 0.05),
+                  cs.surface,
+                ),
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('prefers the attached extension when present', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: _lightScheme,
+            extensions: <ThemeExtension<dynamic>>[
+              const AppSemanticColors(
+                surfaceFill: Color(0xFFFF0000),
+                surfaceCard: Color(0xFFFF0000),
+                success: Color(0xFFFF0000),
+                successContainer: Color(0xFFFF0000),
+                onSuccessContainer: Color(0xFFFF0000),
+                warning: Color(0xFFFF0000),
+                warningContainer: Color(0xFFFF0000),
+                onWarningContainer: Color(0xFFFF0000),
+                searchHighlight: Color(0xFFFF0000),
+                chartSeries: <Color>[Color(0xFFFF0000)],
+              ),
+            ],
+          ),
+          home: Builder(
+            builder: (context) {
+              expect(context.appColors.surfaceFill, const Color(0xFFFF0000));
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+    });
+  });
+
+  group('copyWith / lerp', () {
+    test('copyWith overrides only the given field', () {
+      final app = AppSemanticColors.light(_lightScheme);
+      final copy = app.copyWith(surfaceFill: const Color(0xFFFF0000));
+      expect(copy.surfaceFill, const Color(0xFFFF0000));
+      expect(copy.surfaceCard, app.surfaceCard);
+    });
+
+    test('lerp produces intermediate values', () {
+      final light = AppSemanticColors.light(_lightScheme);
+      final dark = AppSemanticColors.dark(_darkScheme);
+      final mid = light.lerp(dark, 0.5);
+      expect(mid.surfaceFill, isA<Color>());
+      expect(mid.chartSeries, hasLength(light.chartSeries.length));
+    });
+  });
+}

--- a/test/theme/theme_factory_test.dart
+++ b/test/theme/theme_factory_test.dart
@@ -1,5 +1,7 @@
+import 'package:Cuplivo/theme/app_semantic_colors.dart';
 import 'package:Cuplivo/theme/theme_factory.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -39,6 +41,74 @@ void main() {
         );
       }
       expect(kWindowsFontFamilyFallback, contains('Segoe UI Symbol'));
+    });
+  });
+
+  group('semantic color extension & surface container derivation', () {
+    test(
+      'buildLightTheme attaches AppSemanticColors and onSurface app bar',
+      () {
+        final theme = buildLightTheme(null);
+        final scheme = theme.colorScheme;
+        expect(theme.extension<AppSemanticColors>(), isA<AppSemanticColors>());
+        expect(theme.appBarTheme.foregroundColor, scheme.onSurface);
+        expect(theme.dialogTheme.backgroundColor, scheme.surface);
+      },
+    );
+
+    test('buildDarkTheme attaches AppSemanticColors and onSurface app bar', () {
+      final theme = buildDarkTheme(null);
+      final scheme = theme.colorScheme;
+      expect(theme.extension<AppSemanticColors>(), isA<AppSemanticColors>());
+      expect(theme.appBarTheme.foregroundColor, scheme.onSurface);
+      expect(theme.dialogTheme.backgroundColor, scheme.surface);
+    });
+
+    test(
+      'buildLightThemeForScheme attaches extension and derives containers',
+      () {
+        const scheme = ColorScheme.light(surface: Color(0xFFF7F7F7));
+        final theme = buildLightThemeForScheme(scheme);
+        final cs = theme.colorScheme;
+        expect(theme.extension<AppSemanticColors>(), isA<AppSemanticColors>());
+        // Derived container, not the M3 purple-tinted default (0xFFE6E0E9).
+        expect(cs.surfaceContainerHighest, isNot(const Color(0xFFE6E0E9)));
+        expect(
+          cs.surfaceContainerHigh,
+          Color.alphaBlend(
+            const Color(0xFFFFFFFF).withValues(alpha: 0.85),
+            scheme.surface,
+          ),
+        );
+        expect(theme.appBarTheme.foregroundColor, cs.onSurface);
+      },
+    );
+
+    test(
+      'buildDarkThemeForScheme attaches extension and derives containers',
+      () {
+        const scheme = ColorScheme.dark(surface: Color(0xFF1A1B21));
+        final theme = buildDarkThemeForScheme(scheme);
+        final cs = theme.colorScheme;
+        expect(theme.extension<AppSemanticColors>(), isA<AppSemanticColors>());
+        expect(
+          cs.surfaceContainerLowest,
+          Color.alphaBlend(
+            const Color(0xFF000000).withValues(alpha: 0.28),
+            scheme.surface,
+          ),
+        );
+        expect(theme.appBarTheme.foregroundColor, cs.onSurface);
+      },
+    );
+
+    test('pureBackground derives containers against the pure surface', () {
+      final theme = buildLightThemeForScheme(
+        const ColorScheme.light(surface: Color(0xFFF7F7F7)),
+        pureBackground: true,
+      );
+      expect(theme.colorScheme.surface, const Color(0xFFFFFFFF));
+      expect(theme.extension<AppSemanticColors>(), isA<AppSemanticColors>());
     });
   });
 }

--- a/tool/check_colors.py
+++ b/tool/check_colors.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""One-off verification gate for the semantic-color migration (#300).
+
+Scans lib/**/*.dart for hardcoded color idioms. Two buckets:
+
+  * MUST-GO idioms (the migration was supposed to eliminate these): the
+    surfaceFill/surfaceCard/status/text-muted/search-highlight families.
+    Any remaining site is a migration miss and makes this tool exit 1.
+  * INFORMATIONAL deliberate fixed colors: full-opacity Colors.white/black,
+    CupertinoColors, and general Color(0x...) literals. These are printed for
+    review only and must carry a `color-gate: ignore` marker where they are a
+    truly intentional fixed color.
+
+This mirrors upstream Kelivo's `tool/check_colors.sh` gate which was removed
+as "one-off migration verification tooling". It is intentionally NOT wired
+into CI — run it manually after theme-token changes:
+
+    python3 tool/check_colors.py
+
+Always excluded:
+  - lib/theme/**  -> palette definitions, static schemes, semantic token
+                     derivation, design tokens
+  - lines with `color-gate: ignore`  -> deliberate fixed colors
+  - transparent literals (Colors.transparent, CupertinoColors.transparent,
+    Color(0x00000000))
+"""
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+LIB = ROOT / "lib"
+
+IGNORE_MARKER = "color-gate: ignore"
+
+# Idiom families the semantic-color migration was supposed to replace.
+MUST_GO = re.compile(
+    r"(?<!\w)Colors\.(white10|white12|white24|white30|white38|white54|white70|"
+    r"black26|black38|black45|black54|black87|grey|grey\.shade|red|redAccent|"
+    r"red\.shade|green|green\.shade|orange|amber|blue|teal|purple|indigo|pink|"
+    r"brown|cyan|yellow)\b"
+    r"|Color\(0xFF(?:F2F3F5|F7F7F9|1C1C1E|141414|EBEBEB|F1F3F5|F6F7F9|"
+    r"F8F8FA|DADDE2|DDE2E8|D9DDE2|FFD700|B8860B)\)"
+)
+
+# Deliberate fixed colors / general literals (informational).
+INFORMATIONAL = re.compile(
+    r"(?<!\w)Colors\.(white|black)\b"
+    r"|(?<!\w)CupertinoColors\.\w+"
+    r"|Color\(0x[0-9a-fA-F]{6,8}\)"
+    r"|Color\(0X[0-9a-fA-F]{6,8}\)"
+)
+
+TRANSPARENT = re.compile(
+    r"(?<!\w)Colors\.transparent\b"
+    r"|(?<!\w)CupertinoColors\.transparent\b"
+    r"|Color\(0x[0]+\)"
+)
+
+
+def scan():
+    must_go = []
+    info = []
+    for path in sorted(LIB.rglob("*.dart")):
+        rel = path.relative_to(ROOT).as_posix()
+        if rel.startswith("lib/theme/"):
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            # A `color-gate: ignore` marker may sit on the same line or on the
+            # immediately-preceding line (standalone comment lines are stable
+            # under dart format, unlike trailing comments on long expressions).
+            prev_line = lines[lineno - 2] if lineno >= 2 else ""
+            marked = IGNORE_MARKER in line or IGNORE_MARKER in prev_line
+            if marked:
+                continue
+            for match in MUST_GO.finditer(line):
+                if TRANSPARENT.search(match.group(0)):
+                    continue
+                must_go.append(f"{rel}:{lineno}: {match.group(0)}")
+            for match in INFORMATIONAL.finditer(line):
+                if TRANSPARENT.search(match.group(0)):
+                    continue
+                # Don't double-report a literal already flagged as must-go.
+                if match.group(0) in [
+                    m.group(0) for m in MUST_GO.finditer(line)
+                ]:
+                    continue
+                info.append(f"{rel}:{lineno}: {match.group(0)}")
+    return must_go, info
+
+
+def main() -> int:
+    must_go, info = scan()
+    if must_go:
+        print(f"{len(must_go)} MUST-GO migration miss(es):")
+        for h in must_go:
+            print("  " + h)
+        print(
+            "\nThese are migration misses. Either migrate them to semantic "
+            "tokens, or (rarely) mark a deliberate exception with "
+            f"`// {IGNORE_MARKER}`."
+        )
+    else:
+        print("No must-go migration misses in lib/ (excluding lib/theme/).")
+    if info:
+        print(f"\n{len(info)} informational fixed-color site(s) — review only:")
+        for h in info[:40]:
+            print("  " + h)
+        if len(info) > 40:
+            print(f"  ... and {len(info) - 40} more.")
+    return 1 if must_go else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #300. #507 已交付自定义主题系统；本 PR 落地其延后的二期:`AppSemanticColors` 语义色 token 迁移 + `surfaceContainer*` 推导。

## 变更

- **新 `AppSemanticColors` ThemeExtension**(上游逐字移植):`surfaceFill`/`surfaceCard`/`success`/`warning`(+container)/`searchHighlight`/`chartSeries`,全部由激活 ColorScheme 推导或 harmonize,经 `context.appColors` 读取(未挂载时回退推导)
- **`theme_factory.dart`**:4 个 builder 挂载 extension;`_withDerivedSurfaceContainers` 从 scheme surface 推导 M3 `surfaceContainerLowest→Highest`(浅色 High = white@0.85,气泡/弹层保持 ≈白);AppBarTheme 前景改 `onSurface`;补齐 dialogTheme
- **~130 文件迁移**:`white10/12`+`F2F3F5/F7F7F9`→`surfaceFill`;`white@0.96`+`1C1C1E/141414`→`surfaceCard`;muted 文本→`onSurfaceVariant`;hover/scrim→`onSurface`/`scrim`;红→`cs.error`;绿/橙→`success/warning`;金色搜索高亮→`searchHighlight`;统计图表与请求日志角色色→`chartSeries`
- **工具**:`tool/check_colors.py` 一次性校验(0 must-go 遗漏);刻意固定色以 `color-gate: ignore` 标注;**不接入 CI**(上游先加后删,见 ADR-0038)
- **文档/测试**:ADR-0038、CONTEXT.md 主题词条扩充;新增 `app_semantic_colors_test.dart`、扩展 `theme_factory_test.dart`

## 验证

- `dart analyze --fatal-infos lib test` ✅ / `dart format --set-exit-if-changed` ✅ / `tool/check_colors.py` 0 遗漏 ✅
- 本地 `flutter test` 子集 87 通过(theme/背景/显示设置/迷你图)

## 已知(ADR-0038 记录)

- 单色板下 `cs.error` 为纯黑/白,红信号消失(上游一致,单色板身份)
- 暗色 `surfaceFill` 0.16 调亮、`surfaceContainer*` 由紫调默认改中性推导,为预期视觉变化
- 未跑真实桌面/移动端构建,建议合并前人工过一遍渲染