### PR TITLE
fix(android): SAF 挂载同步零文件复制——内部路径白名单与 path_provider 目录布局不匹配

### DIFF
--- a/android/app/src/main/kotlin/com/cup11/cuplivo/SafMountPlugin.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/SafMountPlugin.kt
@@ -214,6 +214,7 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
       } catch (e: FileNotFoundException) {
         mainHandler.post { result.error("uri_not_found", e.message, null) }
       } catch (e: Exception) {
+        android.util.Log.e(TAG, "saf_mount background operation failed", e)
         mainHandler.post { result.error("access_failed", e.message ?: e.javaClass.simpleName, null) }
       }
     }.start()
@@ -301,16 +302,17 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
     }
   }
 
-  private fun copyToPath(uri: Uri, target: File) {
+  private fun copyToPath(uri: Uri, target: File): Boolean {
     val input = appContext.contentResolver.openInputStream(uri)
       ?: throw FileNotFoundException("Cannot open: $uri")
     target.parentFile?.mkdirs()
     input.use { source ->
       FileOutputStream(target).use { destination -> source.copyTo(destination) }
     }
+    return true
   }
 
-  private fun copyFromPath(uri: Uri, source: File) {
+  private fun copyFromPath(uri: Uri, source: File): Boolean {
     if (!source.isFile) throw FileNotFoundException("Cannot open: $source")
     // "rwt": read, write, truncate — overwrite in place without recreating
     // the document (keeps its identity and mtime behavior provider-side).
@@ -321,6 +323,7 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
         FileOutputStream(descriptor.fileDescriptor).use { output -> input.copyTo(output) }
       }
     }
+    return true
   }
 
   private fun createFile(parentUri: Uri, name: String): String {

--- a/android/app/src/main/kotlin/com/cup11/cuplivo/SafMountPlugin.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/SafMountPlugin.kt
@@ -233,6 +233,29 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
     return uri
   }
 
+  /**
+   * Canonical roots of the app-private internal storage that the Dart side
+   * may legitimately stream files through (path_provider layout on Android):
+   *
+   * - [Context.filesDir]            -> /data/user/0/<pkg>/files
+   *   (`getApplicationSupportDirectory`, databases, plugin stores)
+   * - [Context.getDir]("flutter")   -> /data/user/0/<pkg>/app_flutter
+   *   (`getApplicationDocumentsDirectory`: SAF mirrors, uploads, images, …)
+   * - [Context.cacheDir]            -> /data/user/0/<pkg>/cache
+   *   (transient scratch)
+   *
+   * The SAF mirror lives under the DOCUMENTS directory (`app_flutter/
+   * saf_mounts/`), which is a SIBLING of filesDir — NOT inside it. A
+   * whitelist of filesDir alone rejects every mirror/temp path with
+   * bad_args, so no file is ever copied in either direction (issue #528:
+   * partial enumeration, zero-file sync, "sync failed — will retry").
+   */
+  private fun internalRoots(): List<File> = listOf(
+    appContext.filesDir,
+    appContext.getDir("flutter", Context.MODE_PRIVATE),
+    appContext.cacheDir,
+  ).map { it.canonicalFile }
+
   private fun parseInternalFile(
     call: MethodCall,
     key: String,
@@ -244,10 +267,15 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
       return null
     }
     return try {
-      val root = appContext.filesDir.canonicalFile
       val file = File(raw).canonicalFile
-      val rootPrefix = root.path + File.separator
-      if (!file.path.startsWith(rootPrefix)) {
+      // A path exactly equal to one of the roots has nothing to stream;
+      // require it to be strictly INSIDE a root so ".."-spelled roots and
+      // the root directories themselves are rejected.
+      if (!isInsideInternalRoots(file, internalRoots())) {
+        android.util.Log.w(
+          TAG,
+          "Rejected $key outside app-internal storage: ${file.path}",
+        )
         result.error("bad_args", "$key must stay inside app storage", null)
         null
       } else {
@@ -355,6 +383,18 @@ class SafMountPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, ActivityA
   companion object {
     private const val TAG = "SafMountPlugin"
     private const val PICK_TREE_REQUEST_CODE = 4201
+
+    /**
+     * True when [file] (already canonicalized) sits strictly inside one of
+     * [roots] (canonical app-internal directories). Pure so it can be unit
+     * tested without an Android context.
+     */
+    @JvmStatic
+    fun isInsideInternalRoots(file: File, roots: List<File>): Boolean {
+      return roots.any { root ->
+        file.path.startsWith(root.path + File.separator)
+      }
+    }
 
     /**
      * The outstanding pickTree result, shared across plugin instances.

--- a/android/app/src/test/kotlin/com/cup11/cuplivo/SafMountInternalPathTest.kt
+++ b/android/app/src/test/kotlin/com/cup11/cuplivo/SafMountInternalPathTest.kt
@@ -24,6 +24,7 @@ class SafMountInternalPathTest {
 
   private fun pluginRoots(): List<File> =
     listOf(File(filesDir), File(appFlutterDir), File(cacheDir))
+      .map { it.canonicalFile }
 
   private fun allowed(path: String): Boolean =
     SafMountPlugin.isInsideInternalRoots(File(path).canonicalFile, pluginRoots())

--- a/android/app/src/test/kotlin/com/cup11/cuplivo/SafMountInternalPathTest.kt
+++ b/android/app/src/test/kotlin/com/cup11/cuplivo/SafMountInternalPathTest.kt
@@ -1,0 +1,96 @@
+package com.cup11.cuplivo
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for issue #528: the SAF mount mirror lives under the
+ * Flutter DOCUMENTS directory (`getDir("flutter")` -> `/data/user/0/<pkg>/
+ * app_flutter`), which is a sibling of `filesDir`. The old whitelist only
+ * accepted paths inside `filesDir`, so every `copyToPath` / `copyFromPath`
+ * call was rejected with bad_args and no file ever synced.
+ *
+ * These tests pin the corrected whitelist against the path_provider layout.
+ */
+class SafMountInternalPathTest {
+
+  // Simulated Android internal-storage layout for one package.
+  private val dataRoot = "/data/user/0/com.cup11.cuplivo"
+  private val filesDir = "$dataRoot/files"
+  private val appFlutterDir = "$dataRoot/app_flutter"
+  private val cacheDir = "$dataRoot/cache"
+
+  private fun pluginRoots(): List<File> =
+    listOf(File(filesDir), File(appFlutterDir), File(cacheDir))
+
+  private fun allowed(path: String): Boolean =
+    SafMountPlugin.isInsideInternalRoots(File(path).canonicalFile, pluginRoots())
+
+  @Test
+  fun acceptsMirrorFileUnderFlutterDocumentsDirectory() {
+    // THE regression: SAF mirrors live at <documents>/saf_mounts/<mountId>/…
+    // where <documents> == getDir("flutter"), NOT filesDir.
+    assertTrue(
+      allowed("$appFlutterDir/saf_mounts/9f1c2c3e-1111-4aaa-9bbb-2c2c2c2c2c2c/docs/a.txt"),
+    )
+  }
+
+  @Test
+  fun acceptsCopyTempUnderSafStateDirectory() {
+    assertTrue(
+      allowed("$appFlutterDir/saf_mounts/.state/mount-id_copy_tmp"),
+    )
+  }
+
+  @Test
+  fun acceptsFilesInsideFilesDirectory() {
+    assertTrue(allowed("$filesDir/proot/bin/proot"))
+    assertTrue(allowed("$filesDir/some_plugin_store/data.json"))
+  }
+
+  @Test
+  fun acceptsFilesInsideCacheDirectory() {
+    assertTrue(allowed("$cacheDir/saf_copy_scratch/part.bin"))
+  }
+
+  @Test
+  fun rejectsSharedStoragePaths() {
+    assertFalse(allowed("/storage/emulated/0/Documents/a.txt"))
+    assertFalse(allowed("/sdcard/Download/x.bin"))
+  }
+
+  @Test
+  fun rejectsSiblingAppDirectories() {
+    assertFalse(allowed("/data/user/0/com.other.app/files/data.db"))
+    assertFalse(allowed("/data/user/0/com.other.app/app_flutter/saf_mounts/x/f"))
+  }
+
+  @Test
+  fun rejectsParentDirectoriesAndForeignRoots() {
+    assertFalse(allowed("$dataRoot/shared_prefs/settings.xml"))
+    assertFalse(allowed("/etc/passwd"))
+  }
+
+  @Test
+  fun rejectsTraversalResolvedOutsideTheRoots() {
+    // parseInternalFile canonicalizes before checking; a ".."-spelled path
+    // that escapes every root must be rejected after resolution.
+    val escaped = File("$filesDir/../../com.other/files/leak.txt").canonicalFile
+    assertFalse(SafMountPlugin.isInsideInternalRoots(escaped, pluginRoots()))
+  }
+
+  @Test
+  fun rejectsTheRootDirectoriesThemselves() {
+    // Only strict containment counts: streaming a directory itself is not a
+    // valid operation and a bare root must never pass.
+    assertFalse(SafMountPlugin.isInsideInternalRoots(File(filesDir), pluginRoots()))
+    assertFalse(
+      SafMountPlugin.isInsideInternalRoots(File(appFlutterDir), pluginRoots()),
+    )
+    assertFalse(
+      SafMountPlugin.isInsideInternalRoots(File(cacheDir), pluginRoots()),
+    )
+  }
+}


### PR DESCRIPTION
## 问题

Issue #528：Android 上 SAF 挂载同步只出现部分目录结构、零文件复制，手动同步总是失败（"sync failed — will retry"）。换新授权、重启应用均复现。

## 根因

`SafMountPlugin.parseInternalFile` 把合法路径白名单限定为 `Context.filesDir` 内部，但 `path_provider` 的 `getApplicationDocumentsDirectory()` 在 Android 上返回的是 `context.getDir("flutter")`，即 `/data/user/0/<pkg>/app_flutter` —— 它是 `filesDir` 的**兄弟目录**，不在其内部（引擎源码 `PathUtils.getDataDirectory` 可证）。

而 SAF 镜像目录位于 `<documents>/saf_mounts/<mountId>/`，`.state/` 复制临时文件也在其下。于是：

- 每一次 `copyToPath` / `copyFromPath` 都被 `bad_args` 拒绝
- 同步第一轮按字母序先创建了 `.crush` / `Github` 等目录外壳，随后**第一个文件复制即中止** → 镜像里只剩部分空目录、零文件
- 每次手动同步都失败并进入重试循环

Dart 侧测试用 fake channel 完全绕过了原生层路径校验，所以该 bug 从未被测试捕获。与 HyperOS 无关，是确定性路径不匹配。

## 修复

将白名单从"仅 `filesDir`"改为应用私有内部存储的完整布局（与 `path_provider` 在 Android 上的文档映射一致）：

- `filesDir`（`/data/user/0/<pkg>/files`，应用支持目录）
- `getDir("flutter")`（`/data/user/0/<pkg>/app_flutter`，文档目录，SAF 镜像所在）
- `cacheDir`（`/data/user/0/<pkg>/cache`）

判定逻辑提取为纯函数 `SafMountPlugin.isInsideInternalRoots`（与 `LinuxSandboxPlugin.selectSandboxAbi` 做法一致），先规范化再要求**严格位于根内**：

- `..` 拼写后解析逃逸出所有根的路径仍被拒绝
- 根目录本身被拒绝
- 共享存储（`/storage/emulated/0`）与其他应用数据仍不可达

## 测试

新增 `SafMountInternalPathTest`（纯 JUnit，无需 Android 上下文），覆盖：

- ✅ 回归路径：`app_flutter/saf_mounts/<id>/…` 镜像文件与 `.state` 临时文件
- ✅ `filesDir` / `cacheDir` 内路径仍放行
- ❌ 共享存储、兄弟应用数据、`shared_prefs`、`/etc/passwd`
- ❌ 规范化后逃逸的 `..` 路径
- ❌ 裸根目录本身

已用独立脚本按 Java `String.startsWith` 语义模拟验证全部用例符合预期。

Fixes #528