### PR TITLE
perf(markdown): port upstream incremental streaming blocks renderer; drop thinking preview truncation

### DIFF
--- a/dependencies/gpt_markdown/lib/custom_widgets/markdown_config.dart
+++ b/dependencies/gpt_markdown/lib/custom_widgets/markdown_config.dart
@@ -102,7 +102,8 @@ class GptMarkdownConfig {
     this.components,
     this.inlineComponents,
     this.tableBuilder,
-    this.streaming = false,
+    this.preprocessBlocks,
+    this.generation,
   });
 
   /// The direction of the text.
@@ -165,12 +166,14 @@ class GptMarkdownConfig {
   /// The table builder.
   final TableBuilder? tableBuilder;
 
-  /// Whether the content is being streamed. Unlike the builder closures
-  /// (which are excluded from [isSame] because they are recreated every
-  /// build), this value participates in equality: a streaming flag flip with
-  /// unchanged text must regenerate the parse tree, because code-block
-  /// rendering behavior depends on it.
-  final bool streaming;
+  /// Rewrites a block-level fragment before [MarkdownComponent.generate]
+  /// parses it. List items, quotes, and table cells all enter generate
+  /// again, so this is the shared hook for deterministic preprocessing.
+  final String Function(String text)? preprocessBlocks;
+
+  /// Compared by [isSame] so a reused [MdWidget] regenerates when
+  /// image/citation/theme inputs change without a new GptMarkdown key.
+  final Object? generation;
 
   /// A copy of the configuration with the specified parameters.
   GptMarkdownConfig copyWith({
@@ -194,7 +197,8 @@ class GptMarkdownConfig {
     final List<MarkdownComponent>? components,
     final List<MarkdownComponent>? inlineComponents,
     final TableBuilder? tableBuilder,
-    final bool? streaming,
+    final String Function(String text)? preprocessBlocks,
+    final Object? generation,
   }) {
     return GptMarkdownConfig(
       style: style ?? this.style,
@@ -217,7 +221,8 @@ class GptMarkdownConfig {
       components: components ?? this.components,
       inlineComponents: inlineComponents ?? this.inlineComponents,
       tableBuilder: tableBuilder ?? this.tableBuilder,
-      streaming: streaming ?? this.streaming,
+      preprocessBlocks: preprocessBlocks ?? this.preprocessBlocks,
+      generation: generation ?? this.generation,
     );
   }
 
@@ -241,7 +246,6 @@ class GptMarkdownConfig {
         maxLines == other.maxLines &&
         overflow == other.overflow &&
         followLinkColor == other.followLinkColor &&
-        streaming == other.streaming &&
         // latexWorkaround == other.latexWorkaround &&
         // components == other.components &&
         // inlineComponents == other.inlineComponents &&
@@ -254,6 +258,7 @@ class GptMarkdownConfig {
         // imageBuilder == other.imageBuilder &&
         // highlightBuilder == other.highlightBuilder &&
         // onLinkTap == other.onLinkTap &&
-        textDirection == other.textDirection;
+        textDirection == other.textDirection &&
+        generation == other.generation;
   }
 }

--- a/dependencies/gpt_markdown/lib/gpt_markdown.dart
+++ b/dependencies/gpt_markdown/lib/gpt_markdown.dart
@@ -44,7 +44,8 @@ class GptMarkdown extends StatelessWidget {
     this.components,
     this.inlineComponents,
     this.useDollarSignsForLatex = false,
-    this.streaming = false,
+    this.preprocessBlocks,
+    this.generation,
   });
 
   /// The direction of the text.
@@ -102,11 +103,6 @@ class GptMarkdown extends StatelessWidget {
   /// Whether to use dollar signs for LaTeX.
   final bool useDollarSignsForLatex;
 
-  /// Whether the content is being streamed. Participates in config equality
-  /// so a streaming flag flip with unchanged text regenerates the parse tree
-  /// (code-block rendering behavior depends on it).
-  final bool streaming;
-
   /// The table builder.
   final TableBuilder? tableBuilder;
 
@@ -154,6 +150,12 @@ class GptMarkdown extends StatelessWidget {
   /// ```
   final List<MarkdownComponent>? inlineComponents;
 
+  /// See [GptMarkdownConfig.preprocessBlocks].
+  final String Function(String text)? preprocessBlocks;
+
+  /// See [GptMarkdownConfig.generation].
+  final Object? generation;
+
   /// A method to remove extra lines inside block LaTeX.
   // String _removeExtraLinesInsideBlockLatex(String text) {
   //   return text.replaceAllMapped(
@@ -167,7 +169,10 @@ class GptMarkdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    String tex = data.replaceAll('\r\n', '\n').replaceAll('\r', '\n').trim();
+    String tex =
+        data.contains('\r')
+            ? data.replaceAll('\r\n', '\n').replaceAll('\r', '\n').trim()
+            : data.trim();
     if (useDollarSignsForLatex) {
       tex = tex.replaceAllMapped(
         RegExp(r"(?<!\\)\$\$(.*?)(?<!\\)\$\$", dotAll: true),
@@ -213,7 +218,8 @@ class GptMarkdown extends StatelessWidget {
           components: components,
           inlineComponents: inlineComponents,
           tableBuilder: tableBuilder,
-          streaming: streaming,
+          preprocessBlocks: preprocessBlocks,
+          generation: generation,
         ),
       ),
     );

--- a/dependencies/gpt_markdown/lib/markdown_component.dart
+++ b/dependencies/gpt_markdown/lib/markdown_component.dart
@@ -38,6 +38,12 @@ abstract class MarkdownComponent {
     final GptMarkdownConfig config,
     bool includeGlobalComponents,
   ) {
+    if (includeGlobalComponents) {
+      final preprocess = config.preprocessBlocks;
+      if (preprocess != null) {
+        text = preprocess(text);
+      }
+    }
     var components =
         includeGlobalComponents
             ? config.components ?? MarkdownComponent.globalComponents
@@ -615,6 +621,7 @@ class LatexMathMultiLine extends BlockMd {
                   sizeUnderTextStyle: MathSize.large,
                   color:
                       config.style?.color ??
+                      DefaultTextStyle.of(context).style.color ??
                       Theme.of(context).colorScheme.onSurface,
                   fontSize:
                       config.style?.fontSize ??
@@ -690,6 +697,7 @@ class LatexMath extends InlineMd {
                   sizeUnderTextStyle: MathSize.large,
                   color:
                       config.style?.color ??
+                      DefaultTextStyle.of(context).style.color ??
                       Theme.of(context).colorScheme.onSurface,
                   fontSize:
                       config.style?.fontSize ??

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -217,8 +217,6 @@ class SettingsProvider extends ChangeNotifier {
       'display_enable_user_markdown_v1';
   static const String _displayEnableReasoningMarkdownKey =
       'display_enable_reasoning_markdown_v1';
-  static const String _displayStreamingThinkingPreviewTruncateKey =
-      'display_streaming_thinking_preview_truncate_v1';
   static const String _displayEnableAssistantMarkdownKey =
       'display_enable_assistant_markdown_v1';
   static const String _displayShowChatListDateKey =
@@ -1288,8 +1286,6 @@ class SettingsProvider extends ChangeNotifier {
     _enableUserMarkdown = prefs.getBool(_displayEnableUserMarkdownKey) ?? true;
     _enableReasoningMarkdown =
         prefs.getBool(_displayEnableReasoningMarkdownKey) ?? true;
-    _streamingThinkingPreviewTruncate =
-        prefs.getBool(_displayStreamingThinkingPreviewTruncateKey) ?? true;
     _enableAssistantMarkdown =
         prefs.getBool(_displayEnableAssistantMarkdownKey) ?? true;
     _showChatListDate = prefs.getBool(_displayShowChatListDateKey) ?? false;
@@ -4596,19 +4592,6 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     await prefs.setBool(_displayEnableReasoningMarkdownKey, v);
   }
 
-  // Display: bound the streaming thinking preview to its tail (issue #232).
-  // Off = original behavior (full text re-parsed on every streaming update).
-  bool _streamingThinkingPreviewTruncate = true;
-  bool get streamingThinkingPreviewTruncate =>
-      _streamingThinkingPreviewTruncate;
-  Future<void> setStreamingThinkingPreviewTruncate(bool v) async {
-    if (_streamingThinkingPreviewTruncate == v) return;
-    _streamingThinkingPreviewTruncate = v;
-    notifyListeners();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_displayStreamingThinkingPreviewTruncateKey, v);
-  }
-
   // Display: render assistant messages with Markdown
   bool _enableAssistantMarkdown = true;
   bool get enableAssistantMarkdown => _enableAssistantMarkdown;
@@ -5198,7 +5181,6 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     copy._enableMathRendering = _enableMathRendering;
     copy._enableUserMarkdown = _enableUserMarkdown;
     copy._enableReasoningMarkdown = _enableReasoningMarkdown;
-    copy._streamingThinkingPreviewTruncate = _streamingThinkingPreviewTruncate;
     copy._enableAssistantMarkdown = _enableAssistantMarkdown;
     copy._showChatListDate = _showChatListDate;
     copy._autoCollapseCodeBlock = _autoCollapseCodeBlock;

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -90,8 +90,6 @@ class _DisplaySettingsBody extends StatelessWidget {
                   _RowDivider(),
                   _ToggleRowReasoningMarkdown(),
                   _RowDivider(),
-                  _ToggleRowStreamingThinkingPreviewTruncate(),
-                  _RowDivider(),
                   _ToggleRowAssistantMarkdown(),
                   _RowDivider(),
                   _AutoCollapseCodeBlocksSection(),
@@ -2282,22 +2280,6 @@ class _ToggleRowReasoningMarkdown extends StatelessWidget {
       value: sp.enableReasoningMarkdown,
       onChanged: (v) =>
           context.read<SettingsProvider>().setEnableReasoningMarkdown(v),
-    );
-  }
-}
-
-class _ToggleRowStreamingThinkingPreviewTruncate extends StatelessWidget {
-  const _ToggleRowStreamingThinkingPreviewTruncate();
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final sp = context.watch<SettingsProvider>();
-    return _ToggleRow(
-      label: l10n.displaySettingsPageStreamingThinkingPreviewTruncateTitle,
-      value: sp.streamingThinkingPreviewTruncate,
-      onChanged: (v) => context
-          .read<SettingsProvider>()
-          .setStreamingThinkingPreviewTruncate(v),
     );
   }
 }

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -55,21 +55,6 @@ import '../../../theme/app_semantic_colors.dart';
 
 final RegExp _urlSchemeRe = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*:');
 
-/// Upper bound for the streaming thinking preview text (issue #232). While
-/// thinking streams, the collapsed preview re-parses the whole accumulated
-/// markdown on every 150ms UI tick; truncating to the tail (the preview
-/// auto-scrolls to the bottom) makes the per-tick cost O(1) in thinking
-/// length. Full text still renders when the user expands the card.
-const int _streamingThinkingPreviewMaxChars = 2000;
-
-/// Bounds [text] to the tail for the streaming thinking preview unless the
-/// user opted out via [SettingsProvider.streamingThinkingPreviewTruncate].
-String _boundedStreamingPreview(SettingsProvider settings, String text) {
-  if (!settings.streamingThinkingPreviewTruncate) return text;
-  if (text.length <= _streamingThinkingPreviewMaxChars) return text;
-  return '…\n${text.substring(text.length - _streamingThinkingPreviewMaxChars)}';
-}
-
 Uri? _tryNormalizeExternalUri(String raw) {
   var u = raw.trim();
   if (u.isEmpty) return null;
@@ -3963,9 +3948,7 @@ class _ChainOfThoughtReasoningStepState
     final settings = context.watch<SettingsProvider>();
     final state = _stepState;
     final rawText = _sanitize(widget.step.text);
-    final display = state == _ReasoningStepState.preview
-        ? _boundedStreamingPreview(settings, rawText)
-        : rawText;
+    final display = rawText;
     final label = Row(
       children: [
         _Shimmer(
@@ -6246,9 +6229,7 @@ class _ReasoningSectionState extends State<_ReasoningSection>
 
     final bool isLoading = loading;
     final rawText = _sanitize(widget.text);
-    final display = (isLoading && !widget.expanded)
-        ? _boundedStreamingPreview(settings, rawText)
-        : rawText;
+    final display = rawText;
 
     // 未加载：不要再指定 color: fg，让它继承和"加载中"相同的颜色
     Widget reasoningContent(String text) {

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -1916,19 +1916,6 @@ class RenderingSettingsPage extends StatelessWidget {
               _iosDivider(context),
               _iosSwitchRow(
                 context,
-                icon: Lucide.ChevronsDownUp,
-                label: l10n
-                    .displaySettingsPageStreamingThinkingPreviewTruncateTitle,
-                subtitle: l10n
-                    .displaySettingsPageStreamingThinkingPreviewTruncateSubtitle,
-                value: sp.streamingThinkingPreviewTruncate,
-                onChanged: (v) => context
-                    .read<SettingsProvider>()
-                    .setStreamingThinkingPreviewTruncate(v),
-              ),
-              _iosDivider(context),
-              _iosSwitchRow(
-                context,
                 icon: Lucide.MessageSquare,
                 label: l10n.displaySettingsPageEnableAssistantMarkdownTitle,
                 value: sp.enableAssistantMarkdown,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1262,8 +1262,6 @@
   "displaySettingsPageEnableMathSubtitle": "Render LaTeX math (inline and block)",
   "displaySettingsPageEnableUserMarkdownTitle": "Render user messages with Markdown",
   "displaySettingsPageEnableReasoningMarkdownTitle": "Render reasoning (thinking) with Markdown",
-  "displaySettingsPageStreamingThinkingPreviewTruncateTitle": "Limit streaming thinking preview",
-  "displaySettingsPageStreamingThinkingPreviewTruncateSubtitle": "While thinking streams, only the tail of the preview is rendered for speed. Turn off to restore the original full-length live preview.",
   "displaySettingsPageEnableAssistantMarkdownTitle": "Render assistant messages with Markdown",
   "displaySettingsPageMobileCodeBlockWrapTitle": "Mobile Code Block Word Wrap",
   "displaySettingsPageHtmlStreamingShowCodeTitle": "Show code while HTML is generating",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5524,18 +5524,6 @@ abstract class AppLocalizations {
   /// **'Render reasoning (thinking) with Markdown'**
   String get displaySettingsPageEnableReasoningMarkdownTitle;
 
-  /// No description provided for @displaySettingsPageStreamingThinkingPreviewTruncateTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Limit streaming thinking preview'**
-  String get displaySettingsPageStreamingThinkingPreviewTruncateTitle;
-
-  /// No description provided for @displaySettingsPageStreamingThinkingPreviewTruncateSubtitle.
-  ///
-  /// In en, this message translates to:
-  /// **'While thinking streams, only the tail of the preview is rendered for speed. Turn off to restore the original full-length live preview.'**
-  String get displaySettingsPageStreamingThinkingPreviewTruncateSubtitle;
-
   /// No description provided for @displaySettingsPageEnableAssistantMarkdownTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3021,14 +3021,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Render reasoning (thinking) with Markdown';
 
   @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateTitle =>
-      'Limit streaming thinking preview';
-
-  @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateSubtitle =>
-      'While thinking streams, only the tail of the preview is rendered for speed. Turn off to restore the original full-length live preview.';
-
-  @override
   String get displaySettingsPageEnableAssistantMarkdownTitle =>
       'Render assistant messages with Markdown';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2919,14 +2919,6 @@ class AppLocalizationsZh extends AppLocalizations {
       '思维链 Markdown 渲染';
 
   @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateTitle =>
-      '限制流式思考预览长度';
-
-  @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateSubtitle =>
-      '思考过程中只渲染预览的尾部以提升流畅度。关闭可恢复原有的全量实时预览。';
-
-  @override
   String get displaySettingsPageEnableAssistantMarkdownTitle =>
       '助手消息 Markdown 渲染';
 
@@ -11354,14 +11346,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       '思维链 Markdown 渲染';
 
   @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateTitle =>
-      '限制流式思考预览长度';
-
-  @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateSubtitle =>
-      '思考过程中只渲染预览的尾部以提升流畅度。关闭可恢复原有的全量实时预览。';
-
-  @override
   String get displaySettingsPageEnableAssistantMarkdownTitle =>
       '助手消息 Markdown 渲染';
 
@@ -19786,14 +19770,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get displaySettingsPageEnableReasoningMarkdownTitle =>
       '思维鏈 Markdown 渲染';
-
-  @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateTitle =>
-      '限制串流思考預覽長度';
-
-  @override
-  String get displaySettingsPageStreamingThinkingPreviewTruncateSubtitle =>
-      '思考過程中僅渲染預覽的尾部以提升流暢度。關閉可恢復原有的全量即時預覽。';
 
   @override
   String get displaySettingsPageEnableAssistantMarkdownTitle =>

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2081,8 +2081,6 @@
   "displaySettingsPageEnableMathTitle": "启用数学公式渲染",
   "displaySettingsPageEnableUserMarkdownTitle": "用户消息 Markdown 渲染",
   "displaySettingsPageEnableReasoningMarkdownTitle": "思维链 Markdown 渲染",
-  "displaySettingsPageStreamingThinkingPreviewTruncateTitle": "限制流式思考预览长度",
-  "displaySettingsPageStreamingThinkingPreviewTruncateSubtitle": "思考过程中只渲染预览的尾部以提升流畅度。关闭可恢复原有的全量实时预览。",
   "displaySettingsPageEnableAssistantMarkdownTitle": "助手消息 Markdown 渲染",
   "displaySettingsPageEnableMathSubtitle": "渲染 LaTeX 数学公式（行内与块级）",
   "displaySettingsPageEnableImageCropperTitle": "启用图片裁剪",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2117,8 +2117,6 @@
   "displaySettingsPageEnableMathTitle": "启用数学公式渲染",
   "displaySettingsPageEnableUserMarkdownTitle": "用户消息 Markdown 渲染",
   "displaySettingsPageEnableReasoningMarkdownTitle": "思维链 Markdown 渲染",
-  "displaySettingsPageStreamingThinkingPreviewTruncateTitle": "限制流式思考预览长度",
-  "displaySettingsPageStreamingThinkingPreviewTruncateSubtitle": "思考过程中只渲染预览的尾部以提升流畅度。关闭可恢复原有的全量实时预览。",
   "displaySettingsPageEnableAssistantMarkdownTitle": "助手消息 Markdown 渲染",
   "displaySettingsPageEnableMathSubtitle": "渲染 LaTeX 数学公式（行内与块级）",
   "displaySettingsPageEnableImageCropperTitle": "启用图片裁剪",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2072,8 +2072,6 @@
   "displaySettingsPageEnableMathTitle": "啟用數學公式渲染",
   "displaySettingsPageEnableUserMarkdownTitle": "使用者訊息 Markdown 渲染",
   "displaySettingsPageEnableReasoningMarkdownTitle": "思维鏈 Markdown 渲染",
-  "displaySettingsPageStreamingThinkingPreviewTruncateTitle": "限制串流思考預覽長度",
-  "displaySettingsPageStreamingThinkingPreviewTruncateSubtitle": "思考過程中僅渲染預覽的尾部以提升流暢度。關閉可恢復原有的全量即時預覽。",
   "displaySettingsPageEnableAssistantMarkdownTitle": "助手訊息 Markdown 渲染",
   "displaySettingsPageEnableMathSubtitle": "渲染 LaTeX 數學公式（行內與區塊）",
   "displaySettingsPageEnableImageCropperTitle": "啟用圖片裁剪",

--- a/lib/shared/cache/byte_lru_cache.dart
+++ b/lib/shared/cache/byte_lru_cache.dart
@@ -1,0 +1,56 @@
+import 'dart:collection';
+
+typedef CacheByteSize<K, V> = int Function(K key, V value);
+
+/// Least-recently-used cache bounded by decoded memory, not entry count.
+final class ByteLruCache<K, V> {
+  ByteLruCache({required this.maxBytes, required this.sizeOf})
+    : assert(maxBytes > 0);
+
+  final int maxBytes;
+  final CacheByteSize<K, V> sizeOf;
+  final LinkedHashMap<K, _ByteLruEntry<V>> _entries = LinkedHashMap();
+  int _bytes = 0;
+  int _evictions = 0;
+
+  int get bytes => _bytes;
+  int get length => _entries.length;
+  int get evictions => _evictions;
+
+  V? get(K key) {
+    final entry = _entries.remove(key);
+    if (entry == null) return null;
+    _entries[key] = entry;
+    return entry.value;
+  }
+
+  void put(K key, V value) {
+    final previous = _entries.remove(key);
+    if (previous != null) _bytes -= previous.bytes;
+    final bytes = sizeOf(key, value).clamp(0, maxBytes + 1).toInt();
+    if (bytes > maxBytes) {
+      _evictions += previous == null ? 0 : 1;
+      return;
+    }
+    _entries[key] = _ByteLruEntry(value, bytes);
+    _bytes += bytes;
+    while (_bytes > maxBytes && _entries.isNotEmpty) {
+      final oldestKey = _entries.keys.first;
+      final removed = _entries.remove(oldestKey)!;
+      _bytes -= removed.bytes;
+      _evictions++;
+    }
+  }
+
+  void clear() {
+    _entries.clear();
+    _bytes = 0;
+  }
+}
+
+final class _ByteLruEntry<V> {
+  const _ByteLruEntry(this.value, this.bytes);
+
+  final V value;
+  final int bytes;
+}

--- a/lib/shared/widgets/incremental_markdown_document.dart
+++ b/lib/shared/widgets/incremental_markdown_document.dart
@@ -1,0 +1,291 @@
+import 'markdown_line_lexer.dart';
+
+/// A source block in an append-only streaming Markdown document.
+final class IncrementalMarkdownBlock {
+  const IncrementalMarkdownBlock({
+    required this.start,
+    required this.text,
+    required this.stable,
+  });
+
+  final int start;
+
+  /// The block's source, without the blank run that separates it from the
+  /// next block. The splitter skips that run on its own; the widget inserts
+  /// one separator in its place.
+  final String text;
+
+  /// Whether the scanner has committed this block. The unfinished tail —
+  /// and a temporary indent merge of that tail with the last committed
+  /// block — are not stable. Only the tail may receive streaming
+  /// stabilization (tables, unfinished math).
+  final bool stable;
+}
+
+/// Splits streaming Markdown at safe blank-line boundaries and only rescans
+/// the last (possibly incomplete) block when content is appended.
+final class IncrementalMarkdownDocument {
+  static final _listMarker = RegExp(
+    r'^(?:[*+-](?:\s+\[[ xX]\])?|\d{1,9}[.)])(?:\s|$)',
+  );
+
+  String _rawSource = '';
+  String _source = '';
+  bool _rawEndsWithCR = false;
+  List<IncrementalMarkdownBlock> _blocks = const [];
+  final List<IncrementalMarkdownBlock> _stableBlocks = [];
+  final MarkdownLineLexer _lexer = MarkdownLineLexer();
+  final MarkdownDisplayMathScanner _mathScanner = MarkdownDisplayMathScanner();
+  int _rescannedCodeUnits = 0;
+  int _scanCursor = 0;
+  int _lineStart = 0;
+  int _blockStart = 0;
+  int? _pendingListBlankEnd;
+  int? _pendingListContentEnd;
+  bool _blankRunCarriesWhitespace = false;
+
+  List<IncrementalMarkdownBlock> get blocks => _blocks;
+  int get rescannedCodeUnits => _rescannedCodeUnits;
+
+  /// Whether [_source] is still the caller's raw string. False after a CR
+  /// forced a normalized copy.
+  bool get debugReusesCallerSource => identical(_source, _rawSource);
+
+  List<IncrementalMarkdownBlock> update(String source) {
+    if (source == _rawSource) return _blocks;
+    if (!source.startsWith(_rawSource)) {
+      _stableBlocks.clear();
+      _scanCursor = 0;
+      _lineStart = 0;
+      _blockStart = 0;
+      _lexer.reset();
+      _mathScanner.reset();
+      _pendingListBlankEnd = null;
+      _pendingListContentEnd = null;
+      _blankRunCarriesWhitespace = false;
+      final normalized = _normalizeNewlines(source);
+      _rescannedCodeUnits += normalized.length;
+      _source = normalized;
+    } else {
+      final rawSuffix = source.substring(_rawSource.length);
+      if (_canReuseCallerSource(rawSuffix)) {
+        _rescannedCodeUnits += rawSuffix.length;
+        _source = source;
+      } else {
+        final suffix = _normalizeAppendedSuffix(rawSuffix);
+        _rescannedCodeUnits += suffix.length;
+        _source += suffix;
+      }
+    }
+    _rawSource = source;
+    _rawEndsWithCR =
+        source.isNotEmpty && source.codeUnitAt(source.length - 1) == 0x0D;
+    _scanCompletedLines();
+    _blocks = List<IncrementalMarkdownBlock>.unmodifiable(_visibleBlocks());
+    return _blocks;
+  }
+
+  /// The common path never contained a CR, so [source] is already the
+  /// accumulated document. Reuse it instead of copying `_source + suffix`.
+  bool _canReuseCallerSource(String rawSuffix) {
+    return identical(_source, _rawSource) &&
+        !_rawEndsWithCR &&
+        !rawSuffix.contains('\r');
+  }
+
+  /// CRLF and bare CR become LF, the same way `GptMarkdown` rewrites them
+  /// before it parses. U+2028 / U+2029 stay as content: `NewLines` only
+  /// matches `\n\n+`.
+  static String _normalizeNewlines(String source) {
+    if (!source.contains('\r')) return source;
+    return source.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  }
+
+  /// Only the newly appended raw suffix is rewritten. A CR that closed the
+  /// previous chunk plus an LF that opens this one is one newline, not two.
+  String _normalizeAppendedSuffix(String suffix) {
+    if (suffix.isEmpty) return '';
+    var rest = suffix;
+    if (_rawEndsWithCR && rest.codeUnitAt(0) == 0x0A) {
+      rest = rest.substring(1);
+    }
+    return _normalizeNewlines(rest);
+  }
+
+  /// Completed blocks plus the unfinished tail. A non-empty indented tail
+  /// is folded into the last block for the returned list only — the scanner
+  /// itself is left alone until that line is finished. A tail of only
+  /// whitespace is dropped: `GptMarkdown` trims it, so merging would only
+  /// rebuild a block that lays out the same.
+  ///
+  /// A real indented tail re-parses the last committed block on each token
+  /// of that one unfinished line. That is the cost of keeping indent as
+  /// syntax; the alternative is a layout jump when the line completes.
+  List<IncrementalMarkdownBlock> _visibleBlocks() {
+    final tailText = _source.substring(_blockStart);
+    if (tailText.trim().isEmpty) return List.of(_stableBlocks);
+    if (_stableBlocks.isNotEmpty && _startsWithIndent(tailText)) {
+      final last = _stableBlocks.last;
+      return [
+        ..._stableBlocks.sublist(0, _stableBlocks.length - 1),
+        IncrementalMarkdownBlock(
+          start: last.start,
+          text: _source.substring(last.start),
+          stable: false,
+        ),
+      ];
+    }
+    return [
+      ..._stableBlocks,
+      IncrementalMarkdownBlock(
+        start: _blockStart,
+        text: tailText,
+        stable: false,
+      ),
+    ];
+  }
+
+  void _scanCompletedLines() {
+    final mathScan = _mathScanner.synchronize(_source);
+    while (_scanCursor < _source.length) {
+      final newline = _source.indexOf('\n', _scanCursor);
+      if (newline < 0) {
+        _scanCursor = _source.length;
+        return;
+      }
+      final rawLine = _source.substring(_lineStart, newline);
+      final line = rawLine.trimLeft();
+      _lexer.consumePhysicalLine(rawLine);
+      final protected = _lexer.protected || mathScan.covers(_lineStart);
+      final isBlank = line.trim().isEmpty;
+      if (!protected && isBlank) {
+        final end = newline + 1;
+        if (_hasWhitespaceContent(rawLine)) _blankRunCarriesWhitespace = true;
+        if (_blankRunCarriesWhitespace) {
+          // A blank line carrying whitespace is content to the renderers around
+          // it: a rule, a heading and a display-math block each absorb it into
+          // their own match, and plain text lays it out as a line of its own.
+          // Rather than model all of that, refuse the boundary and leave the
+          // run inside one block, which renders the way the document reads.
+          _clearPendingList();
+          if (_lineStart == _blockStart) _mergeLastBlockBack();
+        } else if (_lineStart > _blockStart) {
+          if (_currentBlockIsList()) {
+            _pendingListContentEnd ??= _contentEndBeforeBlank();
+            _pendingListBlankEnd = end;
+          } else {
+            _emitStableBlock(_contentEndBeforeBlank(), end);
+          }
+        } else {
+          // A blank line with no content behind it continues the run that
+          // ended the block before it. `NewLines` collapses the whole run
+          // to one gap, so the completed block stays as it is.
+          _blockStart = end;
+        }
+      } else if (!protected && !isBlank) {
+        _blankRunCarriesWhitespace = false;
+        if (_pendingListBlankEnd != null) {
+          if (_isListContinuation(rawLine, line)) {
+            _clearPendingList();
+          } else {
+            _emitStableBlock(_pendingListContentEnd!, _pendingListBlankEnd!);
+            _clearPendingList();
+          }
+        } else if (_lineStart == _blockStart && _isIndented(rawLine)) {
+          // Indentation is part of the syntax — four spaces stop a heading
+          // from being one — and a block-by-block render trims the leading
+          // whitespace off every block. Keep the line with the block above
+          // so both reach the renderer the way they read in the document.
+          _mergeLastBlockBack();
+        }
+      }
+      _lineStart = newline + 1;
+      _scanCursor = newline + 1;
+    }
+  }
+
+  /// The last content character sits just before the `\n` that starts the
+  /// `\n\n+` run we are looking at.
+  int _contentEndBeforeBlank() => _lineStart > 0 ? _lineStart - 1 : 0;
+
+  void _emitStableBlock(int contentEnd, int nextStart) {
+    if (contentEnd > _blockStart) {
+      _stableBlocks.add(
+        IncrementalMarkdownBlock(
+          start: _blockStart,
+          text: _source.substring(_blockStart, contentEnd),
+          stable: true,
+        ),
+      );
+    }
+    _blockStart = nextStart;
+  }
+
+  /// Reopens the last block so the line just scanned joins it.
+  void _mergeLastBlockBack() {
+    if (_stableBlocks.isEmpty) return;
+    _blockStart = _stableBlocks.removeLast().start;
+  }
+
+  void _clearPendingList() {
+    _pendingListBlankEnd = null;
+    _pendingListContentEnd = null;
+  }
+
+  static bool _isIndented(String rawLine) =>
+      rawLine.isNotEmpty && _isWhitespace(rawLine.codeUnitAt(0));
+
+  static bool _startsWithIndent(String text) =>
+      text.isNotEmpty && _isWhitespace(text.codeUnitAt(0));
+
+  /// Whether a blank [rawLine] carries something other than a line break.
+  /// After CRLF normalization the only break left in a raw line is a stray
+  /// CR; U+2028 / U+2029 / NBSP / spaces are content, not a `NewLines` gap.
+  static bool _hasWhitespaceContent(String rawLine) {
+    for (var i = 0; i < rawLine.length; i++) {
+      final unit = rawLine.codeUnitAt(i);
+      if (unit != 0x0A && unit != 0x0D) return true;
+    }
+    return false;
+  }
+
+  static bool _isWhitespace(int unit) =>
+      unit == 0x20 ||
+      (unit >= 0x09 && unit <= 0x0D) ||
+      (unit >= 0x80 && _isWideWhitespace(unit));
+
+  static bool _isWideWhitespace(int unit) =>
+      unit == 0x85 ||
+      unit == 0xA0 ||
+      unit == 0x1680 ||
+      (unit >= 0x2000 && unit <= 0x200A) ||
+      unit == 0x2028 ||
+      unit == 0x2029 ||
+      unit == 0x202F ||
+      unit == 0x205F ||
+      unit == 0x3000 ||
+      unit == 0xFEFF;
+
+  bool _currentBlockIsList() {
+    var i = _blockStart;
+    while (i < _source.length) {
+      final nl = _source.indexOf('\n', i);
+      final end = nl < 0 ? _source.length : nl;
+      final raw = _source.substring(i, end);
+      if (raw.trim().isNotEmpty) {
+        return _listMarker.hasMatch(raw.trimLeft());
+      }
+      if (nl < 0) break;
+      i = nl + 1;
+    }
+    return false;
+  }
+
+  bool _isListContinuation(String rawLine, String trimmedLeft) {
+    if (rawLine.isNotEmpty &&
+        (rawLine.codeUnitAt(0) == 0x20 || rawLine.codeUnitAt(0) == 0x09)) {
+      return true;
+    }
+    return _listMarker.hasMatch(trimmedLeft);
+  }
+}

--- a/lib/shared/widgets/markdown_line_lexer.dart
+++ b/lib/shared/widgets/markdown_line_lexer.dart
@@ -1,0 +1,1258 @@
+/// Line-level fence / details / inline-code rules.
+///
+/// Display-math pairing lives in [markdownScanDisplayMath] so the splitter,
+/// Details extractor, and trailing-separator classifier cannot drift.
+final class MarkdownLineLexer {
+  int? _fenceMarker;
+  int _fenceLength = 0;
+  final MarkdownDetailsWalker _details = MarkdownDetailsWalker();
+
+  bool get protected => _fenceMarker != null || _details.depth > 0;
+
+  bool get fenced => _fenceMarker != null;
+
+  int get detailsDepth => _details.depth;
+
+  int? get detailsClosedAt => _details.closedAt;
+
+  bool get detailsOverflowed => _details.overflowed;
+
+  void resetDetails() => _details.reset();
+
+  void reset() {
+    _fenceMarker = null;
+    _fenceLength = 0;
+    _details.reset();
+  }
+
+  /// One LF-delimited line, which may still hold LS/PS/`\r` logical rows.
+  /// Block boundaries stay on `\n\n+`; this only updates structure state.
+  void consumePhysicalLine(String rawLine) {
+    var start = 0;
+    while (true) {
+      var end = start;
+      while (end < rawLine.length &&
+          !_isPhysicalLineInternalBreak(rawLine.codeUnitAt(end))) {
+        _noteScanVisit();
+        end++;
+      }
+      consumeLine(rawLine.substring(start, end));
+      if (end >= rawLine.length) return;
+      start = _skipLogicalLineBreak(rawLine, end, rawLine.length);
+    }
+  }
+
+  /// [line] is one logical row. Fence indent is `[ \t]` only; Details
+  /// still use `trimLeft()`.
+  void consumeLine(String line) {
+    _updateFence(line);
+    if (_fenceMarker != null) return;
+    final trimmed = line.trimLeft();
+    _updateDetails(trimmed, () => _LineBackticks.of(trimmed));
+  }
+
+  /// Fence only. True when this line is inside a fence — including the
+  /// line that just closed one.
+  bool consumeFence(String line) {
+    final wasFenced = _fenceMarker != null;
+    _updateFence(line);
+    return _fenceMarker != null || wasFenced;
+  }
+
+  /// CommonMark-style fences: marker plus opening run length. A closer
+  /// must use the same character, be at least as long, and allow only
+  /// spaces or tabs after the run.
+  void _updateFence(String line) {
+    final mark = _fenceMarkOf(line, 0);
+    if (mark == null) return;
+    if (_fenceMarker == null) {
+      _fenceMarker = mark.marker;
+      _fenceLength = mark.length;
+      return;
+    }
+    if (!mark.canClose) return;
+    if (mark.marker != _fenceMarker || mark.length < _fenceLength) return;
+    _fenceMarker = null;
+    _fenceLength = 0;
+  }
+
+  void _updateDetails(String line, _LineBackticks Function() spans) {
+    if (_details.depth == 0 &&
+        MarkdownDetailsWalker.open.matchAsPrefix(line) == null &&
+        MarkdownDetailsWalker.close.matchAsPrefix(line) == null) {
+      return;
+    }
+    _details.consume(line, advance: spans().advance);
+  }
+}
+
+/// Same cap as the recursive [blockPattern] used by [DetailsHtmlMd].
+const int markdownDetailsMaxDepth = 6;
+
+/// Tag walker shared with [DetailsHtmlMd]. Token rules:
+/// tags stay on one logical line; paired inline code is atomic; nesting
+/// stops at [markdownDetailsMaxDepth].
+final class MarkdownDetailsWalker {
+  /// Attributes may use spaces/tabs only; `<` and line breaks are not
+  /// part of the token, so a missing `>` cannot swallow a later closer.
+  /// Tag names are written as character classes so [blockPattern] stays
+  /// case-insensitive after [MarkdownComponent.generate] recompiles
+  /// `.pattern` with the default case-sensitive flag.
+  static const openSource =
+      r'<[Dd][Ee][Tt][Aa][Ii][Ll][Ss](?:[ \t][^><\r\n\u2028\u2029]*)?>';
+  static const closeSource = r'</[Dd][Ee][Tt][Aa][Ii][Ll][Ss]>';
+  static const summaryOpenSource =
+      r'<[Ss][Uu][Mm][Mm][Aa][Rr][Yy](?:[ \t][^><\r\n\u2028\u2029]*)?>';
+  static const summaryCloseSource = r'</[Ss][Uu][Mm][Mm][Aa][Rr][Yy]>';
+
+  static final open = RegExp(openSource, caseSensitive: false);
+  static final close = RegExp(closeSource, caseSensitive: false);
+  static final summaryOpen = RegExp(summaryOpenSource, caseSensitive: false);
+  static final summaryClose = RegExp(summaryCloseSource, caseSensitive: false);
+
+  /// Structure only. Display text is never rewritten; complete blocks are
+  /// lifted out by [MarkdownDetailsRegistry] before they reach the renderer.
+  static String blockPattern({int depth = markdownDetailsMaxDepth}) {
+    final summary =
+        r'\s*'
+        '$summaryOpenSource'
+        '(?:(?!$summaryCloseSource)[\\s\\S])*'
+        '$summaryCloseSource';
+    final safe = '(?!$openSource|$closeSource)[\\s\\S]';
+    if (depth <= 1) {
+      return '$openSource$summary(?:$safe)*$closeSource';
+    }
+    final nested = blockPattern(depth: depth - 1);
+    return '$openSource$summary(?:$safe|$nested)*$closeSource';
+  }
+
+  final List<_DetailsRegion> _stack = [];
+  int _ignoredOpens = 0;
+  bool _overflow = false;
+
+  int get depth => _stack.length;
+
+  /// True after a nested open past [markdownDetailsMaxDepth].
+  bool get overflowed => _overflow;
+
+  /// Index in the last [consume] line just after a tag that returned to
+  /// depth 0. Cleared at the start of each [consume].
+  int? closedAt;
+
+  void reset() {
+    _stack.clear();
+    _ignoredOpens = 0;
+    _overflow = false;
+    closedAt = null;
+  }
+
+  /// Applies the same logical-line + inline-code rules the splitter uses.
+  void consumeText(String text) {
+    var i = 0;
+    while (i < text.length) {
+      var lineEnd = i;
+      while (lineEnd < text.length &&
+          !markdownIsLogicalLineBreak(text.codeUnitAt(lineEnd))) {
+        _noteScanVisit();
+        lineEnd++;
+      }
+      final trimmed = text.substring(i, lineEnd).trimLeft();
+      consume(trimmed, advance: _LineBackticks.of(trimmed).advance);
+      i = _skipLogicalLineBreak(text, lineEnd, text.length);
+    }
+  }
+
+  void consume(
+    String line, {
+    required int Function(int start) advance,
+    int offset = 0,
+    MarkdownDetailsCapture? capture,
+  }) {
+    closedAt = null;
+    var i = 0;
+    while (i < line.length) {
+      _noteScanVisit();
+      if (line.codeUnitAt(i) == 0x60) {
+        i = advance(i);
+        continue;
+      }
+      if (line.codeUnitAt(i) != 0x3C) {
+        i++;
+        continue;
+      }
+      if (_stack.isEmpty) {
+        if (i == 0) {
+          final opened = open.matchAsPrefix(line, i);
+          if (opened != null) {
+            capture?.attrs = _detailsOpenAttrs(opened.group(0)!);
+            _stack.add(_DetailsRegion.afterOpen);
+            i = opened.end;
+            continue;
+          }
+        }
+        i++;
+        continue;
+      }
+      final region = _stack.last;
+      if (region == _DetailsRegion.afterOpen) {
+        final summary = summaryOpen.matchAsPrefix(line, i);
+        if (summary != null) {
+          if (capture != null && _stack.length == 1) {
+            capture.summaryStart = offset + summary.end;
+          }
+          _stack[_stack.length - 1] = _DetailsRegion.inSummary;
+          i = summary.end;
+          continue;
+        }
+        final closed = close.matchAsPrefix(line, i);
+        if (closed != null) {
+          _popDetails(closed.end);
+          i = closed.end;
+          continue;
+        }
+        i++;
+        continue;
+      }
+      if (region == _DetailsRegion.inSummary) {
+        final ended = summaryClose.matchAsPrefix(line, i);
+        if (ended != null) {
+          if (capture != null && _stack.length == 1) {
+            capture.summaryEnd = offset + ended.start;
+            capture.bodyStart = offset + ended.end;
+          }
+          _stack[_stack.length - 1] = _DetailsRegion.inBody;
+          i = ended.end;
+          continue;
+        }
+        i++;
+        continue;
+      }
+      final nested = open.matchAsPrefix(line, i);
+      if (nested != null) {
+        if (_stack.length >= markdownDetailsMaxDepth) {
+          _overflow = true;
+          _ignoredOpens++;
+          i = nested.end;
+          continue;
+        }
+        _stack.add(_DetailsRegion.afterOpen);
+        i = nested.end;
+        continue;
+      }
+      final closed = close.matchAsPrefix(line, i);
+      if (closed != null) {
+        if (_ignoredOpens > 0) {
+          _ignoredOpens--;
+          i = closed.end;
+          continue;
+        }
+        if (capture != null && _stack.length == 1) {
+          capture.bodyEnd = offset + closed.start;
+        }
+        _popDetails(closed.end);
+        i = closed.end;
+        continue;
+      }
+      i++;
+    }
+  }
+
+  void _popDetails(int end) {
+    _stack.removeLast();
+    if (_stack.isEmpty) closedAt = end;
+  }
+}
+
+/// End of a details block that starts at the first non-empty logical line,
+/// or -1 if [text] is not a details block under the shared rules.
+int markdownDetailsExtent(String text, {bool enableMath = false}) {
+  final walker = MarkdownDetailsWalker();
+  final math = markdownScanDisplayMath(text, enableMath: enableMath);
+  var spanAt = 0;
+  var i = 0;
+  var opened = false;
+  while (i < text.length) {
+    var lineEnd = i;
+    while (lineEnd < text.length &&
+        !markdownIsLogicalLineBreak(text.codeUnitAt(lineEnd))) {
+      _noteScanVisit();
+      lineEnd++;
+    }
+    final raw = text.substring(i, lineEnd);
+    final trimmed = raw.trimLeft();
+    while (spanAt < math.spans.length && math.spans[spanAt].end <= i) {
+      _noteScanVisit();
+      spanAt++;
+    }
+    final inMath =
+        spanAt < math.spans.length &&
+        math.spans[spanAt].start < lineEnd &&
+        math.spans[spanAt].end > i;
+    if (!inMath) {
+      walker.consume(trimmed, advance: _LineBackticks.of(trimmed).advance);
+    }
+    // A one-line `<details>…</details>` opens and closes in the same
+    // consume, so depth is 0 afterwards. closedAt still marks the block.
+    if (walker.depth > 0 || walker.closedAt != null) opened = true;
+    if (!opened) {
+      if (trimmed.isNotEmpty) return -1;
+    } else if (walker.depth == 0) {
+      if (walker.overflowed) return -1;
+      final indent = raw.length - trimmed.length;
+      return i + indent + (walker.closedAt ?? trimmed.length);
+    }
+    i = _skipLogicalLineBreak(text, lineEnd, text.length);
+  }
+  return -1;
+}
+
+final class MarkdownDetailsBlock {
+  const MarkdownDetailsBlock({
+    required this.attrs,
+    required this.summary,
+    required this.body,
+  });
+
+  final String attrs;
+  final String summary;
+  final String body;
+
+  bool get initiallyExpanded =>
+      RegExp(r'(?:^|\s)open(?:\s|$|=)', caseSensitive: false).hasMatch(attrs);
+}
+
+final class MarkdownDetailsCapture {
+  String attrs = '';
+  int summaryStart = -1;
+  int summaryEnd = -1;
+  int bodyStart = -1;
+  int bodyEnd = -1;
+}
+
+MarkdownDetailsBlock? markdownParseDetails(
+  String text, {
+  bool enableMath = false,
+}) {
+  final slice = text.trim();
+  final end = markdownDetailsExtent(slice, enableMath: enableMath);
+  if (end < 0) return null;
+  final capture = MarkdownDetailsCapture();
+  final walker = MarkdownDetailsWalker();
+  final math = markdownScanDisplayMath(slice, end: end, enableMath: enableMath);
+  var spanAt = 0;
+  var i = 0;
+  while (i < end) {
+    var lineEnd = i;
+    while (lineEnd < end &&
+        !markdownIsLogicalLineBreak(slice.codeUnitAt(lineEnd))) {
+      _noteScanVisit();
+      lineEnd++;
+    }
+    final raw = slice.substring(i, lineEnd);
+    final indent = raw.length - raw.trimLeft().length;
+    final trimmed = raw.substring(indent);
+    while (spanAt < math.spans.length && math.spans[spanAt].end <= i) {
+      _noteScanVisit();
+      spanAt++;
+    }
+    final inMath =
+        spanAt < math.spans.length &&
+        math.spans[spanAt].start < lineEnd &&
+        math.spans[spanAt].end > i;
+    if (!inMath) {
+      walker.consume(
+        trimmed,
+        advance: _LineBackticks.of(trimmed).advance,
+        offset: i + indent,
+        capture: capture,
+      );
+    }
+    i = _skipLogicalLineBreak(slice, lineEnd, end);
+  }
+  if (capture.summaryStart < 0 ||
+      capture.summaryEnd < capture.summaryStart ||
+      capture.bodyStart < 0 ||
+      capture.bodyEnd < capture.bodyStart) {
+    return null;
+  }
+  return MarkdownDetailsBlock(
+    attrs: capture.attrs,
+    summary: slice.substring(capture.summaryStart, capture.summaryEnd),
+    body: slice.substring(capture.bodyStart, capture.bodyEnd),
+  );
+}
+
+String _detailsOpenAttrs(String tag) {
+  if (tag.length <= 9) return '';
+  return tag.substring(8, tag.length - 1);
+}
+
+final class MarkdownDetailsSegment {
+  const MarkdownDetailsSegment.prose(this.text) : details = null;
+  const MarkdownDetailsSegment.details(this.details) : text = '';
+
+  final String text;
+  final MarkdownDetailsBlock? details;
+}
+
+/// Top-level details blocks, in source order.
+///
+/// One walker walks the whole string. A block is committed only when
+/// global depth goes `0→1→0` without overflow, and the closer sits on a
+/// renderer block boundary (end of line, trailing spaces, or EOF). An
+/// unclosed or overflowed outer therefore cannot promote an inner opener.
+///
+/// When [enableMath] is true, tags inside a successful [markdownScanDisplayMath]
+/// span are not top-level. Unclosed math openers do not hide tags. Tokens
+/// inside a closed span do not update walker depth.
+List<MarkdownDetailsSegment> markdownExtractTopLevelDetails(
+  String text, {
+  bool enableMath = false,
+}) {
+  final segments = <MarkdownDetailsSegment>[];
+  final lexer = MarkdownLineLexer();
+  final math = markdownScanDisplayMath(text, enableMath: enableMath);
+  var cursor = 0;
+  var topStart = -1;
+  var spanAt = 0;
+  var i = 0;
+
+  bool lineIntersectsMath(int lineStart, int lineEnd) {
+    final spans = math.spans;
+    while (spanAt < spans.length && spans[spanAt].end <= lineStart) {
+      _noteScanVisit();
+      spanAt++;
+    }
+    if (spanAt >= spans.length) return false;
+    final span = spans[spanAt];
+    return span.start < lineEnd && span.end > lineStart;
+  }
+
+  while (i < text.length) {
+    var lineEnd = i;
+    while (lineEnd < text.length &&
+        !markdownIsLogicalLineBreak(text.codeUnitAt(lineEnd))) {
+      _noteScanVisit();
+      lineEnd++;
+    }
+    final raw = text.substring(i, lineEnd);
+    final indent = raw.length - raw.trimLeft().length;
+    final trimmed = raw.substring(indent);
+    final inMath = lineIntersectsMath(i, lineEnd);
+    if (!inMath &&
+        lexer.detailsDepth == 0 &&
+        !lexer.fenced &&
+        trimmed.isNotEmpty &&
+        MarkdownDetailsWalker.open.matchAsPrefix(trimmed) != null) {
+      topStart = i;
+    }
+    if (!inMath) lexer.consumeLine(raw);
+    if (topStart >= 0 &&
+        lexer.detailsDepth == 0 &&
+        lexer.detailsClosedAt != null) {
+      final end = i + indent + lexer.detailsClosedAt!;
+      final boundary = _detailsBlockBoundaryEnd(text, end);
+      if (!lexer.detailsOverflowed &&
+          boundary >= 0 &&
+          !math.contains(end - 1)) {
+        final parsed = markdownParseDetails(
+          text.substring(topStart, boundary),
+          enableMath: enableMath,
+        );
+        if (parsed != null) {
+          if (topStart > cursor) {
+            segments.add(
+              MarkdownDetailsSegment.prose(text.substring(cursor, topStart)),
+            );
+          }
+          segments.add(MarkdownDetailsSegment.details(parsed));
+          cursor = boundary;
+        }
+      }
+      topStart = -1;
+      lexer.resetDetails();
+    }
+    i = _skipLogicalLineBreak(text, lineEnd, text.length);
+  }
+  if (cursor < text.length) {
+    segments.add(MarkdownDetailsSegment.prose(text.substring(cursor)));
+  } else if (segments.isEmpty) {
+    segments.add(MarkdownDetailsSegment.prose(text));
+  }
+  return segments;
+}
+
+/// End of the span that can replace a details block, or -1 if [end] is
+/// not a block boundary. Trailing spaces/tabs are absorbed so the
+/// placeholder can occupy the whole line.
+int _detailsBlockBoundaryEnd(String text, int end) {
+  var i = end;
+  while (i < text.length) {
+    final unit = text.codeUnitAt(i);
+    if (unit == 0x20 || unit == 0x09) {
+      i++;
+      continue;
+    }
+    return markdownIsLogicalLineBreak(unit) ? i : -1;
+  }
+  return i;
+}
+
+/// Replaces complete details blocks with placeholders so [DetailsHtmlMd]
+/// can match them without rewriting `<` in the visible source.
+///
+/// Tokens are minted per registry and only [lookup] of an issued token
+/// returns a block. A nonce that does not appear in the source keeps
+/// user text shaped like a placeholder from colliding.
+final class MarkdownDetailsRegistry {
+  MarkdownDetailsRegistry({this.enableMath = false});
+
+  final bool enableMath;
+  final Map<String, MarkdownDetailsBlock> _blocks = {};
+  final Map<String, String> _rewritten = {};
+  String? _nonce;
+  int _nextId = 0;
+
+  bool get hasIssuedPlaceholders => _blocks.isNotEmpty;
+
+  String? _rootSource;
+
+  void _bindRoot(String text) {
+    if (_rootSource != null) return;
+    _rootSource = text;
+    _nonce = _nonceFor(text);
+  }
+
+  /// Pattern for tokens this registry has issued, or a never-match if none.
+  String get placeholderSource {
+    final nonce = _nonce;
+    if (nonce == null) return '(?!)';
+    return '\uE010${RegExp.escape(nonce)}:[0-9]+\uE011';
+  }
+
+  String rewrite(String text) {
+    return _rewritten.putIfAbsent(text, () {
+      _bindRoot(text);
+      final segments = markdownExtractTopLevelDetails(
+        text,
+        enableMath: enableMath,
+      );
+      if (segments.length == 1 && segments.first.details == null) {
+        return text;
+      }
+      final out = StringBuffer();
+      for (final segment in segments) {
+        final details = segment.details;
+        if (details == null) {
+          out.write(segment.text);
+          continue;
+        }
+        final token = '\uE010$_nonce:${_nextId++}\uE011';
+        _blocks[token] = details;
+        out.write(token);
+      }
+      return out.toString();
+    });
+  }
+
+  MarkdownDetailsBlock? lookup(String text) {
+    if (_nonce == null || _blocks.isEmpty) return null;
+    final match = _issuedToken.firstMatch(text.trim());
+    if (match == null) return null;
+    return _blocks[match.group(0)!];
+  }
+
+  static String _nonceFor(String text) {
+    final used = <int>{};
+    var i = 0;
+    while (i < text.length) {
+      _noteScanVisit();
+      if (text.codeUnitAt(i) != 0xE010) {
+        i++;
+        continue;
+      }
+      var j = i + 1;
+      var n = 0;
+      var digits = false;
+      while (j < text.length) {
+        _noteScanVisit();
+        final unit = text.codeUnitAt(j);
+        if (unit >= 0x30 && unit <= 0x39) {
+          digits = true;
+          n = n * 10 + (unit - 0x30);
+          j++;
+          continue;
+        }
+        if (digits && unit == 0x3A) used.add(n);
+        break;
+      }
+      i++;
+    }
+    var nonce = 0;
+    while (used.contains(nonce)) {
+      nonce++;
+    }
+    return '$nonce';
+  }
+
+  RegExp get _issuedToken =>
+      RegExp('\uE010${RegExp.escape(_nonce ?? '')}:[0-9]+\uE011');
+}
+
+enum _DetailsRegion { afterOpen, inSummary, inBody }
+
+/// Backtick runs on one line, paired in a single left-to-right pass.
+///
+/// An unmatched opener stays only that run: treating it as code through the
+/// end of the line would hide a later `$$` on the same line, and looking
+/// for a closer from every opener would rescan the tail once per run.
+final class _LineBackticks {
+  const _LineBackticks._(this._jump);
+
+  static const empty = _LineBackticks._(null);
+
+  final Map<int, int>? _jump;
+
+  int get slotCount => _jump?.length ?? 0;
+
+  int advance(int i) => _jump![i] ?? i + 1;
+
+  static _LineBackticks of(String line) {
+    final starts = <int>[];
+    final lengths = <int>[];
+    var i = 0;
+    while (i < line.length) {
+      _noteScanVisit();
+      if (line.codeUnitAt(i) != 0x60) {
+        i++;
+        continue;
+      }
+      final start = i;
+      i++;
+      while (i < line.length && line.codeUnitAt(i) == 0x60) {
+        _noteScanVisit();
+        i++;
+      }
+      starts.add(start);
+      lengths.add(i - start);
+    }
+    if (starts.isEmpty) return empty;
+
+    final runCount = starts.length;
+    final nextSame = List<int>.filled(runCount, -1);
+    final lastByLength = <int, int>{};
+    for (var r = runCount - 1; r >= 0; r--) {
+      nextSame[r] = lastByLength[lengths[r]] ?? -1;
+      lastByLength[lengths[r]] = r;
+    }
+
+    final jump = <int, int>{};
+    final consumed = List<bool>.filled(runCount, false);
+    for (var r = 0; r < runCount; r++) {
+      if (consumed[r]) continue;
+      final closer = nextSame[r];
+      if (closer >= 0) {
+        jump[starts[r]] = starts[closer] + lengths[closer];
+        for (var k = r; k <= closer; k++) {
+          consumed[k] = true;
+        }
+      } else {
+        jump[starts[r]] = starts[r] + lengths[r];
+        consumed[r] = true;
+      }
+    }
+    return _LineBackticks._(jump);
+  }
+}
+
+int debugMarkdownScanVisits = 0;
+bool _markdownScanCounting = false;
+
+void debugResetMarkdownScanVisits() {
+  debugMarkdownScanVisits = 0;
+  _markdownScanCounting = true;
+}
+
+void debugDisableMarkdownScanVisits() {
+  _markdownScanCounting = false;
+}
+
+/// Jump slots kept for [line]. Proportional to backtick runs, not line length.
+int debugBacktickJumpSlotCount(String line) =>
+    _LineBackticks.of(line).slotCount;
+
+/// Upper bound on visits per source code unit. Several linear passes are
+/// expected; a per-opener rescan of the leftover line would exceed this
+/// on unmatched backtick runs of increasing length.
+const int debugMarkdownScanVisitBudgetFactor = 12;
+
+void _noteScanVisit() {
+  assert(() {
+    if (_markdownScanCounting) debugMarkdownScanVisits++;
+    return true;
+  }());
+}
+
+/// Line terminators a Dart multiline `^` / `$` recognises. The splitter
+/// still only ends blocks on `\n`; these marks stay content there.
+bool markdownIsLogicalLineBreak(int unit) =>
+    unit == 0x0A || unit == 0x0D || unit == 0x2028 || unit == 0x2029;
+
+bool _isPhysicalLineInternalBreak(int unit) =>
+    unit == 0x0D || unit == 0x2028 || unit == 0x2029;
+
+int _skipLogicalLineBreak(String content, int lineEnd, int end) {
+  if (lineEnd >= end) return end;
+  if (content.codeUnitAt(lineEnd) == 0x0D &&
+      lineEnd + 1 < end &&
+      content.codeUnitAt(lineEnd + 1) == 0x0A) {
+    return lineEnd + 2;
+  }
+  return lineEnd + 1;
+}
+
+final class _FenceMark {
+  const _FenceMark({
+    required this.start,
+    required this.marker,
+    required this.length,
+    required this.canClose,
+  });
+
+  final int start;
+  final int marker;
+  final int length;
+  final bool canClose;
+}
+
+int _skipHorizontalIndent(String line, [int start = 0]) {
+  var i = start;
+  while (i < line.length) {
+    final unit = line.codeUnitAt(i);
+    if (unit != 0x20 && unit != 0x09) break;
+    _noteScanVisit();
+    i++;
+  }
+  return i;
+}
+
+_FenceMark? _fenceMarkOf(String rawLine, int lineStart) {
+  final indent = _skipHorizontalIndent(rawLine);
+  if (indent >= rawLine.length) return null;
+  final marker = rawLine.codeUnitAt(indent);
+  if (marker != 0x60 && marker != 0x7E) return null;
+  var n = indent + 1;
+  while (n < rawLine.length && rawLine.codeUnitAt(n) == marker) {
+    _noteScanVisit();
+    n++;
+  }
+  final length = n - indent;
+  if (length < 3) return null;
+  var canClose = true;
+  for (var i = n; i < rawLine.length; i++) {
+    _noteScanVisit();
+    final unit = rawLine.codeUnitAt(i);
+    if (unit != 0x20 && unit != 0x09) {
+      canClose = false;
+      break;
+    }
+  }
+  return _FenceMark(
+    start: lineStart + indent,
+    marker: marker,
+    length: length,
+    canClose: canClose,
+  );
+}
+
+/// A successful `$$…$$` or `\[…\]` span under the shared pairing rules.
+final class MarkdownDisplayMathSpan {
+  const MarkdownDisplayMathSpan({required this.start, required this.end});
+
+  final int start;
+  final int end;
+}
+
+/// Closed display-math spans plus the leftmost unclosed opener, if any.
+///
+/// [contains] is the extractor/classifier view: only successful spans occupy
+/// later content. [covers] is the splitter view: an unclosed opener holds a
+/// later blank until a closer arrives or a later successful span abandons it.
+final class MarkdownDisplayMathScan {
+  const MarkdownDisplayMathScan({this.spans = const [], this.unclosedStart});
+
+  final List<MarkdownDisplayMathSpan> spans;
+  final int? unclosedStart;
+
+  bool contains(int offset) {
+    for (final span in spans) {
+      if (offset >= span.start && offset < span.end) return true;
+    }
+    return false;
+  }
+
+  bool covers(int offset) {
+    if (contains(offset)) return true;
+    return unclosedStart != null && offset >= unclosedStart!;
+  }
+}
+
+/// Incremental collector shared by the splitter, Details extractor, and
+/// trailing-separator classifier. Current-line candidates roll back by
+/// length checkpoint; pairing resumes from the earliest unresolved opener.
+final class MarkdownDisplayMathScanner {
+  String _text = '';
+  var _scannedTo = 0;
+  var _lineStart = 0;
+  var _lineLeading = true;
+  final _dollarOpens = <int>[];
+  final _dollarCloses = <int>[];
+  final _bracketOpens = <int>[];
+  final _bracketCloses = <int>[];
+  final _fenceOpens = <_FenceMark>[];
+  final _fenceCloses = <_FenceMark>[];
+  var _chkDollarOpens = 0;
+  var _chkDollarCloses = 0;
+  var _chkBracketOpens = 0;
+  var _chkBracketCloses = 0;
+  var _chkFenceOpens = 0;
+  var _chkFenceCloses = 0;
+  final _spans = <MarkdownDisplayMathSpan>[];
+  var _frozenSpanCount = 0;
+  var _frozenPos = 0;
+  var _frozenDollarOpenAt = 0;
+  var _frozenBracketOpenAt = 0;
+  var _frozenDollarCloseAt = 0;
+  var _frozenBracketCloseAt = 0;
+  var _frozenFenceOpenAt = 0;
+  var _frozenFenceCloseAt = 0;
+
+  void reset() {
+    _text = '';
+    _scannedTo = 0;
+    _lineStart = 0;
+    _lineLeading = true;
+    _dollarOpens.clear();
+    _dollarCloses.clear();
+    _bracketOpens.clear();
+    _bracketCloses.clear();
+    _fenceOpens.clear();
+    _fenceCloses.clear();
+    _chkDollarOpens = 0;
+    _chkDollarCloses = 0;
+    _chkBracketOpens = 0;
+    _chkBracketCloses = 0;
+    _chkFenceOpens = 0;
+    _chkFenceCloses = 0;
+    _spans.clear();
+    _frozenSpanCount = 0;
+    _frozenPos = 0;
+    _frozenDollarOpenAt = 0;
+    _frozenBracketOpenAt = 0;
+    _frozenDollarCloseAt = 0;
+    _frozenBracketCloseAt = 0;
+    _frozenFenceOpenAt = 0;
+    _frozenFenceCloseAt = 0;
+  }
+
+  MarkdownDisplayMathScan synchronize(
+    String text, {
+    int? end,
+    bool enableMath = true,
+  }) {
+    final limit = end ?? text.length;
+    if (!enableMath || limit <= 0) {
+      reset();
+      return const MarkdownDisplayMathScan();
+    }
+    if (_text.isNotEmpty &&
+        (_scannedTo > limit ||
+            _scannedTo > text.length ||
+            !text.startsWith(
+              _text.substring(0, _scannedTo.clamp(0, _text.length)),
+            ))) {
+      reset();
+    }
+    _text = text;
+    _feed(limit);
+    return _pair(limit);
+  }
+
+  void _feed(int limit) {
+    while (_scannedTo < limit) {
+      final unit = _text.codeUnitAt(_scannedTo);
+      if (!markdownIsLogicalLineBreak(unit) &&
+          _scannedTo + 1 >= limit &&
+          (unit == 0x24 || unit == 0x5C)) {
+        return;
+      }
+      _noteScanVisit();
+      if (markdownIsLogicalLineBreak(unit)) {
+        _rollbackCurrentLine();
+        _collectCompleteLine(_lineStart, _scannedTo);
+        _scannedTo = _skipLogicalLineBreak(_text, _scannedTo, limit);
+        _lineStart = _scannedTo;
+        _lineLeading = true;
+        _checkpointCurrentLine();
+        continue;
+      }
+      _consumeAt(_scannedTo, limit);
+    }
+  }
+
+  void _checkpointCurrentLine() {
+    _chkDollarOpens = _dollarOpens.length;
+    _chkDollarCloses = _dollarCloses.length;
+    _chkBracketOpens = _bracketOpens.length;
+    _chkBracketCloses = _bracketCloses.length;
+    _chkFenceOpens = _fenceOpens.length;
+    _chkFenceCloses = _fenceCloses.length;
+  }
+
+  void _rollbackCurrentLine() {
+    _dollarOpens.length = _chkDollarOpens;
+    _dollarCloses.length = _chkDollarCloses;
+    _bracketOpens.length = _chkBracketOpens;
+    _bracketCloses.length = _chkBracketCloses;
+    _fenceOpens.length = _chkFenceOpens;
+    _fenceCloses.length = _chkFenceCloses;
+  }
+
+  void _consumeAt(int i, int limit) {
+    if (i + 1 < limit && _atDoubleDollar(_text, i)) {
+      if (_lineLeading) _dollarOpens.add(i);
+      _dollarCloses.add(i);
+      _lineLeading = false;
+      _scannedTo = i + 2;
+      return;
+    }
+    if (i + 1 < limit && _atEscaped(_text, i, 0x5B)) {
+      if (_lineLeading) _bracketOpens.add(i);
+      _lineLeading = false;
+      _scannedTo = i + 2;
+      return;
+    }
+    if (i + 1 < limit && _atEscaped(_text, i, 0x5D)) {
+      _bracketCloses.add(i);
+      _lineLeading = false;
+      _scannedTo = i + 2;
+      return;
+    }
+    if (!markdownIsWhitespace(_text.codeUnitAt(i))) {
+      _lineLeading = false;
+      _revokeClosersThrough(i);
+    }
+    _scannedTo = i + 1;
+  }
+
+  void _revokeClosersThrough(int nonWsAt) {
+    while (_dollarCloses.length > _chkDollarCloses) {
+      _noteScanVisit();
+      final closer = _dollarCloses.last;
+      if (closer + 2 > nonWsAt) break;
+      _dollarCloses.removeLast();
+    }
+    while (_bracketCloses.length > _chkBracketCloses) {
+      _noteScanVisit();
+      final closer = _bracketCloses.last;
+      if (closer + 2 > nonWsAt) break;
+      _bracketCloses.removeLast();
+    }
+  }
+
+  void _collectCompleteLine(int start, int end) {
+    final rawLine = _text.substring(start, end);
+    final fence = _fenceMarkOf(rawLine, start);
+    if (fence != null) {
+      _fenceOpens.add(fence);
+      if (fence.canClose) _fenceCloses.add(fence);
+    }
+    final ticks = _LineBackticks.of(rawLine);
+    var lineLeading = true;
+    var j = 0;
+    while (j < rawLine.length) {
+      _noteScanVisit();
+      if (rawLine.codeUnitAt(j) == 0x60) {
+        j = ticks.advance(j);
+        lineLeading = false;
+        continue;
+      }
+      if (_atDoubleDollar(rawLine, j)) {
+        final at = start + j;
+        if (lineLeading) _dollarOpens.add(at);
+        if (_onlyWhitespaceAfter(rawLine, j + 2)) _dollarCloses.add(at);
+        lineLeading = false;
+        j += 2;
+        continue;
+      }
+      if (_atEscaped(rawLine, j, 0x5B)) {
+        if (lineLeading) _bracketOpens.add(start + j);
+        lineLeading = false;
+        j += 2;
+        continue;
+      }
+      if (_atEscaped(rawLine, j, 0x5D)) {
+        if (_onlyWhitespaceAfter(rawLine, j + 2)) {
+          _bracketCloses.add(start + j);
+        }
+        lineLeading = false;
+        j += 2;
+        continue;
+      }
+      if (!markdownIsWhitespace(rawLine.codeUnitAt(j))) lineLeading = false;
+      j++;
+    }
+  }
+
+  MarkdownDisplayMathScan _pair(int limit) {
+    _spans.length = _frozenSpanCount;
+    var pos = _frozenPos;
+    var dollarOpenAt = _frozenDollarOpenAt;
+    var bracketOpenAt = _frozenBracketOpenAt;
+    var dollarCloseAt = _frozenDollarCloseAt;
+    var bracketCloseAt = _frozenBracketCloseAt;
+    var fenceOpenAt = _frozenFenceOpenAt;
+    var fenceCloseAt = _frozenFenceCloseAt;
+    int? unclosedStart;
+    int? earliestUnresolved;
+    final peeked = _peekIncompleteFence(limit);
+
+    int advanceInt(List<int> values, int index, int min) {
+      while (index < values.length && values[index] < min) {
+        _noteScanVisit();
+        index++;
+      }
+      return index;
+    }
+
+    int advanceFence(int index, int min) {
+      while (index < _fenceOpens.length && _fenceOpens[index].start < min) {
+        _noteScanVisit();
+        index++;
+      }
+      return index;
+    }
+
+    void freeze(
+      int nextPos,
+      int nextDollarOpen,
+      int nextBracketOpen,
+      int nextDollarClose,
+      int nextBracketClose,
+      int nextFenceOpen,
+      int nextFenceClose,
+    ) {
+      if (nextPos > _lineStart) return;
+      if (earliestUnresolved != null) return;
+      _frozenSpanCount = _spans.length;
+      _frozenPos = nextPos;
+      _frozenDollarOpenAt = nextDollarOpen;
+      _frozenBracketOpenAt = nextBracketOpen;
+      _frozenDollarCloseAt = nextDollarClose;
+      _frozenBracketCloseAt = nextBracketClose;
+      _frozenFenceOpenAt = nextFenceOpen;
+      _frozenFenceCloseAt = nextFenceClose;
+    }
+
+    while (true) {
+      _noteScanVisit();
+      fenceOpenAt = advanceFence(fenceOpenAt, pos);
+      dollarOpenAt = advanceInt(_dollarOpens, dollarOpenAt, pos);
+      bracketOpenAt = advanceInt(_bracketOpens, bracketOpenAt, pos);
+      final dollarAt = dollarOpenAt < _dollarOpens.length
+          ? _dollarOpens[dollarOpenAt]
+          : null;
+      final bracketAt = bracketOpenAt < _bracketOpens.length
+          ? _bracketOpens[bracketOpenAt]
+          : null;
+      _FenceMark? fenceAt;
+      if (fenceOpenAt < _fenceOpens.length) {
+        fenceAt = _fenceOpens[fenceOpenAt];
+      }
+      if (peeked != null &&
+          peeked.start >= pos &&
+          (fenceAt == null || peeked.start <= fenceAt.start)) {
+        fenceAt = peeked;
+      }
+      final useDollar =
+          dollarAt != null && (bracketAt == null || dollarAt <= bracketAt);
+      final mathAt = useDollar ? dollarAt : bracketAt;
+      if (mathAt == null && fenceAt == null) break;
+
+      final mathFirst =
+          mathAt != null && (fenceAt == null || mathAt <= fenceAt.start);
+      if (mathFirst) {
+        final openAt = mathAt;
+        final closes = useDollar ? _dollarCloses : _bracketCloses;
+        var closeAt = useDollar ? dollarCloseAt : bracketCloseAt;
+        while (closeAt < closes.length && closes[closeAt] < openAt + 2) {
+          _noteScanVisit();
+          closeAt++;
+        }
+        if (useDollar) {
+          dollarCloseAt = closeAt;
+          dollarOpenAt++;
+        } else {
+          bracketCloseAt = closeAt;
+          bracketOpenAt++;
+        }
+        if (closeAt < closes.length) {
+          final closer = closes[closeAt];
+          _spans.add(MarkdownDisplayMathSpan(start: openAt, end: closer + 2));
+          pos = closer + 2;
+          unclosedStart = null;
+          freeze(
+            pos,
+            dollarOpenAt,
+            bracketOpenAt,
+            dollarCloseAt,
+            bracketCloseAt,
+            fenceOpenAt,
+            fenceCloseAt,
+          );
+        } else {
+          unclosedStart ??= openAt;
+          earliestUnresolved ??= openAt;
+          pos = openAt + 2;
+        }
+        continue;
+      }
+
+      final fence = fenceAt!;
+      if (!identical(fence, peeked)) fenceOpenAt++;
+      var closerEnd = -1;
+      while (fenceCloseAt < _fenceCloses.length) {
+        _noteScanVisit();
+        final close = _fenceCloses[fenceCloseAt];
+        if (close.start <= fence.start) {
+          fenceCloseAt++;
+          continue;
+        }
+        if (close.marker == fence.marker && close.length >= fence.length) {
+          closerEnd = close.start + close.length;
+          fenceCloseAt++;
+          break;
+        }
+        fenceCloseAt++;
+      }
+      if (closerEnd < 0 &&
+          peeked != null &&
+          peeked.canClose &&
+          peeked.start > fence.start &&
+          peeked.marker == fence.marker &&
+          peeked.length >= fence.length) {
+        _noteScanVisit();
+        closerEnd = peeked.start + peeked.length;
+      }
+      if (closerEnd >= 0) {
+        pos = closerEnd;
+        freeze(
+          pos,
+          dollarOpenAt,
+          bracketOpenAt,
+          dollarCloseAt,
+          bracketCloseAt,
+          fenceOpenAt,
+          fenceCloseAt,
+        );
+      } else {
+        earliestUnresolved ??= fence.start;
+        break;
+      }
+    }
+
+    if (earliestUnresolved == null &&
+        unclosedStart == null &&
+        pos <= _lineStart) {
+      freeze(
+        pos,
+        dollarOpenAt,
+        bracketOpenAt,
+        dollarCloseAt,
+        bracketCloseAt,
+        fenceOpenAt,
+        fenceCloseAt,
+      );
+    }
+    return MarkdownDisplayMathScan(spans: _spans, unclosedStart: unclosedStart);
+  }
+
+  _FenceMark? _peekIncompleteFence(int limit) {
+    var i = _lineStart;
+    while (i < limit) {
+      final unit = _text.codeUnitAt(i);
+      if (markdownIsLogicalLineBreak(unit)) return null;
+      if (unit != 0x20 && unit != 0x09) {
+        if (unit != 0x60 && unit != 0x7E) return null;
+        return _fenceMarkOf(_text.substring(_lineStart, limit), _lineStart);
+      }
+      _noteScanVisit();
+      i++;
+    }
+    return null;
+  }
+}
+
+/// Successful display-math spans in [text] using the same pairing as
+/// [LatexBlockScrollableMd]: a closer may be followed only by whitespace on
+/// its line; an unclosed opener does not occupy later content; a candidate
+/// that starts inside a successful outer span is discarded; leftmost
+/// successful dollar wins over bracket at the same site.
+///
+/// Fence and math candidates are merged by start: a successful earlier
+/// fence hides inner math, and a successful earlier math span treats inner
+/// fence markers as content. Unclosed fences that start first occupy the
+/// rest of the scan. Details tags are ordinary content.
+MarkdownDisplayMathScan markdownScanDisplayMath(
+  String text, {
+  int? end,
+  bool enableMath = true,
+}) {
+  return MarkdownDisplayMathScanner().synchronize(
+    text,
+    end: end,
+    enableMath: enableMath,
+  );
+}
+
+/// Whether [content] ends (at [end]) with a successful display-math span
+/// that [LatexBlockScrollableMd] would match.
+bool markdownEndsWithDisplayMath(String content, int end) {
+  final spans = markdownScanDisplayMath(content, end: end).spans;
+  return spans.isNotEmpty && spans.last.end == end;
+}
+
+bool _atDoubleDollar(String line, int i) {
+  return i + 1 < line.length &&
+      line.codeUnitAt(i) == 0x24 &&
+      line.codeUnitAt(i + 1) == 0x24;
+}
+
+bool _atEscaped(String line, int i, int unit) {
+  return i + 1 < line.length &&
+      line.codeUnitAt(i) == 0x5C &&
+      line.codeUnitAt(i + 1) == unit;
+}
+
+bool _onlyWhitespaceAfter(String line, int start) {
+  for (var i = start; i < line.length; i++) {
+    _noteScanVisit();
+    if (!markdownIsWhitespace(line.codeUnitAt(i))) return false;
+  }
+  return true;
+}
+
+bool markdownIsWhitespace(int unit) {
+  if (unit == 0x20) return true;
+  if (unit >= 0x09 && unit <= 0x0D) return true;
+  if (unit < 0x80) return false;
+  return unit == 0xA0 ||
+      unit == 0x1680 ||
+      (unit >= 0x2000 && unit <= 0x200A) ||
+      unit == 0x2028 ||
+      unit == 0x2029 ||
+      unit == 0x202F ||
+      unit == 0x205F ||
+      unit == 0x3000 ||
+      unit == 0xFEFF;
+}

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -41,6 +41,9 @@ import 'package:flutter_math_fork/flutter_math.dart';
 import '../../core/providers/settings_provider.dart';
 import '../../desktop/desktop_context_menu.dart';
 import 'html_preview_block.dart';
+import '../cache/byte_lru_cache.dart';
+import 'incremental_markdown_document.dart';
+import 'markdown_line_lexer.dart';
 
 // Inline math is parsed on the UI thread. Bound the lookahead window so a long
 // line with many unmatched openers cannot trigger repeated whole-line scans.
@@ -79,16 +82,28 @@ class MarkdownWithCodeHighlight extends StatefulWidget {
 }
 
 class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
-  // Issue #232: lowered from 8000 so math-heavy answers engage the render
-  // debounce early. Below this, a full markdown re-parse per 50ms stream tick
-  // is cheap; above it, renders are coalesced to the 120ms cadence.
-  static const int _streamingDebounceThresholdChars = 2000;
+  // Streamed text of 512+ chars is rendered as committed blocks plus a live
+  // tail (issue #334): committed blocks are parsed once and never re-parsed,
+  // so the debounce below only gates how often the whole document refreshes,
+  // not the per-tick parse cost (issue #232's original concern).
+  static const int _streamingDebounceThresholdChars = 8000;
+  // Matches the stream controller's publish interval. A longer window would
+  // batch several publishes into one render, and since the timeline is pinned
+  // to the tail while generating, each batch lands as a single upward step
+  // instead of the steady crawl the character smoothing is there to produce.
   static const Duration _streamingLongRenderDebounce = Duration(
-    milliseconds: 120,
+    milliseconds: 50,
   );
 
   late String _renderText;
   Timer? _renderDebounce;
+  final IncrementalMarkdownDocument _incrementalDocument =
+      IncrementalMarkdownDocument();
+  static final ByteLruCache<String, String> _normalizedBlockCache =
+      ByteLruCache<String, String>(
+        maxBytes: 4 << 20,
+        sizeOf: (key, value) => (key.length + value.length) * 2,
+      );
 
   @override
   void initState() {
@@ -134,12 +149,31 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
     final cs = Theme.of(context).colorScheme;
     final sanitizedText = _sanitizeImageLinks(_renderText);
     final imageUrls = _extractImageUrls(sanitizedText);
-    final normalized = _preprocessFences(
-      sanitizedText,
-      enableMath: settings.enableMathRendering,
-      enableDollarLatex: settings.enableDollarLatex,
-      streaming: widget.streaming,
-    );
+    String normalize(String source, {required bool streaming}) {
+      final cacheKey =
+          '${settings.enableMathRendering}:${settings.enableDollarLatex}:$streaming:$source';
+      final cached = _normalizedBlockCache.get(cacheKey);
+      if (cached != null) return cached;
+      final value = _preprocessFences(
+        source,
+        enableMath: settings.enableMathRendering,
+        enableDollarLatex: settings.enableDollarLatex,
+        streaming: streaming,
+      );
+      _normalizedBlockCache.put(cacheKey, value);
+      return value;
+    }
+
+    // 512+ chars engage the incremental splitter; below that a full parse per
+    // tick is cheap and the tail behavior (no block boundaries yet) is simpler.
+    final useIncrementalBlocks =
+        widget.streaming && sanitizedText.length >= 512;
+    final sourceBlocks = useIncrementalBlocks
+        ? _incrementalDocument.update(sanitizedText)
+        : const <IncrementalMarkdownBlock>[];
+    final normalized = useIncrementalBlocks
+        ? null
+        : normalize(sanitizedText, streaming: widget.streaming);
     // Base text style (can be overridden by caller)
     final baseTextStyle =
         (widget.baseStyle ?? Theme.of(context).textTheme.bodyMedium)?.copyWith(
@@ -154,7 +188,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
     final components = List<MarkdownComponent>.from(
       MarkdownComponent.globalComponents,
     );
-    components.removeWhere((c) => c is LatexMathMultiLine);
+    components.removeWhere((c) => c is LatexMathMultiLine || c is HTag);
     final hrIdx = components.indexWhere((c) => c is HrLine);
     if (hrIdx != -1) components[hrIdx] = SoftHrLine();
     components.removeWhere((c) => c is BlockQuote);
@@ -179,7 +213,6 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
     // so lines like "# comment" inside code fences are not parsed as headings.
     components.insert(0, ModernBlockQuote());
     components.insert(0, FencedCodeBlockMd(streaming: widget.streaming));
-    components.insert(0, DetailsHtmlMd());
     // Inline components: keep defaults but make link parsing line-scoped
     final inlineComponents = List<MarkdownComponent>.from(
       MarkdownComponent.inlineComponents,
@@ -264,254 +297,313 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
 
     final appFontFamily = resolveAppFont();
 
-    // Force rebuild of the markdown when key theme colors change to avoid stale styles
-    final markdownWidget = GptMarkdown(
-      key: ValueKey(
-        '${Theme.of(context).brightness.index}-${cs.surface.toARGB32()}-${cs.onSurface.toARGB32()}-${cs.primary.toARGB32()}-${cs.outlineVariant.toARGB32()}-${settings.enableMathRendering}-${settings.enableDollarLatex}',
-      ),
-      normalized,
-      style: baseTextStyle,
-      followLinkColor: true,
-      // Disable built-in $...$ LaTeX so our custom scrollable handlers take over
-      useDollarSignsForLatex: false,
-      streaming: widget.streaming,
-      onLinkTap: (url, title) => _handleLinkTap(context, url),
-      components: components,
-      inlineComponents: inlineComponents,
-      imageBuilder: (ctx, url, width, height) {
-        final imgs = imageUrls.isNotEmpty ? imageUrls : <String>[url];
-        final idx = imgs.indexOf(url);
-        final initial = idx >= 0 ? idx : 0;
-        final provider = _imageProviderFor(url);
-        return GestureDetector(
-          onTap: () {
-            Navigator.of(ctx).push(
-              PageRouteBuilder(
-                pageBuilder: (_, __, ___) =>
-                    ImageViewerPage(images: imgs, initialIndex: initial),
-                transitionDuration: const Duration(milliseconds: 360),
-                reverseTransitionDuration: const Duration(milliseconds: 280),
-                transitionsBuilder: (context, anim, sec, child) {
-                  final curved = CurvedAnimation(
-                    parent: anim,
-                    curve: Curves.easeOutCubic,
-                    reverseCurve: Curves.easeInCubic,
-                  );
-                  return FadeTransition(
-                    opacity: curved,
-                    child: SlideTransition(
-                      position: Tween<Offset>(
-                        begin: const Offset(0, 0.02),
-                        end: Offset.zero,
-                      ).animate(curved),
-                      child: child,
-                    ),
-                  );
-                },
-              ),
-            );
-          },
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: () {
-                  if (provider == null) {
-                    // Missing or unsupported source: show a broken image indicator
-                    return const Icon(Icons.broken_image);
-                  }
-                  return Image(
-                    image: provider,
-                    width: width ?? constraints.maxWidth,
-                    height: height,
-                    fit: BoxFit.contain,
-                    errorBuilder: (context, error, stack) =>
-                        const Icon(Icons.broken_image),
-                  );
-                }(),
+    // Everything baked into the memoized markdown widget below must be part of
+    // this signature (theme colors, math flags, fonts, font metrics, streaming
+    // mode, image list), otherwise a theme/settings change would keep stale
+    // rendering.
+    final themeSignature =
+        '${Theme.of(context).brightness.index}-${cs.surface.toARGB32()}-'
+        '${cs.onSurface.toARGB32()}-${cs.primary.toARGB32()}-'
+        '${cs.outlineVariant.toARGB32()}-${settings.enableMathRendering}-'
+        '${settings.enableDollarLatex}-${widget.streaming}-'
+        '${baseTextStyle?.fontSize}-${baseTextStyle?.height}-'
+        '${baseTextStyle?.letterSpacing}-${baseTextStyle?.fontFamily}-'
+        '$codeFontFamily-$appFontFamily-${_imageRevision(imageUrls)}';
+
+    Widget buildMarkdown(String markdown, Key key) {
+      final detailsRegistry = MarkdownDetailsRegistry(
+        enableMath: settings.enableMathRendering,
+      );
+      return GptMarkdown(
+        key: key,
+        markdown,
+        style: baseTextStyle,
+        followLinkColor: true,
+        // Disable built-in $...$ LaTeX so our custom scrollable handlers take over
+        useDollarSignsForLatex: false,
+        onLinkTap: (url, title) => _handleLinkTap(context, url),
+        preprocessBlocks: detailsRegistry.rewrite,
+        generation: themeSignature,
+        components: [DetailsHtmlMd(detailsRegistry), ...components],
+        inlineComponents: inlineComponents,
+        imageBuilder: (ctx, url, width, height) {
+          final imgs = imageUrls.isNotEmpty ? imageUrls : <String>[url];
+          final idx = imgs.indexOf(url);
+          final initial = idx >= 0 ? idx : 0;
+          final provider = _imageProviderFor(url);
+          return GestureDetector(
+            onTap: () {
+              Navigator.of(ctx).push(
+                PageRouteBuilder(
+                  pageBuilder: (_, __, ___) =>
+                      ImageViewerPage(images: imgs, initialIndex: initial),
+                  transitionDuration: const Duration(milliseconds: 360),
+                  reverseTransitionDuration: const Duration(milliseconds: 280),
+                  transitionsBuilder: (context, anim, sec, child) {
+                    final curved = CurvedAnimation(
+                      parent: anim,
+                      curve: Curves.easeOutCubic,
+                      reverseCurve: Curves.easeInCubic,
+                    );
+                    return FadeTransition(
+                      opacity: curved,
+                      child: SlideTransition(
+                        position: Tween<Offset>(
+                          begin: const Offset(0, 0.02),
+                          end: Offset.zero,
+                        ).animate(curved),
+                        child: child,
+                      ),
+                    );
+                  },
+                ),
               );
             },
-          ),
-        );
-      },
-      linkBuilder: (ctx, span, url, style) {
-        final label = span.toPlainText().trim();
-        // Special handling: [citation](index:id)
-        if (label.toLowerCase() == 'citation') {
-          final citation = _parseCitationRef(url);
-          if (citation != null) {
-            final cs = Theme.of(ctx).colorScheme;
-            return GestureDetector(
-              onTap: () {
-                if (widget.onCitationTap != null && citation.id.isNotEmpty) {
-                  widget.onCitationTap!(citation.id);
-                } else {
-                  // Fallback: do nothing
-                }
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: () {
+                    if (provider == null) {
+                      // Missing or unsupported source: show a broken image indicator
+                      return const Icon(Icons.broken_image);
+                    }
+                    return Image(
+                      image: provider,
+                      width: width ?? constraints.maxWidth,
+                      height: height,
+                      fit: BoxFit.contain,
+                      errorBuilder: (context, error, stack) =>
+                          const Icon(Icons.broken_image),
+                    );
+                  }(),
+                );
               },
-              child: Container(
-                width: 20,
-                height: 20,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  color: cs.primary.withValues(alpha: 0.20),
-                  borderRadius: BorderRadius.circular(10),
+            ),
+          );
+        },
+        linkBuilder: (ctx, span, url, style) {
+          final label = span.toPlainText().trim();
+          // Special handling: [citation](index:id)
+          if (label.toLowerCase() == 'citation') {
+            final citation = _parseCitationRef(url);
+            if (citation != null) {
+              final cs = Theme.of(ctx).colorScheme;
+              return GestureDetector(
+                onTap: () {
+                  if (widget.onCitationTap != null && citation.id.isNotEmpty) {
+                    widget.onCitationTap!(citation.id);
+                  } else {
+                    // Fallback: do nothing
+                  }
+                },
+                child: Container(
+                  width: 20,
+                  height: 20,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: cs.primary.withValues(alpha: 0.20),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    citation.indexText,
+                    style: TextStyle(fontSize: 12, height: 1.0),
+                  ),
                 ),
-                child: Text(
-                  citation.indexText,
-                  style: TextStyle(fontSize: 12, height: 1.0),
-                ),
+              );
+            }
+          }
+          // Default link appearance
+          final cs = Theme.of(ctx).colorScheme;
+          return Text(
+            span.toPlainText(),
+            style: style.copyWith(
+              color: cs.primary,
+              decoration: TextDecoration.none,
+            ),
+            textAlign: TextAlign.start,
+          );
+        },
+        orderedListBuilder: (ctx, no, child, cfg) {
+          final style = (cfg.style ?? TextStyle()).copyWith(
+            fontWeight: AppFontWeights.regular,
+          );
+          // Apply a soft compensation so when chat scale != 100%,
+          // list items don't visually feel larger/smaller than body text.
+          final double kListComp =
+              MarkdownWithCodeHighlight.kMarkdownListScaleCompensation;
+          final mediaQuery = MediaQuery.of(ctx);
+          final double s = mediaQuery.textScaler.scale(1);
+          final double comp = math.pow(s == 0 ? 1.0 : s, -kListComp).toDouble();
+          final double newScale = (s * comp).clamp(0.5, 3.0);
+          return MediaQuery(
+            data: mediaQuery.copyWith(textScaler: TextScaler.linear(newScale)),
+            child: Directionality(
+              textDirection: cfg.textDirection,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                textBaseline: TextBaseline.alphabetic,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                children: [
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(start: 6, end: 6),
+                    child: Text("$no.", style: style),
+                  ),
+                  // Keep child as-is so it inherits context MediaQuery scaling once
+                  Flexible(child: child),
+                ],
               ),
+            ),
+          );
+        },
+        // Note: property name is unOrderedListBuilder (camel-cased with capital O)
+        // Signature in gpt_markdown 1.1.4: (BuildContext ctx, Widget child, GptMarkdownConfig cfg) -> Widget
+        // We compose the bullet + content here to control scaling/spacing.
+        unOrderedListBuilder: (ctx, child, cfg) {
+          final style = (cfg.style ?? TextStyle()).copyWith(
+            fontWeight: AppFontWeights.regular,
+          );
+          final double kListComp =
+              MarkdownWithCodeHighlight.kMarkdownListScaleCompensation;
+          final mediaQuery = MediaQuery.of(ctx);
+          final double s = mediaQuery.textScaler.scale(1);
+          final double comp = math.pow(s == 0 ? 1.0 : s, -kListComp).toDouble();
+          final double newScale = (s * comp).clamp(0.5, 3.0);
+          return MediaQuery(
+            data: mediaQuery.copyWith(textScaler: TextScaler.linear(newScale)),
+            child: Directionality(
+              textDirection: cfg.textDirection,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                textBaseline: TextBaseline.alphabetic,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                children: [
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(start: 6, end: 6),
+                    child: Text('•', style: style),
+                  ),
+                  // Keep child untouched to follow context scaling exactly once
+                  Flexible(child: child),
+                ],
+              ),
+            ),
+          );
+        },
+        tableBuilder: (ctx, rows, style, cfg) {
+          return _MarkdownTableBlock(
+            rows: _MarkdownTableData.fromRows(
+              rows,
+              maxBodyRows: widget.streaming
+                  ? MarkdownWithCodeHighlight._streamingTableMaxRows
+                  : null,
+            ),
+            style: style,
+            config: cfg,
+            appFontFamily: appFontFamily.isEmpty ? null : appFontFamily,
+          );
+        },
+        // Inline `code` styling via highlightBuilder in gpt_markdown
+        highlightBuilder: (ctx, inline, style) {
+          // Unmask dollar signs that were protected during preprocessing
+          String unmasked = inline.replaceAll(_codeDollarMask, r'$');
+          String softened = _softBreakInline(unmasked);
+          final csCtx = Theme.of(ctx).colorScheme;
+          final bg = ctx.appColors.surfaceFill;
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: bg,
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(
+                color: csCtx.outlineVariant.withValues(alpha: 0.22),
+              ),
+            ),
+            child: Text(
+              softened,
+              style: TextStyle(
+                fontFamily: codeFontFamily,
+                fontSize: 13,
+                height: 1.4,
+              ).copyWith(color: csCtx.onSurface),
+              softWrap: true,
+              overflow: TextOverflow.visible,
+            ),
+          );
+        },
+        // Fenced code block styling via codeBuilder (with collapse/expand)
+        codeBuilder: (ctx, name, code, closed) {
+          final lang = name.trim();
+          final restoredCode = _unmaskHtmlTagStartsInsideFencedCode(code);
+          if (lang.toLowerCase() == 'mermaid') {
+            return _MermaidBlock(
+              code: restoredCode,
+              streaming: widget.streaming && !closed,
+            );
+          } else if (lang.toLowerCase() == 'plantuml') {
+            return PlantUMLBlock(code: restoredCode);
+          } else if (lang.toLowerCase() == 'svg') {
+            return SvgPreviewBlock(
+              code: restoredCode,
+              streaming: widget.streaming && !closed,
+            );
+          } else if (_isHtml(lang)) {
+            return HtmlPreviewBlock(
+              code: restoredCode,
+              streaming: widget.streaming && !closed,
             );
           }
-        }
-        // Default link appearance
-        final cs = Theme.of(ctx).colorScheme;
-        return Text(
-          span.toPlainText(),
-          style: style.copyWith(
-            color: cs.primary,
-            decoration: TextDecoration.none,
-          ),
-          textAlign: TextAlign.start,
-        );
-      },
-      orderedListBuilder: (ctx, no, child, cfg) {
-        final style = (cfg.style ?? TextStyle()).copyWith(
-          fontWeight: AppFontWeights.regular,
-        );
-        // Apply a soft compensation so when chat scale != 100%,
-        // list items don't visually feel larger/smaller than body text.
-        final double kListComp =
-            MarkdownWithCodeHighlight.kMarkdownListScaleCompensation;
-        final mediaQuery = MediaQuery.of(ctx);
-        final double s = mediaQuery.textScaler.scale(1);
-        final double comp = math.pow(s == 0 ? 1.0 : s, -kListComp).toDouble();
-        final double newScale = (s * comp).clamp(0.5, 3.0);
-        return MediaQuery(
-          data: mediaQuery.copyWith(textScaler: TextScaler.linear(newScale)),
-          child: Directionality(
-            textDirection: cfg.textDirection,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              textBaseline: TextBaseline.alphabetic,
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              children: [
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(start: 6, end: 6),
-                  child: Text("$no.", style: style),
+          return _CollapsibleCodeBlock(
+            language: lang,
+            code: restoredCode,
+            streaming: widget.streaming,
+            closed: closed,
+          );
+        },
+      );
+    }
+
+    final blockContents = useIncrementalBlocks
+        ? [
+            for (final block in sourceBlocks)
+              normalize(
+                block.text,
+                streaming: widget.streaming && !block.stable,
+              ),
+          ]
+        : const <String>[];
+    final markdownWidget = useIncrementalBlocks
+        ? _MarkdownBlockColumn(
+            children: [
+              for (var i = 0; i < blockContents.length; i++) ...[
+                // Rendering the document as one string keeps the blank run
+                // between two blocks as a real line box. Rendering block by
+                // block drops it, so a long reply is laid out tighter while it
+                // streams and then grows the moment it finishes and switches to
+                // the whole-document render. Put the line back so both paths
+                // agree — unless the block before it ends in something whose own
+                // renderer eats the run.
+                if (i > 0 &&
+                    !_swallowsTrailingBlankLine(
+                      blockContents[i - 1],
+                      mathEnabled: settings.enableMathRendering,
+                    ))
+                  _MarkdownBlockSeparator(style: baseTextStyle),
+                _CachedMarkdownBlock(
+                  key: ValueKey(
+                    'markdown-source-block-${sourceBlocks[i].start}',
+                  ),
+                  content: blockContents[i],
+                  signature: themeSignature,
+                  builder: buildMarkdown,
                 ),
-                // Keep child as-is so it inherits context MediaQuery scaling once
-                Flexible(child: child),
               ],
-            ),
-          ),
-        );
-      },
-      // Note: property name is unOrderedListBuilder (camel-cased with capital O)
-      // Signature in gpt_markdown 1.1.4: (BuildContext ctx, Widget child, GptMarkdownConfig cfg) -> Widget
-      // We compose the bullet + content here to control scaling/spacing.
-      unOrderedListBuilder: (ctx, child, cfg) {
-        final style = (cfg.style ?? TextStyle()).copyWith(
-          fontWeight: AppFontWeights.regular,
-        );
-        final double kListComp =
-            MarkdownWithCodeHighlight.kMarkdownListScaleCompensation;
-        final mediaQuery = MediaQuery.of(ctx);
-        final double s = mediaQuery.textScaler.scale(1);
-        final double comp = math.pow(s == 0 ? 1.0 : s, -kListComp).toDouble();
-        final double newScale = (s * comp).clamp(0.5, 3.0);
-        return MediaQuery(
-          data: mediaQuery.copyWith(textScaler: TextScaler.linear(newScale)),
-          child: Directionality(
-            textDirection: cfg.textDirection,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              textBaseline: TextBaseline.alphabetic,
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              children: [
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(start: 6, end: 6),
-                  child: Text('•', style: style),
-                ),
-                // Keep child untouched to follow context scaling exactly once
-                Flexible(child: child),
-              ],
-            ),
-          ),
-        );
-      },
-      tableBuilder: (ctx, rows, style, cfg) {
-        return _MarkdownTableBlock(
-          rows: _MarkdownTableData.fromRows(
-            rows,
-            maxBodyRows: widget.streaming
-                ? MarkdownWithCodeHighlight._streamingTableMaxRows
-                : null,
-          ),
-          style: style,
-          config: cfg,
-          appFontFamily: appFontFamily.isEmpty ? null : appFontFamily,
-        );
-      },
-      // Inline `code` styling via highlightBuilder in gpt_markdown
-      highlightBuilder: (ctx, inline, style) {
-        // Unmask dollar signs that were protected during preprocessing
-        String unmasked = inline.replaceAll(_codeDollarMask, r'$');
-        String softened = _softBreakInline(unmasked);
-        final csCtx = Theme.of(ctx).colorScheme;
-        final bg = ctx.appColors.surfaceFill;
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          decoration: BoxDecoration(
-            color: bg,
-            borderRadius: BorderRadius.circular(6),
-            border: Border.all(
-              color: csCtx.outlineVariant.withValues(alpha: 0.22),
-            ),
-          ),
-          child: Text(
-            softened,
-            style: TextStyle(
-              fontFamily: codeFontFamily,
-              fontSize: 13,
-              height: 1.4,
-            ).copyWith(color: csCtx.onSurface),
-            softWrap: true,
-            overflow: TextOverflow.visible,
-          ),
-        );
-      },
-      // Fenced code block styling via codeBuilder (with collapse/expand)
-      codeBuilder: (ctx, name, code, closed) {
-        final lang = name.trim();
-        final restoredCode = _unmaskHtmlTagStartsInsideFencedCode(code);
-        if (lang.toLowerCase() == 'mermaid') {
-          return _MermaidBlock(
-            code: restoredCode,
-            streaming: widget.streaming && !closed,
+            ],
+          )
+        : _CachedMarkdownBlock(
+            content: normalized!,
+            signature: themeSignature,
+            builder: buildMarkdown,
           );
-        } else if (lang.toLowerCase() == 'plantuml') {
-          return PlantUMLBlock(code: restoredCode);
-        } else if (lang.toLowerCase() == 'svg') {
-          return SvgPreviewBlock(
-            code: restoredCode,
-            streaming: widget.streaming && !closed,
-          );
-        } else if (_isHtml(lang)) {
-          return HtmlPreviewBlock(
-            code: restoredCode,
-            streaming: widget.streaming && !closed,
-          );
-        }
-        return _CollapsibleCodeBlock(
-          language: lang,
-          code: restoredCode,
-          streaming: widget.streaming,
-          closed: closed,
-        );
-      },
-    );
 
     final result = appFontFamily.isEmpty
         ? markdownWidget
@@ -554,6 +646,198 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
     return Uri.parse(u);
   }
 }
+
+typedef _MarkdownBlockBuilder = Widget Function(String content, Key key);
+
+class _CachedMarkdownBlock extends StatefulWidget {
+  const _CachedMarkdownBlock({
+    super.key,
+    required this.content,
+    required this.signature,
+    required this.builder,
+  });
+
+  final String content;
+  final String signature;
+  final _MarkdownBlockBuilder builder;
+
+  @override
+  State<_CachedMarkdownBlock> createState() => _CachedMarkdownBlockState();
+}
+
+class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
+  Widget? _rendered;
+  String? _identityContent;
+  int _identityEpoch = 0;
+
+  @override
+  void didUpdateWidget(covariant _CachedMarkdownBlock oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.content != widget.content ||
+        oldWidget.signature != widget.signature) {
+      _rendered = null;
+    }
+  }
+
+  Key _parseIdentity(String content) {
+    final previous = _identityContent;
+    if (previous != null &&
+        (content.length < previous.length || !content.startsWith(previous))) {
+      _identityEpoch++;
+    }
+    _identityContent = content;
+    return ValueKey('parsed-markdown-$_identityEpoch');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _rendered ??= widget.builder(
+      widget.content,
+      _parseIdentity(widget.content),
+    );
+  }
+}
+
+/// Whether a whole-document render would fold the blank line after [content]
+/// into the block itself, leaving no gap for a separator to reproduce.
+///
+/// [SoftHrLine] and [LatexBlockScrollableMd] close their pattern with `\s*$`.
+/// The match then runs past the newline that ends the block, so `NewLines`
+/// never sees the `\n\n` it needs and the render lays out no gap. Every other
+/// block — ATX headings included, which only allow horizontal whitespace —
+/// leaves the blank line behind, which is what [_MarkdownBlockSeparator]
+/// stands in for.
+///
+/// This walks in from the end of the block rather than matching a regex over
+/// the whole of it: a pattern like `\$\$[\s\S]*?\$\$\s*$` retries from every
+/// line-leading `$$`, which turns quadratic on a block full of unclosed math,
+/// and the check runs for every stable block on every streaming frame.
+bool _swallowsTrailingBlankLine(String content, {required bool mathEnabled}) {
+  final end = _lastNonWhitespace(content);
+  if (end == 0) return false;
+  if (_isSoftHrLine(content, _lineStartBefore(content, end), end)) return true;
+  return mathEnabled && markdownEndsWithDisplayMath(content, end);
+}
+
+/// One past the last non-whitespace code unit of [content].
+int _lastNonWhitespace(String content) {
+  var end = content.length;
+  while (end > 0 && _isWhitespace(content.codeUnitAt(end - 1))) {
+    end--;
+  }
+  return end;
+}
+
+/// The start of the line that [end] (exclusive) sits on.
+int _lineStartBefore(String content, int end) {
+  var i = end;
+  while (i > 0 && !_isLineBreak(content.codeUnitAt(i - 1))) {
+    i--;
+  }
+  return i;
+}
+
+/// Whether `[start, end)` holds nothing but a run of one rule marker, the way
+/// [SoftHrLine] matches it.
+bool _isSoftHrLine(String content, int start, int end) {
+  var i = start;
+  while (i < end && _isWhitespace(content.codeUnitAt(i))) {
+    i++;
+  }
+  if (i >= end) return false;
+  final marker = content.codeUnitAt(i);
+  if (marker == 0x2E3B) return i + 1 == end; // U+2E3B matched on its own
+  if (marker != 0x2D && marker != 0x2A && marker != 0x5F) return false; // -*_
+  var run = 0;
+  while (i < end && content.codeUnitAt(i) == marker) {
+    i++;
+    run++;
+  }
+  return run >= 3 && i == end;
+}
+
+/// Whitespace as `\s` in a Dart pattern reads it, so leading and trailing runs
+/// are judged the same way the block patterns judge them.
+bool _isWhitespace(int unit) => markdownIsWhitespace(unit);
+
+/// The line terminators `^` and `$` recognise in a multi-line Dart pattern.
+bool _isLineBreak(int unit) => markdownIsLogicalLineBreak(unit);
+
+/// The blank line a whole-document render keeps between two blocks.
+///
+/// `gpt_markdown` renders a run of line breaks through its `NewLines` inline
+/// component, a span of the base font size at a fixed line height, which lays
+/// out as a single blank line however many breaks the run holds. The splitter
+/// only ever ends a block on a run of bare line breaks, so one of these stands
+/// in for every gap it opens.
+class _MarkdownBlockSeparator extends StatelessWidget {
+  const _MarkdownBlockSeparator({required this.style});
+
+  /// The `height` hardcoded by `NewLines` in `gpt_markdown`.
+  static const double _newLinesHeight = 1.15;
+
+  /// The `fontSize` `NewLines` falls back to when the config carries no style.
+  static const double _fallbackFontSize = 14;
+
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    // Lay the blank line out with the text engine instead of computing it as
+    // `fontSize * height`: the engine rounds a line's ascent and descent
+    // separately, off the font's own metrics, so arithmetic here drifts by up
+    // to a pixel per block boundary — a long reply then visibly tightens the
+    // moment it stops streaming. `Text.rich` also picks the text scale up from
+    // the ambient `MediaQuery`, which the whole-document render applies to its
+    // blank lines and a raw `SizedBox` would ignore.
+    //
+    // The paragraph carries the `NewLines` style, and its one run is a space:
+    // the style has to sit on the paragraph because a line box is measured from
+    // the paragraph style when there is no run, and that path rounds
+    // differently from a line that has one. A space is invisible, and the
+    // separator stays out of selection so it cannot be copied.
+    return SelectionContainer.disabled(
+      child: Text.rich(
+        const TextSpan(text: ' '),
+        style: (style ?? const TextStyle()).copyWith(
+          fontSize: style?.fontSize ?? _fallbackFontSize,
+          height: _newLinesHeight,
+        ),
+      ),
+    );
+  }
+}
+
+class _MarkdownBlockColumn extends StatelessWidget {
+  const _MarkdownBlockColumn({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final column = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: children,
+    );
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (!constraints.hasBoundedHeight) return column;
+        return OverflowBox(
+          alignment: Alignment.topCenter,
+          minHeight: 0,
+          maxHeight: double.infinity,
+          child: SizedBox(width: constraints.maxWidth, child: column),
+        );
+      },
+    );
+  }
+}
+
+/// Compact image-list revision. Full URLs — including large data URIs — must
+/// not be copied into every block's cache key.
+int _imageRevision(List<String> urls) =>
+    Object.hash(urls.length, Object.hashAll(urls));
 
 String _displayLanguage(BuildContext context, String? raw) {
   final zh = _isZh(context);
@@ -4673,7 +4957,7 @@ class FencedCodeBlockMd extends BlockMd {
   // - supports both ``` and ~~~
   String get expString =>
       (r"^[ \t]*(([`~])\2{2,})[ \t]*([^\n]*?)\n"
-      r"(?:(?:([\s\S]*?)^[ \t]*\1\2*[ \t]*)|([\s\S]*))");
+      r"(?:(?:([\s\S]*?)^[ \t]*\1\2*[ \t]*$)|([\s\S]*))");
 
   @override
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {
@@ -5127,12 +5411,20 @@ class InlineLatexParenScrollableMd extends InlineMd {
 }
 
 // Balanced ATX-style headings (#, ##, ###, …) with consistent spacing and typography
+/// Single-line ATX. Opening `#{1,6}`, closing `#+`, horizontal blanks only.
+/// Shared by [AtxHeadingMd] and the `## 1.引言` preprocessor so they cannot
+/// drift back into `\s` / cross-line matching.
+const String _atxHeadingLine =
+    r'[ \t]{0,3}(#{1,6})[ \t]+([^\r\n\u2028\u2029]+?)(?:[ \t]+#+[ \t]*)?';
+
 class AtxHeadingMd extends BlockMd {
   @override
-  // Restrict heading content to a single line to avoid swallowing
-  // subsequent blocks (e.g., fenced code) when the engine builds
-  // the regex with dotAll=true. Using [^\n]+ keeps it line-bound.
-  String get expString => (r"^\s{0,3}(#{1,6})\s+([^\n]+?)(?:\s+#+\s*)?$");
+  // `exp` is overridden so BlockMd's `^\ *?` prefix cannot widen the
+  // 0–3 space indent the way `^\ *?^[ \t]{0,3}` would.
+  String get expString => _atxHeadingLine;
+
+  @override
+  RegExp get exp => RegExp('^$_atxHeadingLine\$', multiLine: true);
 
   @override
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {
@@ -5520,6 +5812,8 @@ class _BlockquoteMarkdownContent extends StatelessWidget {
       inlineComponents: config.inlineComponents,
       followLinkColor: config.followLinkColor,
       useDollarSignsForLatex: false,
+      preprocessBlocks: config.preprocessBlocks,
+      generation: config.generation,
     );
   }
 }
@@ -5802,53 +6096,36 @@ class BackslashEscapeMd extends InlineMd {
 }
 
 class DetailsHtmlMd extends BlockMd {
+  DetailsHtmlMd([this.registry]);
+
+  final MarkdownDetailsRegistry? registry;
+
   @override
   RegExp get exp => RegExp(
-    r'^\ *?(?:' + expString + r")$",
+    r'^\ *?(?:' + expString + r')[ \t]*$',
     dotAll: true,
     multiLine: true,
     caseSensitive: false,
   );
 
   @override
-  String get expString => _detailsPattern(6);
+  String get expString =>
+      registry?.placeholderSource ?? MarkdownDetailsWalker.blockPattern();
 
   @override
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {
-    final match = RegExp(
-      r"^<details(?<attrs>[^>]*)>\s*<summary(?:\s+[^>]*)?>(?<summary>[\s\S]*?)<\/summary>(?<body>[\s\S]*)<\/details>$",
-      caseSensitive: false,
-      dotAll: true,
-    ).firstMatch(text.trim());
-
-    if (match == null) {
+    final parsed = registry?.lookup(text) ?? markdownParseDetails(text);
+    if (parsed == null) {
       return config.getRich(TextSpan(text: text, style: config.style));
     }
 
-    final attrs = match.namedGroup('attrs') ?? '';
-    final summary = _plainHtmlText(match.namedGroup('summary') ?? '').trim();
-    final body = (match.namedGroup('body') ?? '').trim();
-    final initiallyExpanded = RegExp(
-      r"(?:^|\s)open(?:\s|$|=)",
-      caseSensitive: false,
-    ).hasMatch(attrs);
-
+    final body = parsed.body.trim();
     return _DetailsHtmlBlock(
-      summary: summary,
-      body: body,
-      initiallyExpanded: initiallyExpanded,
+      summary: _plainHtmlText(parsed.summary).trim(),
+      body: registry?.rewrite(body) ?? body,
+      initiallyExpanded: parsed.initiallyExpanded,
       config: config,
     );
-  }
-
-  static String _detailsPattern(int depth) {
-    final open = r"<details(?:\s+[^>]*)?>";
-    final summary = r"\s*<summary(?:\s+[^>]*)?>[\s\S]*?<\/summary>";
-    if (depth <= 1) {
-      return '$open$summary(?:(?!<details\\b|<\\/details>)[\\s\\S])*<\\/details>';
-    }
-    final nested = _detailsPattern(depth - 1);
-    return '$open$summary(?:(?!<details\\b|<\\/details>)[\\s\\S]|$nested)*<\\/details>';
   }
 
   static String _plainHtmlText(String input) {

--- a/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
@@ -102,50 +102,13 @@ A-->B''',
     },
   );
 
-  testWidgets('streaming thinking preview is truncated to the tail by default '
-      '(issue #232)', (tester) async {
-    const tailMarker = 'TAIL-MARKER-9876';
-    final longThinking = '${'x' * 5000}$tailMarker';
-    await tester.pumpWidget(
-      _buildHarness(
-        child: ChatMessageWidget(
-          message: ChatMessage(
-            id: 'streaming-thinking',
-            role: 'assistant',
-            content: '',
-            conversationId: 'conversation-1',
-            isStreaming: true,
-          ),
-          reasoningText: longThinking,
-          reasoningExpanded: false,
-          reasoningFinishedAt: null,
-          showModelIcon: false,
-        ),
-      ),
-    );
-    await tester.pump();
-
-    final previewMd = tester
-        .widgetList<MarkdownWithCodeHighlight>(
-          find.byType(MarkdownWithCodeHighlight),
-        )
-        .where((md) => md.text.length > 1)
-        .single;
-    expect(previewMd.text.length, lessThanOrEqualTo(2002));
-    expect(previewMd.text, startsWith('…'));
-    expect(previewMd.text, contains(tailMarker));
-  });
-
   testWidgets(
-    'streaming thinking preview renders full text when the truncation '
-    'setting is off',
+    'streaming thinking preview renders the full text while loading',
     (tester) async {
-      final longThinking = '${'x' * 5000}TAIL-MARKER-9876';
+      const tailMarker = 'TAIL-MARKER-9876';
+      final longThinking = '${'x' * 5000}$tailMarker';
       await tester.pumpWidget(
         _buildHarness(
-          initialPrefs: {
-            'display_streaming_thinking_preview_truncate_v1': false,
-          },
           child: ChatMessageWidget(
             message: ChatMessage(
               id: 'streaming-thinking-full',

--- a/test/shared/widgets/incremental_markdown_document_test.dart
+++ b/test/shared/widgets/incremental_markdown_document_test.dart
@@ -1,0 +1,680 @@
+import 'package:Cuplivo/shared/widgets/incremental_markdown_document.dart';
+import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('append-only updates retain completed block identities', () {
+    final document = IncrementalMarkdownDocument();
+    final initial = document.update('first paragraph\n\nsecond');
+    final firstBlock = initial.first;
+
+    final updated = document.update('first paragraph\n\nsecond grows');
+
+    expect(identical(updated.first, firstBlock), isTrue);
+    expect(updated.last.text, 'second grows');
+  });
+
+  test('a line separator before a fence keeps blanks inside the fence', () {
+    for (final mark in const ['\u2028', '\u2029']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'before\n\nText$mark```dart\ncode\n\ninside\n```\n\nafter',
+      );
+      expect(blocks, hasLength(3), reason: mark);
+      expect(blocks[1].text, contains('code\n\ninside'));
+      expect(blocks.last.text, 'after');
+    }
+  });
+
+  test(
+    'a line separator before a tilde fence keeps blanks inside the fence',
+    () {
+      for (final mark in const ['\u2028', '\u2029']) {
+        final document = IncrementalMarkdownDocument();
+        final blocks = document.update(
+          'before\n\nText$mark~~~\ncode\n\ninside\n~~~\n\nafter',
+        );
+        expect(blocks, hasLength(3), reason: mark);
+        expect(blocks[1].text, contains('code\n\ninside'));
+      }
+    },
+  );
+
+  test('a line separator before details keeps blanks inside the details', () {
+    for (final mark in const ['\u2028', '\u2029']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'before\n\nText$mark<details>\n\nbody\n</details>\n\nafter',
+      );
+      expect(blocks, hasLength(3), reason: mark);
+      expect(blocks[1].text, contains('body'));
+      expect(blocks.last.text, 'after');
+    }
+  });
+
+  test('a shorter fence run does not close a longer opening fence', () {
+    for (final item in const [
+      ('````dart\na\n```\n\nb\n````', 'a\n```\n\nb'),
+      ('~~~~\na\n~~~\n\nb\n~~~~', 'a\n~~~\n\nb'),
+      ('`````\na\n```\n\nb\n`````', 'a\n```\n\nb'),
+    ]) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('before\n\n${item.$1}\n\nafter');
+      expect(blocks, hasLength(3), reason: item.$1);
+      expect(blocks[1].text, contains(item.$2), reason: item.$1);
+      expect(blocks.last.text, 'after');
+    }
+  });
+
+  test('a closer with an info string does not close the fence', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'before\n\n```\na\n``` dart\n\nb\n```\n\nafter',
+    );
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('a\n``` dart\n\nb'));
+    expect(blocks.last.text, 'after');
+  });
+
+  test('blank lines inside fences do not split source blocks', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('before\n\n```dart\na\n\nb\n```\n\nafter');
+
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('a\n\nb'));
+  });
+
+  test('blank lines inside display math do not split source blocks', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'before\n\n\$\$\na + b\n\nc + d\n\$\$\n\nafter',
+    );
+
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('a + b\n\nc + d'));
+    expect(blocks[1].text, contains('\$\$'));
+  });
+
+  test(
+    'blank lines inside bracket display math do not split source blocks',
+    () {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'before\n\n\\[\na + b\n\nc + d\n\\]\n\nafter',
+      );
+
+      expect(blocks, hasLength(3));
+      expect(blocks[1].text, contains('a + b\n\nc + d'));
+    },
+  );
+
+  test('blank lines inside details html do not split source blocks', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'before\n\n<details>\n<summary>s</summary>\n\nbody\n\n</details>\n\nafter',
+    );
+
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('body'));
+    expect(blocks[1].text, contains('</details>'));
+  });
+
+  test('blank lines inside a loose list do not split source blocks', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('- first\n\n- second\n\nnext paragraph\n');
+
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, contains('- first\n\n- second'));
+    expect(blocks.last.text, 'next paragraph\n');
+  });
+
+  test('indented list continuation stays in the same source block', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('- item\n\n  still the item\n\nnext\n');
+
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, contains('still the item'));
+    expect(blocks.last.text, 'next\n');
+  });
+
+  test('single-line display math does not swallow the next paragraph', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('\$\$ a + b \$\$\n\nnext');
+
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, r'$$ a + b $$');
+    expect(blocks.last.text, 'next');
+  });
+
+  test('mid-paragraph display math follows successful spans only', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('说明文字 \$\$\na + b\n\nc + d\n\$\$\n\nafter');
+
+    expect(blocks.length, greaterThanOrEqualTo(2));
+    expect(blocks.last.text, contains('after'));
+  });
+
+  test('mid-paragraph bracket display math follows successful spans only', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('说明文字 \\[\na + b\n\nc + d\n\\]\n\nafter');
+
+    expect(blocks.length, greaterThanOrEqualTo(2));
+    expect(blocks.last.text, 'after');
+  });
+
+  test('list-item display math follows successful spans only', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      '- see \$\$\na + b\n\nc + d\n\$\$\n\nafter\n',
+    );
+
+    expect(blocks.length, greaterThanOrEqualTo(2));
+    expect(blocks.last.text, contains('after'));
+  });
+
+  test('inline code dollars do not start display math protection', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'Use `\$\$` as currency.\n\nFirst paragraph.\n\nSecond paragraph.',
+    );
+
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, startsWith('First paragraph.'));
+    expect(blocks.last.text, 'Second paragraph.');
+  });
+
+  test(
+    'closed display math on a line can still open a later bracket block',
+    () {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'text \$\$ a \$\$ \\[\nb\n\nc\n\\]\n\nafter',
+      );
+
+      expect(blocks.length, greaterThanOrEqualTo(2));
+      expect(blocks.last.text, 'after');
+    },
+  );
+
+  test('an unclosed math blank is not committed before the closer arrives', () {
+    final document = IncrementalMarkdownDocument();
+    final first = document.update('\$\$\na\n\n');
+    expect(first, hasLength(1));
+    expect(first.single.stable, isFalse);
+
+    final second = document.update('\$\$\na\n\nb\n\$\$\n\nafter');
+    expect(second, hasLength(2));
+    expect(second.first.text, contains('a\n\nb'));
+    expect(second.last.text, 'after');
+  });
+
+  test('splitter math scan visits stay linear across append chunks', () {
+    _expectDocumentLinearScan((_) => '0123456789abcdef', chunks: 200);
+  });
+
+  test('math-dense splitter scans stay linear one-shot and chunked', () {
+    _expectDocumentLinearScan((_) => '\$\$\nx\n\$\$\n\n', chunks: 80);
+  });
+
+  test('fence-dense splitter scans stay linear one-shot and chunked', () {
+    _expectDocumentLinearScan((_) => '```\nx\n```\n\n', chunks: 80);
+  });
+
+  test('fence indent is horizontal whitespace for the splitter', () {
+    for (final indent in const [' ', '  ', '\t', ' \t']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'before\n\n$indent```\ncode\n\ninside\n```\n\nafter',
+      );
+      expect(blocks, hasLength(3), reason: indent);
+      expect(blocks[1].text, contains('code\n\ninside'), reason: indent);
+      expect(blocks.last.text, 'after', reason: indent);
+    }
+    for (final indent in const ['\u00a0', '\u2003', '\u3000']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        'before\n\n$indent```\ncode\n\ninside\n```\n\nafter',
+      );
+      expect(
+        blocks.any(
+          (block) =>
+              block.text.contains('code') && block.text.contains('inside'),
+        ),
+        isFalse,
+        reason: 'wide space $indent must not keep a fence blank together',
+      );
+    }
+  });
+
+  test('a tailed dollar closer does not split a later successful span', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('\$\$\n\$\$ tail\n\ninside\n\$\$\n\nafter');
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, contains('inside'));
+    expect(blocks.last.text, 'after');
+  });
+
+  test('crossed nested openers stay one successful bracket span', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('\\[\n\$\$\n\\[\n\$\$\n\\]\n\nafter');
+    expect(blocks, hasLength(2));
+    expect(blocks.last.text, 'after');
+  });
+
+  test('inline code details tags do not freeze later paragraph splits', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'Use `<details>` to create a collapsible section.\n\n'
+      'First paragraph.\n\n'
+      'Second paragraph.',
+    );
+
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, startsWith('First paragraph.'));
+    expect(blocks.last.text, 'Second paragraph.');
+  });
+
+  test('prose details mention does not freeze later paragraph splits', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'Use <details> to create a collapsible section.\n\n'
+      'First paragraph.\n\n'
+      'Second paragraph.',
+    );
+
+    expect(blocks, hasLength(3));
+  });
+
+  test('seven nested details keep inner blanks in one block', () {
+    final document = IncrementalMarkdownDocument();
+    final nested = [
+      for (var i = 1; i <= 7; i++) '<details>\n<summary>L$i</summary>',
+      'deep-body',
+      for (var i = 0; i < 7; i++) '</details>',
+    ].join('\n');
+    final blocks = document.update('before\n\n$nested\n\nafter');
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('deep-body'));
+    expect(blocks.last.text, 'after');
+  });
+
+  test('a cross-line details opener does not protect later blanks', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'before\n\n<details\nopen>\n<summary>s</summary>\n\nbody\n</details>\n\nafter',
+    );
+    expect(blocks, hasLength(4));
+    expect(blocks.first.text, 'before');
+    expect(blocks.last.text, 'after');
+  });
+
+  test('mid-line nested details keep the outer block together', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update(
+      'before\n\n'
+      '<details>\n'
+      '<summary>outer</summary>\n'
+      'prefix <details>\n'
+      '<summary>inner</summary>\n\n'
+      'inner body\n'
+      '</details>\n\n'
+      'outer body\n'
+      '</details>\n\n'
+      'after',
+    );
+    expect(blocks, hasLength(3));
+    expect(blocks[1].text, contains('inner body'));
+    expect(blocks[1].text, contains('outer body'));
+    expect(blocks.last.text, 'after');
+  });
+
+  test(
+    'inline details in a details body do not leave the outer block open',
+    () {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        '<details>\n<summary>s</summary>\n'
+        'Use `<details>` here\n\n'
+        'more\n'
+        '</details>\n\n'
+        'after',
+      );
+      expect(blocks, hasLength(2));
+      expect(blocks.last.text, 'after');
+    },
+  );
+
+  test(
+    'inline details tags inside a details summary do not freeze later splits',
+    () {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(
+        '<details><summary>Use `<details>`</summary>\n\n'
+        'body\n'
+        '</details>\n\n'
+        'after',
+      );
+
+      expect(blocks, hasLength(2));
+      expect(blocks.first.text, contains('</details>'));
+      expect(blocks.last.text, 'after');
+    },
+  );
+
+  test('1 MiB append stream scans each source code unit once', () {
+    final document = IncrementalMarkdownDocument();
+    var source = '';
+    final chunk = List<String>.filled(256, '0123456789abcdef').join();
+    for (var index = 0; index < 256; index++) {
+      source += chunk;
+      document.update(source);
+    }
+
+    expect(source.length, 1 << 20);
+    expect(document.rescannedCodeUnits, source.length);
+    expect(document.blocks, hasLength(1));
+  });
+
+  test('extra blank lines do not replace a completed block', () {
+    final document = IncrementalMarkdownDocument();
+    final first = document.update('first paragraph\n\n');
+    final firstBlock = first.single;
+
+    final grown = document.update('first paragraph\n\n\n');
+    expect(identical(grown.single, firstBlock), isTrue);
+    expect(grown.single.text, firstBlock.text);
+    expect(grown.single.text, 'first paragraph');
+
+    final again = document.update('first paragraph\n\n\n\n');
+    expect(identical(again.single, firstBlock), isTrue);
+    expect(again.single.text, 'first paragraph');
+  });
+
+  test('C# paragraphs do not collapse into one block', () {
+    final paragraphs = [for (var i = 0; i < 20; i++) 'Language: C# sample $i'];
+    for (final ending in const ['', '\n', '\n\n']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('${paragraphs.join('\n\n')}$ending');
+      expect(blocks, hasLength(20), reason: 'ending ${ending.length} LFs');
+      expect(_startsAreMonotonicAndUnique(blocks), isTrue);
+    }
+  });
+
+  test('indented unfinished tail is returned with the previous block', () {
+    final document = IncrementalMarkdownDocument();
+    final withoutNewline = document.update('A\n\n    # Heading #');
+    expect(withoutNewline, hasLength(1));
+    expect(withoutNewline.single.text, 'A\n\n    # Heading #');
+
+    final withNewline = document.update('A\n\n    # Heading #\n');
+    expect(withNewline, hasLength(1));
+    expect(withNewline.single.text, 'A\n\n    # Heading #\n');
+
+    final closed = document.update('A\n\n    # Heading #\n\nNext');
+    expect(closed, hasLength(2));
+    expect(closed.first.text, 'A\n\n    # Heading #');
+    expect(closed.last.text, 'Next');
+  });
+
+  test('whitespace-only indent tail keeps the stable block identical', () {
+    final document = IncrementalMarkdownDocument();
+    final first = document.update('A\n\n').single;
+    expect(first.stable, isTrue);
+
+    final afterSpaces = document.update('A\n\n    ');
+    expect(identical(afterSpaces.single, first), isTrue);
+    expect(afterSpaces.single.stable, isTrue);
+    expect(afterSpaces.single.text, 'A');
+
+    final afterHeading = document.update('A\n\n    # Heading #');
+    expect(afterHeading, hasLength(1));
+    expect(afterHeading.single.stable, isFalse);
+    expect(identical(afterHeading.single, first), isFalse);
+    expect(afterHeading.single.text, 'A\n\n    # Heading #');
+  });
+
+  test('only the unfinished tail is marked unstable', () {
+    final document = IncrementalMarkdownDocument();
+    final blocks = document.update('first\n\nsecond');
+    expect(blocks.first.stable, isTrue);
+    expect(blocks.last.stable, isFalse);
+  });
+
+  test('CR then LF across updates is one newline', () {
+    final document = IncrementalMarkdownDocument();
+    document.update('A\r');
+    final blocks = document.update('A\r\n\nB');
+    expect(blocks, hasLength(2));
+    expect(blocks.first.text, 'A');
+    expect(blocks.last.text, 'B');
+  });
+
+  test('a CR-free append reuses the caller source string', () {
+    final document = IncrementalMarkdownDocument();
+    var source = 'Hello';
+    document.update(source);
+    expect(document.debugReusesCallerSource, isTrue);
+
+    source += ' world';
+    document.update(source);
+    expect(document.debugReusesCallerSource, isTrue);
+    expect(document.blocks.single.text, 'Hello world');
+  });
+
+  test('a CR forces a normalized copy of the source', () {
+    final document = IncrementalMarkdownDocument();
+    document.update('A\r\nB');
+    expect(document.debugReusesCallerSource, isFalse);
+    expect(document.blocks.single.text, 'A\nB');
+  });
+
+  test('a CR in an earlier chunk does not rescan the whole source', () {
+    final document = IncrementalMarkdownDocument();
+    var source = 'A\r';
+    document.update(source);
+    final afterCR = document.rescannedCodeUnits;
+    for (var i = 0; i < 100; i++) {
+      source += 'x';
+      document.update(source);
+    }
+    expect(document.rescannedCodeUnits, afterCR + 100);
+  });
+
+  test('line-separator and paragraph-separator are not safe boundaries', () {
+    for (final mark in const ['\u2028', '\u2029']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('A\n$mark\nB');
+      expect(
+        blocks,
+        hasLength(1),
+        reason: 'U+${mark.codeUnitAt(0).toRadixString(16)}',
+      );
+      expect(blocks.single.text, 'A\n$mark\nB');
+    }
+  });
+
+  test('CRLF and bare CR split like LF after normalization', () {
+    for (final pair in const [
+      ('A\r\n\r\nB', 'A'),
+      ('A\r\rB', 'A'),
+      ('A\n\nB', 'A'),
+    ]) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(pair.$1);
+      expect(blocks, hasLength(2), reason: pair.$1);
+      expect(blocks.first.text, pair.$2);
+      expect(blocks.last.text, 'B');
+    }
+  });
+
+  test('nbsp and next-line are content inside a blank run', () {
+    for (final mark in const ['\u00a0', '\u0085', ' ', '\t']) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('A\n$mark\nB');
+      expect(blocks, hasLength(1), reason: 'mark ${mark.codeUnits}');
+    }
+  });
+
+  test('ATX opening hashes do not span a blank line', () {
+    for (final source in const ['#\n\nHeading #', '###\n\nHeading ###']) {
+      for (final ending in const ['', '\n', '\n\n']) {
+        final document = IncrementalMarkdownDocument();
+        final blocks = document.update('$source$ending');
+        expect(
+          blocks.length,
+          greaterThanOrEqualTo(2),
+          reason: '$source ending ${ending.length}',
+        );
+      }
+    }
+  });
+
+  test('seven or more hashes after a heading stay their own block', () {
+    for (final hashes in const [1, 6, 7, 20]) {
+      final closer = '#' * hashes;
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('# Heading\n\n$closer\n\nNext');
+      expect(blocks, hasLength(3), reason: '$hashes closing hashes');
+      expect(blocks[1].text, closer);
+    }
+  });
+
+  test('same-line closing hashes do not merge the next paragraph', () {
+    for (final hashes in const [1, 6, 7, 20]) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update('# Heading ${'#' * hashes}\n\nNext');
+      expect(blocks, hasLength(2), reason: '$hashes closing hashes');
+      expect(blocks.last.text, 'Next');
+    }
+  });
+
+  test(
+    'leading spaces and tabs keep an unfinished heading with the block above',
+    () {
+      for (final indent in const ['', ' ', '   ', '    ', '\t']) {
+        for (final ending in const ['', '\n', '\n\n']) {
+          final document = IncrementalMarkdownDocument();
+          final source = 'A\n\n$indent# Heading #$ending';
+          final blocks = document.update(source);
+          expect(_startsAreMonotonicAndUnique(blocks), isTrue, reason: source);
+          expect(blocks, hasLength(indent.isEmpty ? 2 : 1), reason: source);
+        }
+      }
+    },
+  );
+
+  test('ordinary paragraphs grow one stable block per paragraph', () {
+    final document = IncrementalMarkdownDocument();
+    var source = 'paragraph 1\n\n';
+    var blocks = document.update(source);
+    expect(blocks, hasLength(1));
+    final first = blocks.single;
+    for (var i = 2; i <= 8; i++) {
+      source = '${source}paragraph $i\n\n';
+      blocks = document.update(source);
+      expect(blocks, hasLength(i));
+      expect(_startsAreMonotonicAndUnique(blocks), isTrue);
+      expect(identical(blocks.first, first), isTrue);
+    }
+  });
+
+  test('lists, fences, details and tables still split on the far side', () {
+    const cases = <(String, int)>[
+      ('- one\n\n- two\n\nnext\n', 2),
+      ('```dart\na\n\nb\n```\n\nafter\n', 2),
+      ('<details>\n<summary>s</summary>\n\nbody\n</details>\n\nafter\n', 2),
+      ('| a | b |\n| --- | --- |\n| 1 | 2 |\n\nafter\n', 2),
+      ('before\n\n- one\n\n- two\n', 2),
+      ('before\n\n```\ncode\n```\n', 2),
+      ('before\n\n<details>\nbody\n</details>\n', 2),
+      ('before\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n', 2),
+    ];
+    for (final item in cases) {
+      final document = IncrementalMarkdownDocument();
+      final blocks = document.update(item.$1);
+      expect(blocks, hasLength(item.$2), reason: item.$1);
+    }
+  });
+
+  test(
+    'a second standalone formula does not freeze the following paragraph',
+    () {
+      for (final math in const [
+        r'$$a$$'
+            '\ntext\n'
+            r'$$b$$',
+        r'\[a\]'
+            '\ntext\n'
+            r'\[b\]',
+        r'$$a$$'
+            '\ntext\n'
+            r'\[b\]',
+        r'\[a\]'
+            '\ntext\n'
+            r'$$b$$',
+      ]) {
+        final document = IncrementalMarkdownDocument();
+        final blocks = document.update('$math\n\nNext');
+        expect(blocks, hasLength(2), reason: math);
+        expect(blocks.last.text, 'Next');
+      }
+    },
+  );
+
+  test('streaming prefixes of an indented tail stay one visible block', () {
+    const full = 'A\n\n    # Heading #\n\nNext';
+    final document = IncrementalMarkdownDocument();
+    IncrementalMarkdownBlock? first;
+    for (var end = 1; end <= full.length; end++) {
+      final blocks = document.update(full.substring(0, end));
+      expect(_startsAreMonotonicAndUnique(blocks), isTrue, reason: '[:$end]');
+      if (blocks.isEmpty) continue;
+      first ??= blocks.first;
+      expect(blocks.first.start, first.start);
+    }
+    expect(first, isNotNull);
+    expect(document.blocks, hasLength(2));
+    expect(document.blocks.first.stable, isTrue);
+    expect(document.blocks.last.stable, isFalse);
+  });
+}
+
+void _expectDocumentLinearScan(
+  String Function(int index) chunk, {
+  required int chunks,
+}) {
+  final full = StringBuffer();
+  for (var i = 0; i < chunks; i++) {
+    full.write(chunk(i));
+  }
+  final text = full.toString();
+  debugResetMarkdownScanVisits();
+  IncrementalMarkdownDocument().update(text);
+  expect(
+    debugMarkdownScanVisits,
+    lessThanOrEqualTo(text.length * debugMarkdownScanVisitBudgetFactor),
+  );
+
+  final document = IncrementalMarkdownDocument();
+  var source = '';
+  debugResetMarkdownScanVisits();
+  for (var i = 0; i < chunks; i++) {
+    source += chunk(i);
+    document.update(source);
+  }
+  expect(
+    debugMarkdownScanVisits,
+    lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+  );
+}
+
+bool _startsAreMonotonicAndUnique(List<IncrementalMarkdownBlock> blocks) {
+  final seen = <int>{};
+  var previous = -1;
+  for (final block in blocks) {
+    if (block.start <= previous) return false;
+    if (!seen.add(block.start)) return false;
+    previous = block.start;
+  }
+  return true;
+}

--- a/test/shared/widgets/markdown_line_lexer_test.dart
+++ b/test/shared/widgets/markdown_line_lexer_test.dart
@@ -1,0 +1,730 @@
+import 'package:Cuplivo/shared/widgets/incremental_markdown_document.dart';
+import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
+import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+String _unmatchedBacktickRuns({int maxRun = 200}) {
+  final buffer = StringBuffer();
+  for (var n = 1; n <= maxRun; n++) {
+    if (n > 1) buffer.write(' ');
+    buffer.write('`' * n);
+  }
+  return buffer.toString();
+}
+
+void main() {
+  tearDown(debugDisableMarkdownScanVisits);
+
+  test('unclosed inline code does not hide a later display-math closer', () {
+    const content = '`unclosed\n\$\$ `x` \$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test(
+    'a mid-line details mention does not hide a later display-math closer',
+    () {
+      const content = 'Use <details> here\n\$\$b\$\$';
+      expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    },
+  );
+
+  test('a line-leading details block does hide math inside it', () {
+    const content = '<details>\n\$\$b\$\$\n</details>';
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+  });
+
+  test('fence markers are recognized before inline backticks', () {
+    const content = '```\n`\$\$\n```\n\$\$b\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('a line separator is a logical break for display math', () {
+    const content = 'Text\u2028\$\$b\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('a paragraph separator is a logical break for display math', () {
+    const content = 'Text\u2029\$\$b\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('a carriage return is a logical break for display math', () {
+    const content = 'Text\r\$\$b\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('display-math walk visits stay linear on a long space line', () {
+    final content = '${' ' * 4000}\n\$\$x\$\$';
+    debugResetMarkdownScanVisits();
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(content.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('display-math walk visits stay linear on unmatched backtick runs', () {
+    final content = '${_unmatchedBacktickRuns()}\n\$\$x\$\$';
+    debugResetMarkdownScanVisits();
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(content.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('a longer fence is not closed by a shorter run of the same marker', () {
+    const content = '````\n```\n\$\$b\$\$\n````';
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+  });
+
+  test('a longer fence still allows math after a matching closer', () {
+    const content = '````\n```\n\$\$b\$\$\n````\n\$\$c\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+  });
+
+  test('a tilde fence is not closed by backticks', () {
+    const content = '~~~\n```\n\$\$b\$\$\n~~~';
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+  });
+
+  test(
+    'display-math walk visits stay linear on many short inline-code spans',
+    () {
+      final spans = List<String>.filled(3000, '`x`').join(' ');
+      expect(debugBacktickJumpSlotCount(spans), 3000);
+      debugResetMarkdownScanVisits();
+      final content = '$spans\n\$\$y\$\$';
+      expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+      expect(
+        debugMarkdownScanVisits,
+        lessThanOrEqualTo(content.length * debugMarkdownScanVisitBudgetFactor),
+      );
+    },
+  );
+
+  test('backtick jump table scales with run count on a long line', () {
+    final line = '${'a' * 200000}`x`${'b' * 200000}';
+    expect(debugBacktickJumpSlotCount(line), 1);
+    debugResetMarkdownScanVisits();
+    final content = '$line\n\$\$x\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(content.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('a successful dollar span discards an inner bracket opener', () {
+    const content = '\$\$\n\\[\n\$\$\n\\]';
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+    expect(_scanEnds(content), _rendererEnds(content));
+  });
+
+  test('a successful bracket span discards an inner dollar opener', () {
+    const content = '\\[\n\$\$\n\\]\n\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+    expect(_scanEnds(content), _rendererEnds(content));
+  });
+
+  test('an unclosed bracket does not hide a later dollar span', () {
+    const content = '\\[\n\$\$\nx\n\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(_scanEnds(content), _rendererEnds(content));
+  });
+
+  test('an unclosed dollar does not hide a later bracket span', () {
+    const content = '\$\$\n\\[\nx\n\\]';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(_scanEnds(content), _rendererEnds(content));
+  });
+
+  test('a tailed closer does not end a later successful dollar span', () {
+    const content = '\$\$\n\$\$ tail\n\ninside\n\$\$';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(_normalizedSpans(content), _rendererSpans(content));
+  });
+
+  test('crossed nested openers end on the outer bracket closer', () {
+    const content = '\\[\n\$\$\n\\[\n\$\$\n\\]';
+    expect(markdownEndsWithDisplayMath(content, content.length), isTrue);
+    expect(_normalizedSpans(content), _rendererSpans(content));
+  });
+
+  test('a successful dollar span treats an inner fence marker as content', () {
+    const content = '\$\$\n```\n\$\$';
+    expect(markdownScanDisplayMath(content).spans, hasLength(1));
+    expect(_normalizedSpans(content), _rendererSpans(content));
+  });
+
+  test('an earlier unclosed fence still hides later math', () {
+    const content = '```\n\$\$\nx\n\$\$';
+    expect(markdownScanDisplayMath(content).spans, isEmpty);
+    expect(markdownEndsWithDisplayMath(content, content.length), isFalse);
+  });
+
+  test('an unclosed dollar opener does not occupy later details', () {
+    const content = '\$\$\n<details><summary>s</summary>body</details>';
+    expect(markdownScanDisplayMath(content).spans, isEmpty);
+    final registry = MarkdownDetailsRegistry(enableMath: true);
+    expect(registry.lookup(registry.rewrite(content)), isNotNull);
+  });
+
+  test(
+    'details inside a successful dollar span do not steal a later block',
+    () {
+      const source =
+          '\$\$\n<details>\n\$\$\n'
+          '<details><summary>real</summary>body</details>';
+      final registry = MarkdownDetailsRegistry(enableMath: true);
+      expect(registry.lookup(registry.rewrite(source))!.summary, 'real');
+    },
+  );
+
+  test(
+    'an indented dollar line with a details closer does not change depth',
+    () {
+      const source =
+          '\$\$\n'
+          '  \$\$ </details>\n'
+          '\$\$\n'
+          '<details><summary>real</summary>body</details>';
+      final registry = MarkdownDetailsRegistry(enableMath: true);
+      expect(registry.lookup(registry.rewrite(source))!.summary, 'real');
+    },
+  );
+
+  test(
+    'an indented dollar line with a details opener does not steal a block',
+    () {
+      const source =
+          '\$\$\n'
+          '  \$\$ <details>\n'
+          '\$\$\n'
+          '<details><summary>real</summary>body</details>';
+      final registry = MarkdownDetailsRegistry(enableMath: true);
+      expect(registry.lookup(registry.rewrite(source))!.summary, 'real');
+    },
+  );
+
+  test('math inside outer details does not close the outer block', () {
+    const source =
+        '<details><summary>outer</summary>\n'
+        '\$\$\n'
+        '  \$\$ </details>\n'
+        '\$\$\n'
+        'body\n'
+        '</details>';
+    final registry = MarkdownDetailsRegistry(enableMath: true);
+    final block = registry.lookup(registry.rewrite(source));
+    expect(block, isNotNull);
+    expect(block!.summary, 'outer');
+    expect(block.body, contains('body'));
+  });
+
+  test('details after a closed formula still extract', () {
+    const source =
+        '\$\$\nx\n\$\$\n'
+        '<details><summary>real</summary>body</details>';
+    final registry = MarkdownDetailsRegistry(enableMath: true);
+    expect(registry.lookup(registry.rewrite(source))!.summary, 'real');
+  });
+
+  test('appending plain text keeps later spans after an unresolved opener', () {
+    const first = '\$\$\n```\ncode\n```\n\\[\nx\n\\]\n';
+    const next = '${first}plain tail';
+    final scanner = MarkdownDisplayMathScanner();
+    expect([
+      for (final span in scanner.synchronize(first).spans)
+        (span.start, span.end),
+    ], _normalizedSpans(first));
+    expect([
+      for (final span in scanner.synchronize(next).spans)
+        (span.start, span.end),
+    ], _normalizedSpans(next));
+  });
+
+  test('chunked scanner spans match one-shot on math-dense input', () {
+    final scanner = MarkdownDisplayMathScanner();
+    var source = '';
+    for (var i = 0; i < 20; i++) {
+      source += '\$\$\nx$i\n\$\$\n\n';
+      expect(
+        [
+          for (final span in scanner.synchronize(source).spans)
+            (span.start, span.end),
+        ],
+        [
+          for (final span in markdownScanDisplayMath(source).spans)
+            (span.start, span.end),
+        ],
+      );
+    }
+  });
+
+  test('single-shot and chunked scans stay linear on ordinary text', () {
+    _expectLinearScan((_) => '0123456789abcdef', chunks: 200);
+  });
+
+  test('single-shot and chunked scans stay linear on math-dense text', () {
+    _expectLinearScan((_) => '\$\$\nx\n\$\$\n\n', chunks: 80);
+  });
+
+  test('single-shot and chunked scans stay linear on fence-dense text', () {
+    _expectLinearScan((_) => '```\nx\n```\n\n', chunks: 80);
+  });
+
+  test('fence indent is horizontal whitespace for scanner and renderer', () {
+    for (final indent in const [' ', '  ', '\t', ' \t']) {
+      _expectFenceWhitespace(indent, isFence: true);
+    }
+    for (final indent in const ['\u00a0', '\u2003', '\u3000']) {
+      _expectFenceWhitespace(indent, isFence: false);
+    }
+  });
+
+  test(
+    'display-math spans match LatexBlockScrollableMd on 1-6 line inputs',
+    () {
+      const atoms = <String>[r'$$', r'$$ tail', r'\[', r'\]', 'inside', ''];
+      var cases = 0;
+      void walk(List<String> lines) {
+        final content = lines.join('\n');
+        expect(
+          _normalizedSpans(content),
+          _rendererSpans(content),
+          reason: content.replaceAll('\n', r'\n'),
+        );
+        cases++;
+      }
+
+      void expand(List<String> prefix, int remaining) {
+        if (remaining == 0) {
+          walk(prefix);
+          return;
+        }
+        for (final atom in atoms) {
+          expand([...prefix, atom], remaining - 1);
+        }
+      }
+
+      for (var n = 1; n <= 6; n++) {
+        expand(const [], n);
+      }
+      expect(cases, greaterThan(8000));
+    },
+  );
+
+  test('details walker and DetailsHtmlMd agree on a one-line block', () {
+    _expectDetailsContract(
+      '<details><summary>s</summary>body</details>',
+      isDetails: true,
+    );
+  });
+
+  test('details walker and DetailsHtmlMd agree on inline-code tags', () {
+    const source =
+        '<details>\n<summary>s</summary>\nUse `<details>` here\n\nmore\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+    final parsed = markdownParseDetails(source)!;
+    expect(parsed.summary, 's');
+    expect(parsed.body, contains('more'));
+    expect(parsed.body, contains('`<details>`'));
+  });
+
+  test('details walker and DetailsHtmlMd reject a cross-line opener', () {
+    const source = '<details\nopen>\n<summary>s</summary>\n\nbody\n</details>';
+    _expectDetailsContract(source, isDetails: false);
+  });
+
+  test('details walker and DetailsHtmlMd agree on a mid-line nested block', () {
+    const source =
+        '<details>\n<summary>outer</summary>\n'
+        'prefix <details>\n<summary>inner</summary>\n\n'
+        'inner body\n</details>\n\nouter body\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+  });
+
+  test(
+    'details walker and DetailsHtmlMd agree on inline-code in a summary',
+    () {
+      const source =
+          '<details><summary>Use `<details>`</summary>\n\nbody\n</details>';
+      _expectDetailsContract(source, isDetails: true);
+    },
+  );
+
+  test('details walker and DetailsHtmlMd accept six nested layers', () {
+    _expectDetailsContract(_nestedDetails(6), isDetails: true);
+  });
+
+  test('unclosed details with many code spans stays linear', () {
+    final source =
+        '<details><summary>s</summary>${List.filled(20, '`x`').join(' ')}';
+    _expectUnclosedDetailsScan(source);
+  });
+
+  test('unclosed details with a long backtick run stays linear', () {
+    for (final n in const [40, 60]) {
+      _expectUnclosedDetailsScan('<details><summary>s</summary>${'`' * n}');
+    }
+  });
+
+  test('mixed backtick runs pair the same way as the walker', () {
+    _expectDetailsContract(
+      r'<details><summary>s</summary>`x```<details>y`</details>',
+      isDetails: true,
+    );
+    const remixed = r'<details><summary>s</summary>``x``<details>y``</details>';
+    final walker = MarkdownDetailsWalker()..consumeText(remixed);
+    expect(walker.depth, 1);
+    expect(markdownParseDetails(remixed), isNull);
+    expect(_detailsExpMatches(remixed), isFalse);
+  });
+
+  test('a same-line details prefix without > stays body text', () {
+    const source =
+        '<details><summary>s</summary>before <details missing </details>';
+    _expectDetailsContract(source, isDetails: true);
+    expect(markdownParseDetails(source)!.body, contains('<details missing'));
+  });
+
+  test('details regex does not rematch later backticks as a code span', () {
+    const source = r'<details><summary>s</summary>`x`<details>y`</details>';
+    final walker = MarkdownDetailsWalker()..consumeText(source);
+    expect(walker.depth, 1);
+    expect(markdownDetailsExtent(source), -1);
+    expect(markdownParseDetails(source), isNull);
+    expect(_detailsExpMatches(source), isFalse);
+  });
+
+  test(
+    'details pattern stays case-insensitive after generate recompiles it',
+    () {
+      final recompiled = RegExp(
+        DetailsHtmlMd().exp.pattern,
+        multiLine: true,
+        dotAll: true,
+      );
+      expect(
+        recompiled.hasMatch('<DETAILS><SUMMARY>s</SUMMARY>more</DETAILS>'),
+        isTrue,
+      );
+      expect(
+        recompiled.hasMatch('<Details><Summary>s</Summary>more</Details>'),
+        isTrue,
+      );
+    },
+  );
+
+  test('details walker and DetailsHtmlMd agree on uppercase tags', () {
+    _expectDetailsContract(
+      '<DETAILS><SUMMARY>s</SUMMARY>more</DETAILS>',
+      isDetails: true,
+    );
+    _expectDetailsContract(
+      '<Details><Summary>s</Summary>more</Details>',
+      isDetails: true,
+    );
+  });
+
+  test('a dotted details lookalike stays body text', () {
+    const source =
+        '<details>\n<summary>s</summary>\n<details.foo>\n\nmore\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+    expect(markdownParseDetails(source)!.body, contains('<details.foo>'));
+  });
+
+  test('a self-closing details lookalike stays body text', () {
+    const source =
+        '<details>\n<summary>s</summary>\n<details/>\n\nmore\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+  });
+
+  test('an unclosed details prefix in the body stays body text', () {
+    const source =
+        '<details>\n<summary>s</summary>\nsee <details\n\nmore\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+  });
+
+  test('inline-code lookalikes do not hide a details block', () {
+    const source =
+        '<details>\n<summary>s</summary>\n'
+        'Use `<details.foo>` and `<DETAILS>` here\n\nmore\n</details>';
+    _expectDetailsContract(source, isDetails: true);
+  });
+
+  test('a seventh nested layer overflows and is not one details block', () {
+    final source = _nestedDetails(7);
+    final walker = MarkdownDetailsWalker()..consumeText(source);
+    expect(walker.depth, 0);
+    expect(walker.overflowed, isTrue);
+    expect(markdownDetailsExtent(source), -1);
+    expect(markdownParseDetails(source), isNull);
+    expect(MarkdownDetailsRegistry().rewrite(source), source);
+    expect(_detailsExpMatches(source), isFalse);
+  });
+
+  test('splitter visits stay linear on unmatched backtick runs', () {
+    final source = 'before\n\n${_unmatchedBacktickRuns()}\n\nafter';
+    debugResetMarkdownScanVisits();
+    final blocks = IncrementalMarkdownDocument().update(source);
+    expect(blocks, hasLength(3));
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('details rewrite leaves ordinary inline code and U+E002 unchanged', () {
+    const compare = 'Use `a < b` now';
+    const tagged = 'Use `<details>` here';
+    const doubled = r'Use ``a < b`` now';
+    const unclosed = '<details><summary>s</summary>`a < b` still open';
+    const privateUse = 'hello \uE002 world';
+    for (final source in [compare, tagged, doubled, unclosed, privateUse]) {
+      expect(MarkdownDetailsRegistry().rewrite(source), source);
+    }
+  });
+
+  test('details rewrite replaces a complete block with a placeholder', () {
+    const source = '<details><summary>s</summary>`a < b`</details>';
+    final registry = MarkdownDetailsRegistry();
+    final rewritten = registry.rewrite(source);
+    expect(rewritten, isNot(source));
+    expect(registry.hasIssuedPlaceholders, isTrue);
+    final parsed = registry.lookup(rewritten)!;
+    expect(parsed.summary, 's');
+    expect(parsed.body, '`a < b`');
+    expect(DetailsHtmlMd(registry).exp.hasMatch(rewritten), isTrue);
+  });
+
+  test('extract does not promote a closed block inside an unclosed outer', () {
+    const source =
+        '<details>\n<summary>A</summary>\nunclosed\n'
+        '<details><summary>B</summary>body B</details>';
+    final walker = MarkdownDetailsWalker()..consumeText(source);
+    expect(walker.depth, 1);
+    expect(MarkdownDetailsRegistry().rewrite(source), source);
+    expect(_detailsExpMatches(source), isFalse);
+  });
+
+  test(
+    'extract visits stay linear on consecutive unclosed details openers',
+    () {
+      final source = List.filled(100, '<details>').join('\n');
+      expect(source.length, 999);
+      debugResetMarkdownScanVisits();
+      expect(MarkdownDetailsRegistry().rewrite(source), source);
+      expect(
+        debugMarkdownScanVisits,
+        lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+      );
+    },
+  );
+
+  test('a same-line tail is not rewritten to a placeholder', () {
+    const source = '<details><summary>s</summary>body</details> tail';
+    expect(markdownParseDetails(source), isNotNull);
+    expect(MarkdownDetailsRegistry().rewrite(source), source);
+    expect(_detailsExpMatches(source), isFalse);
+  });
+
+  test('trailing spaces stay a block-boundary placeholder', () {
+    const source = '<details><summary>s</summary>body</details>  ';
+    final registry = MarkdownDetailsRegistry();
+    final rewritten = registry.rewrite(source);
+    expect(registry.hasIssuedPlaceholders, isTrue);
+    expect(DetailsHtmlMd(registry).exp.hasMatch(rewritten), isTrue);
+    expect(registry.lookup(rewritten)!.summary, 's');
+  });
+
+  test('same-line adjacent details are not rewritten', () {
+    const source =
+        '<details><summary>A</summary>a</details>'
+        '<details><summary>B</summary>b</details>';
+    expect(MarkdownDetailsRegistry().rewrite(source), source);
+    expect(_detailsExpMatches(source), isFalse);
+  });
+
+  test('a leading-indent details block is rewritten', () {
+    const source = '  <details><summary>s</summary>body</details>';
+    final registry = MarkdownDetailsRegistry();
+    expect(registry.lookup(registry.rewrite(source))!.summary, 's');
+  });
+
+  test('extract skips details inside display math when math is enabled', () {
+    const source = '\$\$\n<details><summary>s</summary>body</details>\n\$\$';
+    expect(MarkdownDetailsRegistry(enableMath: true).rewrite(source), source);
+    final off = MarkdownDetailsRegistry(enableMath: false);
+    expect(off.rewrite(source), isNot(source));
+    expect(off.hasIssuedPlaceholders, isTrue);
+  });
+
+  test('nonce selection visits stay linear in used-prefix count', () {
+    final prefixes = StringBuffer();
+    for (var i = 0; i < 4000; i++) {
+      prefixes.write('\uE010$i:');
+    }
+    final source = '$prefixes\n<details><summary>s</summary>x</details>';
+    debugResetMarkdownScanVisits();
+    final registry = MarkdownDetailsRegistry();
+    expect(registry.lookup(registry.rewrite(source)), isNotNull);
+    expect(
+      debugMarkdownScanVisits,
+      lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+    );
+  });
+
+  test('a literal placeholder token does not steal a rewritten block', () {
+    const literal = '\uE010DETAILS0\uE011';
+    const details = '<details><summary>real</summary>body</details>';
+    final source = '$details\n\n$literal';
+    final registry = MarkdownDetailsRegistry();
+    final rewritten = registry.rewrite(source);
+    expect(rewritten, contains(literal));
+    expect(registry.lookup(rewritten.split('\n').first)!.summary, 'real');
+    expect(registry.lookup(literal), isNull);
+  });
+
+  test('nonce is chosen from the root even when details are nested', () {
+    const literal = '\uE0100:0\uE011';
+    const source =
+        '- <details><summary>real</summary>body</details>\n- $literal';
+    final registry = MarkdownDetailsRegistry();
+    expect(registry.rewrite(source), source);
+    final item = registry.rewrite(
+      '<details><summary>real</summary>body</details>',
+    );
+    expect(registry.lookup(item)!.summary, 'real');
+    expect(registry.lookup(literal), isNull);
+    expect(item, isNot(literal));
+  });
+}
+
+List<(int, int)> _normalizedSpans(String text) {
+  return [
+    for (final span in markdownScanDisplayMath(text).spans)
+      (span.start, span.end),
+  ];
+}
+
+List<(int, int)> _rendererSpans(String text) {
+  return [
+    for (final match in LatexBlockScrollableMd().exp.allMatches(text))
+      (_skipWsStart(text, match.start, match.end), _trimWsEnd(text, match.end)),
+  ];
+}
+
+bool _scanEnds(String text) => markdownEndsWithDisplayMath(text, text.length);
+
+bool _rendererEnds(String text) {
+  final spans = _rendererSpans(text);
+  return spans.isNotEmpty && spans.last.$2 == text.length;
+}
+
+int _skipWsStart(String text, int start, int end) {
+  var i = start;
+  while (i < end && markdownIsWhitespace(text.codeUnitAt(i))) {
+    i++;
+  }
+  return i;
+}
+
+int _trimWsEnd(String text, int end) {
+  var i = end;
+  while (i > 0 && markdownIsWhitespace(text.codeUnitAt(i - 1))) {
+    i--;
+  }
+  return i;
+}
+
+String _nestedDetails(int levels) {
+  final out = StringBuffer();
+  for (var i = 1; i <= levels; i++) {
+    out.writeln('<details>');
+    out.writeln('<summary>L$i</summary>');
+  }
+  out.write('deep-body');
+  for (var i = 0; i < levels; i++) {
+    out.write('</details>');
+    if (i < levels - 1) out.writeln();
+  }
+  return out.toString();
+}
+
+void _expectDetailsContract(
+  String source, {
+  required bool isDetails,
+  bool overflowed = false,
+}) {
+  final walker = MarkdownDetailsWalker();
+  walker.consumeText(source);
+  expect(walker.depth, 0);
+  expect(walker.overflowed, overflowed);
+  expect(markdownDetailsExtent(source) >= 0, isDetails);
+  expect(markdownParseDetails(source) != null, isDetails);
+  expect(_detailsExpMatches(source), isDetails);
+}
+
+bool _detailsExpMatches(String source) {
+  final registry = MarkdownDetailsRegistry();
+  final rewritten = registry.rewrite(source);
+  return registry.hasIssuedPlaceholders &&
+      DetailsHtmlMd(registry).exp.hasMatch(rewritten);
+}
+
+void _expectLinearScan(
+  String Function(int index) chunk, {
+  required int chunks,
+}) {
+  final full = StringBuffer();
+  for (var i = 0; i < chunks; i++) {
+    full.write(chunk(i));
+  }
+  final text = full.toString();
+  debugResetMarkdownScanVisits();
+  markdownScanDisplayMath(text);
+  expect(
+    debugMarkdownScanVisits,
+    lessThanOrEqualTo(text.length * debugMarkdownScanVisitBudgetFactor),
+  );
+
+  final scanner = MarkdownDisplayMathScanner();
+  var source = '';
+  debugResetMarkdownScanVisits();
+  for (var i = 0; i < chunks; i++) {
+    source += chunk(i);
+    scanner.synchronize(source);
+  }
+  expect(
+    debugMarkdownScanVisits,
+    lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+  );
+}
+
+void _expectFenceWhitespace(String indent, {required bool isFence}) {
+  final probed = '$indent```\n\$\$\nx\n\$\$\n```';
+  expect(
+    markdownScanDisplayMath(probed).spans.isEmpty,
+    isFence,
+    reason: 'scanner indent ${indent.codeUnits}',
+  );
+  expect(
+    FencedCodeBlockMd(streaming: false).exp.matchAsPrefix(probed) != null,
+    isFence,
+    reason: 'renderer indent ${indent.codeUnits}',
+  );
+}
+
+void _expectUnclosedDetailsScan(String source) {
+  debugResetMarkdownScanVisits();
+  expect(_detailsExpMatches(source), isFalse);
+  final walker = MarkdownDetailsWalker()..consumeText(source);
+  expect(walker.depth, 1);
+  expect(markdownParseDetails(source), isNull);
+  expect(
+    debugMarkdownScanVisits,
+    lessThanOrEqualTo(source.length * debugMarkdownScanVisitBudgetFactor),
+  );
+}

--- a/test/shared/widgets/markdown_streaming_height_stability_test.dart
+++ b/test/shared/widgets/markdown_streaming_height_stability_test.dart
@@ -1,0 +1,556 @@
+import 'dart:io';
+
+import "../../support/business_test_harness.dart";
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+import 'package:provider/provider.dart';
+
+/// A long reply is rendered block by block while it streams and as one whole
+/// document once it finishes. If the two render at different heights, the
+/// timeline — which is pinned to the tail during generation — jumps by the
+/// difference on the frame the reply ends. Every case here must measure the
+/// same height on both paths.
+void main() {
+  setUpAll(() async {
+    // The default test font reports whole-pixel metrics for every size, which
+    // hides the per-line rounding a real font goes through. Lay these cases out
+    // with a real font so a separator that only matches on paper still fails.
+    final bytes = File(
+      'dependencies/gpt_markdown/lib/fonts/JetBrainsMono-Regular.ttf',
+    ).readAsBytesSync();
+    await (FontLoader(
+      'markdown-metrics',
+    )..addFont(Future.value(ByteData.view(bytes.buffer)))).load();
+  });
+
+  late SettingsProvider settings;
+
+  setUp(() async {
+    settings = await createBusinessTestPreferences();
+  });
+
+  group('streaming and finished markdown are the same height', () {
+    late WidgetTester boundTester;
+
+    Future<double> heightFor(
+      String text, {
+      required bool streaming,
+      required String tag,
+      required TextStyle style,
+      double textScale = 1.0,
+    }) async {
+      await boundTester.pumpWidget(
+        ChangeNotifierProvider.value(
+          value: settings,
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => MediaQuery(
+                  data: MediaQuery.of(
+                    context,
+                  ).copyWith(textScaler: TextScaler.linear(textScale)),
+                  child: SingleChildScrollView(
+                    child: MarkdownWithCodeHighlight(
+                      key: ValueKey<String>(tag),
+                      text: text,
+                      streaming: streaming,
+                      baseStyle: style,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await boundTester.pump(const Duration(milliseconds: 300));
+      return boundTester.getSize(find.byType(MarkdownWithCodeHighlight)).height;
+    }
+
+    /// The chat bubble's own base style, with the test font substituted in.
+    const baseStyle = TextStyle(
+      fontFamily: 'markdown-metrics',
+      fontSize: 15.7,
+      height: 1.5,
+    );
+
+    Future<void> expectStableText(
+      String label,
+      String text, {
+      TextStyle style = baseStyle,
+      double textScale = 1.0,
+      int minBlocks = 2,
+    }) async {
+      final streamingHeight = await heightFor(
+        text,
+        streaming: true,
+        style: style,
+        textScale: textScale,
+        tag: '$label-streaming',
+      );
+      final renderedBlocks = boundTester
+          .widgetList(find.byType(GptMarkdown))
+          .length;
+      expect(
+        renderedBlocks,
+        greaterThanOrEqualTo(minBlocks),
+        reason:
+            '$label: the streaming render was not split into blocks, so it '
+            'cannot say anything about block boundaries',
+      );
+      final finishedHeight = await heightFor(
+        text,
+        streaming: false,
+        style: style,
+        textScale: textScale,
+        tag: '$label-finished',
+      );
+      expect(
+        streamingHeight,
+        finishedHeight,
+        reason:
+            '$label: the reply would jump '
+            '${finishedHeight - streamingHeight}px when it finishes',
+      );
+    }
+
+    Future<void> expectStableHeight(
+      String label,
+      List<String> blocks, {
+      TextStyle style = baseStyle,
+      double textScale = 1.0,
+      String terminator = '\n',
+    }) {
+      // The splitter only closes a block once the next line is complete, so
+      // without the trailing newline the last boundary is never split and the
+      // case would measure a single block on both paths — passing for free.
+      return expectStableText(
+        label,
+        '${blocks.join('\n\n')}$terminator',
+        style: style,
+        textScale: textScale,
+      );
+    }
+
+    // Only replies over 512 characters are rendered block by block, so every
+    // case has to be padded past that threshold to be meaningful.
+    String pad(int index) =>
+        'Body $index. ${'The rain kept falling on the quiet street. ' * 16}';
+
+    testWidgets('across block shapes', (tester) async {
+      boundTester = tester;
+      tester.view.physicalSize = const Size(1170, 2100);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await expectStableHeight('two paragraphs', [pad(1), pad(2)]);
+      await expectStableHeight('four paragraphs', [
+        pad(1),
+        pad(2),
+        pad(3),
+        pad(4),
+      ]);
+      await expectStableHeight('headings between paragraphs', [
+        '# Heading one',
+        pad(1),
+        '## Heading two',
+        pad(2),
+      ]);
+      await expectStableHeight('paragraph then list', [
+        pad(1),
+        '- one\n- two\n- three',
+        pad(2),
+      ]);
+      await expectStableHeight('list then paragraph', [
+        '- one\n- two\n- three',
+        pad(1),
+      ]);
+      await expectStableHeight('ordered and nested lists', [
+        '1. one\n2. two',
+        pad(1),
+        '- one\n  - a\n  - b\n- two',
+        pad(2),
+      ]);
+      await expectStableHeight('a list that trails off into prose', [
+        '- one\n- two\ntrailing prose on the list',
+        pad(1),
+      ]);
+      await expectStableHeight('a loose list', ['- one\n\n- two', pad(1)]);
+      await expectStableHeight('paragraph then code', [
+        pad(1),
+        '```dart\nvar a = 1;\n```',
+        pad(2),
+      ]);
+      await expectStableHeight('code then paragraph', [
+        '```dart\nvar a = 1;\n```',
+        pad(1),
+      ]);
+      await expectStableHeight('blockquote and table', [
+        '> quoted line one\n> quoted line two',
+        pad(1),
+        '| a | b |\n| --- | --- |\n| 1 | 2 |',
+        pad(2),
+      ]);
+      // A horizontal rule and a display-math block both close their pattern
+      // with `\s*$`, so the whole-document render folds the blank line after
+      // them into the block and leaves no gap to reproduce.
+      await expectStableHeight('horizontal rules', [
+        pad(1),
+        '---',
+        pad(2),
+        'prose then a rule\n---',
+        pad(3),
+      ]);
+      await expectStableHeight('display math', [
+        pad(1),
+        r'$$\frac{a}{b}$$',
+        pad(2),
+        'prose then math\n'
+            r'$$a + b = c$$',
+        pad(3),
+        r'\[a^2 + b^2 = c^2\]',
+        pad(4),
+      ]);
+      await expectStableHeight('crossed display math openers', [
+        pad(1),
+        '\$\$\n\\[\n\$\$\n\\]',
+        pad(2),
+      ]);
+      await expectStableHeight('crossed display math openers reversed', [
+        pad(1),
+        '\\[\n\$\$\n\\]\n\$\$',
+        pad(2),
+      ]);
+      await expectStableHeight('tailed dollar closer then real closer', [
+        pad(1),
+        '\$\$\n\$\$ tail\n\ninside\n\$\$',
+        pad(2),
+      ]);
+      await expectStableHeight('crossed nested openers', [
+        pad(1),
+        '\\[\n\$\$\n\\[\n\$\$\n\\]',
+        pad(2),
+      ]);
+      // Closing hashes are optional decoration on a one-line heading; they
+      // no longer swallow the blank line after it.
+      await expectStableHeight('headings that close with hashes', [
+        pad(1),
+        '# Heading one #',
+        pad(2),
+        '### Heading three ###',
+        pad(3),
+      ]);
+      // The rule and math patterns spell their line breaks and indents as `\s`,
+      // which covers a bare CR and a non-breaking space.
+      await expectStableHeight('rules behind unusual whitespace', [
+        pad(1),
+        'prose then a rule\r---',
+        pad(2),
+        '\u00a0---',
+        pad(3),
+        '\u00a0'
+            r'$$a + b$$',
+        pad(4),
+      ]);
+      // A reply that has just emitted a paragraph break leaves a blank tail
+      // block, which the whole-document render trims away.
+      await expectStableHeight('a reply sitting on a paragraph break', [
+        pad(1),
+        pad(2),
+      ], terminator: '\n\n');
+      await expectStableHeight('a reply sitting on several blank lines', [
+        pad(1),
+        pad(2),
+      ], terminator: '\n\n\n\n');
+      await expectStableHeight('CJK paragraphs', [
+        '这是一个中文段落。' * 12,
+        '这是另一个中文段落。' * 12,
+        pad(1),
+      ]);
+    });
+
+    testWidgets('across blank runs between blocks', (tester) async {
+      boundTester = tester;
+      tester.view.physicalSize = const Size(1170, 2100);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      // `NewLines` collapses a run of line breaks into one blank line, however
+      // many it holds.
+      for (final breaks in ['\n\n', '\n\n\n', '\n\n\n\n', '\n\n\n\n\n']) {
+        await expectStableText(
+          '${breaks.length} line breaks between paragraphs',
+          '${pad(1)}$breaks${pad(2)}\n',
+        );
+      }
+      // A blank line carrying whitespace is content, not a boundary: the block
+      // around it renders whole, so these cases hold the splitter to that.
+      final runs = <String, String>{
+        'a space on the blank line': '\n \n',
+        'a blank line then a space': '\n\n \n',
+        'two whitespace lines': '\n\n \n \n\n',
+        'a tab on the blank line': '\n\t\n',
+        'a no-break space': '\n\u00a0\n',
+        'spaces trailing the paragraph': '  \n\n',
+      };
+      for (final run in runs.entries) {
+        // Every one of these absorbs whitespace ahead of itself differently.
+        final followers = <String, String>{
+          'a paragraph': pad(2),
+          'a heading': '# Heading one',
+          'a heading with closing hashes': '## Heading two ##',
+          'a rule': '---',
+          'display math': r'$$a + b$$',
+          'a list': '- one\n- two',
+          'a code block': '```dart\nvar a = 1;\n```',
+        };
+        for (final next in followers.entries) {
+          await expectStableText(
+            '${run.key} before ${next.key}',
+            '${pad(1)}\n\n${pad(2)}${run.value}${next.value}\n\n${pad(3)}\n',
+          );
+        }
+      }
+      // Indentation is syntax, so an indented line has to reach the renderer
+      // with its indent intact.
+      for (final indented in <String>[
+        '    # Heading #',
+        '    # Heading',
+        '    indented prose',
+        '    ---',
+        '  two spaces of indent',
+      ]) {
+        await expectStableText(
+          'indented block ${indented.trim()}',
+          '${pad(1)}\n\n$indented\n\n${pad(2)}\n',
+        );
+      }
+      // Opening hashes cannot reach a title on a later line, so these stay
+      // ordinary paragraphs on both render paths.
+      await expectStableText(
+        'hashes and a title on separate lines',
+        '${pad(1)}\n\n${pad(2)}\n\n#\nHeading #\n\n${pad(3)}\n',
+      );
+      await expectStableText(
+        'a heading then a lone hash line',
+        '${pad(1)}\n\n${pad(2)}\n\n# Heading one\n\n#\nHeading #'
+            '\n\n## Heading two\n\n${pad(3)}\n',
+      );
+      // A closer that leaves prose behind on its line cannot close the math
+      // block, so the match runs on to the last one — and a closer that ends
+      // its own line closes there, leaving the blank line behind.
+      await expectStableText(
+        'two math spans on one line',
+        '${pad(1)}\n\n'
+            r'$$a$$ tail $$b$$'
+            '\n\n${pad(2)}\n',
+      );
+      await expectStableText(
+        'a math span then a math line',
+        '${pad(1)}\n\n'
+            r'$$a$$'
+            '\ntail '
+            r'$$b$$'
+            '\n\n${pad(2)}\n',
+      );
+      // `String.trim()`, which the whole-document render uses on the source,
+      // takes U+0085 with it while a `\s` pattern does not.
+      await expectStableText(
+        'a reply ending on a next-line character',
+        '${pad(1)}\n\n${pad(2)}\n\n\u0085',
+      );
+    });
+
+    testWidgets('across base font metrics and text scales', (tester) async {
+      boundTester = tester;
+      tester.view.physicalSize = const Size(1170, 2100);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      final shapes = <String>[
+        pad(1),
+        '- one\n- two',
+        pad(2),
+        '---',
+        pad(3),
+        '```dart\nvar a = 1;\n```',
+        pad(4),
+      ];
+
+      for (final fontSize in <double>[11, 14, 15.7, 20, 24]) {
+        for (final height in <double>[1.2, 1.5, 1.7]) {
+          await expectStableHeight(
+            'fontSize $fontSize height $height',
+            shapes,
+            style: baseStyle.copyWith(fontSize: fontSize, height: height),
+          );
+        }
+      }
+      // The chat font scale and the system text scale both land here as a
+      // `MediaQuery` text scale, which the blank lines of a whole-document
+      // render scale with.
+      for (final textScale in <double>[0.7, 0.85, 1.15, 1.3, 2.0]) {
+        await expectStableHeight(
+          'text scale $textScale',
+          shapes,
+          textScale: textScale,
+        );
+      }
+    });
+
+    testWidgets('for a long multi-paragraph reply', (tester) async {
+      boundTester = tester;
+      tester.view.physicalSize = const Size(1170, 2100);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      await expectStableHeight(
+        'thirty paragraphs',
+        List<String>.generate(30, pad),
+      );
+    });
+
+    testWidgets('for streaming prefixes and suffix endings', (tester) async {
+      boundTester = tester;
+      tester.view.physicalSize = const Size(1170, 2100);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
+      final suffixes = <String, String>{
+        'indented heading': '    # Heading #',
+        'three-space heading': '   # Heading #',
+        'tab heading': '\t# Heading #',
+        'one closing hash': '# Heading #',
+        'six closing hashes': '# Heading ######',
+        'seven closing hashes': '# Heading #######',
+        'twenty closing hashes': '# Heading ${'#' * 20}',
+        'seven bare hashes': '#######',
+        'C# paragraph': 'Language: C#',
+        'two dollar formulas':
+            r'$$a$$'
+            '\ntext\n'
+            r'$$b$$',
+        'two bracket formulas':
+            r'\[a\]'
+            '\ntext\n'
+            r'\[b\]',
+        'mixed math':
+            r'$$a$$'
+            '\ntext\n'
+            r'\[b\]',
+        'dollar with tail then bracket':
+            r'$$a$$ tail'
+            '\ntext\n'
+            r'\[b\]',
+        'unclosed bracket then dollar':
+            r'\['
+            '\ntext\n'
+            r'$$b$$',
+        'fence bracket then dollar':
+            '```\n\\[\n```\n'
+            r'$$b$$',
+        'line separator between paragraphs': 'A\n\u2028\nB',
+        'paragraph separator between paragraphs': 'A\n\u2029\nB',
+        'crlf paragraphs': 'A\r\n\r\nB',
+        'bare cr paragraphs': 'A\r\rB',
+        'nbsp blank run': 'A\n\u00a0\nB',
+        'next-line blank run': 'A\n\u0085\nB',
+        'hash then title across a blank': '#\n\nHeading #',
+        'opening hash then indented title': '#\n    #Title #',
+        'unclosed backtick then dollar': '`unclosed\n\$\$ `x` \$\$',
+        'mid-line details then dollar': 'Use <details> here\n\$\$b\$\$',
+        'line separator then dollar': 'Text\u2028\$\$b\$\$',
+        'paragraph separator then dollar': 'Text\u2029\$\$b\$\$',
+        'line separator then fence': 'Text\u2028```dart\ncode\n\ninside\n```',
+        'paragraph separator then fence':
+            'Text\u2029```dart\ncode\n\ninside\n```',
+        'line separator then tilde fence': 'Text\u2028~~~\ncode\n\ninside\n~~~',
+        'line separator then details':
+            'Text\u2028<details>\n\nbody\n</details>',
+        'four-backtick fence with short closer': '````dart\na\n```\n\nb\n````',
+        'four-tilde fence with short closer': '~~~~\na\n~~~\n\nb\n~~~~',
+        'fence info closer': '```dart\na\n``` not-a-closer\nfollowing\n```',
+        'tilde fence info closer': '~~~\na\n~~~ not-a-closer\nfollowing\n~~~',
+        'four-backtick fence info closer':
+            '````dart\na\n```` not-a-closer\nfollowing\n````',
+        'mid-line nested details':
+            '<details>\n<summary>outer</summary>\n'
+            'prefix <details>\n<summary>inner</summary>\n\n'
+            'inner body\n</details>\n\nouter body\n</details>',
+        'details with inline-code tag':
+            '<details>\n<summary>s</summary>\n'
+            'Use `<details>` here\n\nmore\n</details>',
+        'cross-line details opener':
+            '<details\nopen>\n<summary>s</summary>\n\nbody\n</details>',
+        'seven nested details': [
+          for (var i = 1; i <= 7; i++) '<details>\n<summary>L$i</summary>',
+          'deep-body',
+          for (var i = 0; i < 7; i++) '</details>',
+        ].join('\n'),
+        'uppercase details tags': '<DETAILS><SUMMARY>s</SUMMARY>more</DETAILS>',
+        'dotted details lookalike':
+            '<details>\n<summary>s</summary>\n<details.foo>\n\nmore\n</details>',
+        'self-closing details lookalike':
+            '<details>\n<summary>s</summary>\n<details/>\n\nmore\n</details>',
+        'unclosed details with code spans':
+            '<details><summary>s</summary>${List.filled(20, '`x`').join(' ')}',
+        'rematched details backticks':
+            r'<details><summary>s</summary>`x`<details>y`</details>',
+        'mixed one and three tick details':
+            r'<details><summary>s</summary>`x```<details>y`</details>',
+        'mixed two-tick details':
+            r'<details><summary>s</summary>``x``<details>y``</details>',
+        'same-line details prefix without gt':
+            '<details><summary>s</summary>before <details missing </details>',
+        'sixty backtick details prefix':
+            '<details><summary>s</summary>${'`' * 60}',
+      };
+
+      for (final suffix in suffixes.entries) {
+        for (final ending in const ['', '\n', '\n\n']) {
+          await expectStableText(
+            '${suffix.key} ending ${ending.length} LFs',
+            '${pad(1)}\n\n${pad(2)}\n\n${suffix.value}$ending',
+          );
+        }
+      }
+
+      await expectStableText(
+        'twenty C# paragraphs',
+        [
+          pad(1),
+          for (var i = 0; i < 20; i++) 'Language: C# sample $i',
+          pad(2),
+        ].join('\n\n'),
+      );
+
+      const growth = <String, String>{
+        'indented heading growth': '    # Heading #',
+        'two dollar formulas growth':
+            r'$$a$$'
+            '\ntext\n'
+            r'$$b$$',
+        'hash then title growth': '#\n\nHeading #',
+      };
+      for (final item in growth.entries) {
+        final text = '${pad(1)}\n\n${item.value}\n\n${pad(2)}\n';
+        for (var i = 0; i < text.length; i++) {
+          if (text.codeUnitAt(i) != 0x0A && i != text.length - 1) continue;
+          await expectStableText(
+            '${item.key} prefix ${i + 1}',
+            text.substring(0, i + 1),
+            minBlocks: 1,
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:Cuplivo/features/chat/pages/image_viewer_page.dart';
 import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
 import 'package:Cuplivo/shared/widgets/export_capture_scope.dart';
@@ -48,6 +50,27 @@ List<WidgetSpan> _collectWidgetSpans(InlineSpan span) {
     spans.addAll(_collectWidgetSpans(child));
   }
   return spans;
+}
+
+double? _spanFontSize(WidgetTester tester, String text) {
+  for (final span in _resolvedTextSpansFromRichText(tester)) {
+    if (span.text.contains(text)) return span.style.fontSize;
+  }
+  return null;
+}
+
+String _nestedDetailsHtml(int levels) {
+  final out = StringBuffer();
+  for (var i = 1; i <= levels; i++) {
+    out.writeln('<details>');
+    out.writeln('<summary>L$i</summary>');
+  }
+  out.write('deep-body');
+  for (var i = 0; i < levels; i++) {
+    out.write('</details>');
+    if (i < levels - 1) out.writeln();
+  }
+  return out.toString();
 }
 
 List<WidgetSpan> _widgetSpansFromRichText(WidgetTester tester) {
@@ -974,7 +997,11 @@ Inline ***strong emphasis*** text.
       await tester.pump(const Duration(milliseconds: 50));
       text.value = '$baseLines\nframe-3';
       await tester.pump(const Duration(milliseconds: 50));
-      await tester.pump(const Duration(milliseconds: 40));
+      // The throttle publishes the text the last build saw, so the newest value
+      // lands one window later. Give it that window rather than pinning the
+      // test to the exact interval.
+      await tester.pump(const Duration(milliseconds: 60));
+      await tester.pump(const Duration(milliseconds: 60));
 
       expect(find.textContaining('frame-3'), findsOneWidget);
     },
@@ -4124,6 +4151,620 @@ void main() {
 
       expect(find.text('Copy LaTeX'), findsOneWidget);
       expect(find.text('SELECTION_TOOLBAR_MARKER'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'streaming text between 512 and 4096 uses incremental markdown blocks',
+    (tester) async {
+      final paragraph = 'Streaming markdown paragraph for block split. ' * 6;
+      final text = List<String>.generate(
+        4,
+        (index) => '$paragraph$index',
+      ).join('\n\n');
+      expect(text.length, greaterThanOrEqualTo(512));
+      expect(text.length, lessThan(4096));
+
+      await tester.pumpWidget(_markdownHarness(text, streaming: true));
+      await tester.pump();
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget.runtimeType.toString() == '_MarkdownBlockColumn',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget.runtimeType.toString() == '_CachedMarkdownBlock',
+        ),
+        findsAtLeastNWidgets(2),
+      );
+    },
+  );
+
+  testWidgets('streaming markdown uses AtxHeadingMd and not the default HTag', (
+    tester,
+  ) async {
+    final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+    await tester.pumpWidget(
+      _markdownHarness('$pad\n\n# Real heading\n\nNext', streaming: true),
+    );
+    await tester.pump();
+
+    final markdown = tester.widget<GptMarkdown>(find.byType(GptMarkdown).first);
+    expect(markdown.components!.whereType<HTag>(), isEmpty);
+    expect(markdown.components!.whereType<AtxHeadingMd>(), hasLength(1));
+    expect(_spanFontSize(tester, 'Real heading'), 24);
+  });
+
+  testWidgets('a completed pipe row is not turned into a streaming table', (
+    tester,
+  ) async {
+    final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+    final text = '$pad\n\n| a | b |\n\nNext paragraph';
+    await tester.pumpWidget(_markdownHarness(text, streaming: true));
+    await tester.pump();
+    expect(find.byType(Table), findsNothing);
+    expect(find.byKey(const ValueKey('markdown-table-body')), findsNothing);
+
+    await tester.pumpWidget(_markdownHarness(text, streaming: false));
+    await tester.pump();
+    expect(find.byType(Table), findsNothing);
+  });
+
+  testWidgets('appending to the same tail keeps an expanded details open', (
+    tester,
+  ) async {
+    final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+    final text = ValueNotifier<String>(
+      '$pad\n\n<details><summary>s</summary>\n\nhidden\n</details>',
+    );
+    await tester.pumpWidget(_streamingMarkdownHarness(text));
+    await tester.pump();
+
+    await tester.tap(find.text('s'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('hidden', findRichText: true), findsWidgets);
+
+    text.value =
+        '$pad\n\n<details><summary>s</summary>\n\nhidden\n</details>\n'
+        'more from the same block';
+    await tester.pump();
+    expect(find.textContaining('hidden', findRichText: true), findsWidgets);
+    expect(
+      find.textContaining('more from the same block', findRichText: true),
+      findsWidgets,
+    );
+  });
+
+  testWidgets(
+    'replacing a tail resets an expanded details instead of appending',
+    (tester) async {
+      final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+      final text = ValueNotifier<String>(
+        '$pad\n\n<details><summary>s</summary>\n\nhidden\n</details>',
+      );
+      await tester.pumpWidget(_streamingMarkdownHarness(text));
+      await tester.pump();
+
+      await tester.tap(find.text('s'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('hidden', findRichText: true), findsWidgets);
+
+      text.value =
+          '$pad\n\n<details><summary>other</summary>\n\nhidden\n</details>';
+      await tester.pump();
+      expect(find.text('other'), findsOneWidget);
+      expect(find.textContaining('hidden', findRichText: true), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'appending an image keeps an earlier expanded details open and shows the new image',
+    (tester) async {
+      final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+      const second = 'https://example.com/b.png';
+      final text = ValueNotifier<String>(
+        '<details><summary>s</summary>\n\nhidden\n</details>\n\n'
+        '![42x24]($_transparentPngDataUrl)\n\n$pad\n\n',
+      );
+      await tester.pumpWidget(_streamingMarkdownHarness(text, width: 360));
+      await tester.pump();
+
+      expect(find.textContaining('hidden', findRichText: true), findsNothing);
+      await tester.tap(find.text('s'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining('hidden', findRichText: true), findsWidgets);
+
+      text.value =
+          '<details><summary>s</summary>\n\nhidden\n</details>\n\n'
+          '![42x24]($_transparentPngDataUrl)\n\n$pad\n\n\n![]($second)';
+      await tester.pump();
+      expect(find.textContaining('hidden', findRichText: true), findsWidgets);
+
+      await tester.tap(find.byType(Image).first);
+      await tester.pumpAndSettle();
+      final viewer = tester.widget<ImageViewerPage>(
+        find.byType(ImageViewerPage),
+      );
+      expect(viewer.images, hasLength(2));
+      expect(viewer.images.last, second);
+    },
+  );
+
+  testWidgets('details walker, DetailsHtmlMd, and the widget share tokenization', (
+    tester,
+  ) async {
+    Future<void> expectShared({
+      required String source,
+      required bool isDetails,
+      int depth = 0,
+      String? summary,
+      String? hiddenBody,
+      String? visibleText,
+    }) async {
+      final walker = MarkdownDetailsWalker()..consumeText(source);
+      expect(walker.depth, depth);
+      expect(walker.overflowed, isFalse);
+      expect(markdownDetailsExtent(source) >= 0, isDetails);
+      expect(markdownParseDetails(source) != null, isDetails);
+      final registry = MarkdownDetailsRegistry();
+      final rewritten = registry.rewrite(source);
+      expect(
+        registry.hasIssuedPlaceholders &&
+            DetailsHtmlMd(registry).exp.hasMatch(rewritten),
+        isDetails,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+      final details = find.byWidgetPredicate(
+        (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+      );
+      if (!isDetails) {
+        expect(details, findsNothing);
+        if (visibleText != null) {
+          expect(
+            find.textContaining(visibleText, findRichText: true),
+            findsWidgets,
+          );
+        }
+        return;
+      }
+      expect(details, findsOneWidget);
+      if (summary != null) {
+        expect(find.text(summary), findsOneWidget);
+      }
+      if (hiddenBody == null) return;
+      expect(find.textContaining(hiddenBody, findRichText: true), findsNothing);
+      await tester.tap(find.text(summary!));
+      await tester.pumpAndSettle();
+      expect(find.textContaining(hiddenBody, findRichText: true), findsWidgets);
+    }
+
+    await expectShared(
+      source:
+          '<details>\n<summary>s</summary>\nUse `<details>` here\n\nmore\n</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source: '<details><summary>s</summary>body</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'body',
+    );
+    await expectShared(
+      source: '<details\nopen>\n<summary>s</summary>\n\nbody\n</details>',
+      isDetails: false,
+      visibleText: 'body',
+    );
+    await expectShared(
+      source:
+          '<details>\n<summary>outer</summary>\n'
+          'prefix <details>\n<summary>inner</summary>\n\n'
+          'inner body\n</details>\n\nouter body\n</details>',
+      isDetails: true,
+      summary: 'outer',
+      hiddenBody: 'outer body',
+    );
+    await expectShared(
+      source: '<details><summary>Use `<details>`</summary>\n\nbody\n</details>',
+      isDetails: true,
+    );
+    await expectShared(
+      source: _nestedDetailsHtml(6),
+      isDetails: true,
+      summary: 'L1',
+      hiddenBody: 'L2',
+    );
+    await expectShared(
+      source: '<DETAILS><SUMMARY>s</SUMMARY>more</DETAILS>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source: '<Details><Summary>s</Summary>more</Details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source:
+          '<details>\n<summary>s</summary>\n<details.foo>\n\nmore\n</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source: '<details>\n<summary>s</summary>\n<details/>\n\nmore\n</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source:
+          '<details>\n<summary>s</summary>\nsee <details\n\nmore\n</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source:
+          '<details>\n<summary>s</summary>\n'
+          'Use `<details.foo>` and `<DETAILS>` here\n\nmore\n</details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'more',
+    );
+    await expectShared(
+      source: r'<details><summary>s</summary>`x`<details>y`</details>',
+      isDetails: false,
+      depth: 1,
+    );
+    await expectShared(
+      source: r'<details><summary>s</summary>`x```<details>y`</details>',
+      isDetails: true,
+      summary: 's',
+    );
+    await expectShared(
+      source: r'<details><summary>s</summary>``x``<details>y``</details>',
+      isDetails: false,
+      depth: 1,
+    );
+    await expectShared(
+      source: '<details><summary>s</summary>before <details missing </details>',
+      isDetails: true,
+      summary: 's',
+      hiddenBody: 'before',
+    );
+  });
+
+  testWidgets('details registry keeps walker top-level and block boundaries', (
+    tester,
+  ) async {
+    Finder detailsFinder() => find.byWidgetPredicate(
+      (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+    );
+
+    Future<String> pumpSource(String source) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+      return tester
+          .widgetList<GptMarkdown>(find.byType(GptMarkdown))
+          .map((widget) => widget.data)
+          .join('\n');
+    }
+
+    const nestedUnclosed =
+        '<details>\n<summary>A</summary>\nunclosed\n'
+        '<details><summary>B</summary>body B</details>';
+    var data = await pumpSource(nestedUnclosed);
+    expect(detailsFinder(), findsNothing);
+    expect(data, isNot(contains('\uE010')));
+    expect(find.textContaining('body B', findRichText: true), findsWidgets);
+
+    data = await pumpSource(_nestedDetailsHtml(7));
+    expect(detailsFinder(), findsNothing);
+    expect(data, isNot(contains('\uE010')));
+    expect(find.text('L2'), findsNothing);
+
+    const tailed = '<details><summary>s</summary>body</details> tail';
+    data = await pumpSource(tailed);
+    expect(detailsFinder(), findsNothing);
+    expect(data, isNot(contains('\uE010')));
+    expect(find.textContaining('tail', findRichText: true), findsWidgets);
+
+    data = await pumpSource('<details><summary>s</summary>body</details>  ');
+    expect(detailsFinder(), findsOneWidget);
+    expect(find.text('s'), findsOneWidget);
+
+    const adjacent =
+        '<details><summary>A</summary>a</details>'
+        '<details><summary>B</summary>b</details>';
+    data = await pumpSource(adjacent);
+    expect(detailsFinder(), findsNothing);
+    expect(data, isNot(contains('\uE010')));
+
+    data = await pumpSource('  <details><summary>s</summary>body</details>');
+    expect(detailsFinder(), findsOneWidget);
+    expect(find.text('s'), findsOneWidget);
+
+    const literal = '\uE010DETAILS0\uE011';
+    data = await pumpSource(
+      '<details><summary>real</summary>body</details>\n\n$literal',
+    );
+    expect(detailsFinder(), findsOneWidget);
+    expect(find.text('real'), findsOneWidget);
+    expect(data, contains(literal));
+    expect(find.textContaining(literal, findRichText: true), findsWidgets);
+  });
+
+  testWidgets('details render inside list, quote, table, and details body', (
+    tester,
+  ) async {
+    Finder detailsFinder() => find.byWidgetPredicate(
+      (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+    );
+
+    Future<void> expectFoldable(String source, String summary) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+      expect(detailsFinder(), findsWidgets);
+      expect(find.textContaining(summary, findRichText: true), findsWidgets);
+      expect(find.textContaining('body', findRichText: true), findsNothing);
+      await tester.tap(find.textContaining(summary, findRichText: true).first);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('body', findRichText: true), findsWidgets);
+    }
+
+    await expectFoldable(
+      '- <details><summary>list</summary>body</details>',
+      'list',
+    );
+    await expectFoldable(
+      '> <details><summary>quote</summary>body</details>',
+      'quote',
+    );
+    await expectFoldable(
+      '| x |\n| --- |\n| <details><summary>cell</summary>body</details> |',
+      'cell',
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(
+      _markdownHarness(
+        '<details><summary>outer</summary>\n\n'
+        '<details><summary>inner</summary>body</details>\n'
+        '</details>',
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text('outer'));
+    await tester.pumpAndSettle();
+    expect(find.text('inner'), findsOneWidget);
+    expect(find.textContaining('body', findRichText: true), findsNothing);
+    await tester.tap(find.text('inner'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('body', findRichText: true), findsWidgets);
+  });
+
+  testWidgets('details inside display math follow the math-rendering flag', (
+    tester,
+  ) async {
+    Finder detailsFinder() => find.byWidgetPredicate(
+      (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+    );
+    const source = '\$\$\n<details><summary>s</summary>body</details>\n\$\$';
+    late SettingsProvider settings;
+
+    await tester.pumpWidget(
+      _settingsHarness(
+        onSettingsReady: (value) => settings = value,
+        child: const MarkdownWithCodeHighlight(text: source),
+      ),
+    );
+    await tester.pump();
+    expect(detailsFinder(), findsNothing);
+    expect(_findMathWidget(), findsOneWidget);
+
+    await settings.setEnableMathRendering(false);
+    await tester.pumpAndSettle();
+    expect(detailsFinder(), findsOneWidget);
+    expect(_findMathWidget(), findsNothing);
+    expect(find.text('s'), findsOneWidget);
+  });
+
+  testWidgets(
+    'an unclosed dollar opener does not hide a following details block',
+    (tester) async {
+      Finder detailsFinder() => find.byWidgetPredicate(
+        (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+      );
+      await tester.pumpWidget(
+        _markdownHarness('\$\$\n<details><summary>s</summary>body</details>'),
+      );
+      await tester.pump();
+      expect(detailsFinder(), findsOneWidget);
+      expect(find.text('s'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'four-space hashes are not rendered as a heading on either path',
+    (tester) async {
+      final pad = 'Body. ${'The rain kept falling on the quiet street. ' * 16}';
+      final text = '$pad\n\n    # Not a heading\n\nNext';
+      for (final streaming in const [true, false]) {
+        await tester.pumpWidget(_markdownHarness(text, streaming: streaming));
+        await tester.pump();
+        expect(
+          _spanFontSize(tester, 'Not a heading'),
+          isNot(24),
+          reason: streaming ? 'streaming' : 'finished',
+        );
+        final markdown = tester.widget<GptMarkdown>(
+          find.byType(GptMarkdown).first,
+        );
+        expect(markdown.components!.whereType<HTag>(), isEmpty);
+      }
+    },
+  );
+
+  testWidgets(
+    'image data URIs are not copied into the parsed markdown cache key',
+    (tester) async {
+      await tester.pumpWidget(
+        _markdownHarness('![42x24]($_transparentPngDataUrl)', width: 160),
+      );
+      await tester.pump();
+
+      final key = tester.widget<GptMarkdown>(find.byType(GptMarkdown)).key;
+      expect(key, isA<ValueKey<String>>());
+      final value = (key! as ValueKey<String>).value;
+      expect(value, startsWith('parsed-markdown-'));
+      expect(value.contains('data:image'), isFalse);
+      expect(value.contains('iVBORw0KGgo'), isFalse);
+    },
+  );
+
+  testWidgets(
+    'sibling list fragments do not collide on a literal placeholder token',
+    (tester) async {
+      const literal = '\uE0100:0\uE011';
+      await tester.pumpWidget(
+        _markdownHarness(
+          '- <details><summary>real</summary>body</details>\n- $literal',
+        ),
+      );
+      await tester.pump();
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('real'), findsOneWidget);
+      expect(find.textContaining(literal, findRichText: true), findsWidgets);
+    },
+  );
+
+  testWidgets('inline code keeps a literal less-than and U+E002', (
+    tester,
+  ) async {
+    Future<void> expectUnmasked({
+      required String source,
+      required String visible,
+      bool expectDetails = false,
+    }) async {
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+      final data = tester
+          .widgetList<GptMarkdown>(find.byType(GptMarkdown))
+          .map((widget) => widget.data)
+          .join('\n');
+      expect(find.byType(GptMarkdown), findsWidgets);
+      expect(data, isNot(contains('\uE002')));
+      final details = find.byWidgetPredicate(
+        (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
+      );
+      expect(details, expectDetails ? findsOneWidget : findsNothing);
+      if (expectDetails) {
+        expect(find.textContaining(visible, findRichText: true), findsNothing);
+        await tester.tap(find.text('s'));
+        await tester.pumpAndSettle();
+      } else {
+        expect(data, contains(visible));
+      }
+      expect(find.textContaining(visible, findRichText: true), findsWidgets);
+    }
+
+    await expectUnmasked(source: 'Use `a < b` now', visible: 'a < b');
+    await expectUnmasked(source: r'Use ``a < b`` now', visible: 'a < b');
+    await expectUnmasked(source: r'Use `<details>` here', visible: '<details>');
+    await expectUnmasked(
+      source: '<details><summary>s</summary>`a < b` still open',
+      visible: 'a < b',
+    );
+    await expectUnmasked(
+      source: '<details><summary>s</summary>\n\nUse `a < b` now\n</details>',
+      visible: 'a < b',
+      expectDetails: true,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(_markdownHarness('hello \uE002 world'));
+    await tester.pump();
+    final privateData = tester
+        .widget<GptMarkdown>(find.byType(GptMarkdown))
+        .data;
+    expect(privateData, contains('\uE002'));
+    expect(privateData, isNot(contains('hello < world')));
+    expect(
+      find.textContaining('hello \uE002 world', findRichText: true),
+      findsWidgets,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpWidget(_markdownHarness('Use `a \uE002 b` now'));
+    await tester.pump();
+    expect(find.text('a \uE002 b'), findsWidgets);
+    expect(
+      tester.widget<GptMarkdown>(find.byType(GptMarkdown)).data,
+      contains('\uE002'),
+    );
+  });
+
+  test('FencedCodeBlockMd does not close on an info-string fence line', () {
+    for (final item in const [
+      ('```', '```', '```dart\na\n``` not-a-closer\nfollowing\n```'),
+      ('~~~', '~~~', '~~~\na\n~~~ not-a-closer\nfollowing\n~~~'),
+      ('````', '````', '````dart\na\n```` not-a-closer\nfollowing\n````'),
+      ('~~~~', '~~~~', '~~~~\na\n~~~~ not-a-closer\nfollowing\n~~~~'),
+      ('````', '```', '````dart\na\n``` not-a-closer\nfollowing\n````'),
+    ]) {
+      final match = FencedCodeBlockMd(streaming: false).exp.firstMatch(item.$3);
+      expect(match, isNotNull, reason: item.$3);
+      expect(match!.group(0), item.$3, reason: item.$3);
+      expect(match.group(4), contains('not-a-closer'), reason: item.$3);
+      expect(match.group(4), contains('following'), reason: item.$3);
+    }
+  });
+
+  testWidgets(
+    'MarkdownWithCodeHighlight keeps an info-string fence line inside the code block',
+    (tester) async {
+      for (final source in const [
+        '```dart\na\n``` not-a-closer\nfollowing\n```',
+        '~~~\na\n~~~ not-a-closer\nfollowing\n~~~',
+        '````dart\na\n```` not-a-closer\nfollowing\n````',
+      ]) {
+        await tester.pumpWidget(_markdownHarness(source));
+        await tester.pump();
+        expect(
+          find.descendant(
+            of: find.byType(SelectableHighlightView),
+            matching: find.textContaining('not-a-closer'),
+          ),
+          findsOneWidget,
+          reason: source,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(SelectableHighlightView),
+            matching: find.textContaining('following'),
+          ),
+          findsOneWidget,
+          reason: source,
+        );
+      }
     },
   );
 }


### PR DESCRIPTION
## Summary

Fixes #334.

Streaming markdown re-parsed the entire text on every tick (issue #334). Instead of merging the divergent PR #442, we ported upstream kelivo's hardened incremental renderer (cb2e8890, incl. the Aug 17–19 follow-up fixes) wholesale, and dropped the issue #232 thinking-preview truncation the port makes obsolete.

## What changed

1. **Incremental streaming renderer** (`markdown_with_highlight.dart` + 2 new files + `byte_lru_cache.dart`):
   - `IncrementalMarkdownDocument` splits append-only text at safe blank-line boundaries (fence/math/details/list/quote aware, whitespace-blank-run safe, CR-normalized); committed blocks parse once (`_CachedMarkdownBlock` + 4 MiB LRU), only the live tail re-parses — per-tick cost O(tail).
   - `MarkdownLineLexer` shares fence/details/inline-code token rules with the renderer; `DetailsHtmlMd` now uses `MarkdownDetailsRegistry` + `preprocessBlocks` hook.
   - `_MarkdownBlockColumn` + `_MarkdownBlockSeparator` (text-engine blank line, suppressed after HR/display-math) keep streaming and finished layouts pixel-equal (height-stability suite: 5/5).
   - `AtxHeadingMd` moved to horizontal-blanks pattern (`# h #` no longer swallows the following blank); `FencedCodeBlockMd` closes only at line end; debounce 8000 chars / 50 ms (matches stream publish).
2. **Vendored `gpt_markdown`**: `streaming:` replaced by `preprocessBlocks` + `generation` (config equality now includes generation), CR fast path, `LatexMath` DefaultTextStyle color fallback.
3. **Revert issue #232 truncation**: the streaming thinking preview no longer caps at 2000 chars — it renders the full chain (100 px bottom-scrolled window unchanged; full text selectable/scrollable while streaming). `streamingThinkingPreviewTruncate` setting removed from provider, desktop/mobile settings pages, and the 4 ARB files.

## Verification

- `dart analyze --fatal-infos lib test` — clean
- 290 tests green: 4 markdown suites (incl. ported lexer/splitter/height-stability + 17 widget tests) + chat streaming + settings + changelog dialog
- `flutter gen-l10n` — `desiredFileName.txt` `{}`

## Notes

- PR #442 closed in favor of this port.
- Desktop build not run locally (settings row removal only, low risk); full `flutter test` left to CI.
