### PR TITLE
fix(gemini): route every 3.x model through thinkingLevel

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -48,23 +48,49 @@ bool _isGemma4Model(String modelId) {
   ).hasMatch(modelId);
 }
 
-bool _isGemini35FlashModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.5-flash([._:@/-]|$)', caseSensitive: false),
-  );
+// Non-text Gemini variants: they take a raw budget, not a thinking level, so
+// they fall through to the Gemini 2.x branch. Holding them out here also stops
+// the `-` terminator in the family patterns below from swallowing the suffix and
+// reading `gemini-3.1-flash-image` as plain `gemini-3.1-flash`.
+final _gemini3NonTextSuffix = RegExp(
+  r'(^|[-_/])(image|tts|live)([-._:@/]|$)',
+  caseSensitive: false,
+);
+
+// Thresholds where a Gemini 3 family changed its thinking contract. Naming them
+// keeps the next release a one-line edit instead of a hunt for bare numbers.
+const _gemini3ProMediumMinor = 1; // pro gained 'medium' in 3.1
+const _gemini3FlashModernMinor =
+    5; // flash defaults to 'medium' and 64K from 3.5
+const _gemini3FlashNoMinimalMinor = 7; // flash dropped 'minimal' in 3.7
+
+final _gemini3FlashId = RegExp(
+  r'gemini-3(?:\.(?<minor>\d+))?-flash([._:@/-]|$)',
+  caseSensitive: false,
+);
+final _gemini3ProId = RegExp(
+  r'gemini-3(?:\.(?<minor>\d+))?-pro(-preview)?([._:@/-]|$)',
+  caseSensitive: false,
+);
+final _gemini3FlashLiteId = RegExp(
+  r'gemini-3(?:\.\d+)?-flash-lite([._:@/-]|$)',
+  caseSensitive: false,
+);
+
+// Minor version behind a Gemini 3 id (0 for plain `gemini-3-`), or null when the
+// id is not that family. Matching by version keeps unreleased 3.x models on the
+// Gemini 3 branches instead of the Gemini 2.x fallback.
+int? _gemini3Minor(String modelId, RegExp family) {
+  if (_gemini3NonTextSuffix.hasMatch(modelId)) return null;
+  final match = family.firstMatch(modelId);
+  if (match == null) return null;
+  return int.tryParse(match.namedGroup('minor') ?? '0') ?? 0;
 }
 
-bool _isGemini35FlashLiteModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.5-flash-lite([._:@/-]|$)', caseSensitive: false),
-  );
-}
+int? _gemini3FlashMinor(String modelId) =>
+    _gemini3Minor(modelId, _gemini3FlashId);
 
-bool _isGemini36PlusFlashModel(String modelId) {
-  return modelId.contains(
-    RegExp(r'gemini-3\.(?:6|7)-flash([._:@/-]|$)', caseSensitive: false),
-  );
-}
+int? _gemini3ProMinor(String modelId) => _gemini3Minor(modelId, _gemini3ProId);
 
 bool _isGemini3TextModel(String modelId) {
   return modelId.contains(
@@ -89,59 +115,35 @@ Map<String, dynamic> _googleThinkingConfig(
     };
   }
 
-  // Match gemini-3-pro or gemini-3-pro-preview (and similar variants)
-  final isGemini3ProImage = upstreamModelId.contains(
-    RegExp(r'gemini-3-pro-image(-preview)?', caseSensitive: false),
-  );
-  final isGemini31Pro = upstreamModelId.contains(
-    RegExp(r'gemini-3\.1-pro(-preview)?', caseSensitive: false),
-  );
-  final isGemini3Pro = upstreamModelId.contains(
-    RegExp(r'gemini-3-pro(-preview)?', caseSensitive: false),
-  );
-  final isGemini3Flash = upstreamModelId.contains(
-    RegExp(r'gemini-3-flash(-preview)?', caseSensitive: false),
-  );
-  final isGemini35Flash = _isGemini35FlashModel(upstreamModelId);
-  final isGemini35FlashLite = _isGemini35FlashLiteModel(upstreamModelId);
-  final isGemini36PlusFlash = _isGemini36PlusFlashModel(upstreamModelId);
-  if (isGemini3ProImage) {
-    return {
-      'includeThoughts': true,
-      if (budget != null && budget >= 0) 'thinkingBudget': budget,
-    };
-  }
-  // Gemini 3.1 Pro: supports 'low', 'medium', 'high' (no minimal)
-  if (isGemini31Pro) {
+  final proMinor = _gemini3ProMinor(upstreamModelId);
+  if (proMinor != null) {
+    // gemini-3-pro has only 'low' and 'high'; 3.1 added 'medium'.
+    final hasMedium = proMinor >= _gemini3ProMediumMinor;
     String level = 'high';
     if (off) {
       level = 'low';
     } else if (budget != null && budget > 0) {
       if (budget < 8000) {
         level = 'low';
-      } else if (budget < 24000) {
-        level = 'medium'; // gemini 3.1 pro support medium
+      } else if (budget < 24000 && hasMedium) {
+        level = 'medium';
       }
     }
-    return {'includeThoughts': true, 'thinkingLevel': level};
+    // Gemini 3 always thinks, so "off" means hiding thoughts at the lowest level.
+    return {'includeThoughts': !off, 'thinkingLevel': level};
   }
-  // Gemini 3 Pro: supports 'low' and 'high' only (no off)
-  if (isGemini3Pro) {
-    String level = 'high';
-    if (off || (budget != null && budget > 0 && budget < 8000)) {
-      // Off or Light (1024) -> low
-      level = 'low';
-    }
-    return {'includeThoughts': true, 'thinkingLevel': level};
-  }
-  // Gemini 3 Flash, 3.5 Flash/Lite, and 3.6/3.7 Flash support
-  // 'minimal', 'low', 'medium', and 'high'.
-  if (isGemini3Flash || isGemini35Flash || isGemini36PlusFlash) {
-    String level = isGemini35FlashLite
-        ? 'minimal'
-        : (isGemini35Flash || isGemini36PlusFlash ? 'medium' : 'high');
+
+  final flashMinor = _gemini3FlashMinor(upstreamModelId);
+  if (flashMinor != null) {
+    // Flash dropped 'minimal' in 3.7, so the floor there is 'low' instead.
+    final lowest = flashMinor >= _gemini3FlashNoMinimalMinor
+        ? 'low'
+        : 'minimal';
+    String level = _gemini3FlashLiteId.hasMatch(upstreamModelId)
+        ? lowest
+        : (flashMinor >= _gemini3FlashModernMinor ? 'medium' : 'high');
     if (off) {
-      level = 'minimal';
+      level = lowest;
     } else if (budget != null && budget > 0) {
       // Light (1024) -> low, Medium (16000) -> medium, Heavy (32000) -> high
       if (budget < 8000) {
@@ -152,7 +154,7 @@ Map<String, dynamic> _googleThinkingConfig(
         level = 'high';
       }
     }
-    return {'includeThoughts': true, 'thinkingLevel': level};
+    return {'includeThoughts': !off, 'thinkingLevel': level};
   }
   // Gemini 2.x and below: use thinkingBudget
   if (off) return {'includeThoughts': false};
@@ -266,8 +268,8 @@ Map<String, dynamic> _googleApiPart(Map part) {
 }
 
 int? _defaultGeminiMaxOutputTokens(String upstreamModelId) {
-  if (_isGemini35FlashModel(upstreamModelId) ||
-      _isGemini36PlusFlashModel(upstreamModelId)) {
+  final flashMinor = _gemini3FlashMinor(upstreamModelId);
+  if (flashMinor != null && flashMinor >= _gemini3FlashModernMinor) {
     return 65536;
   }
   return null;

--- a/test/google_thinking_config_test.dart
+++ b/test/google_thinking_config_test.dart
@@ -81,6 +81,33 @@ Map<String, dynamic>? _thinkingConfig(Map<String, dynamic> body) {
   return thinkingConfig.cast<String, dynamic>();
 }
 
+// Runs one request against a throwaway local server and returns the body it saw.
+Future<Map<String, dynamic>> _capture({
+  required String modelId,
+  int? thinkingBudget,
+}) async {
+  late Map<String, dynamic> body;
+  final server = await _startGeminiServer((b) => body = b);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  final chunks = await ChatApiService.sendMessageStream(
+    config: _geminiConfig(
+      'http://${server.address.address}:${server.port}/v1beta',
+    ),
+    modelId: modelId,
+    messages: const [
+      {'role': 'user', 'content': 'hello'},
+    ],
+    thinkingBudget: thinkingBudget,
+    stream: false,
+  ).toList();
+
+  expect(chunks.last.isDone, isTrue, reason: modelId);
+  return body;
+}
+
 void main() {
   group('Google Gemma 4 thinking config', () {
     test('non-stream request maps custom budget to thinking level', () async {
@@ -171,7 +198,7 @@ void main() {
     });
   });
 
-  group('latest Gemini Flash thinking config', () {
+  group('Gemini 3.x thinking config', () {
     test('Gemini 3.6 Flash defaults to medium with 64K output', () async {
       late Map<String, dynamic> capturedBody;
       final server = await _startGeminiServer((body) {
@@ -262,6 +289,141 @@ void main() {
       expect(
         (capturedBody['generationConfig'] as Map)['maxOutputTokens'],
         65536,
+      );
+    });
+
+    test('Gemini 3.7 Flash uses thinkingLevel, never thinkingBudget', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.7-flash',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'medium',
+      });
+      expect((body['generationConfig'] as Map)['maxOutputTokens'], 65536);
+    });
+
+    test('Gemini 3.1 Pro maps budget to medium thinkingLevel', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-pro-preview',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'medium',
+      });
+    });
+
+    // Gemini 3.0 pro has no 'medium'; 'off' hides thoughts at 'low'.
+    test('Gemini 3 Pro floors at low and hides thoughts when off', () async {
+      final body = await _capture(modelId: 'gemini-3-pro', thinkingBudget: 0);
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': false,
+        'thinkingLevel': 'low',
+      });
+    });
+
+    test('Gemini 3 Pro never maps to medium', () async {
+      final body = await _capture(
+        modelId: 'gemini-3-pro',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingLevel': 'high',
+      });
+      expect(_thinkingConfig(body)!.containsKey('thinkingBudget'), isFalse);
+    });
+
+    test(
+      'Gemini 3.7 Flash floors at low because minimal is unsupported',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.7-flash',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': false,
+          'thinkingLevel': 'low',
+        });
+      },
+    );
+
+    test(
+      'Gemini 3.6 Flash still floors at minimal when thinking is off',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.6-flash',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': false,
+          'thinkingLevel': 'minimal',
+        });
+      },
+    );
+
+    test('Gemini 3.7 Flash-Lite floors at low when thinking is off', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.7-flash-lite',
+        thinkingBudget: 0,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': false,
+        'thinkingLevel': 'low',
+      });
+    });
+
+    // Non-text flash ids fall through to the raw-budget branch and get no 64K
+    // default: maxOutputTokens stays unset and the API applies its own default.
+    test('image ids never get thinkingLevel or a 64K default', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.5-flash-image',
+        thinkingBudget: 16000,
+      );
+
+      expect(_thinkingConfig(body), {
+        'includeThoughts': true,
+        'thinkingBudget': 16000,
+      });
+      expect(
+        (body['generationConfig'] as Map).containsKey('maxOutputTokens'),
+        isFalse,
+      );
+    });
+
+    // Image ids fall through to the raw-budget branch; the off case is the only
+    // one that distinguishes that from the old dedicated image branch.
+    test('image ids hide thoughts when thinking is off', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-flash-image',
+        thinkingBudget: 0,
+      );
+
+      expect(_thinkingConfig(body), {'includeThoughts': false});
+    });
+
+    test('TTS ids never get a thinkingLevel', () async {
+      final body = await _capture(
+        modelId: 'gemini-3.1-flash-tts-preview',
+        thinkingBudget: 16000,
+      );
+
+      expect(
+        _thinkingConfig(body)?.containsKey('thinkingLevel'),
+        isNot(isTrue),
+      );
+      expect(
+        (body['generationConfig'] as Map).containsKey('maxOutputTokens'),
+        isFalse,
       );
     });
   });


### PR DESCRIPTION
Port of Chevey339/kelivo#918. Gemini 3 thinking config matched a hardcoded model id list, so any release outside it (gemini-3.2-pro, future 3.x...) fell into the Gemini 2.x branch and sent thinkingBudget, which Gemini 3 rejects. Match on the parsed minor version instead.

- thinkingLevel now covers any gemini-3[.N]-pro/-flash id via version parsing, with named thresholds (pro medium ≥3.1, flash 64K/medium ≥3.5, flash no-minimal ≥3.7; 3.7 off floors at low)
- Image/TTS/Live ids held out of the version match — they fall through to the raw-budget branch; dedicated pro-image branch removed
- "Off" now sends includeThoughts: false at the model's lowest tier (was true, contradicting the 2.x branch) — Gemini 3 always thinks, but stops reporting it
- Test renamed google_gemma4_... -> google_thinking_config_test.dart, +8 cases (3-pro off/medium-gate, 3.5-flash-image raw-budget/64K, 3.7-flash-lite off, image/tts exclusion)

Verified: flutter test (16 cases + neighboring gemini tests, all green), dart analyze --fatal-infos lib test. Live-API off-path on 3.0 models unverified (no credentials); includeThoughts:false follows the Gemini 3 thinkingConfig contract.
