### PR TITLE
fix(windows): stabilize streaming markdown accessibility tree

### DIFF
--- a/lib/desktop/setting/tts_services_pane.dart
+++ b/lib/desktop/setting/tts_services_pane.dart
@@ -14,6 +14,7 @@ import '../../features/settings/widgets/mimo_reference_audio_picker.dart';
 import '../../features/settings/widgets/voice_service_widgets.dart';
 import '../../shared/widgets/ios_switch.dart';
 import '../../shared/widgets/snackbar.dart';
+import '../../shared/widgets/sf_slider_tile.dart';
 import '../../theme/app_font_weights.dart';
 import '../../theme/app_semantic_colors.dart';
 
@@ -671,10 +672,14 @@ class _SystemTtsCardState extends State<_SystemTtsCard> {
                       color: cs.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
-                  Slider(
+                  SfSliderTile(
                     value: rate,
                     min: 0.1,
                     max: 1.0,
+                    label: rate.toStringAsFixed(2),
+                    semanticLabel: l10n.ttsServicesPageSpeechRateLabel,
+                    semanticFormatterCallback: (value) =>
+                        value.toStringAsFixed(2),
                     onChanged: (v) {
                       rate = v;
                       if (ctx.mounted) (ctx as Element).markNeedsBuild();
@@ -689,10 +694,14 @@ class _SystemTtsCardState extends State<_SystemTtsCard> {
                       color: cs.onSurface.withValues(alpha: 0.7),
                     ),
                   ),
-                  Slider(
+                  SfSliderTile(
                     value: pitch,
                     min: 0.5,
                     max: 2.0,
+                    label: pitch.toStringAsFixed(2),
+                    semanticLabel: l10n.ttsServicesPagePitchLabel,
+                    semanticFormatterCallback: (value) =>
+                        value.toStringAsFixed(2),
                     onChanged: (v) {
                       pitch = v;
                       if (ctx.mounted) (ctx as Element).markNeedsBuild();

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -40,6 +40,7 @@ import '../../../core/models/assistant_regex.dart';
 import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/version_switcher.dart';
+import '../../../shared/widgets/windows_ax_tree_safe_tooltip.dart';
 import '../../../desktop/desktop_context_menu.dart';
 import '../../../desktop/menu_anchor.dart';
 import '../../../shared/widgets/emoji_text.dart';
@@ -220,7 +221,7 @@ Widget _buildTextToSpeechReplayRow(
         ),
       ),
       const SizedBox(width: 8),
-      Tooltip(
+      WindowsAxTreeSafeTooltip(
         message: l10n.ttsFloatingReplayTooltip,
         child: IosIconButton(
           size: 14,
@@ -418,7 +419,7 @@ void _showToolDetail(BuildContext context, ToolUIPart part) {
                               overflow: TextOverflow.ellipsis,
                             ),
                           ),
-                          Tooltip(
+                          WindowsAxTreeSafeTooltip(
                             message: l10n.mcpPageClose,
                             child: IconButton(
                               icon: Icon(
@@ -4816,7 +4817,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                                 overflow: TextOverflow.ellipsis,
                               ),
                             ),
-                            Tooltip(
+                            WindowsAxTreeSafeTooltip(
                               message: l10n.mcpPageClose,
                               child: IconButton(
                                 icon: Icon(

--- a/lib/features/home/widgets/multi_ai_comparison_view.dart
+++ b/lib/features/home/widgets/multi_ai_comparison_view.dart
@@ -4,6 +4,7 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../theme/app_font_weights.dart';
 import '../../../theme/app_semantic_colors.dart';
+import '../../../shared/widgets/windows_ax_tree_safe_tooltip.dart';
 import '../../../utils/platform_utils.dart';
 import '../../chat/pages/reading_mode_page.dart';
 import '../../chat/widgets/chat_message_widget.dart'
@@ -466,7 +467,7 @@ class _AddModelButton extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     return Padding(
       padding: const EdgeInsets.only(right: 6),
-      child: Tooltip(
+      child: WindowsAxTreeSafeTooltip(
         message: l10n.multiAIAddModelTooltip,
         child: GestureDetector(
           onTap: onTap,
@@ -511,7 +512,7 @@ class _ModeButtonState extends State<_ModeButton> {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Tooltip(
+    return WindowsAxTreeSafeTooltip(
       message: widget.tooltip,
       child: GestureDetector(
         onTapDown: (_) => setState(() => _pressed = true),

--- a/lib/shared/dialogs/image_compression_dialog.dart
+++ b/lib/shared/dialogs/image_compression_dialog.dart
@@ -6,6 +6,7 @@ import '../../icons/lucide_adapter.dart';
 import '../../l10n/app_localizations.dart';
 import '../../utils/format.dart';
 import '../widgets/ios_tactile.dart';
+import '../widgets/sf_slider_tile.dart';
 
 /// Compression config returned by [ImageCompressionDialog].
 class CompressionConfig {
@@ -288,7 +289,6 @@ class _ImageCompressionDialogBodyState
   }
 
   Widget _buildQualitySlider(ColorScheme cs, AppLocalizations l10n) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -312,34 +312,23 @@ class _ImageCompressionDialogBodyState
             ),
           ],
         ),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 3,
-            activeTrackColor: cs.primary,
-            inactiveTrackColor: cs.onSurface.withValues(
-              alpha: isDark ? 0.22 : 0.18,
-            ),
-            thumbColor: cs.primary,
-            overlayColor: cs.primary.withValues(alpha: 0.12),
-            showValueIndicator: ShowValueIndicator.never,
-          ),
-          child: Slider(
-            value: _quality.toDouble(),
-            min: _minQuality.toDouble(),
-            max: _maxQuality.toDouble(),
-            divisions: _maxQuality - _minQuality,
-            onChanged: (_hasAlpha && _keepPng)
-                ? null
-                : (v) => setState(() => _quality = v.round()),
-          ),
+        SfSliderTile(
+          value: _quality.toDouble(),
+          min: _minQuality.toDouble(),
+          max: _maxQuality.toDouble(),
+          divisions: _maxQuality - _minQuality,
+          label: '$_quality%',
+          semanticLabel: l10n.imageCompressionQuality,
+          semanticFormatterCallback: (value) => '${value.round()}%',
+          onChanged: (_hasAlpha && _keepPng)
+              ? null
+              : (value) => setState(() => _quality = value.round()),
         ),
       ],
     );
   }
 
   Widget _buildDimensionSlider(ColorScheme cs, AppLocalizations l10n) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -363,24 +352,15 @@ class _ImageCompressionDialogBodyState
             ),
           ],
         ),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 3,
-            activeTrackColor: cs.primary,
-            inactiveTrackColor: cs.onSurface.withValues(
-              alpha: isDark ? 0.22 : 0.18,
-            ),
-            thumbColor: cs.primary,
-            overlayColor: cs.primary.withValues(alpha: 0.12),
-            showValueIndicator: ShowValueIndicator.never,
-          ),
-          child: Slider(
-            value: _maxDimension.toDouble(),
-            min: _sliderMin.toDouble(),
-            max: _maxDimensionUpper.toDouble(),
-            divisions: ((_maxDimensionUpper - _sliderMin) ~/ 64).clamp(1, 100),
-            onChanged: (v) => setState(() => _maxDimension = v.round()),
-          ),
+        SfSliderTile(
+          value: _maxDimension.toDouble(),
+          min: _sliderMin.toDouble(),
+          max: _maxDimensionUpper.toDouble(),
+          divisions: ((_maxDimensionUpper - _sliderMin) ~/ 64).clamp(1, 100),
+          label: '$_maxDimension px',
+          semanticLabel: l10n.imageCompressionMaxDimension,
+          semanticFormatterCallback: (value) => '${value.round()} px',
+          onChanged: (value) => setState(() => _maxDimension = value.round()),
         ),
         const SizedBox(height: 4),
         Row(

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -44,6 +44,7 @@ import 'html_preview_block.dart';
 import '../cache/byte_lru_cache.dart';
 import 'incremental_markdown_document.dart';
 import 'markdown_line_lexer.dart';
+import 'windows_ax_tree_safe_tooltip.dart';
 
 // Inline math is parsed on the UI thread. Bound the lookahead window so a long
 // line with many unmatched openers cannot trigger repeated whole-line scans.
@@ -587,7 +588,12 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                       blockContents[i - 1],
                       mathEnabled: settings.enableMathRendering,
                     ))
-                  _MarkdownBlockSeparator(style: baseTextStyle),
+                  _MarkdownBlockSeparator(
+                    key: ValueKey(
+                      'markdown-block-separator-${sourceBlocks[i].start}',
+                    ),
+                    style: baseTextStyle,
+                  ),
                 _CachedMarkdownBlock(
                   key: ValueKey(
                     'markdown-source-block-${sourceBlocks[i].start}',
@@ -682,7 +688,8 @@ class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
   Key _parseIdentity(String content) {
     final previous = _identityContent;
     if (previous != null &&
-        (content.length < previous.length || !content.startsWith(previous))) {
+        !content.startsWith(previous) &&
+        !previous.startsWith(content)) {
       _identityEpoch++;
     }
     _identityContent = content;
@@ -771,7 +778,7 @@ bool _isLineBreak(int unit) => markdownIsLogicalLineBreak(unit);
 /// only ever ends a block on a run of bare line breaks, so one of these stands
 /// in for every gap it opens.
 class _MarkdownBlockSeparator extends StatelessWidget {
-  const _MarkdownBlockSeparator({required this.style});
+  const _MarkdownBlockSeparator({super.key, required this.style});
 
   /// The `height` hardcoded by `NewLines` in `gpt_markdown`.
   static const double _newLinesHeight = 1.15;
@@ -2943,7 +2950,7 @@ class _CodeBlockIconAction extends StatelessWidget {
     final color = Theme.of(
       context,
     ).colorScheme.onSurfaceVariant.withValues(alpha: 0.5);
-    return Tooltip(
+    return WindowsAxTreeSafeTooltip(
       message: label,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(4),
@@ -3795,7 +3802,7 @@ class _MarkdownTableToolbar extends StatelessWidget {
             ),
           ),
           _copyButton(context),
-          Tooltip(
+          WindowsAxTreeSafeTooltip(
             message: imageActionLabel,
             child: IosIconButton(
               icon: Lucide.ImageDown,
@@ -3808,7 +3815,7 @@ class _MarkdownTableToolbar extends StatelessWidget {
               color: cs.onSurfaceVariant.withValues(alpha: 0.68),
             ),
           ),
-          Tooltip(
+          WindowsAxTreeSafeTooltip(
             message: exportLabel,
             child: IosIconButton(
               icon: Lucide.Download,
@@ -3830,7 +3837,7 @@ class _MarkdownTableToolbar extends StatelessWidget {
     final showMenu = showCopyMenu && tsvCopyLabel != null && onCopyTsv != null;
 
     if (!showMenu) {
-      return Tooltip(
+      return WindowsAxTreeSafeTooltip(
         message: copyLabel,
         child: IosIconButton(
           icon: Lucide.Copy,
@@ -3845,7 +3852,7 @@ class _MarkdownTableToolbar extends StatelessWidget {
       );
     }
 
-    return Tooltip(
+    return WindowsAxTreeSafeTooltip(
       message: copyLabel,
       child: IosIconButton(
         key: _copyMenuKey,

--- a/lib/shared/widgets/sf_slider_tile.dart
+++ b/lib/shared/widgets/sf_slider_tile.dart
@@ -50,7 +50,8 @@ class SfSliderTile extends StatelessWidget {
   /// Text shown in the waterdrop tooltip while interacting.
   final String label;
 
-  final ValueChanged<double> onChanged;
+  /// Called while the value changes. A null callback disables the slider.
+  final ValueChanged<double>? onChanged;
 
   final ValueChanged<double>? onChangeEnd;
 
@@ -173,7 +174,7 @@ class SfSliderTile extends StatelessWidget {
                   ],
           ),
         ),
-        onChanged: (v) => onChanged(_toDouble(v)),
+        onChanged: onChanged == null ? null : (v) => onChanged!(_toDouble(v)),
         onChangeEnd: onChangeEnd == null
             ? null
             : (v) => onChangeEnd!(_toDouble(v)),

--- a/lib/shared/widgets/windows_ax_tree_safe_tooltip.dart
+++ b/lib/shared/widgets/windows_ax_tree_safe_tooltip.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// A Material tooltip isolated from sibling tooltip traversal anchors on
+/// Windows.
+///
+/// Flutter 3.44 can merge multiple [Tooltip] traversal-parent semantics into
+/// one `IndexedSemantics` node (for example, inside a chat [ListView]). Only
+/// one traversal identifier survives that merge, so Windows receives an
+/// orphan accessibility node and rejects the entire AXTree update. Giving
+/// every tooltip its own semantics container prevents that merge while
+/// preserving the native tooltip UI and accessibility description.
+///
+/// Remove the Windows-specific container once the framework fix for
+/// https://github.com/flutter/flutter/issues/182444 reaches the minimum
+/// supported Flutter stable version.
+class WindowsAxTreeSafeTooltip extends StatelessWidget {
+  const WindowsAxTreeSafeTooltip({
+    super.key,
+    required this.message,
+    required this.child,
+  });
+
+  final String message;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final tooltip = Tooltip(message: message, child: child);
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.windows) {
+      return tooltip;
+    }
+    return Semantics(container: true, child: tooltip);
+  }
+}

--- a/test/shared/dialogs/image_compression_dialog_test.dart
+++ b/test/shared/dialogs/image_compression_dialog_test.dart
@@ -1,0 +1,48 @@
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/dialogs/image_compression_dialog.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:syncfusion_flutter_sliders/sliders.dart';
+
+void main() {
+  testWidgets('image compression dialog uses overlay-free sliders on Windows', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => ImageCompressionDialog.show(
+              context,
+              imagePath: 'missing-image.png',
+              totalImageCount: 1,
+              originalWidth: 2048,
+              originalHeight: 1024,
+              hasRealAlpha: true,
+              onCompress: (_) async {},
+            ),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+
+    expect(find.byType(Slider), findsNothing);
+    expect(find.byType(SfSlider), findsNWidgets(2));
+
+    final sliders = tester.widgetList<SfSlider>(find.byType(SfSlider)).toList();
+    expect(sliders.first.onChanged, isNull);
+    expect(sliders.first.stepSize, 1);
+    expect(sliders.last.onChanged, isNotNull);
+    expect(sliders.last.stepSize, 64);
+  });
+}

--- a/test/shared/dialogs/image_compression_dialog_test.dart
+++ b/test/shared/dialogs/image_compression_dialog_test.dart
@@ -10,39 +10,43 @@ void main() {
     tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.windows;
-    addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-    await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Builder(
-          builder: (context) => TextButton(
-            onPressed: () => ImageCompressionDialog.show(
-              context,
-              imagePath: 'missing-image.png',
-              totalImageCount: 1,
-              originalWidth: 2048,
-              originalHeight: 1024,
-              hasRealAlpha: true,
-              onCompress: (_) async {},
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => TextButton(
+              onPressed: () => ImageCompressionDialog.show(
+                context,
+                imagePath: 'missing-image.png',
+                totalImageCount: 1,
+                originalWidth: 2048,
+                originalHeight: 1024,
+                hasRealAlpha: true,
+                onCompress: (_) async {},
+              ),
+              child: const Text('open'),
             ),
-            child: const Text('open'),
           ),
         ),
-      ),
-    );
+      );
 
-    await tester.tap(find.text('open'));
-    await tester.pump();
+      await tester.tap(find.text('open'));
+      await tester.pump();
 
-    expect(find.byType(Slider), findsNothing);
-    expect(find.byType(SfSlider), findsNWidgets(2));
+      expect(find.byType(Slider), findsNothing);
+      expect(find.byType(SfSlider), findsNWidgets(2));
 
-    final sliders = tester.widgetList<SfSlider>(find.byType(SfSlider)).toList();
-    expect(sliders.first.onChanged, isNull);
-    expect(sliders.first.stepSize, 1);
-    expect(sliders.last.onChanged, isNotNull);
-    expect(sliders.last.stepSize, 64);
+      final sliders = tester
+          .widgetList<SfSlider>(find.byType(SfSlider))
+          .toList();
+      expect(sliders.first.onChanged, isNull);
+      expect(sliders.first.stepSize, 1);
+      expect(sliders.last.onChanged, isNotNull);
+      expect(sliders.last.stepSize, 64);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 }

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -980,6 +980,82 @@ Inline ***strong emphasis*** text.
   });
 
   testWidgets(
+    'MarkdownWithCodeHighlight preserves a block parse identity when its live tail commits',
+    (tester) async {
+      final paragraph = 'A long streaming paragraph. ${'content ' * 70}';
+      final text = ValueNotifier<String>('$paragraph\n');
+      addTearDown(text.dispose);
+
+      await tester.pumpWidget(_streamingMarkdownHarness(text));
+      await tester.pump();
+
+      final firstBlock = find.byKey(const ValueKey('markdown-source-block-0'));
+      final firstMarkdown = find.descendant(
+        of: firstBlock,
+        matching: find.byType(GptMarkdown),
+      );
+      final originalElement = tester.element(firstMarkdown);
+      expect(
+        tester.widget<GptMarkdown>(firstMarkdown).key,
+        const ValueKey('parsed-markdown-0'),
+      );
+
+      // The second newline commits the tail as a stable source block. Its
+      // normalized content shrinks by the pending newline, but it is still the
+      // same append-only parse and must keep its semantics/render identity.
+      text.value = '$paragraph\n\nnext paragraph';
+      await tester.pump();
+
+      final committedMarkdown = find.descendant(
+        of: firstBlock,
+        matching: find.byType(GptMarkdown),
+      );
+      expect(tester.element(committedMarkdown), same(originalElement));
+      expect(
+        tester.widget<GptMarkdown>(committedMarkdown).key,
+        const ValueKey('parsed-markdown-0'),
+      );
+      expect(
+        find.byKey(
+          ValueKey('markdown-block-separator-${paragraph.length + 2}'),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight replaces parse identity for a true source rewrite',
+    (tester) async {
+      final text = ValueNotifier<String>('alpha ${'content ' * 70}');
+      addTearDown(text.dispose);
+
+      await tester.pumpWidget(_streamingMarkdownHarness(text));
+      await tester.pump();
+
+      final firstBlock = find.byKey(const ValueKey('markdown-source-block-0'));
+      final firstMarkdown = find.descendant(
+        of: firstBlock,
+        matching: find.byType(GptMarkdown),
+      );
+      final originalElement = tester.element(firstMarkdown);
+
+      text.value = 'beta ${'replacement ' * 60}';
+      await tester.pump();
+
+      final rewrittenMarkdown = find.descendant(
+        of: firstBlock,
+        matching: find.byType(GptMarkdown),
+      );
+      expect(tester.element(rewrittenMarkdown), isNot(same(originalElement)));
+      expect(
+        tester.widget<GptMarkdown>(rewrittenMarkdown).key,
+        const ValueKey('parsed-markdown-1'),
+      );
+    },
+  );
+
+  testWidgets(
     'MarkdownWithCodeHighlight keeps refreshing during continuous long streams',
     (tester) async {
       final baseLines = List<String>.filled(

--- a/test/shared/widgets/sf_slider_tile_test.dart
+++ b/test/shared/widgets/sf_slider_tile_test.dart
@@ -55,6 +55,24 @@ void main() {
     expect(slider.stepSize, isNull);
   });
 
+  testWidgets('null onChanged disables the slider', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const SfSliderTile(
+          value: 75,
+          min: 30,
+          max: 100,
+          divisions: 70,
+          label: '—',
+          onChanged: null,
+        ),
+      ),
+    );
+
+    final slider = tester.widget<SfSlider>(find.byType(SfSlider));
+    expect(slider.onChanged, isNull);
+  });
+
   testWidgets('clamps out-of-range value before rendering', (tester) async {
     await tester.pumpWidget(
       wrap(

--- a/test/shared/widgets/windows_ax_tree_safe_tooltip_test.dart
+++ b/test/shared/widgets/windows_ax_tree_safe_tooltip_test.dart
@@ -1,0 +1,82 @@
+import 'package:Cuplivo/shared/widgets/windows_ax_tree_safe_tooltip.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Windows tooltips stay in separate semantics containers inside a list item',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      final semantics = tester.ensureSemantics();
+      addTearDown(semantics.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ListView(
+            children: [
+              Row(
+                children: const [
+                  WindowsAxTreeSafeTooltip(
+                    key: ValueKey('tooltip-a'),
+                    message: 'Tooltip A',
+                    child: Text('A'),
+                  ),
+                  WindowsAxTreeSafeTooltip(
+                    key: ValueKey('tooltip-b'),
+                    message: 'Tooltip B',
+                    child: Text('B'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      for (final key in const ['tooltip-a', 'tooltip-b']) {
+        final containers = tester
+            .widgetList<Semantics>(
+              find.descendant(
+                of: find.byKey(ValueKey(key)),
+                matching: find.byType(Semantics),
+              ),
+            )
+            .where((widget) => widget.container);
+        expect(containers, hasLength(1));
+      }
+
+      final traversal = tester.semantics.simulatedAccessibilityTraversal();
+      expect(traversal, contains(isSemantics(tooltip: 'Tooltip A')));
+      expect(traversal, contains(isSemantics(tooltip: 'Tooltip B')));
+    },
+  );
+
+  testWidgets('non-Windows tooltip does not add a semantics container', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: WindowsAxTreeSafeTooltip(
+          key: ValueKey('tooltip'),
+          message: 'Tooltip',
+          child: Text('child'),
+        ),
+      ),
+    );
+
+    final containers = tester
+        .widgetList<Semantics>(
+          find.descendant(
+            of: find.byKey(const ValueKey('tooltip')),
+            matching: find.byType(Semantics),
+          ),
+        )
+        .where((widget) => widget.container);
+    expect(containers, isEmpty);
+  });
+}

--- a/test/shared/widgets/windows_ax_tree_safe_tooltip_test.dart
+++ b/test/shared/widgets/windows_ax_tree_safe_tooltip_test.dart
@@ -8,48 +8,50 @@ void main() {
     'Windows tooltips stay in separate semantics containers inside a list item',
     (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.windows;
-      addTearDown(() => debugDefaultTargetPlatformOverride = null);
       final semantics = tester.ensureSemantics();
-      addTearDown(semantics.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: ListView(
-            children: [
-              Row(
-                children: const [
-                  WindowsAxTreeSafeTooltip(
-                    key: ValueKey('tooltip-a'),
-                    message: 'Tooltip A',
-                    child: Text('A'),
-                  ),
-                  WindowsAxTreeSafeTooltip(
-                    key: ValueKey('tooltip-b'),
-                    message: 'Tooltip B',
-                    child: Text('B'),
-                  ),
-                ],
-              ),
-            ],
+      try {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ListView(
+              children: [
+                Row(
+                  children: const [
+                    WindowsAxTreeSafeTooltip(
+                      key: ValueKey('tooltip-a'),
+                      message: 'Tooltip A',
+                      child: Text('A'),
+                    ),
+                    WindowsAxTreeSafeTooltip(
+                      key: ValueKey('tooltip-b'),
+                      message: 'Tooltip B',
+                      child: Text('B'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
-        ),
-      );
+        );
 
-      for (final key in const ['tooltip-a', 'tooltip-b']) {
-        final containers = tester
-            .widgetList<Semantics>(
-              find.descendant(
-                of: find.byKey(ValueKey(key)),
-                matching: find.byType(Semantics),
-              ),
-            )
-            .where((widget) => widget.container);
-        expect(containers, hasLength(1));
+        for (final key in const ['tooltip-a', 'tooltip-b']) {
+          final containers = tester
+              .widgetList<Semantics>(
+                find.descendant(
+                  of: find.byKey(ValueKey(key)),
+                  matching: find.byType(Semantics),
+                ),
+              )
+              .where((widget) => widget.container);
+          expect(containers, hasLength(1));
+        }
+
+        final traversal = tester.semantics.simulatedAccessibilityTraversal();
+        expect(traversal, contains(isSemantics(tooltip: 'Tooltip A')));
+        expect(traversal, contains(isSemantics(tooltip: 'Tooltip B')));
+      } finally {
+        semantics.dispose();
+        debugDefaultTargetPlatformOverride = null;
       }
-
-      final traversal = tester.semantics.simulatedAccessibilityTraversal();
-      expect(traversal, contains(isSemantics(tooltip: 'Tooltip A')));
-      expect(traversal, contains(isSemantics(tooltip: 'Tooltip B')));
     },
   );
 
@@ -57,26 +59,28 @@ void main() {
     tester,
   ) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
-    addTearDown(() => debugDefaultTargetPlatformOverride = null);
-
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: WindowsAxTreeSafeTooltip(
-          key: ValueKey('tooltip'),
-          message: 'Tooltip',
-          child: Text('child'),
-        ),
-      ),
-    );
-
-    final containers = tester
-        .widgetList<Semantics>(
-          find.descendant(
-            of: find.byKey(const ValueKey('tooltip')),
-            matching: find.byType(Semantics),
+    try {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: WindowsAxTreeSafeTooltip(
+            key: ValueKey('tooltip'),
+            message: 'Tooltip',
+            child: Text('child'),
           ),
-        )
-        .where((widget) => widget.container);
-    expect(containers, isEmpty);
+        ),
+      );
+
+      final containers = tester
+          .widgetList<Semantics>(
+            find.descendant(
+              of: find.byKey(const ValueKey('tooltip')),
+              matching: find.byType(Semantics),
+            ),
+          )
+          .where((widget) => widget.container);
+      expect(containers, isEmpty);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 }


### PR DESCRIPTION
## Summary

- preserve incremental Markdown rendering, the 512-character threshold, stable-block caching, and the full reasoning text
- keep a streaming Markdown block parse identity stable when tail normalization shortens it to a prefix, and key separators by the following source offset
- isolate chat, Markdown toolbar, and Multi-AI tooltips in Windows semantics containers to avoid conflicting traversal parents
- replace Windows-reachable Material sliders with the overlay-free shared Syncfusion slider, including the disabled quality state
- add regression coverage for Markdown identity, tooltip semantics isolation, and slider behavior

## Why

Flutter 3.44.8 can reject a Windows accessibility-tree update when incremental Markdown churn leaves an orphan node, when sibling Tooltip traversal anchors merge under one IndexedSemantics node, or when Material Slider contributes an OverlayPortal. During long streamed reasoning this repeats the accessibility_bridge error and risks the previous Windows crash mode.

The fix is application-side and does not hide semantics or degrade streaming behavior.

## Verification

Passed in PR Checks:
- Dart formatting check for changed files
- l10n generation and untranslated-message check
- dart analyze --fatal-infos for lib and test
- complete flutter test suite
- Android Kotlin unit tests

Also performed static repository searches confirming:
- no Material Slider remains in lib/desktop or the image-compression dialog
- the selected chat, Markdown toolbar, and Multi-AI paths no longer use raw Tooltip

Intentionally not run locally per request:
- local build
- local analyze or test
- Windows/NVDA manual verification

Final platform validation still requires Flutter 3.44.8 on Windows with NVDA while streaming a reasoning response longer than 512 characters.