### PR TITLE
fix(backup): merge restore never adopts provider proxy settings (#512)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,12 @@
   - Import automatically skips mode selection for `cuplivo_incr_` files
   - Empty export (0 conversations matched) shows a confirmation warning before producing the file
 
+## Backup Merge Semantics (智能合并)
+
+- **Flat scalar settings**: restored only if absent locally — an existing local preference is preserved (per the "仅添加不存在的数据" contract).
+- **Structured JSON keys** (`provider_configs_v1`, `assistant_memories_v1`, `mcp_servers_v1`, `asr_services_v1`, `pinned_models_v1`, tags/maps, groups): merged per-structure; the backup wins on conflicts (dedup by id where applicable).
+- **Provider proxy is device-local**: within `provider_configs_v1`, a provider that already exists locally keeps its 6 proxy fields (`proxyEnabled/Type/Host/Port/Username/Password`) from the backup NEVER — local values win; a legacy local config with no proxy block at all is forced to the app's no-proxy defaults instead of adopting the backup's proxy. Brand-new providers imported by the merge keep their backup proxy as-is (nothing local to preserve). (issue #512) LAN sync rides the same merge path, so a sync peer's proxy never lands on the device either; overwrite restore still imports proxy settings wholesale.
+
 ## Markdown Batch Export (批量导出 Markdown)
 
 - **Markdown 批量导出 (batch Markdown export)**: Conversation-level batch export producing one human-readable `.md` file per selected conversation. Distinct from **备份/backup** (data-level JSON ZIP) and from message-level 导出 (single conversation, curated selection). Entry: the conversation batch-select mode in `SideDrawer` (mobile drawer + desktop sidebars).

--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -87,6 +87,31 @@ class DataSync {
   // this past 1 without relaxing Kelivo's _parseChatBackup constraint first.
   static const int _chatsJsonVersion = 1;
 
+  // Proxy fields inside a provider config. Proxy is device-local: during a
+  // merge restore these fields are never adopted from the backup for
+  // providers that already exist locally (issue #512).
+  static const List<String> _providerProxyFields = [
+    'proxyEnabled',
+    'proxyType',
+    'proxyHost',
+    'proxyPort',
+    'proxyUsername',
+    'proxyPassword',
+  ];
+
+  // The no-proxy state the app writes for fresh configs (mirrors
+  // SettingsProvider's defaults). Used when a legacy local provider config
+  // carries no proxy block at all, so the backup's proxy never survives even
+  // in disabled form.
+  static const Map<String, dynamic> _noProxyProviderDefaults = {
+    'proxyEnabled': false,
+    'proxyType': 'http',
+    'proxyHost': '',
+    'proxyPort': '8080',
+    'proxyUsername': '',
+    'proxyPassword': '',
+  };
+
   // ===== WebDAV helpers =====
   Uri _collectionUri(WebDavConfig cfg) {
     String base = cfg.url.trim();
@@ -1448,7 +1473,12 @@ class DataSync {
               if (mergeableKeys.contains(key)) {
                 // Special handling for mergeable configurations
                 if (key == 'provider_configs_v1' && existing.containsKey(key)) {
-                  // Merge provider configs: combine both maps
+                  // Merge provider configs per provider key. The backup wins
+                  // for all fields EXCEPT the proxy block, which is
+                  // device-local: an existing provider's proxy is composed
+                  // from its local block over the no-proxy defaults — the
+                  // backup's proxy never lands on the device (issue #512).
+                  // Brand-new providers keep their backup proxy.
                   try {
                     final existingConfigs =
                         jsonDecode(existing[key] as String)
@@ -1456,8 +1486,34 @@ class DataSync {
                     final newConfigs =
                         jsonDecode(newValue as String) as Map<String, dynamic>;
 
-                    // Merge configs, new values override existing for same keys
-                    final mergedConfigs = {...existingConfigs, ...newConfigs};
+                    // Start from the local configs so providers absent from
+                    // the backup survive the merge untouched.
+                    final mergedConfigs = <String, dynamic>{...existingConfigs};
+                    for (final entry in newConfigs.entries) {
+                      final providerKey = entry.key;
+                      final incoming = entry.value;
+                      final local = existingConfigs[providerKey];
+                      if (incoming is! Map || local is! Map) {
+                        // Malformed entry: keep the prior verbatim behavior
+                        // for this entry and continue merging the rest.
+                        mergedConfigs[providerKey] = incoming;
+                        continue;
+                      }
+                      final localMap = local.cast<String, dynamic>();
+                      // The proxy fields of an existing provider are composed
+                      // from the local block (where present) over the
+                      // no-proxy defaults — the backup's proxy never lands on
+                      // the device, whether the local block is full, partial,
+                      // or absent entirely.
+                      final merged = <String, dynamic>{
+                        ...incoming.cast<String, dynamic>(),
+                        ..._noProxyProviderDefaults,
+                        for (final field in _providerProxyFields)
+                          if (localMap.containsKey(field))
+                            field: localMap[field],
+                      };
+                      mergedConfigs[providerKey] = merged;
+                    }
                     await prefs.restoreSingle(key, jsonEncode(mergedConfigs));
                   } catch (e) {
                     // If merge fails, keep existing

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -669,6 +669,307 @@ void main() {
       },
     );
 
+    group('merge restore: provider proxy is device-local (issue #512)', () {
+      Future<void> restoreMerge(Map<String, dynamic> backupSettings) async {
+        final settingsFile = File('${root.path}/proxy_settings.json');
+        await settingsFile.writeAsString(jsonEncode(backupSettings));
+
+        final zipFile = File('${root.path}/proxy_merge_backup.zip');
+        final encoder = ZipFileEncoder();
+        encoder.create(zipFile.path);
+        encoder.addFileSync(settingsFile, 'settings.json');
+        encoder.closeSync();
+
+        final sync = DataSync(chatService: ChatService());
+        await sync.restoreFromLocalFile(
+          zipFile,
+          const WebDavConfig(includeChats: false, includeFiles: false),
+          mode: RestoreMode.merge,
+        );
+      }
+
+      Map<String, dynamic> providerConfig(
+        String id,
+        String baseUrl,
+        Map<String, dynamic> proxy,
+      ) => {
+        'id': id,
+        'type': 'openai',
+        'name': id,
+        'baseUrl': baseUrl,
+        'apiKey': 'key-$id',
+        'models': <String>[],
+        ...proxy,
+      };
+
+      const localProxy = {
+        'proxyEnabled': true,
+        'proxyType': 'socks5',
+        'proxyHost': '127.0.0.1',
+        'proxyPort': '1080',
+        'proxyUsername': 'local-user',
+        'proxyPassword': 'local-pass',
+      };
+
+      const backupProxy = {
+        'proxyEnabled': false,
+        'proxyType': 'http',
+        'proxyHost': 'proxy.backup.example',
+        'proxyPort': '3128',
+        'proxyUsername': '',
+        'proxyPassword': '',
+      };
+
+      test(
+        'existing provider keeps local proxy, backup updates other fields',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'provider_configs_v1': jsonEncode({
+              'MyProvider': providerConfig(
+                'MyProvider',
+                'https://local.example/v1',
+                localProxy,
+              ),
+            }),
+          });
+
+          await restoreMerge({
+            'provider_configs_v1': jsonEncode({
+              'MyProvider': providerConfig(
+                'MyProvider',
+                'https://backup.example/v1',
+                backupProxy,
+              ),
+            }),
+          });
+
+          final prefs = await SharedPreferences.getInstance();
+          final configs =
+              jsonDecode(prefs.getString('provider_configs_v1')!)
+                  as Map<String, dynamic>;
+          final merged = configs['MyProvider'] as Map<String, dynamic>;
+
+          // Non-proxy fields come from the backup.
+          expect(merged['baseUrl'], 'https://backup.example/v1');
+          expect(merged['apiKey'], 'key-MyProvider');
+
+          // Proxy fields stay local.
+          expect(merged['proxyEnabled'], isTrue);
+          expect(merged['proxyType'], 'socks5');
+          expect(merged['proxyHost'], '127.0.0.1');
+          expect(merged['proxyPort'], '1080');
+          expect(merged['proxyUsername'], 'local-user');
+          expect(merged['proxyPassword'], 'local-pass');
+        },
+      );
+
+      test('new provider imported from backup keeps its proxy', () async {
+        SharedPreferences.setMockInitialValues({
+          'provider_configs_v1': jsonEncode({
+            'Existing': providerConfig(
+              'Existing',
+              'https://local.example/v1',
+              localProxy,
+            ),
+          }),
+        });
+
+        await restoreMerge({
+          'provider_configs_v1': jsonEncode({
+            'Existing': providerConfig(
+              'Existing',
+              'https://backup.example/v1',
+              backupProxy,
+            ),
+            'NewProvider': providerConfig(
+              'NewProvider',
+              'https://new.example/v1',
+              backupProxy,
+            ),
+          }),
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final configs =
+            jsonDecode(prefs.getString('provider_configs_v1')!)
+                as Map<String, dynamic>;
+
+        // Existing provider: proxy preserved locally, other fields updated.
+        final existing = configs['Existing'] as Map<String, dynamic>;
+        expect(existing['baseUrl'], 'https://backup.example/v1');
+        expect(existing['proxyHost'], '127.0.0.1');
+
+        // New provider: proxy imported as-is.
+        final added = configs['NewProvider'] as Map<String, dynamic>;
+        expect(added['proxyEnabled'], isFalse);
+        expect(added['proxyHost'], 'proxy.backup.example');
+        expect(added['proxyPort'], '3128');
+      });
+
+      test(
+        'legacy local provider without a proxy block gets no-proxy defaults',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'provider_configs_v1': jsonEncode({
+              'Legacy': {
+                'id': 'Legacy',
+                'type': 'openai',
+                'name': 'Legacy',
+                'baseUrl': 'https://local.example/v1',
+                'apiKey': 'legacy-key',
+                'models': <String>[],
+              },
+            }),
+          });
+
+          await restoreMerge({
+            'provider_configs_v1': jsonEncode({
+              'Legacy': providerConfig(
+                'Legacy',
+                'https://backup.example/v1',
+                backupProxy,
+              ),
+            }),
+          });
+
+          final prefs = await SharedPreferences.getInstance();
+          final configs =
+              jsonDecode(prefs.getString('provider_configs_v1')!)
+                  as Map<String, dynamic>;
+          final merged = configs['Legacy'] as Map<String, dynamic>;
+
+          // Other fields still come from the backup.
+          expect(merged['baseUrl'], 'https://backup.example/v1');
+
+          // But the backup's proxy is replaced by the no-proxy defaults.
+          expect(merged['proxyEnabled'], isFalse);
+          expect(merged['proxyType'], 'http');
+          expect(merged['proxyHost'], '');
+          expect(merged['proxyPort'], '8080');
+          expect(merged['proxyUsername'], '');
+          expect(merged['proxyPassword'], '');
+        },
+      );
+
+      test(
+        'partial local proxy block never blends backup proxy fields',
+        () async {
+          // A local config imported from a third-party tool may carry only part
+          // of the proxy block (e.g. no password fields at all).
+          SharedPreferences.setMockInitialValues({
+            'provider_configs_v1': jsonEncode({
+              'Partial': {
+                'id': 'Partial',
+                'type': 'openai',
+                'name': 'Partial',
+                'baseUrl': 'https://local.example/v1',
+                'apiKey': 'partial-key',
+                'models': <String>[],
+                'proxyEnabled': true,
+                'proxyType': 'socks5',
+                'proxyHost': '127.0.0.1',
+                'proxyPort': '1080',
+              },
+            }),
+          });
+
+          await restoreMerge({
+            'provider_configs_v1': jsonEncode({
+              'Partial': providerConfig(
+                'Partial',
+                'https://backup.example/v1',
+                backupProxy,
+              ),
+            }),
+          });
+
+          final prefs = await SharedPreferences.getInstance();
+          final configs =
+              jsonDecode(prefs.getString('provider_configs_v1')!)
+                  as Map<String, dynamic>;
+          final merged = configs['Partial'] as Map<String, dynamic>;
+
+          // Present local fields win.
+          expect(merged['proxyEnabled'], isTrue);
+          expect(merged['proxyHost'], '127.0.0.1');
+
+          // Missing local fields fall to the no-proxy defaults, never the
+          // backup's values (backup had username/password empty, host
+          // proxy.backup.example — none of it may survive).
+          expect(merged['proxyUsername'], '');
+          expect(merged['proxyPassword'], '');
+        },
+      );
+
+      test('malformed provider entry does not abort the whole merge', () async {
+        SharedPreferences.setMockInitialValues({
+          'provider_configs_v1': jsonEncode({
+            'LocalOnly': providerConfig(
+              'LocalOnly',
+              'https://local.example/v1',
+              localProxy,
+            ),
+          }),
+        });
+
+        await restoreMerge({
+          'provider_configs_v1': jsonEncode({
+            'GoodProvider': providerConfig(
+              'GoodProvider',
+              'https://backup.example/v1',
+              backupProxy,
+            ),
+            // Non-object provider value (hand-edited or legacy data).
+            'BrokenProvider': 'not-a-config',
+          }),
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final configs =
+            jsonDecode(prefs.getString('provider_configs_v1')!)
+                as Map<String, dynamic>;
+
+        // The malformed entry is carried over verbatim and the merge of the
+        // valid entries still completes.
+        expect(configs['BrokenProvider'], 'not-a-config');
+        expect(configs.keys, containsAll(['LocalOnly', 'GoodProvider']));
+        final added = configs['GoodProvider'] as Map<String, dynamic>;
+        expect(added['proxyHost'], 'proxy.backup.example');
+      });
+
+      test('local providers absent from the backup survive merge', () async {
+        SharedPreferences.setMockInitialValues({
+          'provider_configs_v1': jsonEncode({
+            'LocalOnly': providerConfig(
+              'LocalOnly',
+              'https://local.example/v1',
+              localProxy,
+            ),
+          }),
+        });
+
+        await restoreMerge({
+          'provider_configs_v1': jsonEncode({
+            'BackupOnly': providerConfig(
+              'BackupOnly',
+              'https://backup.example/v1',
+              backupProxy,
+            ),
+          }),
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final configs =
+            jsonDecode(prefs.getString('provider_configs_v1')!)
+                as Map<String, dynamic>;
+
+        expect(configs.keys, containsAll(['LocalOnly', 'BackupOnly']));
+        final local = configs['LocalOnly'] as Map<String, dynamic>;
+        expect(local['baseUrl'], 'https://local.example/v1');
+        expect(local['proxyHost'], '127.0.0.1');
+      });
+    });
+
     test('cleans temporary restore files after a file-copy failure', () async {
       final sourceDir = Directory('${root.path}/source_upload');
       await sourceDir.create(recursive: true);


### PR DESCRIPTION
代理设置常常和本地环境强关联，因此智能合并时不应替换代理设置。
