### PR TITLE
feat(ocr): support official GLM-OCR and empty prompts

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -1053,11 +1053,9 @@ class SettingsProvider extends ChangeNotifier {
         _ocrModelId = parts.sublist(1).join('::');
       }
     }
-    // load OCR prompt
+    // load OCR prompt (null = default; empty string is an explicit clear)
     final ocrp = prefs.getString(_ocrPromptKey);
-    _ocrPrompt = (ocrp == null || ocrp.trim().isEmpty)
-        ? defaultOcrPrompt
-        : ocrp;
+    _ocrPrompt = ocrp ?? defaultOcrPrompt;
     // load summary model
     final summarySel = prefs.getString(_summaryModelKey);
     if (summarySel != null && summarySel.contains('::')) {
@@ -3599,7 +3597,7 @@ Please translate the <source_text> section:
   }
 
   Future<void> setOcrPrompt(String prompt) async {
-    _ocrPrompt = prompt.trim().isEmpty ? defaultOcrPrompt : prompt;
+    _ocrPrompt = prompt.trim();
     notifyListeners();
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_ocrPromptKey, _ocrPrompt);

--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -36,6 +36,7 @@ part 'providers/google_common.dart';
 part 'providers/google_gemini.dart';
 part 'providers/google_vertex.dart';
 part 'providers/claude_official.dart';
+part 'providers/zhipu_layout_parsing.dart';
 
 typedef ToolCallHandler =
     Future<String> Function(
@@ -644,10 +645,12 @@ class ChatApiService {
         kind == ProviderKind.openai &&
         allowImagesApiRouting &&
         _shouldUseOpenAIImagesApi(config, modelId);
+    final useZhipuLayoutParsing = shouldUseZhipuLayoutParsing(config, modelId);
     final unicodeSafeMessages = _sanitizeMessages(messages);
     final stripUnsupportedImageInputs =
         !ocrActive &&
         !useOpenAIImagesApi &&
+        !useZhipuLayoutParsing &&
         !supportsImageInput(config, modelId);
     final safeMessages = stripUnsupportedImageInputs
         ? await _stripImageInputsFromMessages(unicodeSafeMessages)
@@ -658,7 +661,16 @@ class ChatApiService {
     final client = _clientFor(config, cancelToken);
 
     try {
-      if (kind == ProviderKind.openai) {
+      if (useZhipuLayoutParsing) {
+        yield* sendZhipuLayoutParsingStream(
+          client,
+          config,
+          modelId,
+          safeMessages,
+          userMediaPaths: safeUserMediaPaths,
+          extraHeaders: extraHeaders,
+        );
+      } else if (kind == ProviderKind.openai) {
         if (useOpenAIImagesApi) {
           yield* _sendOpenAIImagesStream(
             client,

--- a/lib/core/services/api/providers/zhipu_layout_parsing.dart
+++ b/lib/core/services/api/providers/zhipu_layout_parsing.dart
@@ -1,0 +1,166 @@
+part of '../chat_api_service.dart';
+
+const String officialGlmOcrModelId = 'glm-ocr';
+
+/// Official GLM-OCR uses `/layout_parsing` with `{model, file}`, not Chat
+/// Completions.
+bool shouldUseZhipuLayoutParsing(ProviderConfig config, String modelId) {
+  return isOfficialZhipuHost(config) &&
+      isOfficialGlmOcrModel(_apiModelId(config, modelId));
+}
+
+bool isOfficialZhipuHost(ProviderConfig config) {
+  final host = Uri.tryParse(config.baseUrl.trim())?.host.toLowerCase() ?? '';
+  return host == 'open.bigmodel.cn';
+}
+
+bool isOfficialGlmOcrModel(String modelId) {
+  return modelId.trim().toLowerCase() == officialGlmOcrModelId;
+}
+
+Stream<ChatStreamChunk> sendZhipuLayoutParsingStream(
+  http.Client client,
+  ProviderConfig config,
+  String modelId,
+  List<Map<String, dynamic>> messages, {
+  List<String>? userMediaPaths,
+  Map<String, String>? extraHeaders,
+}) async* {
+  final file = await _resolveLayoutParsingFile(
+    messages: messages,
+    userMediaPaths: userMediaPaths,
+  );
+  final body = <String, dynamic>{'model': officialGlmOcrModelId, 'file': file};
+  final response = await client.post(
+    _layoutParsingUrl(config),
+    headers: <String, String>{
+      'Authorization': 'Bearer ${_apiKeyForRequest(config, modelId)}',
+      'Content-Type': 'application/json',
+      ..._customHeaders(config, modelId, includeCodexAuth: false),
+      if (extraHeaders != null) ...extraHeaders,
+    },
+    body: jsonEncode(body),
+  );
+  final decoded = _decodeLayoutParsingResponse(response);
+  final usage = _usageFromResponse(decoded);
+  yield ChatStreamChunk(
+    content: _mdResultsFromResponse(decoded),
+    isDone: true,
+    totalTokens: usage?.totalTokens ?? 0,
+    usage: usage,
+    consumedUsage: usage,
+  );
+}
+
+Uri _layoutParsingUrl(ProviderConfig config) {
+  final rawBase = config.baseUrl.endsWith('/')
+      ? config.baseUrl.substring(0, config.baseUrl.length - 1)
+      : config.baseUrl;
+  return Uri.parse('$rawBase/layout_parsing');
+}
+
+Future<String> _resolveLayoutParsingFile({
+  required List<Map<String, dynamic>> messages,
+  List<String>? userMediaPaths,
+}) async {
+  for (final path in userMediaPaths ?? const <String>[]) {
+    final encoded = await _encodeLayoutParsingFile(path);
+    if (encoded != null) return encoded;
+  }
+  for (var i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i]['role'] ?? '').toString() != 'user') continue;
+    final encoded = await _encodeLayoutParsingFileFromContent(
+      messages[i]['content'],
+    );
+    if (encoded != null) return encoded;
+  }
+  throw const HttpException('GLM-OCR requires an image or PDF file.');
+}
+
+Future<String?> _encodeLayoutParsingFileFromContent(dynamic content) async {
+  if (content is List) {
+    for (final part in content) {
+      if (part is! Map) continue;
+      final type = (part['type'] ?? '').toString();
+      if (type != 'image_url' && type != 'input_image' && type != 'image') {
+        continue;
+      }
+      final image = part['image_url'] ?? part['input_image'];
+      final source = image is Map
+          ? (image['url'] ?? image['image_url'] ?? '').toString()
+          : image?.toString() ?? '';
+      final encoded = await _encodeLayoutParsingFile(source);
+      if (encoded != null) return encoded;
+    }
+    return null;
+  }
+  final raw = (content ?? '').toString().trim();
+  if (raw.startsWith('http://') ||
+      raw.startsWith('https://') ||
+      raw.startsWith('data:')) {
+    return raw;
+  }
+  return null;
+}
+
+Future<String?> _encodeLayoutParsingFile(String source) async {
+  final trimmed = source.trim();
+  if (trimmed.isEmpty) return null;
+  if (trimmed.startsWith('http://') ||
+      trimmed.startsWith('https://') ||
+      trimmed.startsWith('data:')) {
+    return trimmed;
+  }
+  try {
+    final fixed = SandboxPathResolver.fix(trimmed);
+    final file = File(fixed);
+    if (!await file.exists()) return null;
+    return await _encodeBase64File(fixed, withPrefix: true);
+  } catch (_) {
+    return null;
+  }
+}
+
+Map<String, dynamic> _decodeLayoutParsingResponse(http.Response response) {
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw HttpException('HTTP ${response.statusCode}: ${response.body}');
+  }
+  final decoded = jsonDecode(response.body);
+  if (decoded is! Map) {
+    throw const FormatException('GLM-OCR returned a non-object body.');
+  }
+  return decoded.cast<String, dynamic>();
+}
+
+String _mdResultsFromResponse(Map<String, dynamic> response) {
+  final raw = response['md_results'];
+  if (raw is String) return raw.trim();
+  if (raw is List) {
+    return [
+      for (final item in raw)
+        if (item != null && item.toString().trim().isNotEmpty)
+          item.toString().trim(),
+    ].join('\n\n');
+  }
+  return '';
+}
+
+TokenUsage? _usageFromResponse(Map<String, dynamic> response) {
+  final usage = response['usage'];
+  if (usage is! Map) return null;
+  final prompt = _asInt(usage['prompt_tokens']);
+  final completion = _asInt(usage['completion_tokens']);
+  final total = _asInt(usage['total_tokens']);
+  if (prompt == 0 && completion == 0 && total == 0) return null;
+  return TokenUsage(
+    promptTokens: prompt,
+    completionTokens: completion,
+    totalTokens: total > 0 ? total : prompt + completion,
+  );
+}
+
+int _asInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value?.toString() ?? '') ?? 0;
+}

--- a/lib/features/home/services/ocr_service.dart
+++ b/lib/features/home/services/ocr_service.dart
@@ -26,6 +26,9 @@ class OcrService {
   final int maxCacheEntries;
   final ChatService? chatService;
 
+  static const String defaultOcrUserPrompt =
+      'Please perform OCR on the attached image(s) and return only the extracted text and visual descriptions.';
+
   /// OCR 缓存 (path -> cached OCR text)
   final Map<String, OcrCacheEntry> _cache = <String, OcrCacheEntry>{};
 
@@ -69,6 +72,16 @@ class OcrService {
     chatService?.clearCacheByType('ocr');
   }
 
+  /// 构建发给 OCR 模型的消息。提示词为空时不附加 system，以兼容
+  /// GLM-OCR 等专用接口。
+  static List<Map<String, dynamic>> buildOcrRequestMessages(String prompt) {
+    final trimmed = prompt.trim();
+    return <Map<String, dynamic>>[
+      if (trimmed.isNotEmpty) {'role': 'system', 'content': trimmed},
+      {'role': 'user', 'content': defaultOcrUserPrompt},
+    ];
+  }
+
   /// 运行 OCR 识别图片内容
   ///
   /// [imagePaths] 图片路径列表
@@ -88,14 +101,7 @@ class OcrService {
 
     final cfg = settings.getProviderConfig(prov);
 
-    final messages = <Map<String, dynamic>>[
-      {'role': 'system', 'content': settings.ocrPrompt},
-      {
-        'role': 'user',
-        'content':
-            'Please perform OCR on the attached image(s) and return only the extracted text and visual descriptions.',
-      },
-    ];
+    final messages = buildOcrRequestMessages(settings.ocrPrompt);
 
     String out = '';
     try {

--- a/test/features/home/services/ocr_service_test.dart
+++ b/test/features/home/services/ocr_service_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/home/services/ocr_service.dart';
+
+void main() {
+  group('OcrService LRU cache', () {
+    test('caches text and returns it with recency bump', () {
+      final service = OcrService();
+      service.cacheOcrText('a', 'one');
+      service.cacheOcrText('b', 'two');
+
+      expect(service.getCachedOcrText('a'), 'one');
+      expect(service.getCachedOcrText('b'), 'two');
+      expect(service.cacheSize, 2);
+    });
+
+    test('LRU evicts oldest memory entries', () {
+      final service = OcrService(maxCacheEntries: 2);
+      service.cacheOcrText('h1', 'one');
+      service.cacheOcrText('h2', 'two');
+      service.cacheOcrText('h3', 'three');
+      expect(service.cacheSize, 2);
+      expect(service.getCachedOcrText('h1'), isNull);
+      expect(service.getCachedOcrText('h2'), 'two');
+      expect(service.getCachedOcrText('h3'), 'three');
+    });
+
+    test('access bumps recency so recently read entries survive eviction', () {
+      final service = OcrService(maxCacheEntries: 2);
+      service.cacheOcrText('h1', 'one');
+      service.cacheOcrText('h2', 'two');
+      service.getCachedOcrText('h1');
+      service.cacheOcrText('h3', 'three');
+      expect(service.cacheSize, 2);
+      expect(service.getCachedOcrText('h1'), 'one');
+      expect(service.getCachedOcrText('h2'), isNull);
+      expect(service.getCachedOcrText('h3'), 'three');
+    });
+
+    test('empty and whitespace paths are ignored', () {
+      final service = OcrService(maxCacheEntries: 2);
+      service.cacheOcrText('   ', 'ignored');
+      service.cacheOcrText('', 'ignored');
+      expect(service.cacheSize, 0);
+    });
+  });
+
+  group('OcrService request messages', () {
+    test('includes a system message when the OCR prompt is set', () {
+      expect(OcrService.buildOcrRequestMessages('Read the image.'), [
+        {'role': 'system', 'content': 'Read the image.'},
+        {'role': 'user', 'content': OcrService.defaultOcrUserPrompt},
+      ]);
+    });
+
+    test('omits the system message when the OCR prompt is empty', () {
+      expect(OcrService.buildOcrRequestMessages('   '), [
+        {'role': 'user', 'content': OcrService.defaultOcrUserPrompt},
+      ]);
+    });
+  });
+
+  group('OcrService wrapOcrBlock', () {
+    test('wraps extracted text in an image_file_ocr block', () {
+      final block = OcrService().wrapOcrBlock('  extracted text  ');
+      expect(block, contains('<image_file_ocr>'));
+      expect(block, contains('extracted text'));
+      expect(block, contains('</image_file_ocr>'));
+    });
+  });
+}

--- a/test/settings_provider_ocr_prompt_test.dart
+++ b/test/settings_provider_ocr_prompt_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+Future<void> _waitForSettingsLoad() async {
+  for (var i = 0; i < 25; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsProvider OCR prompt', () {
+    test('defaults to the built-in OCR prompt when unset', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+
+      expect(settings.ocrPrompt, SettingsProvider.defaultOcrPrompt);
+    });
+
+    test('persists an explicitly empty OCR prompt', () async {
+      SharedPreferences.setMockInitialValues({});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.setOcrPrompt('   ');
+
+      expect(settings.ocrPrompt, isEmpty);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('ocr_prompt_v1'), isEmpty);
+    });
+
+    test(
+      'reloads an explicitly empty OCR prompt instead of the default',
+      () async {
+        SharedPreferences.setMockInitialValues({'ocr_prompt_v1': ''});
+        final settings = SettingsProvider();
+
+        await _waitForSettingsLoad();
+
+        expect(settings.ocrPrompt, isEmpty);
+      },
+    );
+
+    test('reset restores the built-in OCR prompt', () async {
+      SharedPreferences.setMockInitialValues({'ocr_prompt_v1': ''});
+      final settings = SettingsProvider();
+
+      await _waitForSettingsLoad();
+      await settings.resetOcrPrompt();
+
+      expect(settings.ocrPrompt, SettingsProvider.defaultOcrPrompt);
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString('ocr_prompt_v1'),
+        SettingsProvider.defaultOcrPrompt,
+      );
+    });
+  });
+}

--- a/test/zhipu_layout_parsing_api_test.dart
+++ b/test/zhipu_layout_parsing_api_test.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _config(
+  String baseUrl, {
+  String id = 'Zhipu AI',
+  Map<String, dynamic> modelOverrides = const <String, dynamic>{},
+  List<Map<String, String>> customBody = const <Map<String, String>>[],
+}) {
+  return ProviderConfig(
+    id: id,
+    enabled: true,
+    name: id,
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    modelOverrides: modelOverrides,
+    customBody: customBody,
+  );
+}
+
+ProviderConfig _officialConfig({
+  Map<String, dynamic> modelOverrides = const <String, dynamic>{},
+  List<Map<String, String>> customBody = const <Map<String, String>>[],
+}) {
+  return _config(
+    'https://open.bigmodel.cn/api/paas/v4',
+    modelOverrides: modelOverrides,
+    customBody: customBody,
+  );
+}
+
+String _localBaseUrl(HttpServer server) {
+  return 'http://${server.address.address}:${server.port}/api/paas/v4';
+}
+
+Future<({Uri uri, Map<String, dynamic> body, List<ChatStreamChunk> chunks})>
+_captureLayoutParsing({
+  required ProviderConfig config,
+  required String modelId,
+  required List<Map<String, dynamic>> messages,
+  List<String>? userMediaPaths,
+  Map<String, dynamic> responseBody = const {
+    'id': 'task_1',
+    'created': 1727156815,
+    'model': 'GLM-OCR',
+    'md_results': '# Title\nExtracted text',
+    'usage': {'prompt_tokens': 3, 'completion_tokens': 5, 'total_tokens': 8},
+  },
+}) async {
+  late Uri requestUri;
+  late Map<String, dynamic> requestBody;
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  server.listen((request) async {
+    requestUri = request.uri;
+    requestBody = (jsonDecode(await utf8.decoder.bind(request).join()) as Map)
+        .cast<String, dynamic>();
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType = ContentType.json;
+    request.response.write(jsonEncode(responseBody));
+    await request.response.close();
+  });
+
+  final client = http.Client();
+  addTearDown(client.close);
+  final chunks = await sendZhipuLayoutParsingStream(
+    client,
+    config.copyWith(baseUrl: _localBaseUrl(server)),
+    modelId,
+    messages,
+    userMediaPaths: userMediaPaths,
+  ).toList();
+
+  return (uri: requestUri, body: requestBody, chunks: chunks);
+}
+
+void main() {
+  group('GLM-OCR layout parsing', () {
+    test('only routes official Zhipu host + glm-ocr', () {
+      expect(shouldUseZhipuLayoutParsing(_officialConfig(), 'glm-ocr'), isTrue);
+      expect(shouldUseZhipuLayoutParsing(_officialConfig(), 'GLM-OCR'), isTrue);
+      expect(
+        shouldUseZhipuLayoutParsing(
+          _officialConfig(
+            modelOverrides: const {
+              'My OCR': {'apiModelId': 'glm-ocr'},
+            },
+          ),
+          'My OCR',
+        ),
+        isTrue,
+      );
+      expect(
+        shouldUseZhipuLayoutParsing(_officialConfig(), 'zhipu/glm-ocr'),
+        isFalse,
+      );
+      expect(
+        shouldUseZhipuLayoutParsing(_officialConfig(), 'glm-ocr-v1'),
+        isFalse,
+      );
+      expect(
+        shouldUseZhipuLayoutParsing(
+          _config('https://openrouter.ai/api/v1', id: 'OpenRouter'),
+          'glm-ocr',
+        ),
+        isFalse,
+      );
+      expect(
+        shouldUseZhipuLayoutParsing(
+          _config('http://127.0.0.1:8000/v1', id: 'vLLM'),
+          'glm-ocr',
+        ),
+        isFalse,
+      );
+    });
+
+    test('posts only {model: glm-ocr, file} and reads md_results', () async {
+      final captured = await _captureLayoutParsing(
+        config: _officialConfig(
+          customBody: const [
+            {'key': 'stream_options', 'value': '{"include_usage":true}'},
+            {'key': 'thinking', 'value': '{"type":"enabled"}'},
+          ],
+        ),
+        modelId: 'glm-ocr',
+        messages: const [
+          {'role': 'system', 'content': 'should not be sent'},
+          {'role': 'user', 'content': 'Please perform OCR'},
+        ],
+        userMediaPaths: const [
+          'https://cdn.bigmodel.cn/static/logo/introduction.png',
+        ],
+      );
+
+      expect(captured.uri.path, '/api/paas/v4/layout_parsing');
+      expect(captured.body, {
+        'model': officialGlmOcrModelId,
+        'file': 'https://cdn.bigmodel.cn/static/logo/introduction.png',
+      });
+      expect(captured.body.containsKey('messages'), isFalse);
+      expect(captured.body.containsKey('stream_options'), isFalse);
+      expect(captured.body.containsKey('thinking'), isFalse);
+      expect(
+        captured.chunks
+            .where((c) => c.content.isNotEmpty)
+            .map((c) => c.content)
+            .join(),
+        '# Title\nExtracted text',
+      );
+    });
+
+    test('always sends official model id glm-ocr', () async {
+      final captured = await _captureLayoutParsing(
+        config: _officialConfig(
+          modelOverrides: const {
+            'zhipu/glm-ocr': {'apiModelId': 'zhipu/glm-ocr'},
+          },
+        ),
+        modelId: 'zhipu/glm-ocr',
+        messages: const [
+          {'role': 'user', 'content': ''},
+        ],
+        userMediaPaths: const [
+          'https://cdn.bigmodel.cn/static/logo/introduction.png',
+        ],
+      );
+
+      expect(captured.body['model'], officialGlmOcrModelId);
+    });
+
+    test('encodes local files as data URIs', () async {
+      final dir = await Directory.systemTemp.createTemp('cuplivo_glm_ocr_');
+      addTearDown(() => dir.delete(recursive: true));
+      final file = File('${dir.path}/sample.png');
+      await file.writeAsBytes(const [1, 2, 3, 4]);
+
+      final captured = await _captureLayoutParsing(
+        config: _officialConfig(),
+        modelId: 'glm-ocr',
+        messages: const [
+          {'role': 'user', 'content': ''},
+        ],
+        userMediaPaths: [file.path],
+      );
+
+      expect(captured.body['model'], officialGlmOcrModelId);
+      expect(
+        captured.body['file'],
+        'data:image/png;base64,${base64Encode(const [1, 2, 3, 4])}',
+      );
+    });
+
+    test('reads a list-valued md_results and parses usage', () async {
+      final captured = await _captureLayoutParsing(
+        config: _officialConfig(),
+        modelId: 'glm-ocr',
+        messages: const [
+          {'role': 'user', 'content': ''},
+        ],
+        userMediaPaths: const [
+          'https://cdn.bigmodel.cn/static/logo/introduction.png',
+        ],
+        responseBody: const {
+          'md_results': ['page one', '', 'page two'],
+          'usage': {'prompt_tokens': 10, 'completion_tokens': 20},
+        },
+      );
+
+      expect(captured.chunks.single.content, 'page one\n\npage two');
+      expect(captured.chunks.single.usage?.promptTokens, 10);
+      expect(captured.chunks.single.usage?.completionTokens, 20);
+      expect(captured.chunks.single.usage?.totalTokens, 30);
+    });
+
+    test('throws when no image or PDF file is available', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final client = http.Client();
+      addTearDown(client.close);
+
+      await expectLater(
+        sendZhipuLayoutParsingStream(
+          client,
+          _officialConfig().copyWith(baseUrl: _localBaseUrl(server)),
+          'glm-ocr',
+          const [
+            {'role': 'user', 'content': 'no image here'},
+          ],
+        ).toList(),
+        throwsA(isA<HttpException>()),
+      );
+    });
+
+    test('does not reroute non-official hosts to layout_parsing', () async {
+      late Uri requestUri;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        requestUri = request.uri;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'choices': [
+              {
+                'message': {'content': 'ok'},
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final client = http.Client();
+      ChatApiService.debugClientFactory = (cfg, {proxy}) => client;
+      addTearDown(() => ChatApiService.debugClientFactory = null);
+
+      await ChatApiService.sendMessageStream(
+        config: _config(_localBaseUrl(server), id: 'OpenRouter'),
+        modelId: 'glm-ocr',
+        messages: const [
+          {'role': 'user', 'content': 'ocr'},
+        ],
+        userMediaPaths: const [
+          'https://cdn.bigmodel.cn/static/logo/introduction.png',
+        ],
+        ocrActive: true,
+        stream: false,
+      ).toList();
+
+      expect(requestUri.path, isNot(contains('layout_parsing')));
+      expect(requestUri.path, contains('chat/completions'));
+    });
+  });
+}


### PR DESCRIPTION
## What

Ports upstream #883: empty OCR system prompts are now persisted (system message omitted per request), and official Zhipu `glm-ocr` is routed to `/layout_parsing` with `{model, file}` instead of Chat Completions.

## How

`settings_provider` keeps an explicit empty OCR prompt; `ocr_service` builds request messages without a system turn when the prompt is blank; new `zhipu_layout_parsing` provider resolves image/PDF files (URL, data URI, or base64) and parses `md_results`/`usage`. 26 tests added/adapted; `dart analyze --fatal-infos lib test` clean.
