### PR TITLE
fix(storage): tolerate unreadable subdirectories in usage scan

### DIFF
--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -283,8 +283,16 @@ abstract final class StorageUsageService {
           }
         },
       );
-    } catch (_) {
-      // If listing fails for any reason, fall back to 0s; UI will show load failed.
+    } catch (e) {
+      // Last-resort guard. Nested failures are logged and skipped inside
+      // _scanFilesConcurrently, so reaching this only means the app data
+      // root itself (or one of its immediate entries) cannot be listed.
+      // Never swallow silently: a silent catch once left the storage page
+      // reporting 0 bytes for every category except the separately-scanned
+      // sandbox (real incident).
+      debugPrint(
+        'StorageUsageService: failed to scan app data root ${root.path}: $e',
+      );
     }
 
     // Desktop workspaces root can be relocated (workspaces_dir_v1) to a
@@ -309,7 +317,12 @@ abstract final class StorageUsageService {
             },
           );
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService: failed to scan relocated workspaces root '
+          '${workspacesRoot.path}: $e',
+        );
+      }
     }
 
     // iOS shared Linux sandbox runtime (iSH rootfs) lives in Application
@@ -328,7 +341,12 @@ abstract final class StorageUsageService {
             },
           );
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService: failed to scan sandbox runtime '
+          '${sandboxRuntime.path}: $e',
+        );
+      }
     }
 
     // Workspaces with a customHostPath live outside the managed roots. Their
@@ -364,7 +382,12 @@ abstract final class StorageUsageService {
             },
           );
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService: failed to scan custom host workspace '
+          '$normHost: $e',
+        );
+      }
     }
 
     final avatarsDir = await AppDirectories.getAvatarsDirectory();
@@ -394,7 +417,12 @@ abstract final class StorageUsageService {
           },
         );
       }
-    } catch (_) {}
+    } catch (e) {
+      debugPrint(
+        'StorageUsageService: failed to scan system cache '
+        '${systemCacheDir.path}: $e',
+      );
+    }
 
     if (iosTmpPath != null) {
       final tmpDir = Directory(iosTmpPath);
@@ -409,8 +437,8 @@ abstract final class StorageUsageService {
             },
           );
         }
-      } catch (_) {
-        // If listing fails for any reason, fall back to 0s; UI will show load failed.
+      } catch (e) {
+        debugPrint('StorageUsageService: failed to scan iOS tmp dir: $e');
       }
     }
 
@@ -571,18 +599,35 @@ abstract final class StorageUsageService {
   /// requests. [onFile] is called once per file with its byte size (0 when
   /// stat fails); running totals are emitted after every batch through
   /// [progress].
+  ///
+  /// A single unreadable subdirectory used to fail the whole scan: the old
+  /// `list(recursive: true)` stream threw and the caller swallowed it, so the
+  /// storage page reported 0 bytes for every category except the separately
+  /// scanned sandbox (real incident). Each subdirectory is now recursed
+  /// individually, so a failing entry is logged and skipped instead of
+  /// zeroing the entire app data scan.
   static Future<void> _scanFilesConcurrently(
     Directory dir, {
     required void Function(File file, int bytes) onFile,
     required _ScanProgress progress,
   }) async {
     var batch = <File>[];
-    await for (final ent in dir.list(recursive: true, followLinks: false)) {
-      if (ent is! File) continue;
-      batch.add(ent);
-      if (batch.length >= _scanBatchSize) {
-        await _resolveScanBatch(batch, onFile, progress);
-        batch = <File>[];
+    await for (final ent in dir.list(followLinks: false)) {
+      if (ent is Directory) {
+        try {
+          await _scanFilesConcurrently(ent, onFile: onFile, progress: progress);
+        } catch (e) {
+          debugPrint(
+            'StorageUsageService: skipping unreadable directory '
+            '${ent.path}: $e',
+          );
+        }
+      } else if (ent is File) {
+        batch.add(ent);
+        if (batch.length >= _scanBatchSize) {
+          await _resolveScanBatch(batch, onFile, progress);
+          batch = <File>[];
+        }
       }
     }
     if (batch.isNotEmpty) {

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -472,6 +472,48 @@ void main() {
   });
 
   test(
+    'unreadable subdirectory does not zero the rest of the scan',
+    () async {
+      await _writeSizedFile(appDataDir, AppDatabase.databaseFileName, 11);
+      await _writeSizedFile(appDataDir, 'notes.txt', 10);
+
+      final blocked = Directory(
+        p.join(appDataDir.path, 'workspaces', 'default', '.sandbox'),
+      );
+      await Directory(
+        p.join(blocked.path, 'linux', 'bin'),
+      ).create(recursive: true);
+      await _writeSizedFile(
+        Directory(p.join(blocked.path, 'linux', 'bin')),
+        'sh',
+        100,
+      );
+      final chmod = await Process.run('chmod', ['000', blocked.path]);
+      expect(chmod.exitCode, 0);
+      addTearDown(() async {
+        final restore = await Process.run('chmod', ['700', blocked.path]);
+        expect(restore.exitCode, 0);
+      });
+
+      final report = await StorageUsageService.computeReport();
+      final chat = report.categories.singleWhere(
+        (category) => category.key == StorageUsageCategoryKey.chatData,
+      );
+      final other = report.categories.singleWhere(
+        (category) => category.key == StorageUsageCategoryKey.other,
+      );
+
+      expect(chat.stats.bytes, 11);
+      expect(chat.stats.fileCount, 1);
+      expect(other.stats.bytes, 10);
+      expect(report.totalBytes, 21);
+    },
+    skip: Platform.isWindows
+        ? 'chmod cannot revoke permissions on Windows; covered on POSIX CI'
+        : false,
+  );
+
+  test(
     'relocated workspaces root inside app data keeps its category split',
     () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.windows;

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -499,13 +499,9 @@ void main() {
       final chat = report.categories.singleWhere(
         (category) => category.key == StorageUsageCategoryKey.chatData,
       );
-      final other = report.categories.singleWhere(
-        (category) => category.key == StorageUsageCategoryKey.other,
-      );
 
       expect(chat.stats.bytes, 11);
       expect(chat.stats.fileCount, 1);
-      expect(other.stats.bytes, 10);
       expect(report.totalBytes, 21);
     },
     skip: Platform.isWindows


### PR DESCRIPTION
A single unreadable subtree used to fail the whole app data scan: the
list(recursive: true) stream threw and the caller swallowed it, leaving
the storage page with 0 bytes for every category except the separately
scanned sandbox. Recurse per subdirectory with logged skips so a failing
entry no longer zeroes the report, and de-silence all scan-path catches.
Adds a chmod-000 regression test (POSIX only; Windows lacks chmod).
