### PR TITLE
fix(chat): adopt layout-phase bottom pinning via super_sliver_list

### DIFF
--- a/lib/features/group_chat/pages/group_chat_page.dart
+++ b/lib/features/group_chat/pages/group_chat_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
@@ -52,7 +52,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
   final _isProcessingFiles = ValueNotifier<bool>(false);
   final _translations = <String, TranslationUiState>{};
 
-  late ListObserverController _observerController;
+  late ListController _listController;
   late ChatService _chatService;
   late stream_ctrl.StreamController _streamController;
   late ChatController _chatController;
@@ -75,7 +75,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
     super.didChangeDependencies();
     if (_initialized) return;
     _initialized = true;
-    _observerController = ListObserverController(controller: _scrollController);
+    _listController = ListController();
     _chatService = context.read<ChatService>();
     _streamController = stream_ctrl.StreamController(
       chatService: _chatService,
@@ -213,6 +213,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
     _isProcessingFiles.dispose();
     _inputController.dispose();
     _scrollController.dispose();
+    _listController.dispose();
     _inputFocus.dispose();
     super.dispose();
   }
@@ -387,6 +388,10 @@ class _GroupChatPageState extends State<GroupChatPage> {
 
     final messages = _chatController.collapsedMessages;
     final byGroup = _chatController.groupedMessages;
+    final settings = context.watch<SettingsProvider>();
+    final currentAssistant = context
+        .watch<AssistantProvider>()
+        .currentAssistant;
 
     return Scaffold(
       appBar: AppBar(
@@ -428,7 +433,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
                   )
                 : MessageListView(
                     scrollController: _scrollController,
-                    observerController: _observerController,
+                    listController: _listController,
                     messages: messages,
                     byGroup: byGroup,
                     versionSelections: _chatController.versionSelections,
@@ -441,6 +446,15 @@ class _GroupChatPageState extends State<GroupChatPage> {
                     selectedItems: const <String>{},
                     dividerPadding: EdgeInsets.zero,
                     isProcessingFiles: _isProcessingFiles,
+                    chatFontScale: settings.chatFontScale,
+                    collapseThinking: settings.autoCollapseThinking,
+                    collapsedCodeLines: settings.autoCollapseCodeBlock
+                        ? settings.autoCollapseCodeBlockLines
+                        : null,
+                    showModelIcon: settings.showModelIcon,
+                    showUserAvatar: settings.showUserAvatar,
+                    showTokenStats: settings.showTokenStats,
+                    assistant: currentAssistant,
                     streamingContentNotifier:
                         _streamController.streamingContentNotifier,
                     resolveSpeaker: _resolveSpeaker,

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -133,7 +133,7 @@ class HomePageController extends ChangeNotifier {
   final FocusNode _inputFocus;
   final TextEditingController _inputController;
   final ChatInputBarController _mediaController;
-  final ScrollController _scrollController;
+  ScrollController _scrollController;
 
   // ============================================================================
   // Services & Controllers (created internally)
@@ -501,7 +501,12 @@ class HomePageController extends ChangeNotifier {
         );
       }
     };
-    _viewModel.onScrollToBottom = () => _scrollToBottomSoon();
+    _viewModel.onScrollToBottom = () {
+      _scrollCtrl.resetUserScrolling();
+      _scrollCtrl.scrollToBottom(
+        animate: !_chatController.isCurrentConversationLoading,
+      );
+    };
     _viewModel.onHapticFeedback = () {
       try {
         final settings = _context.read<SettingsProvider>();
@@ -510,11 +515,12 @@ class HomePageController extends ChangeNotifier {
     };
     _viewModel.onConversationSwitched = () {
       _restoreMessageUiState();
-      _scrollToBottom(animate: false);
+      _scrollCtrl.positionAtBottomOnNextLayout();
     };
     _viewModel.onStreamFinished = () {
       // Trigger UI update when streaming finishes
       notifyListeners();
+      _scrollCtrl.stickToBottomAfterGeneration();
     };
     _viewModel.onAssistantMessageFinished = _handleAssistantMessageFinished;
   }
@@ -536,7 +542,19 @@ class HomePageController extends ChangeNotifier {
           _context.read<SettingsProvider>().autoScrollEnabled,
       getAutoScrollIdleSeconds: () =>
           _context.read<SettingsProvider>().autoScrollIdleSeconds,
+      getTopRevealInset: () =>
+          kToolbarHeight + MediaQuery.paddingOf(_context).top,
+      isGenerating: () => _chatController.isCurrentConversationLoading,
     );
+  }
+
+  /// Give a newly opened conversation its own scroll state.
+  void replaceScrollController(ScrollController controller) {
+    if (identical(_scrollController, controller)) return;
+    _scrollCtrl.dispose();
+    _scrollController = controller;
+    _initializeScrollController();
+    _scrollCtrl.positionAtBottomOnNextLayout();
   }
 
   void _initializeProviders() {
@@ -1191,7 +1209,6 @@ class HomePageController extends ChangeNotifier {
     }
 
     await _viewModel.switchConversation(id);
-    _scrollCtrl.clearObserverCache();
     recoverMultiAIState();
     _syncHeadlessChunks();
     notifyListeners();
@@ -1255,7 +1272,6 @@ class HomePageController extends ChangeNotifier {
       _mediaController.restoreInput(initialDraft);
       notifyListeners();
     }
-    _scrollCtrl.clearObserverCache();
     if (!isDesktopPlatform) {
       try {
         await _convoFadeController.forward();
@@ -2591,10 +2607,7 @@ class HomePageController extends ChangeNotifier {
 
   Future<void> scrollToMessageId(String targetId) async {
     if (_chatController.indexOfCollapsedMessageId(targetId) < 0) {
-      final loaded = _viewModel.loadUntilMessageVisible(targetId);
-      if (loaded) {
-        _scrollCtrl.clearObserverCache();
-      }
+      _viewModel.loadUntilMessageVisible(targetId);
       try {
         await WidgetsBinding.instance.endOfFrame;
       } catch (_) {}
@@ -2623,7 +2636,6 @@ class HomePageController extends ChangeNotifier {
       final loaded = _chatController.loadStartWindow();
       if (loaded) {
         _viewModel.restoreMessageUiState();
-        _scrollCtrl.clearObserverCache();
       }
     }
     _scrollCtrl.scrollToTop(animate: animate);
@@ -2634,7 +2646,6 @@ class HomePageController extends ChangeNotifier {
       final loaded = _chatController.loadEndWindow();
       if (loaded) {
         _viewModel.restoreMessageUiState();
-        _scrollCtrl.clearObserverCache();
       }
     }
     _scrollToBottom(animate: animate);

--- a/lib/features/home/controllers/message_render_model.dart
+++ b/lib/features/home/controllers/message_render_model.dart
@@ -1,0 +1,104 @@
+import '../../../core/models/chat_message.dart';
+
+/// Immutable, precomputed input for one logical timeline slot.
+///
+/// Renderer code must not scan the full message list or sort revisions while
+/// building an individual row.
+final class MessageRenderModel {
+  const MessageRenderModel({
+    required this.slotId,
+    required this.message,
+    required this.versions,
+    required this.availableVersions,
+    required this.selectedVersion,
+    required this.versionCount,
+    required this.selectedVersionIndex,
+    required this.showContextDivider,
+    required this.isLatestCompleteAssistant,
+  });
+
+  final String slotId;
+  final ChatMessage message;
+  final List<ChatMessage> versions;
+  final List<int> availableVersions;
+  final int selectedVersion;
+  final int versionCount;
+  final int selectedVersionIndex;
+  final bool showContextDivider;
+  final bool isLatestCompleteAssistant;
+}
+
+final class MessageRenderModelProjector {
+  const MessageRenderModelProjector._();
+
+  static List<MessageRenderModel> project({
+    required List<ChatMessage> messages,
+    required Map<String, List<ChatMessage>> byGroup,
+    required Map<String, int> versionSelections,
+    Map<String, int> versionCounts = const <String, int>{},
+    required int contextDividerIndex,
+  }) {
+    var latestCompleteAssistantIndex = -1;
+    for (var index = messages.length - 1; index >= 0; index--) {
+      final message = messages[index];
+      if (message.role == 'assistant' && !message.isStreaming) {
+        latestCompleteAssistantIndex = index;
+        break;
+      }
+    }
+
+    return List<MessageRenderModel>.unmodifiable([
+      for (final (index, message) in messages.indexed)
+        _projectSlot(
+          index: index,
+          message: message,
+          versions: byGroup[message.groupId ?? message.id],
+          selectedVersion: versionSelections[message.groupId ?? message.id],
+          authoritativeVersionCount:
+              versionCounts[message.groupId ?? message.id],
+          contextDividerIndex: contextDividerIndex,
+          latestCompleteAssistantIndex: latestCompleteAssistantIndex,
+        ),
+    ]);
+  }
+
+  static MessageRenderModel _projectSlot({
+    required int index,
+    required ChatMessage message,
+    required List<ChatMessage>? versions,
+    required int? selectedVersion,
+    required int? authoritativeVersionCount,
+    required int contextDividerIndex,
+    required int latestCompleteAssistantIndex,
+  }) {
+    final sortedVersions = List<ChatMessage>.of(
+      versions ?? const <ChatMessage>[],
+    )..sort((left, right) => left.version.compareTo(right.version));
+    final loadedVersionCount = sortedVersions.isEmpty
+        ? 1
+        : sortedVersions.length;
+    final versionCount = (authoritativeVersionCount ?? loadedVersionCount)
+        .clamp(loadedVersionCount, 1 << 31)
+        .toInt();
+    final availableVersions = sortedVersions.isEmpty
+        ? <int>[message.version]
+        : sortedVersions.map((version) => version.version).toList();
+    final effectiveSelectedVersion =
+        selectedVersion != null && availableVersions.contains(selectedVersion)
+        ? selectedVersion
+        : message.version;
+    final selectedIndex = availableVersions.indexOf(effectiveSelectedVersion);
+    return MessageRenderModel(
+      slotId: message.groupId ?? message.id,
+      message: message,
+      versions: List<ChatMessage>.unmodifiable(sortedVersions),
+      availableVersions: List<int>.unmodifiable(availableVersions),
+      selectedVersion: effectiveSelectedVersion,
+      versionCount: versionCount,
+      selectedVersionIndex: selectedIndex < 0 ? 0 : selectedIndex,
+      showContextDivider:
+          contextDividerIndex >= 0 && index == contextDividerIndex,
+      isLatestCompleteAssistant: index == latestCompleteAssistantIndex,
+    );
+  }
+}

--- a/lib/features/home/controllers/scroll_controller.dart
+++ b/lib/features/home/controllers/scroll_controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 
 // ============================================================================
 // Auto-follow ScrollController / ScrollPosition
@@ -17,6 +17,57 @@ import 'package:scrollview_observer/scrollview_observer.dart';
 class ChatAutoFollowScrollController extends ScrollController {
   /// Callback checked during layout to decide whether to auto-follow bottom.
   bool Function() shouldAutoFollow = () => false;
+
+  /// One-frame positioning request used when a conversation window is opened.
+  ///
+  /// Unlike a post-frame `jumpTo`, this is consumed by the scroll position
+  /// while the new list is being laid out, so an old conversation offset is
+  /// never painted for the new conversation.
+  bool _positionAtBottomDuringLayout = false;
+
+  /// Whether the active bottom request must stand down while the user drags.
+  ///
+  /// A single-frame request (opening a conversation) owns the frame outright.
+  /// A request held across several frames has to yield to a real gesture, or
+  /// it would fight the drag for as long as it is held.
+  bool _bottomRequestYieldsToUserScroll = false;
+  int _layoutBottomRequest = 0;
+  bool _preserveDistanceFromEndDuringLayout = false;
+  double _preservedDistanceFromEnd = 0;
+  int _layoutDistanceRequest = 0;
+
+  /// Whether a one-frame layout positioning request is currently armed.
+  ///
+  /// While one is active it owns the scroll position for the upcoming layout,
+  /// so anchor-restoring jumps scheduled by the list must stand down.
+  bool get hasActiveLayoutPositioningRequest =>
+      _positionAtBottomDuringLayout || _preserveDistanceFromEndDuringLayout;
+
+  int requestPositionAtBottomDuringLayout({bool yieldsToUserScroll = false}) {
+    _positionAtBottomDuringLayout = true;
+    _bottomRequestYieldsToUserScroll = yieldsToUserScroll;
+    return ++_layoutBottomRequest;
+  }
+
+  void finishPositionAtBottomDuringLayout(int request) {
+    if (request == _layoutBottomRequest) {
+      _positionAtBottomDuringLayout = false;
+    }
+  }
+
+  int? requestPreserveDistanceFromEndDuringLayout() {
+    if (!hasClients || positions.length != 1) return null;
+    final position = this.position;
+    _preservedDistanceFromEnd = position.maxScrollExtent - position.pixels;
+    _preserveDistanceFromEndDuringLayout = true;
+    return ++_layoutDistanceRequest;
+  }
+
+  void finishPreserveDistanceFromEndDuringLayout(int request) {
+    if (request == _layoutDistanceRequest) {
+      _preserveDistanceFromEndDuringLayout = false;
+    }
+  }
 
   @override
   ScrollPosition createScrollPosition(
@@ -43,6 +94,25 @@ class _AutoFollowScrollPosition extends ScrollPositionWithSingleContext {
 
   final ChatAutoFollowScrollController controller;
 
+  _IndexedScrollActivity beginIndexedAnimation(VoidCallback onCanceled) {
+    final indexedActivity = _IndexedScrollActivity(this, onCanceled);
+    beginActivity(indexedActivity);
+    return indexedActivity;
+  }
+
+  bool updateIndexedAnimation(
+    _IndexedScrollActivity indexedActivity,
+    double value,
+  ) {
+    if (!identical(activity, indexedActivity)) return false;
+    setPixels(value.clamp(minScrollExtent, maxScrollExtent));
+    return true;
+  }
+
+  void finishIndexedAnimation(_IndexedScrollActivity indexedActivity) {
+    if (identical(activity, indexedActivity)) indexedActivity.finish();
+  }
+
   @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
     final result = super.applyContentDimensions(
@@ -54,15 +124,64 @@ class _AutoFollowScrollPosition extends ScrollPositionWithSingleContext {
     // controller listener that sets _isUserScrolling.  Without this check,
     // correctPixels would override the user's drag for one frame, causing a
     // "stuck / can't scroll up" feeling.
-    if (controller.shouldAutoFollow() &&
-        userScrollDirection == ScrollDirection.idle) {
+    final bottomRequestActive =
+        controller._positionAtBottomDuringLayout &&
+        (!controller._bottomRequestYieldsToUserScroll ||
+            userScrollDirection == ScrollDirection.idle);
+    final shouldPositionAtBottom =
+        bottomRequestActive ||
+        (controller.shouldAutoFollow() &&
+            userScrollDirection == ScrollDirection.idle);
+    if (shouldPositionAtBottom) {
       final gap = this.maxScrollExtent - pixels;
       if (gap > 0.5) {
         correctPixels(this.maxScrollExtent);
         return false; // Force viewport re-layout with corrected position
       }
     }
+    if (controller._preserveDistanceFromEndDuringLayout &&
+        userScrollDirection == ScrollDirection.idle) {
+      final target =
+          (this.maxScrollExtent - controller._preservedDistanceFromEnd).clamp(
+            this.minScrollExtent,
+            this.maxScrollExtent,
+          );
+      if ((target - pixels).abs() > 0.5) {
+        correctPixels(target);
+        return false;
+      }
+    }
     return result;
+  }
+}
+
+/// A single continuous scroll activity for an indexed target whose measured
+/// offset can change while it enters SuperListView's cache area.
+class _IndexedScrollActivity extends ScrollActivity {
+  _IndexedScrollActivity(super.delegate, this._onCanceled);
+
+  final VoidCallback _onCanceled;
+  bool _finishing = false;
+
+  void finish() {
+    if (_finishing) return;
+    _finishing = true;
+    delegate.goIdle();
+  }
+
+  @override
+  bool get shouldIgnorePointer => true;
+
+  @override
+  bool get isScrolling => true;
+
+  @override
+  double get velocity => 0;
+
+  @override
+  void dispose() {
+    if (!_finishing) _onCanceled();
+    super.dispose();
   }
 }
 
@@ -74,8 +193,8 @@ class _AutoFollowScrollPosition extends ScrollPositionWithSingleContext {
 ///
 /// This controller handles:
 /// - Auto-scroll to bottom during streaming (zero-lag via custom ScrollPosition)
-/// - Jump to previous question navigation
-/// - Scroll to specific message by ID (via ListObserverController)
+/// - Jump to adjacent-message navigation
+/// - Scroll to specific message by ID through a variable-extent index
 /// - Scroll state monitoring (user scrolling detection)
 /// - Visibility state for navigation buttons
 class ChatScrollController {
@@ -84,16 +203,23 @@ class ChatScrollController {
     required this._onStateChanged,
     required this._getAutoScrollEnabled,
     required this._getAutoScrollIdleSeconds,
+    this._getTopRevealInset,
+    this.isGenerating,
   }) {
     final scrollController = _scrollController;
+    _messageListController = ListController(
+      onDetached: _cancelIndexedNavigationForDetach,
+    );
     _scrollController.addListener(_onScrollControllerChanged);
-    _observerController = ListObserverController(controller: scrollController)
-      ..cacheJumpIndexOffset = false;
 
     // Wire auto-follow callback for zero-lag bottom pinning
     if (scrollController is ChatAutoFollowScrollController) {
       scrollController.shouldAutoFollow = () =>
-          _getAutoScrollEnabled() && _autoStickToBottom && !_isUserScrolling;
+          _getAutoScrollEnabled() &&
+          (isGenerating?.call() ?? false) &&
+          _autoStickToBottom &&
+          !_isUserScrolling &&
+          !_explicitBottomAnimationInProgress;
     }
   }
 
@@ -101,9 +227,11 @@ class ChatScrollController {
   final VoidCallback _onStateChanged;
   final bool Function() _getAutoScrollEnabled;
   final int Function() _getAutoScrollIdleSeconds;
+  final double Function()? _getTopRevealInset;
+  final bool Function()? isGenerating;
 
-  /// Observer controller for precise index-based scroll navigation.
-  late final ListObserverController _observerController;
+  /// Index and extent state shared with the message list.
+  late final ListController _messageListController;
 
   // ============================================================================
   // State Fields
@@ -132,10 +260,25 @@ class ChatScrollController {
   /// Timer for detecting end of user scroll.
   Timer? _userScrollTimer;
 
-  /// Scheduling state for batched auto-scroll (used by explicit scroll-to-bottom).
-  bool _autoScrollScheduled = false;
+  /// Live held bottom pin (see [stickToBottomAfterGeneration]).
+  Timer? _bottomHoldTimer;
+  int? _bottomHoldRequest;
 
-  /// Anchor for chained "jump to previous question" navigation.
+  /// Request currently queued for the next-frame bottom scroll.
+  int? _scheduledBottomScrollRequest;
+
+  /// A driven scroll and the layout-time tail pin must never own pixels in the
+  /// same frame.
+  bool _explicitBottomAnimationInProgress = false;
+  bool get explicitBottomAnimationInProgress =>
+      _explicitBottomAnimationInProgress;
+  int _bottomScrollRequest = 0;
+  int _deferredBottomRequest = 0;
+  int _indexedNavigationRequest = 0;
+  AnimationController? _indexedAnimationController;
+  _IndexedScrollActivity? _indexedScrollActivity;
+
+  /// Anchor for chained adjacent-message navigation.
   String? _lastJumpUserMessageId;
   String? get lastJumpUserMessageId => _lastJumpUserMessageId;
 
@@ -149,8 +292,8 @@ class ChatScrollController {
   /// Get the underlying scroll controller.
   ScrollController get scrollController => _scrollController;
 
-  /// Get the observer controller for wrapping ListView.
-  ListObserverController get observerController => _observerController;
+  /// Get the indexed controller attached to the message list.
+  ListController get messageListController => _messageListController;
 
   /// Check if scroll controller has clients attached.
   bool get hasClients => _scrollController.hasClients;
@@ -164,6 +307,17 @@ class ChatScrollController {
     if (!_scrollController.hasClients) return true;
     final pos = _scrollController.position;
     return (pos.maxScrollExtent - pos.pixels) <= tolerance;
+  }
+
+  /// Keeps an already-bottom-aligned mobile timeline pinned while its viewport
+  /// shrinks, for example as the software keyboard opens.
+  ///
+  /// This must be requested before the new viewport dimensions are laid out;
+  /// otherwise the old pixel offset paints one frame above the new bottom.
+  bool pinBottomDuringViewportResizeIfNeeded() {
+    if (!isNearBottom(24)) return false;
+    positionAtBottomOnNextLayout();
+    return true;
   }
 
   /// Check if the scroll view has enough content to scroll.
@@ -195,31 +349,6 @@ class ChatScrollController {
       if (!_scrollController.hasClients) return;
       final autoScrollEnabled = _getAutoScrollEnabled();
 
-      // Detect user scrolling
-      if (_scrollController.position.userScrollDirection !=
-          ScrollDirection.idle) {
-        _isUserScrolling = true;
-        _autoStickToBottom = false;
-        // Reset chained jump anchor when user manually scrolls
-        _lastJumpUserMessageId = null;
-
-        // Show navigation buttons on scroll activity
-        if (!_showNavButtons) {
-          _showNavButtons = true;
-          _onStateChanged();
-        }
-        _resetNavButtonsHideTimer();
-
-        // Cancel previous timer and set a new one
-        _userScrollTimer?.cancel();
-        final secs = _getAutoScrollIdleSeconds();
-        _userScrollTimer = Timer(Duration(seconds: secs), () {
-          _isUserScrolling = false;
-          refreshAutoStickToBottom();
-          _onStateChanged();
-        });
-      }
-
       // Only show when not near bottom
       final atBottom = isNearBottom(24);
       if (!atBottom) {
@@ -240,6 +369,27 @@ class ChatScrollController {
         _onStateChanged();
       }
     } catch (_) {}
+  }
+
+  /// Records scroll intent from a real pointer, wheel, or keyboard input.
+  /// Programmatic position changes must never call this method.
+  void handleUserScrollIntent() {
+    _cancelProgrammaticNavigation();
+    _isUserScrolling = true;
+    _autoStickToBottom = false;
+    _lastJumpUserMessageId = null;
+    if (!_showNavButtons) {
+      _showNavButtons = true;
+      _onStateChanged();
+    }
+    _resetNavButtonsHideTimer();
+    _userScrollTimer?.cancel();
+    final secs = _getAutoScrollIdleSeconds();
+    _userScrollTimer = Timer(Duration(seconds: secs), () {
+      _isUserScrolling = false;
+      refreshAutoStickToBottom();
+      _onStateChanged();
+    });
   }
 
   /// Reset the auto-hide timer for navigation buttons.
@@ -278,21 +428,71 @@ class ChatScrollController {
   // Scroll To Bottom Methods
   // ============================================================================
 
+  /// Position a newly opened conversation at its tail before the next paint.
+  ///
+  /// The initial position participates in layout instead of correcting a
+  /// visible frame afterward. The flag remains active for the whole frame
+  /// because a lazy viewport may refine its max extent more than once
+  /// during layout.
+  void positionAtBottomOnNextLayout() {
+    _cancelProgrammaticNavigation(stopDrivenScroll: true);
+    _lastJumpUserMessageId = null;
+    _isUserScrolling = false;
+    _userScrollTimer?.cancel();
+    _autoStickToBottom = true;
+    final controller = _scrollController;
+    if (controller is! ChatAutoFollowScrollController) {
+      _scheduleExplicitScrollToBottom(animate: false);
+      return;
+    }
+    final request = controller.requestPositionAtBottomDuringLayout();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.finishPositionAtBottomDuringLayout(request);
+    });
+  }
+
+  /// Resolve the actual indexed tail before a switched conversation is shown.
+  ///
+  /// A lazy list's first maxScrollExtent can still be based on estimated item
+  /// heights. Avoid treating that estimate as the destination: request the
+  /// last item directly and wait for the tail extent to become concrete.
+  Future<void> settleAtBottomBeforeReveal() async {
+    _cancelProgrammaticNavigation(stopDrivenScroll: true);
+    _lastJumpUserMessageId = null;
+    _isUserScrolling = false;
+    _userScrollTimer?.cancel();
+    _autoStickToBottom = true;
+
+    for (var pass = 0; pass < 3; pass++) {
+      if (_scrollController.hasClients && _messageListController.isAttached) {
+        break;
+      }
+      await WidgetsBinding.instance.endOfFrame;
+    }
+    if (!_scrollController.hasClients) return;
+
+    final request = ++_bottomScrollRequest;
+    await _animateToBottom(animate: false, request: request);
+  }
+
   /// Scroll to the bottom of the list.
   ///
   /// [animate] - Whether to animate the scroll (default: true).
   void scrollToBottom({bool animate = true}) {
     _autoStickToBottom = true;
-    _scheduleExplicitScrollToBottom(animate: animate);
+    final generating = isGenerating?.call() ?? false;
+    _scheduleExplicitScrollToBottom(animate: animate && !generating);
   }
 
   /// Force scroll to bottom (used when user explicitly clicks the button).
-  void forceScrollToBottom() {
+  void forceScrollToBottom({bool animate = true}) {
+    _cancelProgrammaticNavigation(stopDrivenScroll: true);
     _isUserScrolling = false;
     _userScrollTimer?.cancel();
     _lastJumpUserMessageId = null;
     revealNavButtons();
-    scrollToBottom();
+    _autoStickToBottom = true;
+    _scheduleExplicitScrollToBottom(animate: animate);
   }
 
   /// Force scroll after rebuilds when switching topics/conversations.
@@ -302,21 +502,84 @@ class ChatScrollController {
   }) {
     _isUserScrolling = false;
     _userScrollTimer?.cancel();
-    WidgetsBinding.instance.addPostFrameCallback(
-      (_) => scrollToBottom(animate: animate),
+    final request = ++_deferredBottomRequest;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (request == _deferredBottomRequest) {
+        scrollToBottom(animate: animate);
+      }
+    });
+    Future.delayed(postSwitchDelay, () {
+      if (request == _deferredBottomRequest) {
+        scrollToBottom(animate: animate);
+      }
+    });
+  }
+
+  /// After generation ends, pin to bottom if the user was still following.
+  ///
+  /// Layout-phase auto-follow requires [isGenerating], which is already false
+  /// when the terminal message widget is swapped in and typically grows.
+  void stickToBottomAfterGeneration() {
+    if (!_getAutoScrollEnabled()) return;
+    if (!_autoStickToBottom || _isUserScrolling) return;
+    // The tail keeps changing height for a few frames after the reply ends:
+    // the terminal widget adds its action bar and token stats, a finished
+    // thinking card collapses, the sanitized content is republished. Each of
+    // those lands after layout-phase follow has been switched off, so catching
+    // up afterwards — instantly or animated — is visible as the timeline
+    // jumping and then sliding. Holding the layout pin across that window
+    // absorbs the height changes before they are ever painted.
+    _holdBottomDuringLayout(_postGenerationPinWindow);
+  }
+
+  /// How long the bottom pin is held after generation ends.
+  static const Duration _postGenerationPinWindow = Duration(milliseconds: 450);
+
+  /// Pin to the tail during layout for [duration], yielding to real gestures.
+  void _holdBottomDuringLayout(Duration duration) {
+    final controller = _scrollController;
+    if (controller is! ChatAutoFollowScrollController) {
+      _scheduleExplicitScrollToBottom(animate: false);
+      return;
+    }
+    _cancelProgrammaticNavigation();
+    final request = controller.requestPositionAtBottomDuringLayout(
+      yieldsToUserScroll: true,
     );
-    Future.delayed(postSwitchDelay, () => scrollToBottom(animate: animate));
+    _bottomHoldRequest = request;
+    _bottomHoldTimer = Timer(duration, _releaseBottomHold);
+  }
+
+  /// Ends an active held pin, if any.
+  void _releaseBottomHold() {
+    _bottomHoldTimer?.cancel();
+    _bottomHoldTimer = null;
+    final request = _bottomHoldRequest;
+    if (request == null) return;
+    _bottomHoldRequest = null;
+    final controller = _scrollController;
+    if (controller is ChatAutoFollowScrollController) {
+      controller.finishPositionAtBottomDuringLayout(request);
+    }
   }
 
   /// Ensure scroll reaches bottom even after widget tree transitions.
   void scrollToBottomSoon({bool animate = true}) {
-    WidgetsBinding.instance.addPostFrameCallback(
-      (_) => scrollToBottom(animate: animate),
-    );
-    Future.delayed(
-      const Duration(milliseconds: 120),
-      () => scrollToBottom(animate: animate),
-    );
+    final request = ++_deferredBottomRequest;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (request == _deferredBottomRequest) {
+        scrollToBottom(animate: animate);
+      }
+    });
+    Future.delayed(const Duration(milliseconds: 120), () {
+      // The retry exists for widget-tree transitions that invalidate the
+      // post-frame attempt; restarting a live animation here would cause a
+      // visible velocity discontinuity instead.
+      if (request == _deferredBottomRequest &&
+          !_explicitBottomAnimationInProgress) {
+        scrollToBottom(animate: animate);
+      }
+    });
   }
 
   /// Auto-scroll to bottom if conditions are met (called from onStreamTick).
@@ -341,11 +604,16 @@ class ChatScrollController {
   /// Used for user-triggered "go to bottom" and as fallback for streaming
   /// auto-scroll when the custom [ScrollPosition] is not available.
   void _scheduleExplicitScrollToBottom({bool animate = true}) {
-    if (_autoScrollScheduled) return;
-    _autoScrollScheduled = true;
+    final request = ++_bottomScrollRequest;
+    _scheduledBottomScrollRequest = request;
+    _explicitBottomAnimationInProgress =
+        animate && _scrollController.hasClients;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      _autoScrollScheduled = false;
-      await _animateToBottom(animate: animate);
+      if (_scheduledBottomScrollRequest == request) {
+        _scheduledBottomScrollRequest = null;
+      }
+      if (request != _bottomScrollRequest) return;
+      await _animateToBottom(animate: animate, request: request);
     });
   }
 
@@ -354,38 +622,122 @@ class ChatScrollController {
   /// Used for explicit scroll-to-bottom requests (user-triggered button,
   /// conversation switch, etc.). Streaming auto-scroll is handled by the
   /// custom [ScrollPosition] instead.
-  Future<void> _animateToBottom({bool animate = true}) async {
+  Future<void> _animateToBottom({
+    bool animate = true,
+    required int request,
+  }) async {
     try {
-      if (!_scrollController.hasClients) return;
-
-      // Prevent using controller while it is still attached to old/new list
-      if (_scrollController.positions.length != 1) {
-        Future.microtask(() => _animateToBottom(animate: animate));
+      if (request != _bottomScrollRequest || !_scrollController.hasClients) {
         return;
+      }
+      _explicitBottomAnimationInProgress = false;
+
+      // Prevent using a controller while it is still attached to both the old
+      // and new conversation. Keep this awaitable for pre-reveal settling.
+      if (_scrollController.positions.length != 1) {
+        await WidgetsBinding.instance.endOfFrame;
+        if (request != _bottomScrollRequest ||
+            _scrollController.positions.length != 1) {
+          return;
+        }
       }
       final pos = _scrollController.position;
-      final max = pos.maxScrollExtent;
-      final distance = (max - pos.pixels).abs();
-      if (distance < 0.5) {
+      final hasIndexedTail =
+          _messageListController.isAttached &&
+          _messageListController.numberOfItems > 0;
+      if (hasIndexedTail) {
+        final lastIndex = _messageListController.numberOfItems - 1;
+        final target = pos.maxScrollExtent;
+        if ((target - pos.pixels).abs() <= 0.5) {
+          _updateJumpToBottomVisibility(false);
+          _autoStickToBottom = true;
+          return;
+        }
+        if (animate) {
+          _explicitBottomAnimationInProgress = true;
+          try {
+            await _animateToMessageIndex(
+              index: lastIndex,
+              alignment: 1,
+              bottomRequest: request,
+            );
+          } finally {
+            if (request == _bottomScrollRequest) {
+              _explicitBottomAnimationInProgress = false;
+            }
+          }
+          if (request != _bottomScrollRequest) return;
+          _updateJumpToBottomVisibility(false);
+          _autoStickToBottom = true;
+          return;
+        }
+        for (var pass = 0; pass < 4; pass++) {
+          if (request != _bottomScrollRequest ||
+              !_scrollController.hasClients ||
+              !_messageListController.isAttached ||
+              lastIndex >= _messageListController.numberOfItems) {
+            return;
+          }
+          _messageListController.jumpToItem(
+            index: lastIndex,
+            scrollController: _scrollController,
+            alignment: 1,
+          );
+          await WidgetsBinding.instance.endOfFrame;
+          if (request != _bottomScrollRequest) return;
+          final visible = _messageListController.visibleRange;
+          final extentIsEstimated = _messageListController
+              .extentForIndex(lastIndex)
+              .$2;
+          if (!extentIsEstimated &&
+              visible != null &&
+              visible.$1 <= lastIndex &&
+              visible.$2 >= lastIndex &&
+              pass > 0) {
+            break;
+          }
+        }
+        if (request != _bottomScrollRequest) return;
+        final tailPosition = _scrollController.position;
+        if (tailPosition.maxScrollExtent - tailPosition.pixels > 0.5) {
+          tailPosition.jumpTo(tailPosition.maxScrollExtent);
+          await WidgetsBinding.instance.endOfFrame;
+        }
+        if (request != _bottomScrollRequest) return;
         _updateJumpToBottomVisibility(false);
+        _autoStickToBottom = true;
         return;
       }
 
-      if (animate) {
+      final start = pos.pixels;
+      final target = pos.maxScrollExtent;
+      final distance = (target - start).abs();
+      final animateNearby = animate && distance >= 0.5;
+
+      if (animateNearby) {
         final durationMs = distance < 500
             ? 250
             : distance < 2000
             ? 350
             : 450;
-        await pos.animateTo(
-          max,
-          duration: Duration(milliseconds: durationMs),
-          curve: Curves.easeOutCubic,
-        );
-      } else {
-        pos.jumpTo(max);
+        pos.jumpTo(start.clamp(pos.minScrollExtent, pos.maxScrollExtent));
+        _explicitBottomAnimationInProgress = true;
+        try {
+          await pos.animateTo(
+            target.clamp(pos.minScrollExtent, pos.maxScrollExtent),
+            duration: Duration(milliseconds: durationMs),
+            curve: Curves.easeOutCubic,
+          );
+        } finally {
+          if (request == _bottomScrollRequest) {
+            _explicitBottomAnimationInProgress = false;
+          }
+        }
+      } else if (distance >= 0.5) {
+        pos.jumpTo(target);
       }
 
+      if (request != _bottomScrollRequest) return;
       _updateJumpToBottomVisibility(false);
       _autoStickToBottom = true;
     } catch (_) {}
@@ -402,10 +754,70 @@ class ChatScrollController {
   // Navigation Methods
   // ============================================================================
 
+  double _currentTopRevealInset() {
+    try {
+      final inset = _getTopRevealInset?.call() ?? 0.0;
+      if (!inset.isFinite || inset <= 0) return 0;
+      if (!_scrollController.hasClients) return inset;
+      return inset
+          .clamp(0.0, _scrollController.position.viewportDimension)
+          .toDouble();
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  double _messageRevealOffset(int index, double alignment) {
+    // This is the same offset query used internally by jumpToItem.
+    // ignore: invalid_use_of_visible_for_testing_member
+    final rawOffset = _messageListController.getOffsetToReveal(
+      index,
+      alignment,
+    );
+    final normalizedAlignment = alignment.clamp(0.0, 1.0).toDouble();
+    return rawOffset - _currentTopRevealInset() * (1.0 - normalizedAlignment);
+  }
+
+  void _correctMessageReveal(int index, double alignment) {
+    if (!_scrollController.hasClients ||
+        !_messageListController.isAttached ||
+        index < 0 ||
+        index >= _messageListController.numberOfItems) {
+      return;
+    }
+    final position = _scrollController.position;
+    final target = _messageRevealOffset(
+      index,
+      alignment,
+    ).clamp(position.minScrollExtent, position.maxScrollExtent).toDouble();
+    if ((position.pixels - target).abs() > 0.5) {
+      position.jumpTo(target);
+    }
+  }
+
+  int? _firstVisibleMessageBelowTopOverlay() {
+    if (!_scrollController.hasClients || !_messageListController.isAttached) {
+      return null;
+    }
+    final visible = _messageListController.visibleRange;
+    if (visible == null) return null;
+    final topBoundary =
+        _scrollController.position.pixels + _currentTopRevealInset();
+    for (var index = visible.$1; index <= visible.$2; index++) {
+      if (index < 0 || index >= _messageListController.numberOfItems) continue;
+      // ignore: invalid_use_of_visible_for_testing_member
+      final leading = _messageListController.getOffsetToReveal(index, 0);
+      final extent = _messageListController.extentForIndex(index).$1;
+      if (leading + extent > topBoundary + 0.5) return index;
+    }
+    return visible.$2;
+  }
+
   /// Scroll to the top of the list.
   void scrollToTop({bool animate = true}) {
     try {
       if (!_scrollController.hasClients) return;
+      _cancelProgrammaticNavigation(stopDrivenScroll: true);
       _lastJumpUserMessageId = null;
       revealNavButtons();
 
@@ -428,139 +840,291 @@ class ChatScrollController {
     } catch (_) {}
   }
 
-  /// Jump to the previous user message (question) above the current viewport.
-  ///
-  /// Uses ListObserverController for precise index-based navigation.
-  Future<void> jumpToPreviousQuestion({
+  /// Jump to the message immediately before the current indexed anchor.
+  Future<bool> jumpToPreviousQuestion({
     required List<dynamic> messages,
     required int Function(String id) indexOfId,
   }) async {
     try {
-      if (!_scrollController.hasClients) return;
-      if (messages.isEmpty) return;
+      if (!_scrollController.hasClients || !_messageListController.isAttached) {
+        return false;
+      }
+      if (messages.isEmpty) return false;
 
       revealNavButtons();
 
-      // Determine anchor index
-      int anchor;
-      if (_lastJumpUserMessageId != null) {
-        final idx = indexOfId(_lastJumpUserMessageId!);
-        anchor = idx >= 0 ? idx : messages.length - 1;
-      } else {
-        // Use observer to find currently visible items
-        final result = await _observerController.dispatchOnceObserve(
-          isDependObserveCallback: false,
-        );
-        final visible = result.observeResult?.displayingChildIndexList;
-        anchor = (visible != null && visible.isNotEmpty)
-            ? visible.last
-            : messages.length - 1;
-      }
+      final cursorIndex = _lastJumpUserMessageId == null
+          ? -1
+          : indexOfId(_lastJumpUserMessageId!);
+      final anchor = cursorIndex >= 0
+          ? cursorIndex
+          : (_firstVisibleMessageBelowTopOverlay() ?? messages.length - 1);
 
-      // Search backward for previous user message
-      int target = -1;
-      for (int i = anchor - 1; i >= 0; i--) {
-        if (messages[i].role == 'user') {
-          target = i;
-          break;
-        }
-      }
+      final target = anchor - 1;
       if (target < 0) {
-        _scrollController.jumpTo(0.0);
         _lastJumpUserMessageId = null;
-        return;
+        return false;
       }
 
-      await _observerController.animateTo(
-        index: target,
-        alignment: 0.08,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOutCubic,
-      );
       _lastJumpUserMessageId = messages[target].id;
-    } catch (_) {}
+      await _animateToMessageIndex(index: target, alignment: 0);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
-  /// Jump to the next user message (question) below the current viewport.
-  ///
-  /// Uses ListObserverController for precise index-based navigation.
-  Future<void> jumpToNextQuestion({
+  /// Jump to the message immediately after the current indexed anchor.
+  Future<bool> jumpToNextQuestion({
     required List<dynamic> messages,
     required int Function(String id) indexOfId,
   }) async {
     try {
-      if (!_scrollController.hasClients) return;
-      if (messages.isEmpty) return;
+      if (!_scrollController.hasClients || !_messageListController.isAttached) {
+        return false;
+      }
+      if (messages.isEmpty) return false;
 
       revealNavButtons();
 
-      // Determine anchor index
-      int anchor;
-      if (_lastJumpUserMessageId != null) {
-        final idx = indexOfId(_lastJumpUserMessageId!);
-        anchor = idx >= 0 ? idx : 0;
-      } else {
-        // Use observer to find currently visible items
-        final result = await _observerController.dispatchOnceObserve(
-          isDependObserveCallback: false,
-        );
-        final visible = result.observeResult?.displayingChildIndexList;
-        anchor = (visible != null && visible.isNotEmpty) ? visible.first : 0;
-      }
+      final cursorIndex = _lastJumpUserMessageId == null
+          ? -1
+          : indexOfId(_lastJumpUserMessageId!);
+      final anchor = cursorIndex >= 0
+          ? cursorIndex
+          : (_firstVisibleMessageBelowTopOverlay() ?? 0);
 
-      // Search forward for next user message
-      int target = -1;
-      for (int i = anchor + 1; i < messages.length; i++) {
-        if (messages[i].role == 'user') {
-          target = i;
-          break;
-        }
-      }
-      if (target < 0) {
-        forceScrollToBottom();
+      final target = anchor + 1;
+      if (target >= messages.length) {
         _lastJumpUserMessageId = null;
-        return;
+        return false;
       }
 
-      await _observerController.animateTo(
-        index: target,
-        alignment: 0.08,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOutCubic,
-      );
       _lastJumpUserMessageId = messages[target].id;
-    } catch (_) {}
+      await _animateToMessageIndex(index: target, alignment: 0);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   /// Scroll to a specific message by index (from mini map or search).
   ///
-  /// Uses ListObserverController for precise index-based scrolling,
-  /// replacing the old linear-ratio + paging-loop approach.
+  /// Direct index positioning: distant targets do not build or animate
+  /// through every intermediate message.
   Future<void> scrollToMessageId({
     required String targetId,
     required int targetIndex,
   }) async {
     try {
-      if (!_scrollController.hasClients) return;
+      if (!_scrollController.hasClients || !_messageListController.isAttached) {
+        return;
+      }
       if (targetIndex < 0) return;
-
-      await _observerController.animateTo(
+      if (targetIndex >= _messageListController.numberOfItems) return;
+      _cancelProgrammaticNavigation(stopDrivenScroll: true);
+      final request = ++_indexedNavigationRequest;
+      _messageListController.jumpToItem(
         index: targetIndex,
-        alignment: 0.1,
-        duration: const Duration(milliseconds: 250),
-        curve: Curves.easeOutCubic,
+        scrollController: _scrollController,
+        alignment: 0,
       );
+      _correctMessageReveal(targetIndex, 0);
+      for (var pass = 0; pass < 3; pass++) {
+        await WidgetsBinding.instance.endOfFrame;
+        if (request != _indexedNavigationRequest ||
+            !_scrollController.hasClients ||
+            !_messageListController.isAttached ||
+            targetIndex >= _messageListController.numberOfItems) {
+          return;
+        }
+        _correctMessageReveal(targetIndex, 0);
+        final estimated = _messageListController.extentForIndex(targetIndex).$2;
+        if (!estimated && pass > 0) break;
+      }
       _lastJumpUserMessageId = targetId;
     } catch (_) {}
   }
 
-  // ============================================================================
-  // Observer Cache Management
-  // ============================================================================
+  Future<void> _animateToMessageIndex({
+    required int index,
+    required double alignment,
+    int? bottomRequest,
+  }) async {
+    if (!_scrollController.hasClients ||
+        !_messageListController.isAttached ||
+        index < 0 ||
+        index >= _messageListController.numberOfItems) {
+      return;
+    }
+    if (bottomRequest == null) {
+      _cancelProgrammaticNavigation(stopDrivenScroll: true);
+      _autoStickToBottom = false;
+    } else {
+      if (bottomRequest != _bottomScrollRequest) return;
+      _cancelIndexedNavigation();
+    }
+    final request = ++_indexedNavigationRequest;
+    final position = _scrollController.position;
+    final estimatedDistance =
+        ((bottomRequest == null
+                    ? _messageRevealOffset(index, alignment)
+                    : position.maxScrollExtent) -
+                position.pixels)
+            .abs();
+    final duration = estimatedDistance < 320
+        ? const Duration(milliseconds: 220)
+        : estimatedDistance < 1000
+        ? const Duration(milliseconds: 280)
+        : const Duration(milliseconds: 360);
+    final animationController = AnimationController(
+      vsync: position.context.vsync,
+      duration: duration,
+    );
+    _indexedAnimationController = animationController;
+    _IndexedScrollActivity? indexedActivity;
+    if (position is _AutoFollowScrollPosition) {
+      late final _IndexedScrollActivity startedActivity;
+      startedActivity = position.beginIndexedAnimation(
+        () => _cancelIndexedAnimationFromActivity(startedActivity),
+      );
+      indexedActivity = startedActivity;
+      _indexedScrollActivity = startedActivity;
+    }
+    final animation = CurvedAnimation(
+      parent: animationController,
+      curve: Curves.easeOutCubic,
+    );
+    var previousProgress = 0.0;
+    bool movePosition(double value) {
+      final activity = indexedActivity;
+      if (position is _AutoFollowScrollPosition && activity != null) {
+        return position.updateIndexedAnimation(activity, value);
+      }
+      position.jumpTo(value);
+      position.isScrollingNotifier.value = true;
+      return true;
+    }
 
-  /// Clear observer's cached offset data (call on conversation switch).
-  void clearObserverCache() {
-    _observerController.clearScrollIndexCache();
+    void updatePosition() {
+      if (request != _indexedNavigationRequest ||
+          (bottomRequest != null && bottomRequest != _bottomScrollRequest) ||
+          !_scrollController.hasClients ||
+          !_messageListController.isAttached ||
+          index >= _messageListController.numberOfItems) {
+        animationController.stop(canceled: false);
+        return;
+      }
+
+      // SuperListView can replace an estimated extent with the real extent
+      // while the target enters its cache area. Re-read the indexed offset on
+      // every tick so that correction is absorbed by this one continuous
+      // animation instead of becoming a visible jump after it.
+      final target =
+          (bottomRequest == null
+                  ? _messageRevealOffset(index, alignment)
+                  : position.maxScrollExtent)
+              .clamp(position.minScrollExtent, position.maxScrollExtent);
+      final progress = animation.value;
+      final remainingProgress = 1.0 - previousProgress;
+      final stepProgress = remainingProgress <= 0.0001
+          ? 1.0
+          : ((progress - previousProgress) / remainingProgress).clamp(0.0, 1.0);
+      // Interpolate from the current pixels through only the remaining
+      // progress. If a lazy extent changes, this spreads the correction over
+      // the rest of the animation instead of applying all elapsed progress to
+      // the new target in one frame.
+      final next = position.pixels + (target - position.pixels) * stepProgress;
+      previousProgress = progress;
+      if ((next - position.pixels).abs() > 0.01) {
+        if (!movePosition(next)) {
+          animationController.stop(canceled: false);
+        }
+      }
+    }
+
+    animation.addListener(updatePosition);
+    if (indexedActivity == null) position.isScrollingNotifier.value = true;
+    try {
+      await animationController.forward().orCancel;
+    } on TickerCanceled {
+      // A new navigation request, user gesture, or detached timeline owns the
+      // next position. Cancellation is an expected terminal state.
+    } finally {
+      animation.removeListener(updatePosition);
+      animation.dispose();
+      if (identical(_indexedAnimationController, animationController)) {
+        _indexedAnimationController = null;
+        final activity = indexedActivity;
+        if (identical(_indexedScrollActivity, activity)) {
+          _indexedScrollActivity = null;
+          if (position is _AutoFollowScrollPosition && activity != null) {
+            position.finishIndexedAnimation(activity);
+          }
+        } else if (activity == null) {
+          position.isScrollingNotifier.value = false;
+        }
+        animationController.dispose();
+      }
+    }
+  }
+
+  void _cancelIndexedAnimationFromActivity(
+    _IndexedScrollActivity indexedActivity,
+  ) {
+    if (!identical(_indexedScrollActivity, indexedActivity)) return;
+    _indexedScrollActivity = null;
+    _indexedNavigationRequest++;
+    final animationController = _indexedAnimationController;
+    _indexedAnimationController = null;
+    animationController?.stop();
+    animationController?.dispose();
+  }
+
+  void _cancelIndexedNavigationForDetach() {
+    _indexedNavigationRequest++;
+    // ScrollPosition disposal owns the activity at this point. Calling
+    // goIdle from ListController.onDetached would dispatch a scroll-end
+    // notification through an already deactivated widget tree.
+    _indexedScrollActivity = null;
+    final animationController = _indexedAnimationController;
+    _indexedAnimationController = null;
+    animationController?.stop();
+    animationController?.dispose();
+  }
+
+  void _cancelIndexedNavigation() {
+    _indexedNavigationRequest++;
+    final indexedActivity = _indexedScrollActivity;
+    _indexedScrollActivity = null;
+    if (indexedActivity != null &&
+        _scrollController.hasClients &&
+        _scrollController.position is _AutoFollowScrollPosition) {
+      (_scrollController.position as _AutoFollowScrollPosition)
+          .finishIndexedAnimation(indexedActivity);
+    }
+    final animationController = _indexedAnimationController;
+    _indexedAnimationController = null;
+    if (animationController == null) return;
+    if (_scrollController.hasClients && indexedActivity == null) {
+      _scrollController.position.isScrollingNotifier.value = false;
+    }
+    animationController.stop();
+    animationController.dispose();
+  }
+
+  void _cancelProgrammaticNavigation({bool stopDrivenScroll = false}) {
+    _releaseBottomHold();
+    _bottomScrollRequest++;
+    _deferredBottomRequest++;
+    _scheduledBottomScrollRequest = null;
+    _cancelIndexedNavigation();
+    _explicitBottomAnimationInProgress = false;
+    if (!stopDrivenScroll || !_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    if (position is ScrollPositionWithSingleContext) {
+      position.goIdle();
+    }
   }
 
   // ============================================================================
@@ -569,6 +1133,7 @@ class ChatScrollController {
 
   /// Reset the last jump user message ID (e.g., when starting new navigation).
   void resetLastJumpUserMessageId() {
+    _cancelIndexedNavigation();
     _lastJumpUserMessageId = null;
   }
 
@@ -592,5 +1157,8 @@ class ChatScrollController {
     _scrollController.removeListener(_onScrollControllerChanged);
     _userScrollTimer?.cancel();
     _navButtonsHideTimer?.cancel();
+    _bottomHoldTimer?.cancel();
+    _cancelIndexedNavigation();
+    _messageListController.dispose();
   }
 }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show File;
+import 'dart:io' show File, Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:desktop_drop/desktop_drop.dart';
@@ -587,7 +587,7 @@ class _HomePageState extends State<HomePage>
   final ChatInputBarController _mediaController = ChatInputBarController();
   final ImageGenerationOptionsController _imageGenController =
       ImageGenerationOptionsController();
-  final scroll_ctrl.ChatAutoFollowScrollController _scrollController =
+  scroll_ctrl.ChatAutoFollowScrollController _scrollController =
       scroll_ctrl.ChatAutoFollowScrollController();
   final BackdropKey _messageListBackdropKey = BackdropKey();
   final GlobalKey _inputBarKey = GlobalKey();
@@ -595,6 +595,8 @@ class _HomePageState extends State<HomePage>
   final GlobalKey _selectionActionBarKey = GlobalKey();
   bool _scrollNavHovering = false;
   bool _presetsExpanded = false;
+  String? _scrollConversationId;
+  double _lastViewInsetBottom = 0;
   StreamSubscription<String>? _processTextSub;
 
   // ============================================================================
@@ -632,6 +634,7 @@ class _HomePageState extends State<HomePage>
     _initProcessText();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      _lastViewInsetBottom = View.of(context).viewInsets.bottom;
       _controller.measureInputBar();
       if (!mounted) return;
       context.read<WorldBookProvider>().initialize();
@@ -679,6 +682,16 @@ class _HomePageState extends State<HomePage>
   }
 
   @override
+  void didChangeMetrics() {
+    if (!mounted) return;
+    final nextInset = View.of(context).viewInsets.bottom;
+    final keyboardOpening = nextInset > _lastViewInsetBottom + 0.5;
+    _lastViewInsetBottom = nextInset;
+    if (!keyboardOpening) return;
+    _controller.scrollCtrl.pinBottomDuringViewportResizeIfNeeded();
+  }
+
+  @override
   void didPushNext() {
     _controller.onDidPushNext();
   }
@@ -713,6 +726,15 @@ class _HomePageState extends State<HomePage>
   }
 
   void _onControllerChanged() {
+    final conversationId = _controller.currentConversation?.id;
+    if (conversationId != null && conversationId != _scrollConversationId) {
+      _scrollConversationId = conversationId;
+      final previous = _scrollController;
+      final replacement = scroll_ctrl.ChatAutoFollowScrollController();
+      _scrollController = replacement;
+      _controller.replaceScrollController(replacement);
+      WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+    }
     if (mounted) setState(() {});
   }
 
@@ -1376,6 +1398,7 @@ class _HomePageState extends State<HomePage>
     }
 
     final settings = context.watch<SettingsProvider>();
+    final assistant = context.watch<AssistantProvider>().currentAssistant;
     final suggestionsEnabled =
         settings.suggestionModelProvider != null &&
         settings.suggestionModelId != null;
@@ -1424,7 +1447,8 @@ class _HomePageState extends State<HomePage>
     final messageList = MessageListView(
       isProcessingFiles: _controller.isProcessingFiles,
       scrollController: _scrollController,
-      observerController: _controller.scrollCtrl.observerController,
+      listController: _controller.scrollCtrl.messageListController,
+      onUserScrollIntent: _controller.scrollCtrl.handleUserScrollIntent,
       messages: messages,
       headerWidget: presetHeaderWidget,
       byGroup: _controller.chatController.groupedMessages,
@@ -1444,6 +1468,20 @@ class _HomePageState extends State<HomePage>
       topContentPadding: topContentPadding,
       bottomContentPadding: bottomContentPadding,
       dividerPadding: dividerPadding,
+      chatFontScale: settings.chatFontScale,
+      collapseThinking: settings.autoCollapseThinking,
+      collapsedCodeLines: settings.autoCollapseCodeBlock
+          ? settings.autoCollapseCodeBlockLines
+          : null,
+      wrapCodeBlocks:
+          Platform.isMacOS ||
+          Platform.isWindows ||
+          Platform.isLinux ||
+          settings.mobileCodeBlockWrap,
+      showModelIcon: settings.showModelIcon,
+      showUserAvatar: settings.showUserAvatar,
+      showTokenStats: settings.showTokenStats,
+      assistant: assistant,
       streamingContentNotifier: _controller.streamingContentNotifier,
       spotlightMessageId: _controller.spotlightMessageId,
       spotlightToken: _controller.spotlightToken,

--- a/lib/features/home/utils/chat_layout_constants.dart
+++ b/lib/features/home/utils/chat_layout_constants.dart
@@ -5,4 +5,12 @@ class ChatLayoutConstants {
 
   /// Max width for the chat input bar area.
   static const double maxInputWidth = 860.0;
+
+  /// Duration of the fade-then-collapse deletion animation. The widget wraps
+  /// flagged slots ([MessageListView] `removingSlotIds`) with
+  /// [_SlotRemovalAnimator]; wiring the controller-side wait/release flow is
+  /// still pending, so today removals apply instantly.
+  static const Duration slotRemovalAnimationDuration = Duration(
+    milliseconds: 240,
+  );
 }

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -1222,14 +1222,24 @@ class _ChatInputBarState extends State<ChatInputBar>
     if (_ownsVoiceSession || _finishingVoice) return;
     final text = _controller.text.trim();
     if (text.isEmpty && _images.isEmpty && _docs.isEmpty) return;
+    final images = List.of(_images);
+    final docs = List.of(_docs);
+    final submittedValue = _controller.value;
+    // The content has moved into the conversation or the queue — clear the
+    // input before awaiting so the composer shrink and the message growth
+    // never land in separate frames (the cause of the visible send bounce).
     _isSubmitting = true;
+    setState(() {
+      _controller.clear();
+      _resetMedia(images: true, docs: true);
+    });
     try {
       final result =
           await widget.onSend?.call(
             ChatInputData(
               text: text,
-              imagePaths: List.of(_images),
-              documents: List.of(_docs),
+              imagePaths: images,
+              documents: docs,
               allowImagesApiRouting: _allowImagesApiRouting,
               extraBody: _imageGenerationExtraBody(),
             ),
@@ -1239,8 +1249,6 @@ class _ChatInputBarState extends State<ChatInputBar>
       if (result == ChatInputSubmissionResult.sent ||
           result == ChatInputSubmissionResult.queued) {
         setState(() {
-          _controller.clear();
-          _resetMedia(images: true, docs: true);
           // The restored queued input has been consumed by this send — the
           // "restored input must not route" flag must not stick to unrelated
           // later sends on the same (non-image) model.
@@ -1248,8 +1256,7 @@ class _ChatInputBarState extends State<ChatInputBar>
             widget.conversationId,
           );
         });
-        // The content has moved into the conversation or the queue — clear
-        // the draft immediately so a process death right after sending
+        // Clear the draft immediately so a process death right after sending
         // cannot resurrect it (best-effort: the underlying prefs write is
         // itself async fire-and-forget).
         _clearPersistedDraft();
@@ -1259,6 +1266,32 @@ class _ChatInputBarState extends State<ChatInputBar>
             widget.focusNode?.requestFocus();
           }
         } catch (_) {}
+      } else {
+        // The submit was rejected — the content is still the user's, so put
+        // the submitted text/media back into the bar and re-persist the
+        // draft. Newer user input typed during the flight is preserved.
+        if (_controller.text.isEmpty) {
+          setState(() {
+            _controller.value = TextEditingValue(
+              text: submittedValue.text,
+              selection: TextSelection.collapsed(
+                offset: submittedValue.text.length,
+              ),
+              composing: TextRange.empty,
+            );
+            _images
+              ..clear()
+              ..addAll(images);
+            _imageSizes.clear();
+            for (final p in images) {
+              _imageSizes[p] = _fileSize(p);
+            }
+            _docs
+              ..clear()
+              ..addAll(docs);
+          });
+          _scheduleDraftSave();
+        }
       }
     } finally {
       _isSubmitting = false;

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -1,27 +1,31 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 
-import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_message.dart';
-import '../../../core/providers/settings_provider.dart';
+import '../../../core/models/assistant.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/storage/message_locate_bus.dart';
+import '../../../core/services/streaming_content_notifier.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../chat/pages/reading_mode_page.dart';
 import '../../chat/widgets/chat_message_widget.dart';
+import '../../chat/utils/thinking_tag_parser.dart';
 import '../../chat/widgets/message_more_sheet.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
-import '../../../core/services/streaming_content_notifier.dart';
+import '../controllers/message_render_model.dart';
+import '../controllers/scroll_controller.dart' as scroll_ctrl;
 import '../services/ask_user_interaction_service.dart';
 import '../utils/chat_layout_constants.dart';
 import 'model_icon.dart';
@@ -88,14 +92,16 @@ class TranslationUiState {
 /// Widget that displays the chat message list.
 ///
 /// Accepts pre-collapsed messages and pre-computed byGroup from the controller
-/// to avoid redundant computation on every build. Wraps the ListView with
-/// ListViewObserver for precise index-based scroll navigation.
+/// to avoid redundant computation on every build. Uses a variable-extent lazy
+/// list so large histories can scroll and navigate by index without laying out
+/// every preceding message.
 class MessageListView extends StatefulWidget {
   const MessageListView({
     super.key,
     required this.scrollController,
-    required this.observerController,
+    required this.listController,
     required this.messages,
+    this.renderModels,
     required this.byGroup,
     required this.versionSelections,
     this.truncCollapsedIndex = -1,
@@ -115,6 +121,7 @@ class MessageListView extends StatefulWidget {
     this.streamingContentNotifier,
     this.spotlightMessageId,
     this.spotlightToken = 0,
+    this.removingSlotIds = const <String>{},
     this.onVersionChange,
     this.onRegenerateMessage,
     this.onResendMessage,
@@ -138,23 +145,32 @@ class MessageListView extends StatefulWidget {
     this.onToggleReasoningSegment,
     this.buildPinnedStreamingIndicator,
     this.hasMoreBefore = false,
+    this.isLoadingWindow = false,
     this.onLoadMoreBefore,
     this.hasMoreAfter = false,
     this.onLoadMoreAfter,
+    this.onUserScrollIntent,
     this.hideMoreActions,
     this.headerWidget,
     this.resolveSpeaker,
+    this.chatFontScale = 1,
+    this.collapseThinking = true,
+    this.collapsedCodeLines,
+    this.wrapCodeBlocks = false,
+    this.showModelIcon = true,
+    this.showUserAvatar = true,
+    this.showTokenStats = false,
+    this.assistant,
   });
 
   final ScrollController scrollController;
-  final ListObserverController observerController;
-
-  /// When set, assistant chrome (name/avatar) uses this per-message speaker
-  /// instead of [AssistantProvider.currentAssistant]. Used by group chat.
-  final Assistant? Function(ChatMessage message)? resolveSpeaker;
+  final ListController listController;
 
   /// Pre-collapsed messages (from ChatController.collapsedMessages).
   final List<ChatMessage> messages;
+
+  /// Precomputed one-per-slot renderer inputs. Must match [messages] order.
+  final List<MessageRenderModel>? renderModels;
 
   /// All messages grouped by groupId (from ChatController.groupedMessages).
   final Map<String, List<ChatMessage>> byGroup;
@@ -191,6 +207,10 @@ class MessageListView extends StatefulWidget {
   /// so re-selecting the same message re-triggers the pulse.
   final int spotlightToken;
 
+  /// Slots currently fading out ahead of their deletion. The slot data stays
+  /// in [messages] until the removal animation completes.
+  final Set<String> removingSlotIds;
+
   // Callbacks
   final OnVersionChange? onVersionChange;
   final OnRegenerateMessage? onRegenerateMessage;
@@ -204,6 +224,11 @@ class MessageListView extends StatefulWidget {
   final OnShareMessage? onShareMessage;
   final OnSelectMessages? onSelectMessages;
   final OnSpeakMessage? onSpeakMessage;
+  final List<String> suggestions;
+
+  /// Inline widgets rendered after specific message items (e.g. Multi-AI card groups).
+  final Map<String, Widget>? afterMessageWidgets;
+
   final OnSuggestionTap? onSuggestionTap;
   final OnQuoteSelection? onQuoteSelection;
   final OnRecoveredAskUserAnswer? onRecoveredAskUserAnswer;
@@ -212,39 +237,854 @@ class MessageListView extends StatefulWidget {
   final void Function(String messageId)? onToggleTranslation;
   final void Function(String messageId, int segmentIndex)?
   onToggleReasoningSegment;
+  final Widget Function()? buildPinnedStreamingIndicator;
 
   /// Actions to hide from the message more sheet, computed by caller.
   final Set<MessageMoreAction> Function()? hideMoreActions;
 
-  final List<String> suggestions;
-
-  /// Inline widgets rendered after specific message items (e.g. Multi-AI card groups).
-  final Map<String, Widget>? afterMessageWidgets;
-
-  final Widget Function()? buildPinnedStreamingIndicator;
-  final bool hasMoreBefore;
-  final bool Function()? onLoadMoreBefore;
-  final bool hasMoreAfter;
-  final bool Function()? onLoadMoreAfter;
+  /// When set, assistant chrome (name/avatar) uses this per-message speaker
+  /// instead of [AssistantProvider.currentAssistant]. Used by group chat.
+  final Assistant? Function(ChatMessage message)? resolveSpeaker;
 
   /// An optional widget rendered as the first item in the list.
   /// When provided, [messages] indices are shifted by 1.
   final Widget? headerWidget;
+
+  final bool hasMoreBefore;
+
+  /// True only while a cold initial window load is in flight; fast-path cache
+  /// hits resolve within one frame batch and never surface the skeleton.
+  final bool isLoadingWindow;
+  final bool Function()? onLoadMoreBefore;
+  final bool hasMoreAfter;
+  final bool Function()? onLoadMoreAfter;
+  final VoidCallback? onUserScrollIntent;
+  final double chatFontScale;
+
+  /// Whether finished thinking blocks render collapsed (display setting).
+  final bool collapseThinking;
+
+  /// Lines a long code block collapses to, or null when it stays expanded.
+  final int? collapsedCodeLines;
+
+  /// Whether code blocks wrap (desktop, or the mobile wrap setting) instead of
+  /// scrolling horizontally.
+  final bool wrapCodeBlocks;
+
+  final bool showModelIcon;
+  final bool showUserAvatar;
+  final bool showTokenStats;
+  final Assistant? assistant;
+
+  @visibleForTesting
+  static const Key windowSkeletonKey = ValueKey<String>(
+    'timeline-window-skeleton',
+  );
 
   @override
   State<MessageListView> createState() => _MessageListViewState();
 }
 
 class _MessageListViewState extends State<MessageListView> {
-  static const double _streamingUpdateDeferBottomTolerance = 24.0;
+  static const double _streamingUpdateDeferBottomTolerance = 56.0;
 
   bool _historyLoadScheduled = false;
+  bool _pointerDragInProgress = false;
+  bool _userScrollActive = false;
+  ScrollMetrics? _latestPointerDragMetrics;
   final ValueNotifier<bool> _deferStreamingMessageUpdates = ValueNotifier<bool>(
     false,
   );
   DateTime? _lastHistoryLoadAt;
   Timer? _scrollIdleTimer;
   bool _pointerScrollActivityCheckScheduled = false;
+  late List<MessageRenderModel> _effectiveRenderModels;
+  late Map<String, int> _slotIndexById;
+  final FocusNode _keyboardFocusNode = FocusNode(
+    debugLabel: 'timeline-keyboard-scroll-region',
+  );
+
+  String _slotId(ChatMessage message) => message.groupId ?? message.id;
+
+  /// Resolves the assistant owning [message]'s conversation (conversation
+  /// assistantId → provider), falling back to null. This is what makes
+  /// handoff child conversations render their target assistant's avatar and
+  /// name instead of the globally-selected current assistant (resolveSpeaker
+  /// is only wired for group chats).
+  Assistant? _assistantForConversation(
+    BuildContext context,
+    ChatMessage message,
+  ) {
+    try {
+      final chatService = context.read<ChatService>();
+      final convo = chatService.getConversation(message.conversationId);
+      final aId = convo?.assistantId;
+      if (aId == null || aId.isEmpty) return null;
+      return context.read<AssistantProvider>().getById(aId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The [headerWidget] occupies list item 0; each message's list index is its
+  /// model index shifted by this offset.
+  int get _headerOffset => widget.headerWidget != null ? 1 : 0;
+
+  /// Number of SuperListView items (header + messages).
+  int get _itemCount => _effectiveRenderModels.length + _headerOffset;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshRenderModels();
+  }
+
+  @override
+  void didUpdateWidget(covariant MessageListView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldRenderModels = _effectiveRenderModels;
+    _refreshRenderModels();
+    _synchronizeExtentCache(oldWidget, oldRenderModels);
+  }
+
+  void _refreshRenderModels() {
+    _effectiveRenderModels =
+        widget.renderModels ??
+        MessageRenderModelProjector.project(
+          messages: widget.messages,
+          byGroup: widget.byGroup,
+          versionSelections: widget.versionSelections,
+          contextDividerIndex: widget.truncCollapsedIndex,
+        );
+    _slotIndexById = <String, int>{
+      for (var index = 0; index < _effectiveRenderModels.length; index++)
+        _effectiveRenderModels[index].slotId: index + _headerOffset,
+    };
+  }
+
+  /// Header row + action bar + vertical margins around a bubble.
+  static const double _estimateChrome = 96.0;
+
+  /// Height of a collapsed inline thinking card.
+  static const double _estimateCollapsedCard = 44.0;
+
+  /// Characters scanned before a message's line density is extrapolated.
+  static const int _estimateScanLimit = 8000;
+
+  /// Font size fenced code renders at, before scaling.
+  static const double _estimateCodeFontSize = 13.0;
+
+  /// Longest message the thinking parser is run over.
+  static const int _estimateParseLimit = 64000;
+
+  /// Cached estimates kept before the memo is dropped wholesale.
+  static const int _extentEstimateCacheLimit = 512;
+
+  final Map<String, _ExtentEstimate> _extentEstimateCache = {};
+
+  /// System accessibility text scale, which multiplies the chat font scale.
+  double _systemTextScale = 1.0;
+
+  /// Display settings the estimate depends on, refreshed in [build].
+  _EstimateSettings _estimateSettings = const _EstimateSettings(
+    collapseThinking: true,
+    collapsedCodeLines: null,
+    wrapCodeBlocks: false,
+  );
+
+  /// Font scale the currently stored extents were estimated at.
+  double? _estimatedFontScale;
+
+  /// Drops stored extents after the system text scale changed.
+  ///
+  /// Only the widget-driven inputs go through [_synchronizeExtentCache]; a
+  /// system accessibility change arrives through MediaQuery without touching
+  /// the item count, so SuperSliverList would otherwise keep off-screen
+  /// estimates made at the old scale until each of them is scrolled into view.
+  void _invalidateEstimatesIfScaleChanged() {
+    final scale = widget.chatFontScale * _systemTextScale;
+    if (_estimatedFontScale == scale) return;
+    final hadEstimates = _estimatedFontScale != null;
+    _estimatedFontScale = scale;
+    if (!hadEstimates) return;
+    final controller = widget.listController;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !controller.isAttached || controller.isLocked) return;
+      controller.invalidateAllExtents();
+    });
+  }
+
+  /// Rough height of a message bubble, used for items that never got laid out.
+  ///
+  /// SuperSliverList's default estimate is a flat 100px. In a long chat a real
+  /// bubble is one to two orders of magnitude taller than that, so every time
+  /// layout replaces an estimate with a measurement the total extent — and with
+  /// it the bottom-pinned scroll offset — moves by tens of thousands of pixels.
+  /// When that lands across two frames the timeline visibly flicks away from
+  /// the bottom and back. A content-derived estimate keeps those corrections
+  /// small; it does not need to be exact, only the right order of magnitude.
+  double _estimateItemExtent(int? index, double crossAxisExtent) {
+    // A null index asks whether one extent fits every item. Answering with a
+    // positive number makes SuperSliverList apply it to the whole list without
+    // ever consulting the per-item branch below, so this has to be 0.
+    if (index == null) return 0;
+    final models = _effectiveRenderModels;
+    // Item 0 may be the header widget, whose height the list measures as soon
+    // as it lays out. Until then a neutral estimate keeps the derivation from
+    // hitting the message space below.
+    if (_headerOffset == 1 && index == 0) return _estimateChrome;
+    final messageIndex = index - _headerOffset;
+    if (messageIndex < 0 || messageIndex >= models.length) {
+      return _estimateChrome;
+    }
+
+    final message = models[messageIndex].message;
+    final text = message.content;
+    final reasoning = message.role == 'assistant'
+        ? widget.reasoning[message.id]
+        : null;
+    final reasoningSegments = message.role == 'assistant'
+        ? widget.reasoningSegments[message.id]
+        : null;
+    final hasReasoning =
+        (reasoning?.text.isNotEmpty ?? false) ||
+        (reasoningSegments?.isNotEmpty ?? false);
+    if (text.isEmpty && !hasReasoning) return _estimateChrome;
+
+    // Layout asks for the same item repeatedly (every resize, every window
+    // change), and the scan below is linear in the message length, so a memo
+    // keyed by everything the result depends on keeps the layout phase cheap.
+    // The content is compared by identity: an edited or streamed message always
+    // carries a new string, and equal-length rewrites must not hit the memo.
+    final fontScale = widget.chatFontScale * _systemTextScale;
+    final settings = _estimateSettings;
+    final reasoningSignature = _reasoningEstimateSignature(
+      reasoning,
+      reasoningSegments,
+    );
+    final cached = _extentEstimateCache[message.id];
+    if (cached != null &&
+        identical(cached.content, text) &&
+        cached.crossAxisExtent == crossAxisExtent &&
+        cached.fontScale == fontScale &&
+        cached.settings == settings &&
+        cached.reasoningSignature == reasoningSignature) {
+      return cached.extent;
+    }
+
+    // Inline thinking renders as its own card. When it is collapsed only the
+    // visible remainder takes space, so parse it out with the same parser the
+    // renderer uses instead of guessing at the tag syntax.
+    var body = text;
+    var collapsedCards = 0;
+    if (settings.collapseThinking &&
+        message.role != 'user' &&
+        text.length <= _estimateParseLimit &&
+        text.contains('<')) {
+      final parsed = ThinkingTagParser.parseLegacyInlineBlocks(text);
+      if (parsed.hasThinking) {
+        body = parsed.visibleContent;
+        collapsedCards = parsed.thinkingTexts.length;
+      }
+    }
+
+    final fontSize = 15.6 * fontScale;
+    final lineHeight = fontSize * 1.5;
+    // User bubbles are inset and never span the full width.
+    final bubbleWidth = crossAxisExtent * (message.role == 'user' ? 0.85 : 1.0);
+    final textWidth = math.max(80.0, bubbleWidth - 28);
+    // Wide (CJK) glyphs are about twice as wide as Latin ones, so the mix
+    // decides how many characters fit on a line.
+    final charWidth = fontSize * (0.5 + 0.55 * _wideCharRatio(body));
+    final charsPerLine = math.max(1.0, textWidth / charWidth);
+    // Code renders in a fixed 13px monospace face, so it wraps at a different
+    // column and stacks at a different row height than the body text.
+    final codeFontSize = _estimateCodeFontSize * fontScale;
+    final codeCharsPerLine = math.max(1.0, textWidth / (codeFontSize * 0.6));
+    final extent =
+        _wrappedLineCount(
+              body,
+              charsPerLine: charsPerLine,
+              codeCharsPerLine: settings.wrapCodeBlocks
+                  ? codeCharsPerLine
+                  : null,
+              codeLineRatio: codeFontSize / fontSize,
+              collapsedCodeLines: settings.collapsedCodeLines,
+            ) *
+            lineHeight +
+        _estimateChrome +
+        collapsedCards * _estimateCollapsedCard +
+        _estimateReasoningExtent(
+          reasoning,
+          reasoningSegments,
+          textWidth: textWidth,
+          fontScale: fontScale,
+        );
+
+    if (_extentEstimateCache.length > _extentEstimateCacheLimit) {
+      _extentEstimateCache.clear();
+    }
+    _extentEstimateCache[message.id] = _ExtentEstimate(
+      content: text,
+      crossAxisExtent: crossAxisExtent,
+      fontScale: fontScale,
+      settings: settings,
+      reasoningSignature: reasoningSignature,
+      extent: extent,
+    );
+    return extent;
+  }
+
+  /// Estimated height of the reasoning card(s) rendered above the answer.
+  ///
+  /// Reasoning lives outside [ChatMessage.content], so the content-only
+  /// estimate misses it entirely: a reasoning-heavy message gets estimated an
+  /// order of magnitude too short, and every scroll or anchor computation
+  /// across the unmeasured region is off by the same amount. Mirrors the
+  /// renderer's choice of showing the segments when present and otherwise the
+  /// single reasoning block.
+  double _estimateReasoningExtent(
+    stream_ctrl.ReasoningData? reasoning,
+    List<stream_ctrl.ReasoningSegmentData>? segments, {
+    required double textWidth,
+    required double fontScale,
+  }) {
+    var extent = 0.0;
+    void addCard(String reasoningText, bool expanded) {
+      if (reasoningText.isEmpty) return;
+      extent += _estimateCollapsedCard;
+      if (!expanded) return;
+      final fontSize = 13.0 * fontScale;
+      final charWidth = fontSize * (0.5 + 0.55 * _wideCharRatio(reasoningText));
+      final charsPerLine = math.max(1.0, textWidth / charWidth);
+      extent +=
+          _wrappedLineCount(
+            reasoningText,
+            charsPerLine: charsPerLine,
+            codeCharsPerLine: null,
+            codeLineRatio: 1.0,
+            collapsedCodeLines: null,
+          ) *
+          (fontSize * 1.5);
+    }
+
+    if (segments != null && segments.isNotEmpty) {
+      for (final segment in segments) {
+        addCard(segment.text, segment.expanded);
+      }
+    } else if (reasoning != null) {
+      addCard(reasoning.text, reasoning.expanded);
+    }
+    return extent;
+  }
+
+  /// Identity of the reasoning inputs an estimate was computed from.
+  ///
+  /// Reasoning state objects mutate in place, but their text is replaced with
+  /// a new string on every change, so text identity plus the expanded flags
+  /// distinguishes every state the estimate depends on.
+  int _reasoningEstimateSignature(
+    stream_ctrl.ReasoningData? reasoning,
+    List<stream_ctrl.ReasoningSegmentData>? segments,
+  ) {
+    if (reasoning == null && (segments == null || segments.isEmpty)) return 0;
+    return Object.hashAll([
+      if (reasoning != null) ...[
+        identityHashCode(reasoning.text),
+        reasoning.expanded,
+      ],
+      if (segments != null)
+        for (final segment in segments) ...[
+          identityHashCode(segment.text),
+          segment.expanded,
+        ],
+    ]);
+  }
+
+  /// Rendered height in body lines, wrapping each hard line separately.
+  ///
+  /// Dividing the whole length by [charsPerLine] would collapse blank lines and
+  /// short lines, which is exactly the shape chat messages tend to have. Two
+  /// constructs would otherwise be counted wrong: a Markdown link hides its
+  /// target, and a fenced code block renders in its own font — wrapping at
+  /// [codeCharsPerLine] when the renderer wraps, or staying one row per source
+  /// line when it scrolls horizontally instead ([codeCharsPerLine] null), each
+  /// row [codeLineRatio] of a body line tall. A block may also be collapsed to
+  /// [collapsedCodeLines] source lines.
+  double _wrappedLineCount(
+    String text, {
+    required double charsPerLine,
+    required double? codeCharsPerLine,
+    required double codeLineRatio,
+    required int? collapsedCodeLines,
+  }) {
+    var lines = 0.0;
+    var visible = 0; // rendered characters on the current line
+    var fenceRows = 0.0; // rendered rows inside the open code fence
+    var fenceSourceLines = 0; // hard lines inside the open code fence
+    var inFence = false;
+    var index = 0;
+
+    void endLine() {
+      if (inFence) {
+        fenceSourceLines++;
+        fenceRows += visible == 0 || codeCharsPerLine == null
+            ? 1.0 // one row per source line: code scrolls sideways
+            : (visible / codeCharsPerLine).ceilToDouble();
+      } else {
+        lines += visible == 0 ? 1.0 : (visible / charsPerLine).ceilToDouble();
+      }
+      visible = 0;
+    }
+
+    void endFence() {
+      // Collapsing hides source lines, so the wrapped rows shrink with them.
+      final shown = collapsedCodeLines == null || fenceSourceLines == 0
+          ? fenceRows
+          : fenceRows * math.min(1.0, collapsedCodeLines / fenceSourceLines);
+      lines += shown * codeLineRatio;
+      fenceRows = 0;
+      fenceSourceLines = 0;
+    }
+
+    // Very long messages only need the right order of magnitude, so the scan is
+    // budgeted per character — a single-line megabyte of JSON must not walk the
+    // whole string — and the tail is extrapolated at the observed density.
+    while (index < text.length && index < _estimateScanLimit) {
+      final unit = text.codeUnitAt(index);
+      if (unit == 0x0A) {
+        endLine();
+        index++;
+        continue;
+      }
+      if (unit == 0x60 && _isFenceMarker(text, index)) {
+        if (inFence) {
+          endLine();
+          endFence();
+          inFence = false;
+        } else {
+          endLine();
+          inFence = true;
+        }
+        index += 3;
+        continue;
+      }
+      if (unit == 0x5D && index + 1 < text.length) {
+        // A Markdown link renders its label, never its target.
+        if (text.codeUnitAt(index + 1) == 0x28) {
+          final close = text.indexOf(')', index + 2);
+          if (close > 0) {
+            visible++;
+            index = close + 1;
+            continue;
+          }
+        }
+      }
+      visible++;
+      index++;
+    }
+    endLine();
+    if (inFence) endFence();
+    if (index >= text.length) return lines;
+    return lines * (text.length / math.max(1, index));
+  }
+
+  /// Whether a ``` fence marker starts at [index].
+  bool _isFenceMarker(String text, int index) {
+    if (index + 2 >= text.length) return false;
+    if (text.codeUnitAt(index + 1) != 0x60 ||
+        text.codeUnitAt(index + 2) != 0x60) {
+      return false;
+    }
+    return index == 0 || text.codeUnitAt(index - 1) == 0x0A;
+  }
+
+  /// Fraction of wide glyphs, sampled so the cost stays flat for huge messages.
+  double _wideCharRatio(String text) {
+    const samples = 256;
+    final step = math.max(1, text.length ~/ samples);
+    var wide = 0;
+    var seen = 0;
+    for (var index = 0; index < text.length; index += step) {
+      if (text.codeUnitAt(index) >= 0x2E80) wide++;
+      seen++;
+    }
+    return seen == 0 ? 0 : wide / seen;
+  }
+
+  int? _findMessageIndexByKey(Key key) {
+    if (key is! ValueKey<String>) return null;
+    return _slotIndexById[key.value];
+  }
+
+  void _synchronizeExtentCache(
+    MessageListView oldWidget,
+    List<MessageRenderModel> oldModels,
+  ) {
+    final controller = widget.listController;
+    if (!identical(controller, oldWidget.listController) ||
+        !controller.isAttached) {
+      return;
+    }
+    if (controller.isLocked) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && controller.isAttached && !controller.isLocked) {
+          controller.invalidateAllExtents();
+        }
+      });
+      return;
+    }
+
+    final newModels = _effectiveRenderModels;
+    final metricInputsChanged =
+        oldWidget.chatFontScale != widget.chatFontScale ||
+        oldWidget.selecting != widget.selecting ||
+        oldWidget.showModelIcon != widget.showModelIcon ||
+        oldWidget.showUserAvatar != widget.showUserAvatar ||
+        oldWidget.showTokenStats != widget.showTokenStats ||
+        oldWidget.collapseThinking != widget.collapseThinking ||
+        oldWidget.collapsedCodeLines != widget.collapsedCodeLines ||
+        oldWidget.wrapCodeBlocks != widget.wrapCodeBlocks ||
+        !identical(oldWidget.assistant, widget.assistant);
+    if (metricInputsChanged) {
+      controller.invalidateAllExtents();
+      return;
+    }
+
+    if (oldModels.length < newModels.length &&
+        _isPrefix(oldModels, newModels)) {
+      return;
+    }
+    if (oldModels.length < newModels.length &&
+        _isSuffix(oldModels, newModels)) {
+      final anchor = _captureVisibleAnchor(controller);
+      final added = newModels.length - oldModels.length;
+      for (var index = 0; index < added; index++) {
+        controller.addItem(index + _headerOffset);
+      }
+      if (anchor != null) {
+        _restoreVisibleAnchorAfterLayout(
+          controller,
+          index: anchor.index + added,
+          alignment: anchor.alignment,
+        );
+      }
+      return;
+    }
+    if (newModels.length < oldModels.length &&
+        _isPrefix(newModels, oldModels)) {
+      return;
+    }
+    if (newModels.length < oldModels.length) {
+      final removedOldIndices = _removedOldIndices(oldModels, newModels);
+      if (removedOldIndices != null) {
+        // Removing the extents at the deleted indices keeps every surviving
+        // slot's measured height attached to its new index; the fallback
+        // below would instead drop all measurements and let the list drift
+        // while it re-measures the whole window over several frames.
+        final anchor = _captureVisibleAnchorForRemoval(
+          controller,
+          removedOldIndices,
+        );
+        for (var index = removedOldIndices.length - 1; index >= 0; index--) {
+          controller.removeItem(removedOldIndices[index] + _headerOffset);
+        }
+        if (anchor != null) {
+          _restoreVisibleAnchorAfterLayout(
+            controller,
+            index: anchor.index,
+            alignment: anchor.alignment,
+          );
+        }
+        return;
+      }
+    }
+
+    if (oldModels.length == newModels.length) {
+      final added = _leadingShiftForEqualWindow(oldModels, newModels);
+      if (added != null) {
+        final anchor = _captureVisibleAnchor(controller);
+        for (var index = 0; index < added; index++) {
+          controller.addItem(index + _headerOffset);
+        }
+        for (var index = 0; index < added; index++) {
+          controller.removeItem(newModels.length + _headerOffset);
+        }
+        if (anchor != null && anchor.index + added < newModels.length) {
+          _restoreVisibleAnchorAfterLayout(
+            controller,
+            index: anchor.index + added,
+            alignment: anchor.alignment,
+          );
+        }
+        return;
+      }
+
+      var slotsMatch = true;
+      final changedIndices = <int>[];
+      for (var index = 0; index < newModels.length; index++) {
+        if (oldModels[index].slotId != newModels[index].slotId) {
+          slotsMatch = false;
+          break;
+        }
+        if (_messageExtentMayHaveChanged(
+          oldModels[index].message,
+          newModels[index].message,
+        )) {
+          changedIndices.add(index);
+        }
+      }
+      if (slotsMatch) {
+        final visible = controller.visibleRange;
+        final scrollController = widget.scrollController;
+        if (changedIndices.length == 1 &&
+            visible != null &&
+            changedIndices.single < visible.$1 &&
+            scrollController is scroll_ctrl.ChatAutoFollowScrollController) {
+          final request = scrollController
+              .requestPreserveDistanceFromEndDuringLayout();
+          if (request != null) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              scrollController.finishPreserveDistanceFromEndDuringLayout(
+                request,
+              );
+            });
+          }
+        }
+        for (final index in changedIndices) {
+          controller.invalidateExtent(index);
+        }
+        return;
+      }
+    }
+
+    controller.invalidateAllExtents();
+  }
+
+  /// Whether a layout-phase positioning request (bottom pin, preserved
+  /// distance, streaming auto-follow) owns the scroll position this frame.
+  /// Anchor restoration must stand down instead of fighting it.
+  bool get _layoutPositionOwnedElsewhere {
+    final scrollController = widget.scrollController;
+    return scrollController is scroll_ctrl.ChatAutoFollowScrollController &&
+        (scrollController.hasActiveLayoutPositioningRequest ||
+            scrollController.shouldAutoFollow());
+  }
+
+  ({int index, double alignment})? _captureVisibleAnchor(
+    ListController controller,
+  ) {
+    if (!widget.scrollController.hasClients) return null;
+    if (_layoutPositionOwnedElsewhere) return null;
+    final visible = controller.visibleRange;
+    if (visible == null) return null;
+    final itemIndex = visible.$1 < _headerOffset ? _headerOffset : visible.$1;
+    if (itemIndex >= controller.numberOfItems) return null;
+    final anchor = _anchorAtIndex(controller, itemIndex);
+    return (index: itemIndex - _headerOffset, alignment: anchor.alignment);
+  }
+
+  /// Captures the topmost visible slot that survives a removal, as an anchor
+  /// expressed in post-removal model index space.
+  ///
+  /// When every visible slot is being removed, the anchor falls to the
+  /// nearest surviving slot below, whose content slides up into the vacated
+  /// viewport; failing that, the nearest surviving slot above.
+  ({int index, double alignment})? _captureVisibleAnchorForRemoval(
+    ListController controller,
+    List<int> removedOldIndices,
+  ) {
+    if (!widget.scrollController.hasClients) return null;
+    if (_layoutPositionOwnedElsewhere) return null;
+    final visible = controller.visibleRange;
+    if (visible == null) return null;
+    final removed = removedOldIndices.toSet();
+    final itemCount = controller.numberOfItems;
+    int? anchorItemIndex;
+    for (var item = visible.$1; item < itemCount; item++) {
+      final model = item - _headerOffset;
+      if (model >= 0 && !removed.contains(model)) {
+        anchorItemIndex = item;
+        break;
+      }
+    }
+    if (anchorItemIndex == null) {
+      for (var item = visible.$1 - 1; item >= 0; item--) {
+        final model = item - _headerOffset;
+        if (model >= 0 && !removed.contains(model)) {
+          anchorItemIndex = item;
+          break;
+        }
+      }
+    }
+    if (anchorItemIndex == null) return null;
+    final anchor = _anchorAtIndex(controller, anchorItemIndex);
+    var anchorNewIndex = anchorItemIndex - _headerOffset;
+    for (final removedIndex in removedOldIndices) {
+      if (removedIndex < anchorNewIndex) anchorNewIndex--;
+    }
+    return (index: anchorNewIndex, alignment: anchor.alignment);
+  }
+
+  ({int index, double alignment}) _anchorAtIndex(
+    ListController controller,
+    int index,
+  ) {
+    final position = widget.scrollController.position;
+    final itemExtent = controller.extentForIndex(index).$1;
+    // The scroll position is defined by where children were actually painted,
+    // while the extent list's offsets partly derive from estimated heights of
+    // rows that never entered layout. Mixing the two frames would bake their
+    // accumulated difference into the alignment, and the restore jump would
+    // land the anchor shifted by exactly that error — with estimate-heavy
+    // histories (long reasoning payloads, huge messages) that reads as the
+    // viewport jumping to a random place. Anchor on the painted offset and
+    // only fall back to the estimated one when the child is not built.
+    final itemLeading =
+        _paintedLeadingOffset(index) ??
+        // This is the same offset query used by jumpToItem. It is safe here,
+        // before the new child list enters layout.
+        // ignore: invalid_use_of_visible_for_testing_member
+        controller.getOffsetToReveal(index, 0);
+    final availableAlignmentExtent = position.viewportDimension - itemExtent;
+    final alignment = availableAlignmentExtent.abs() < 0.5
+        ? 0.0
+        : (itemLeading - position.pixels) / availableAlignmentExtent;
+    return (index: index, alignment: alignment);
+  }
+
+  /// The scroll offset at which the child for [index] was actually laid out,
+  /// or null when that child is not currently built.
+  double? _paintedLeadingOffset(int index) {
+    final root = context.findRenderObject();
+    if (root == null) return null;
+    RenderSliverMultiBoxAdaptor? sliver;
+    void visit(RenderObject node) {
+      if (sliver != null) return;
+      if (node is RenderSliverMultiBoxAdaptor) {
+        sliver = node;
+        return;
+      }
+      node.visitChildren(visit);
+    }
+
+    visit(root);
+    final list = sliver;
+    if (list == null || list.geometry == null) return null;
+    for (
+      var child = list.firstChild;
+      child != null;
+      child = list.childAfter(child)
+    ) {
+      final parentData = child.parentData;
+      if (parentData is! SliverMultiBoxAdaptorParentData) continue;
+      if (parentData.index != index) continue;
+      if (parentData.keptAlive) return null;
+      final layoutOffset = parentData.layoutOffset;
+      if (layoutOffset == null) return null;
+      return layoutOffset + list.constraints.precedingScrollExtent;
+    }
+    return null;
+  }
+
+  /// Old-list indices whose slots are absent from the new list, or null when
+  /// the new list is not simply the old list with some slots removed.
+  List<int>? _removedOldIndices(
+    List<MessageRenderModel> oldModels,
+    List<MessageRenderModel> newModels,
+  ) {
+    final removed = <int>[];
+    var newIndex = 0;
+    for (var oldIndex = 0; oldIndex < oldModels.length; oldIndex++) {
+      if (newIndex < newModels.length &&
+          oldModels[oldIndex].slotId == newModels[newIndex].slotId) {
+        newIndex++;
+      } else {
+        removed.add(oldIndex);
+      }
+    }
+    if (newIndex != newModels.length || removed.isEmpty) return null;
+    return removed;
+  }
+
+  void _restoreVisibleAnchorAfterLayout(
+    ListController controller, {
+    required int index,
+    required double alignment,
+  }) {
+    final scrollController = widget.scrollController;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted ||
+          !controller.isAttached ||
+          controller.isLocked ||
+          !scrollController.hasClients ||
+          index < 0 ||
+          index >= _effectiveRenderModels.length) {
+        return;
+      }
+      controller.jumpToItem(
+        index: index + _headerOffset,
+        scrollController: scrollController,
+        alignment: alignment,
+      );
+    });
+  }
+
+  bool _messageExtentMayHaveChanged(ChatMessage old, ChatMessage current) {
+    return old.id != current.id ||
+        old.role != current.role ||
+        old.content != current.content ||
+        old.reasoningText != current.reasoningText ||
+        old.translation != current.translation ||
+        old.reasoningSegmentsJson != current.reasoningSegmentsJson ||
+        old.modelId != current.modelId ||
+        old.providerId != current.providerId ||
+        old.totalTokens != current.totalTokens ||
+        old.promptTokens != current.promptTokens ||
+        old.completionTokens != current.completionTokens ||
+        old.cachedTokens != current.cachedTokens ||
+        old.durationMs != current.durationMs;
+  }
+
+  bool _isPrefix(
+    List<MessageRenderModel> prefix,
+    List<MessageRenderModel> values,
+  ) {
+    if (prefix.length > values.length) return false;
+    for (var index = 0; index < prefix.length; index++) {
+      if (prefix[index].slotId != values[index].slotId) return false;
+    }
+    return true;
+  }
+
+  bool _isSuffix(
+    List<MessageRenderModel> suffix,
+    List<MessageRenderModel> values,
+  ) {
+    if (suffix.length > values.length) return false;
+    final offset = values.length - suffix.length;
+    for (var index = 0; index < suffix.length; index++) {
+      if (suffix[index].slotId != values[offset + index].slotId) return false;
+    }
+    return true;
+  }
+
+  int? _leadingShiftForEqualWindow(
+    List<MessageRenderModel> oldModels,
+    List<MessageRenderModel> newModels,
+  ) {
+    if (oldModels.isEmpty || oldModels.length != newModels.length) return null;
+    final shift = newModels.indexWhere(
+      (model) => model.slotId == oldModels.first.slotId,
+    );
+    if (shift <= 0) return null;
+    for (var index = 0; index < oldModels.length - shift; index++) {
+      if (oldModels[index].slotId != newModels[index + shift].slotId) {
+        return null;
+      }
+    }
+    return shift;
+  }
 
   bool get _isDesktopPlatform =>
       defaultTargetPlatform == TargetPlatform.macOS ||
@@ -262,6 +1102,7 @@ class _MessageListViewState extends State<MessageListView> {
   void dispose() {
     _scrollIdleTimer?.cancel();
     _deferStreamingMessageUpdates.dispose();
+    _keyboardFocusNode.dispose();
     super.dispose();
   }
 
@@ -302,6 +1143,22 @@ class _MessageListViewState extends State<MessageListView> {
 
   @override
   Widget build(BuildContext context) {
+    // Items render at the system scale times the chat scale (see the MediaQuery
+    // override in _buildMessageItem), so the estimate has to use both.
+    _systemTextScale = MediaQuery.textScalerOf(context).scale(1);
+    _estimateSettings = _EstimateSettings(
+      collapseThinking: widget.collapseThinking,
+      collapsedCodeLines: widget.collapsedCodeLines,
+      wrapCodeBlocks: widget.wrapCodeBlocks,
+    );
+    _invalidateEstimatesIfScaleChanged();
+    final presentation = _MessagePresentation(
+      chatFontScale: widget.chatFontScale,
+      showModelIcon: widget.showModelIcon,
+      showUserAvatar: widget.showUserAvatar,
+      showTokenStats: widget.showTokenStats,
+      assistant: widget.assistant,
+    );
     return LayoutBuilder(
       builder: (context, constraints) {
         final horizontalPad =
@@ -311,9 +1168,14 @@ class _MessageListViewState extends State<MessageListView> {
         return ValueListenableBuilder<bool>(
           valueListenable: widget.isProcessingFiles,
           builder: (context, isProcessing, child) {
-            final hasHeader = widget.headerWidget != null;
-            final list = ListView.builder(
+            final list = SuperListView.builder(
               controller: widget.scrollController,
+              listController: widget.listController,
+              cacheExtent: 600,
+              delayPopulatingCacheArea: false,
+              addRepaintBoundaries: false,
+              findChildIndexCallback: _findMessageIndexByKey,
+              extentEstimation: _estimateItemExtent,
               padding: EdgeInsets.fromLTRB(
                 horizontalPad,
                 widget.topContentPadding,
@@ -321,50 +1183,68 @@ class _MessageListViewState extends State<MessageListView> {
                 widget.bottomContentPadding +
                     (widget.isPinnedIndicatorActive ? 12 : 0),
               ),
-              itemCount: hasHeader
-                  ? widget.messages.length + 1
-                  : widget.messages.length,
+              itemCount: _itemCount,
               keyboardDismissBehavior: _keyboardDismissBehavior,
               itemBuilder: (context, index) {
-                // headerWidget occupies index 0; message index = index - 1
-                if (hasHeader && index == 0) {
+                if (_headerOffset == 1 && index == 0) {
                   return widget.headerWidget!;
                 }
-                final adjustedIndex = hasHeader ? index - 1 : index;
-                if (adjustedIndex < 0 ||
-                    adjustedIndex >= widget.messages.length) {
+                final messageIndex = index - _headerOffset;
+                if (messageIndex < 0 ||
+                    messageIndex >= _effectiveRenderModels.length) {
                   return const SizedBox.shrink();
                 }
                 return _buildMessageItem(
                   context,
-                  index: adjustedIndex,
+                  index: messageIndex,
                   isProcessingFiles: isProcessing,
+                  presentation: presentation,
                 );
               },
             );
 
-            final observedList = ListViewObserver(
-              controller: widget.observerController,
+            final historyList = NotificationListener<ScrollNotification>(
+              onNotification: _handleScrollNotification,
               child: list,
             );
 
-            final historyList = NotificationListener<ScrollNotification>(
-              onNotification: _handleScrollNotification,
-              child: observedList,
-            );
-
             final userScrollAwareList = Listener(
+              onPointerDown: (event) {
+                if (_isDesktopPlatform) _keyboardFocusNode.requestFocus();
+                if (event.buttons != 0 &&
+                    event.buttons != kSecondaryMouseButton) {
+                  _pointerDragInProgress = true;
+                  _latestPointerDragMetrics = null;
+                }
+              },
+              onPointerUp: (_) => _settlePointerDrag(),
+              onPointerCancel: (_) => _settlePointerDrag(),
               onPointerSignal: (event) {
                 if (event is PointerScrollEvent) {
                   _schedulePointerScrollActivityCheck();
                 }
               },
-              child: historyList,
+              child: Focus(
+                key: const ValueKey('timeline-keyboard-scroll-region'),
+                focusNode: _keyboardFocusNode,
+                onKeyEvent: _handleTimelineKeyEvent,
+                child: historyList,
+              ),
             );
 
             return Stack(
               children: [
                 userScrollAwareList,
+                if (_effectiveRenderModels.isEmpty && widget.isLoadingWindow)
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: _WindowLoadingSkeleton(
+                        key: MessageListView.windowSkeletonKey,
+                        horizontalPadding: horizontalPad,
+                        topPadding: widget.topContentPadding,
+                      ),
+                    ),
+                  ),
                 if (widget.isPinnedIndicatorActive &&
                     widget.buildPinnedStreamingIndicator != null)
                   widget.buildPinnedStreamingIndicator!(),
@@ -376,36 +1256,52 @@ class _MessageListViewState extends State<MessageListView> {
     );
   }
 
+  KeyEventResult _handleTimelineKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final key = event.logicalKey;
+    if (key != LogicalKeyboardKey.arrowUp &&
+        key != LogicalKeyboardKey.arrowDown &&
+        key != LogicalKeyboardKey.pageUp &&
+        key != LogicalKeyboardKey.pageDown &&
+        key != LogicalKeyboardKey.home &&
+        key != LogicalKeyboardKey.end) {
+      return KeyEventResult.ignored;
+    }
+    widget.onUserScrollIntent?.call();
+    return KeyEventResult.ignored;
+  }
+
   bool _handleScrollNotification(ScrollNotification notification) {
     if (notification.depth != 0) return false;
     if (notification.metrics.axis != Axis.vertical) return false;
     if (notification is ScrollUpdateNotification) {
       if (notification.dragDetails != null) {
-        _handleUserScrollActivity(notification.metrics);
-      }
-      if (_deferStreamingMessageUpdates.value) {
-        _scheduleStreamingUpdateResume();
+        _recordPointerDrag(notification.metrics);
       }
     } else if (notification is OverscrollNotification) {
       if (notification.dragDetails != null) {
-        _handleUserScrollActivity(notification.metrics);
-      }
-      if (_deferStreamingMessageUpdates.value) {
-        _scheduleStreamingUpdateResume();
+        _recordPointerDrag(notification.metrics);
       }
     } else if (notification is ScrollStartNotification &&
         notification.dragDetails != null) {
-      _handleUserScrollActivity(notification.metrics);
+      _recordPointerDrag(notification.metrics);
     }
     if (notification is UserScrollNotification) {
       final shouldDefer = notification.direction != ScrollDirection.idle;
       if (shouldDefer) {
-        _handleUserScrollActivity(notification.metrics);
+        _userScrollActive = true;
+        _scrollIdleTimer?.cancel();
+        _scrollIdleTimer = null;
+        _setDeferStreamingMessageUpdates(true);
       } else {
+        _userScrollActive = false;
         _scheduleStreamingUpdateResume();
       }
     }
     if (notification is ScrollEndNotification) {
+      _userScrollActive = false;
       _scheduleStreamingUpdateResume();
     }
     if (_historyLoadScheduled) return false;
@@ -421,21 +1317,31 @@ class _MessageListViewState extends State<MessageListView> {
         notification.metrics.maxScrollExtent - notification.metrics.pixels <=
         96;
     if (isNearTop && widget.hasMoreBefore && widget.onLoadMoreBefore != null) {
-      _scheduleHistoryLoad(
-        keepAnchorFromTop: true,
-        beforeExtent: notification.metrics.maxScrollExtent,
-        load: widget.onLoadMoreBefore!,
-      );
+      _scheduleHistoryLoad(load: widget.onLoadMoreBefore!);
     } else if (isNearBottom &&
         widget.hasMoreAfter &&
         widget.onLoadMoreAfter != null) {
-      _scheduleHistoryLoad(
-        keepAnchorFromTop: false,
-        beforeExtent: notification.metrics.maxScrollExtent,
-        load: widget.onLoadMoreAfter!,
-      );
+      _scheduleHistoryLoad(load: widget.onLoadMoreAfter!);
     }
     return false;
+  }
+
+  void _recordPointerDrag(ScrollMetrics metrics) {
+    _pointerDragInProgress = true;
+    _latestPointerDragMetrics = metrics;
+  }
+
+  void _settlePointerDrag([ScrollMetrics? metrics]) {
+    if (!_pointerDragInProgress) return;
+    _pointerDragInProgress = false;
+    final settledMetrics = metrics ?? _latestPointerDragMetrics;
+    _latestPointerDragMetrics = null;
+    // A pointer press that produced no scroll activity (a plain tap on a
+    // bubble) must not register as user scroll intent: canceling the
+    // layout-phase bottom follow on a tap while a reply streams would leave
+    // the timeline unpinned for the whole idle window.
+    if (settledMetrics == null) return;
+    _handleUserScrollActivity(settledMetrics);
   }
 
   void _schedulePointerScrollActivityCheck() {
@@ -449,6 +1355,7 @@ class _MessageListViewState extends State<MessageListView> {
   }
 
   void _handleUserScrollActivity([ScrollMetrics? metrics]) {
+    widget.onUserScrollIntent?.call();
     if (_isWithinStreamingAutoFollowBand(metrics)) {
       _resumeStreamingMessageUpdates();
       return;
@@ -459,13 +1366,17 @@ class _MessageListViewState extends State<MessageListView> {
 
   bool _isWithinStreamingAutoFollowBand([ScrollMetrics? metrics]) {
     if (metrics != null) {
-      return metrics.maxScrollExtent - metrics.pixels <=
-          _streamingUpdateDeferBottomTolerance;
+      final gap = _contentMaxScrollExtent(metrics) - metrics.pixels;
+      return gap <= _streamingUpdateDeferBottomTolerance;
     }
     if (!widget.scrollController.hasClients) return true;
     final position = widget.scrollController.position;
-    return position.maxScrollExtent - position.pixels <=
-        _streamingUpdateDeferBottomTolerance;
+    final gap = _contentMaxScrollExtent(position) - position.pixels;
+    return gap <= _streamingUpdateDeferBottomTolerance;
+  }
+
+  double _contentMaxScrollExtent(ScrollMetrics metrics) {
+    return metrics.maxScrollExtent;
   }
 
   void _setDeferStreamingMessageUpdates(bool value) {
@@ -474,6 +1385,7 @@ class _MessageListViewState extends State<MessageListView> {
   }
 
   void _scheduleStreamingUpdateResume() {
+    if (_pointerDragInProgress || _userScrollActive) return;
     _scrollIdleTimer?.cancel();
     _scrollIdleTimer = Timer(
       const Duration(milliseconds: 160),
@@ -488,75 +1400,47 @@ class _MessageListViewState extends State<MessageListView> {
     _deferStreamingMessageUpdates.value = false;
   }
 
-  void _scheduleHistoryLoad({
-    required bool keepAnchorFromTop,
-    required double beforeExtent,
-    required bool Function() load,
-  }) {
+  void _scheduleHistoryLoad({required bool Function() load}) {
     _historyLoadScheduled = true;
     _lastHistoryLoadAt = DateTime.now();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) {
         _historyLoadScheduled = false;
         return;
       }
 
       final loaded = load();
+      if (!mounted) {
+        _historyLoadScheduled = false;
+        return;
+      }
       if (!loaded) {
         _historyLoadScheduled = false;
         return;
       }
 
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _historyLoadScheduled = false;
-        if (!mounted || !widget.scrollController.hasClients) return;
-        if (!keepAnchorFromTop) return;
-        final after = widget.scrollController.position.maxScrollExtent;
-        final delta = after - beforeExtent;
-        if (delta <= 0) return;
-        final target = (widget.scrollController.offset + delta).clamp(
-          widget.scrollController.position.minScrollExtent,
-          widget.scrollController.position.maxScrollExtent,
-        );
-        widget.scrollController.jumpTo(target);
-      });
+      // Keep pagination locked through the rebuild and anchor restoration.
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      _historyLoadScheduled = false;
     });
-  }
-
-  /// Resolves the assistant owning [message]'s conversation (conversation
-  /// assistantId → provider), falling back to null. This is what makes
-  /// handoff child conversations render their target assistant's avatar and
-  /// name instead of the globally-selected current assistant (resolveSpeaker
-  /// is only wired for group chats).
-  Assistant? _assistantForConversation(
-    BuildContext context,
-    ChatMessage message,
-  ) {
-    try {
-      final chatService = context.read<ChatService>();
-      final convo = chatService.getConversation(message.conversationId);
-      final aId = convo?.assistantId;
-      if (aId == null || aId.isEmpty) return null;
-      return context.read<AssistantProvider>().getById(aId);
-    } catch (_) {
-      return null;
-    }
   }
 
   Widget _buildMessageItem(
     BuildContext context, {
     required int index,
     required bool isProcessingFiles,
+    required _MessagePresentation presentation,
   }) {
-    final message = widget.messages[index];
+    final model = _effectiveRenderModels[index];
+    final message = model.message;
     final r = widget.reasoning[message.id];
     final t = widget.translations[message.id];
-    final chatScale = context.watch<SettingsProvider>().chatFontScale;
-    final resolved = widget.resolveSpeaker?.call(message);
+    final resolvedSpeaker = widget.resolveSpeaker?.call(message);
     final assistant =
-        resolved ??
+        resolvedSpeaker ??
         _assistantForConversation(context, message) ??
-        context.watch<AssistantProvider>().currentAssistant;
+        presentation.assistant;
     final forceSpeakerChrome =
         widget.resolveSpeaker != null && message.role == 'assistant';
     final useAssistAvatar = forceSpeakerChrome
@@ -565,35 +1449,29 @@ class _MessageListViewState extends State<MessageListView> {
     final useAssistName = forceSpeakerChrome
         ? true
         : assistant?.useAssistantName == true;
-    final showDivider =
-        widget.truncCollapsedIndex >= 0 && index == widget.truncCollapsedIndex;
-    final gid = (message.groupId ?? message.id);
-    final vers = (widget.byGroup[gid] ?? const <ChatMessage>[]).toList()
-      ..sort((a, b) => a.version.compareTo(b.version));
-    int selectedIdx =
-        widget.versionSelections[gid] ??
-        (vers.isNotEmpty ? vers.length - 1 : 0);
-    final total = vers.length;
-    if (selectedIdx < 0) selectedIdx = 0;
-    if (total > 0 && selectedIdx > total - 1) selectedIdx = total - 1;
-    final latestAssistantIndex = _latestAssistantMessageIndex();
+    final gid = model.slotId;
+    final availableVersions = model.availableVersions;
+    final selectedVersion = model.selectedVersion;
+    final selectedIdx = model.selectedVersionIndex;
+    final total = availableVersions.length;
     final messageSuggestions =
         !widget.selecting &&
-            index == latestAssistantIndex &&
-            message.role == 'assistant' &&
-            !message.isStreaming &&
+            model.isLatestCompleteAssistant &&
             widget.onSuggestionTap != null
         ? widget.suggestions
         : const <String>[];
 
-    // Generation and translation both use a per-message notifier. This keeps
-    // high-frequency updates out of the HomePage rebuild path.
-    final isLiveMessage =
+    // Check if this is a streaming message that should use ValueListenableBuilder.
+    // The notifier also carries live partial translations for finished
+    // messages (onTranslationStarted registers it regardless of streaming
+    // state), so the gate is keyed on notifier presence only.
+    final isStreaming =
+        message.role == 'assistant' &&
         widget.streamingContentNotifier != null &&
         widget.streamingContentNotifier!.hasNotifier(message.id);
 
     final messageColumn = Column(
-      key: ValueKey(message.id),
+      key: ValueKey<String>('timeline-slot:${_slotId(message)}'),
       mainAxisSize: MainAxisSize.min,
       children: [
         Row(
@@ -624,9 +1502,11 @@ class _MessageListViewState extends State<MessageListView> {
                     return MediaQuery(
                       // Keep chat font scaling without rebuilding on keyboard insets.
                       data: data.copyWith(
-                        textScaler: TextScaler.linear(textScale * chatScale),
+                        textScaler: TextScaler.linear(
+                          textScale * presentation.chatFontScale,
+                        ),
                       ),
-                      child: isLiveMessage
+                      child: isStreaming
                           ? _buildStreamingMessageWidget(
                               context,
                               message: message,
@@ -637,10 +1517,13 @@ class _MessageListViewState extends State<MessageListView> {
                               useAssistName: useAssistName,
                               assistant: assistant,
                               gid: gid,
+                              availableVersions: availableVersions,
+                              selectedVersion: selectedVersion,
                               selectedIdx: selectedIdx,
                               total: total,
                               isProcessingFiles: isProcessingFiles,
                               suggestions: messageSuggestions,
+                              presentation: presentation,
                             )
                           : _buildChatMessageWidget(
                               context,
@@ -652,10 +1535,13 @@ class _MessageListViewState extends State<MessageListView> {
                               useAssistName: useAssistName,
                               assistant: assistant,
                               gid: gid,
+                              availableVersions: availableVersions,
+                              selectedVersion: selectedVersion,
                               selectedIdx: selectedIdx,
                               total: total,
                               isProcessingFiles: isProcessingFiles,
                               suggestions: messageSuggestions,
+                              presentation: presentation,
                             ),
                     );
                   },
@@ -678,59 +1564,58 @@ class _MessageListViewState extends State<MessageListView> {
             ),
           ],
         ),
-        if (showDivider)
+        if (model.showContextDivider)
           Padding(
             padding: widget.dividerPadding,
             child: _buildContextDivider(context),
           ),
-        if (widget.afterMessageWidgets?.containsKey(
-              message.groupId ?? message.id,
-            ) ==
-            true)
-          widget.afterMessageWidgets![message.groupId ?? message.id]!,
+        if (widget.afterMessageWidgets?.containsKey(model.slotId) == true)
+          widget.afterMessageWidgets![model.slotId]!,
       ],
     );
-
     final isSpotlight =
         widget.spotlightMessageId != null &&
         message.id == widget.spotlightMessageId;
-    if (!isSpotlight) return messageColumn;
+    final Widget item = isSpotlight
+        ? RepaintBoundary(
+            child: TweenAnimationBuilder<double>(
+              key: ValueKey('spotlight-${widget.spotlightToken}'),
+              tween: Tween<double>(begin: 1.0, end: 0.0),
+              duration: const Duration(milliseconds: 1200),
+              curve: Curves.easeOut,
+              builder: (context, opacity, child) {
+                return Stack(
+                  children: [
+                    child!,
+                    if (opacity > 0.0)
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: const Color(
+                                0xFFFFA726,
+                              ).withValues(alpha: opacity * 0.30),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                );
+              },
+              child: messageColumn,
+            ),
+          )
+        : RepaintBoundary(child: messageColumn);
 
-    return TweenAnimationBuilder<double>(
-      key: ValueKey('spotlight-${widget.spotlightToken}'),
-      tween: Tween<double>(begin: 1.0, end: 0.0),
-      duration: const Duration(milliseconds: 1200),
-      curve: Curves.easeOut,
-      builder: (context, opacity, child) {
-        return Stack(
-          children: [
-            child!,
-            if (opacity > 0.0)
-              Positioned.fill(
-                child: IgnorePointer(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: const Color(
-                        0xFFFFA726,
-                      ).withValues(alpha: opacity * 0.30),
-                      borderRadius: BorderRadius.circular(4),
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        );
-      },
-      child: messageColumn,
+    // The animator wraps the item's RepaintBoundary so the fade only
+    // re-composites the boundary's cached layer instead of repainting the
+    // message subtree every animation frame.
+    return _SlotRemovalAnimator(
+      key: ValueKey<String>(model.slotId),
+      removing: widget.removingSlotIds.contains(model.slotId),
+      child: item,
     );
-  }
-
-  int _latestAssistantMessageIndex() {
-    for (var i = widget.messages.length - 1; i >= 0; i--) {
-      final message = widget.messages[i];
-      if (message.role == 'assistant' && !message.isStreaming) return i;
-    }
-    return -1;
   }
 
   /// Build a streaming message widget that uses ValueListenableBuilder
@@ -745,10 +1630,13 @@ class _MessageListViewState extends State<MessageListView> {
     required bool useAssistName,
     required dynamic assistant,
     required String gid,
+    required List<int> availableVersions,
+    required int selectedVersion,
     required int selectedIdx,
     required int total,
     required bool isProcessingFiles,
     required List<String> suggestions,
+    required _MessagePresentation presentation,
   }) {
     return _StreamingMessageDataGate(
       notifier: widget.streamingContentNotifier!.getNotifier(message.id),
@@ -797,10 +1685,13 @@ class _MessageListViewState extends State<MessageListView> {
             useAssistName: useAssistName,
             assistant: assistant,
             gid: gid,
+            availableVersions: availableVersions,
+            selectedVersion: selectedVersion,
             selectedIdx: selectedIdx,
             total: total,
             isProcessingFiles: isProcessingFiles,
             suggestions: suggestions,
+            presentation: presentation,
             enableStreamingTextMotion: !deferUpdates,
             translationStreaming: data.translation != null,
           ),
@@ -820,24 +1711,35 @@ class _MessageListViewState extends State<MessageListView> {
     required bool useAssistName,
     required dynamic assistant,
     required String gid,
+    required List<int> availableVersions,
+    required int selectedVersion,
     required int selectedIdx,
     required int total,
     required bool isProcessingFiles,
     required List<String> suggestions,
+    required _MessagePresentation presentation,
     bool enableStreamingTextMotion = true,
     bool translationStreaming = false,
   }) {
+    final currentIdx = availableVersions.indexOf(selectedVersion);
     final chatWidget = ChatMessageWidget(
       message: message,
       enableStreamingTextMotion: enableStreamingTextMotion,
       translationStreaming: translationStreaming,
-      versionIndex: selectedIdx,
+      versionIndex: currentIdx < 0 ? selectedIdx : currentIdx,
       versionCount: total > 0 ? total : 1,
-      onPrevVersion: (selectedIdx > 0)
-          ? () => widget.onVersionChange?.call(gid, selectedIdx - 1)
+      onPrevVersion: (currentIdx > 0)
+          ? () => widget.onVersionChange?.call(
+              gid,
+              availableVersions[currentIdx - 1],
+            )
           : null,
-      onNextVersion: (selectedIdx < total - 1)
-          ? () => widget.onVersionChange?.call(gid, selectedIdx + 1)
+      onNextVersion:
+          (currentIdx >= 0 && currentIdx < availableVersions.length - 1)
+          ? () => widget.onVersionChange?.call(
+              gid,
+              availableVersions[currentIdx + 1],
+            )
           : null,
       modelIcon:
           (!useAssistAvatar &&
@@ -850,17 +1752,15 @@ class _MessageListViewState extends State<MessageListView> {
               size: 30,
             )
           : null,
-      showModelIcon: useAssistAvatar
-          ? false
-          : context.watch<SettingsProvider>().showModelIcon,
+      showModelIcon: useAssistAvatar ? false : presentation.showModelIcon,
       useAssistantAvatar: useAssistAvatar && message.role == 'assistant',
       useAssistantName: useAssistName && message.role == 'assistant',
       assistantName: (useAssistAvatar || useAssistName)
           ? (assistant?.name ?? 'Assistant')
           : null,
       assistantAvatar: useAssistAvatar ? (assistant?.avatar ?? '') : null,
-      showUserAvatar: context.watch<SettingsProvider>().showUserAvatar,
-      showTokenStats: context.watch<SettingsProvider>().showTokenStats,
+      showUserAvatar: presentation.showUserAvatar,
+      showTokenStats: presentation.showTokenStats,
       hideStreamingIndicator:
           isProcessingFiles ||
           (widget.isPinnedIndicatorActive &&
@@ -1069,6 +1969,162 @@ class _MessageListViewState extends State<MessageListView> {
   }
 }
 
+/// Display settings that change how tall a message renders.
+final class _EstimateSettings {
+  const _EstimateSettings({
+    required this.collapseThinking,
+    required this.collapsedCodeLines,
+    required this.wrapCodeBlocks,
+  });
+
+  /// Whether finished thinking blocks render as a collapsed card.
+  final bool collapseThinking;
+
+  /// Lines a long code block collapses to, or null when it stays expanded.
+  final int? collapsedCodeLines;
+
+  /// Whether code blocks wrap instead of scrolling horizontally.
+  final bool wrapCodeBlocks;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _EstimateSettings &&
+      other.collapseThinking == collapseThinking &&
+      other.collapsedCodeLines == collapsedCodeLines &&
+      other.wrapCodeBlocks == wrapCodeBlocks;
+
+  @override
+  int get hashCode =>
+      Object.hash(collapseThinking, collapsedCodeLines, wrapCodeBlocks);
+}
+
+/// A memoized extent estimate together with everything it was derived from.
+final class _ExtentEstimate {
+  const _ExtentEstimate({
+    required this.content,
+    required this.crossAxisExtent,
+    required this.fontScale,
+    required this.settings,
+    required this.reasoningSignature,
+    required this.extent,
+  });
+
+  final String content;
+  final double crossAxisExtent;
+  final double fontScale;
+  final _EstimateSettings settings;
+  final int reasoningSignature;
+  final double extent;
+}
+
+final class _MessagePresentation {
+  const _MessagePresentation({
+    required this.chatFontScale,
+    required this.showModelIcon,
+    required this.showUserAvatar,
+    required this.showTokenStats,
+    required this.assistant,
+  });
+
+  final double chatFontScale;
+  final bool showModelIcon;
+  final bool showUserAvatar;
+  final bool showTokenStats;
+  final Assistant? assistant;
+}
+
+/// Fades out and collapses a timeline slot ahead of its deletion.
+///
+/// The fade runs first so the message visually disappears, then the height
+/// collapses so the neighbouring messages splice together. The slot's data is
+/// removed only after [ChatLayoutConstants.slotRemovalAnimationDuration], at
+/// which point the slot is already zero-height and its removal is invisible.
+class _SlotRemovalAnimator extends StatefulWidget {
+  const _SlotRemovalAnimator({
+    super.key,
+    required this.removing,
+    required this.child,
+  });
+
+  final bool removing;
+  final Widget child;
+
+  @override
+  State<_SlotRemovalAnimator> createState() => _SlotRemovalAnimatorState();
+}
+
+class _SlotRemovalAnimatorState extends State<_SlotRemovalAnimator>
+    with SingleTickerProviderStateMixin {
+  AnimationController? _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.removing) _startRemoval();
+  }
+
+  @override
+  void didUpdateWidget(covariant _SlotRemovalAnimator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.removing && !oldWidget.removing) {
+      _startRemoval();
+    } else if (!widget.removing && oldWidget.removing) {
+      // The deletion was aborted (the slot usually unmounts instead of ever
+      // reaching this), so restore the message. A rebuild of this element is
+      // already in progress, so no setState is needed.
+      _controller?.dispose();
+      _controller = null;
+    }
+  }
+
+  void _startRemoval() {
+    final controller = AnimationController(
+      vsync: this,
+      duration: ChatLayoutConstants.slotRemovalAnimationDuration,
+    );
+    controller.addListener(() => setState(() {}));
+    _controller = controller;
+    controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = _controller;
+    final removing = controller != null;
+    final progress = controller?.value ?? 0.0;
+    final opacity = removing
+        ? 1.0 - Curves.easeOut.transform(math.min(1.0, progress / 0.6))
+        : 1.0;
+    final heightFactor = removing
+        ? 1.0 -
+              Curves.easeInOutCubic.transform(
+                math.max(0.0, (progress - 0.2) / 0.8),
+              )
+        : 1.0;
+    // The wrapper chain is present even when idle: swapping widget types when
+    // the animation starts would reparent — and therefore rebuild — the whole
+    // message subtree, which for a huge message is a visible hitch. All
+    // wrappers are pass-throughs at their idle values.
+    return ClipRect(
+      clipBehavior: removing ? Clip.hardEdge : Clip.none,
+      child: Align(
+        alignment: Alignment.topCenter,
+        heightFactor: heightFactor.clamp(0.0, 1.0),
+        child: Opacity(
+          opacity: opacity.clamp(0.0, 1.0),
+          child: IgnorePointer(ignoring: removing, child: widget.child),
+        ),
+      ),
+    );
+  }
+}
+
 class _StreamingMessageDataGate extends StatefulWidget {
   const _StreamingMessageDataGate({
     required this.notifier,
@@ -1171,4 +2227,80 @@ class _StreamingMessageDataGateState extends State<_StreamingMessageDataGate> {
   @override
   Widget build(BuildContext context) =>
       widget.builder(context, _visibleData, _deferUpdates);
+}
+
+/// Bubble-shaped shimmer skeleton shown only while a cold initial window
+/// load is in flight and the list has no messages yet.
+class _WindowLoadingSkeleton extends StatefulWidget {
+  const _WindowLoadingSkeleton({
+    super.key,
+    required this.horizontalPadding,
+    required this.topPadding,
+  });
+
+  final double horizontalPadding;
+  final double topPadding;
+
+  @override
+  State<_WindowLoadingSkeleton> createState() => _WindowLoadingSkeletonState();
+}
+
+class _WindowLoadingSkeletonState extends State<_WindowLoadingSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 900),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final bubbleColor = cs.onSurface.withValues(alpha: 0.08);
+
+    Widget bubble({required bool alignEnd, required double widthFactor}) {
+      return Align(
+        alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
+        child: FractionallySizedBox(
+          widthFactor: widthFactor,
+          child: Container(
+            height: 44,
+            decoration: BoxDecoration(
+              color: bubbleColor,
+              borderRadius: BorderRadius.circular(16),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        widget.horizontalPadding + 12,
+        widget.topPadding + 24,
+        widget.horizontalPadding + 12,
+        0,
+      ),
+      child: FadeTransition(
+        opacity: _pulse.drive(Tween<double>(begin: 0.45, end: 1.0)),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            bubble(alignEnd: false, widthFactor: 0.62),
+            const SizedBox(height: 14),
+            bubble(alignEnd: true, widthFactor: 0.48),
+            const SizedBox(height: 14),
+            bubble(alignEnd: false, widthFactor: 0.7),
+            const SizedBox(height: 14),
+            bubble(alignEnd: true, widthFactor: 0.55),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/lib/features/home/widgets/scroll_nav_buttons.dart
+++ b/lib/features/home/widgets/scroll_nav_buttons.dart
@@ -7,8 +7,8 @@ const scrollNavHoverRegionKey = ValueKey('scroll-nav-hover-region');
 ///
 /// Buttons (from top to bottom):
 /// - Scroll to top (chevrons-up)
-/// - Previous user message (chevron-up)
-/// - Next user message (chevron-down)
+/// - Previous message (chevron-up)
+/// - Next message (chevron-down)
 /// - Scroll to bottom (chevrons-down)
 ///
 /// Shows with slide-in animation from right when user scrolls,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
   webview_windows: ^0.4.0
   flutter_math_fork: ^0.7.4
   scrollable_positioned_list: ^0.3.8
-  scrollview_observer: ^1.26.0
+  super_sliver_list: ^0.4.1
   image_gallery_saver_plus: ^4.0.1
   haptic_feedback: ^0.6.4+3
   system_fonts: ^1.0.1

--- a/test/features/home/controllers/scroll_controller_test.dart
+++ b/test/features/home/controllers/scroll_controller_test.dart
@@ -1,7 +1,7 @@
 import 'package:Cuplivo/features/home/controllers/scroll_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 
 void main() {
   group('ChatScrollController streaming auto-follow', () {
@@ -56,6 +56,7 @@ void main() {
         onStateChanged: () {},
         getAutoScrollEnabled: () => autoScrollEnabled,
         getAutoScrollIdleSeconds: () => 8,
+        isGenerating: () => true,
       );
 
       await tester.pumpWidget(
@@ -104,7 +105,7 @@ void main() {
       await tester.pumpWidget(
         _ObservedScrollHarness(
           scrollController: scrollController,
-          observerController: chatScrollController.observerController,
+          listController: chatScrollController.messageListController,
           messages: messages,
         ),
       );
@@ -118,7 +119,7 @@ void main() {
       await tester.pumpAndSettle();
       await navigation;
 
-      expect(chatScrollController.lastJumpUserMessageId, 'message-15');
+      expect(chatScrollController.lastJumpUserMessageId, 'message-10');
 
       chatScrollController.dispose();
       scrollController.dispose();
@@ -143,7 +144,7 @@ void main() {
       await tester.pumpWidget(
         _ObservedScrollHarness(
           scrollController: scrollController,
-          observerController: chatScrollController.observerController,
+          listController: chatScrollController.messageListController,
           messages: messages,
         ),
       );
@@ -157,7 +158,7 @@ void main() {
       await tester.pumpAndSettle();
       await navigation;
 
-      expect(chatScrollController.lastJumpUserMessageId, 'message-15');
+      expect(chatScrollController.lastJumpUserMessageId, 'message-12');
 
       chatScrollController.dispose();
       scrollController.dispose();
@@ -194,12 +195,12 @@ class _ScrollHarness extends StatelessWidget {
 class _ObservedScrollHarness extends StatelessWidget {
   const _ObservedScrollHarness({
     required this.scrollController,
-    required this.observerController,
+    required this.listController,
     required this.messages,
   });
 
   final ScrollController scrollController;
-  final ListObserverController observerController;
+  final ListController listController;
   final List<_NavMessage> messages;
 
   @override
@@ -207,19 +208,17 @@ class _ObservedScrollHarness extends StatelessWidget {
     return MaterialApp(
       home: SizedBox(
         height: 600,
-        child: ListViewObserver(
-          controller: observerController,
-          child: ListView.builder(
-            controller: scrollController,
-            itemCount: messages.length,
-            itemBuilder: (context, index) {
-              final message = messages[index];
-              return SizedBox(
-                height: 80,
-                child: Text('${message.role} ${message.id}'),
-              );
-            },
-          ),
+        child: SuperListView.builder(
+          controller: scrollController,
+          listController: listController,
+          itemCount: messages.length,
+          itemBuilder: (context, index) {
+            final message = messages[index];
+            return SizedBox(
+              height: 80,
+              child: Text('${message.role} ${message.id}'),
+            );
+          },
         ),
       ),
     );

--- a/test/features/home/widgets/message_list_view_edit_entry_test.dart
+++ b/test/features/home/widgets/message_list_view_edit_entry_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -90,14 +90,14 @@ class _MessageListHarness extends StatefulWidget {
 
 class _MessageListHarnessState extends State<_MessageListHarness> {
   late final ScrollController scrollController;
-  late final ListObserverController observerController;
+  late final ListController listController;
   late final ValueNotifier<bool> isProcessingFiles;
 
   @override
   void initState() {
     super.initState();
     scrollController = ScrollController();
-    observerController = ListObserverController(controller: scrollController);
+    listController = ListController();
     isProcessingFiles = ValueNotifier<bool>(false);
   }
 
@@ -125,7 +125,7 @@ class _MessageListHarnessState extends State<_MessageListHarness> {
         home: Scaffold(
           body: MessageListView(
             scrollController: scrollController,
-            observerController: observerController,
+            listController: listController,
             messages: widget.messages,
             byGroup: const {},
             versionSelections: const {},

--- a/test/features/home/widgets/message_list_view_padding_test.dart
+++ b/test/features/home/widgets/message_list_view_padding_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:scrollview_observer/scrollview_observer.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -26,9 +26,7 @@ void main() {
   testWidgets('macOS 消息列表滚动不主动清除文本选区焦点', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
 
     try {
@@ -37,7 +35,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: const [],
               byGroup: const {},
               versionSelections: const {},
@@ -55,7 +53,7 @@ void main() {
         ),
       );
 
-      final listView = tester.widget<ListView>(find.byType(ListView));
+      final listView = tester.widget<SuperListView>(find.byType(SuperListView));
       expect(
         listView.keyboardDismissBehavior,
         ScrollViewKeyboardDismissBehavior.manual,
@@ -70,9 +68,7 @@ void main() {
   testWidgets('Android 消息列表滚动仍然收起键盘', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
 
     try {
@@ -81,7 +77,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: const [],
               byGroup: const {},
               versionSelections: const {},
@@ -99,7 +95,7 @@ void main() {
         ),
       );
 
-      final listView = tester.widget<ListView>(find.byType(ListView));
+      final listView = tester.widget<SuperListView>(find.byType(SuperListView));
       expect(
         listView.keyboardDismissBehavior,
         ScrollViewKeyboardDismissBehavior.onDrag,
@@ -113,9 +109,7 @@ void main() {
 
   testWidgets('消息列表底部留白使用传入的输入框覆盖高度', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
 
     await tester.pumpWidget(
@@ -123,7 +117,7 @@ void main() {
         home: Scaffold(
           body: MessageListView(
             scrollController: scrollController,
-            observerController: observerController,
+            listController: listController,
             messages: const [],
             byGroup: const {},
             versionSelections: const {},
@@ -142,7 +136,7 @@ void main() {
       ),
     );
 
-    final listView = tester.widget<ListView>(find.byType(ListView));
+    final listView = tester.widget<SuperListView>(find.byType(SuperListView));
     expect((listView.padding as EdgeInsets).bottom, 144);
 
     scrollController.dispose();
@@ -151,9 +145,7 @@ void main() {
 
   testWidgets('消息列表顶部留白使用传入的导航栏覆盖高度', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
 
     await tester.pumpWidget(
@@ -161,7 +153,7 @@ void main() {
         home: Scaffold(
           body: MessageListView(
             scrollController: scrollController,
-            observerController: observerController,
+            listController: listController,
             messages: const [],
             byGroup: const {},
             versionSelections: const {},
@@ -181,7 +173,7 @@ void main() {
       ),
     );
 
-    final listView = tester.widget<ListView>(find.byType(ListView));
+    final listView = tester.widget<SuperListView>(find.byType(SuperListView));
     expect((listView.padding as EdgeInsets).top, 88);
     expect((listView.padding as EdgeInsets).bottom, 144);
 
@@ -191,9 +183,7 @@ void main() {
 
   testWidgets('置顶流式指示器激活时保留额外底部空间', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
 
     await tester.pumpWidget(
@@ -201,7 +191,7 @@ void main() {
         home: Scaffold(
           body: MessageListView(
             scrollController: scrollController,
-            observerController: observerController,
+            listController: listController,
             messages: const [],
             byGroup: const {},
             versionSelections: const {},
@@ -221,7 +211,7 @@ void main() {
       ),
     );
 
-    final listView = tester.widget<ListView>(find.byType(ListView));
+    final listView = tester.widget<SuperListView>(find.byType(SuperListView));
     expect((listView.padding as EdgeInsets).bottom, 156);
 
     scrollController.dispose();
@@ -230,9 +220,7 @@ void main() {
 
   testWidgets('流式思考更新缺少起始时间时保留已有计时起点', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
     final streamingNotifier = StreamingContentNotifier();
     const messageId = 'reasoning-streaming-message';
@@ -269,7 +257,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: messages,
               byGroup: const {},
               versionSelections: const {},
@@ -305,9 +293,7 @@ void main() {
 
   testWidgets('思考卡内部滚动不暂停流式正文更新', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
     final streamingNotifier = StreamingContentNotifier();
     const messageId = 'nested-reasoning-scroll-message';
@@ -344,7 +330,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: messages,
               byGroup: const {},
               versionSelections: const {},
@@ -387,9 +373,7 @@ void main() {
 
   testWidgets('用户拖动离开底部时暂停应用流式内容更新', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
     final streamingNotifier = StreamingContentNotifier();
     final messages = <ChatMessage>[
@@ -425,7 +409,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: messages,
               byGroup: const {},
               versionSelections: const {},
@@ -450,7 +434,7 @@ void main() {
     await tester.pump();
 
     final gesture = await tester.startGesture(
-      tester.getCenter(find.byType(ListView)),
+      tester.getCenter(find.byType(SuperListView)),
     );
     await gesture.moveBy(const Offset(0, 96));
     await tester.pump();
@@ -475,11 +459,10 @@ void main() {
     streamingNotifier.dispose();
   });
 
-  testWidgets('贴近底部时用户滚动不暂停应用流式内容更新', (tester) async {
+  testWidgets('贴近底部时用户滚动仍登记意图并在松手后恢复流式内容', (tester) async {
+    var userIntentCalls = 0;
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
     final streamingNotifier = StreamingContentNotifier();
     final messages = <ChatMessage>[
@@ -515,7 +498,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: messages,
               byGroup: const {},
               versionSelections: const {},
@@ -530,6 +513,7 @@ void main() {
               isProcessingFiles: isProcessingFiles,
               bottomContentPadding: 16,
               streamingContentNotifier: streamingNotifier,
+              onUserScrollIntent: () => userIntentCalls++,
             ),
           ),
         ),
@@ -540,10 +524,14 @@ void main() {
     await tester.pump();
 
     final gesture = await tester.startGesture(
-      tester.getCenter(find.byType(ListView)),
+      tester.getCenter(find.byType(SuperListView)),
     );
     await gesture.moveBy(const Offset(0, 8));
     await tester.pump();
+    await gesture.moveBy(const Offset(0, -4));
+    await tester.pump();
+
+    expect(userIntentCalls, 0);
 
     streamingNotifier.updateContent(
       'bottom-streaming-message',
@@ -551,21 +539,23 @@ void main() {
       3,
     );
     await tester.pump();
-
-    expect(find.text('updated while still near bottom'), findsOneWidget);
+    expect(find.text('updated while still near bottom'), findsNothing);
 
     await gesture.up();
+    await tester.pump(const Duration(milliseconds: 220));
+
+    expect(userIntentCalls, 1);
+    expect(find.text('updated while still near bottom'), findsOneWidget);
 
     scrollController.dispose();
+    listController.dispose();
     isProcessingFiles.dispose();
     streamingNotifier.dispose();
   });
 
   testWidgets('滚轮滚动时暂停应用流式内容更新', (tester) async {
     final scrollController = ScrollController();
-    final observerController = ListObserverController(
-      controller: scrollController,
-    );
+    final listController = ListController();
     final isProcessingFiles = ValueNotifier<bool>(false);
     final streamingNotifier = StreamingContentNotifier();
     final messages = <ChatMessage>[
@@ -601,7 +591,7 @@ void main() {
           home: Scaffold(
             body: MessageListView(
               scrollController: scrollController,
-              observerController: observerController,
+              listController: listController,
               messages: messages,
               byGroup: const {},
               versionSelections: const {},
@@ -627,7 +617,7 @@ void main() {
 
     final pointer = TestPointer(1, PointerDeviceKind.mouse);
     await tester.sendEventToBinding(
-      pointer.hover(tester.getCenter(find.byType(ListView))),
+      pointer.hover(tester.getCenter(find.byType(SuperListView))),
     );
     await tester.sendEventToBinding(pointer.scroll(const Offset(0, -96)));
     await tester.pump();
@@ -647,6 +637,134 @@ void main() {
     expect(find.text('updated while wheel scrolling'), findsOneWidget);
 
     scrollController.dispose();
+    isProcessingFiles.dispose();
+    streamingNotifier.dispose();
+  });
+
+  testWidgets('流式生成期间点击消息不登记滚动意图', (tester) async {
+    var userIntentCalls = 0;
+    final scrollController = ScrollController();
+    final listController = ListController();
+    final isProcessingFiles = ValueNotifier<bool>(false);
+    final streamingNotifier = StreamingContentNotifier();
+    final messages = <ChatMessage>[
+      ChatMessage(
+        id: 'tap-streaming-message',
+        role: 'assistant',
+        content: 'initial tap stream content',
+        conversationId: 'conversation-1',
+        isStreaming: true,
+      ),
+    ];
+    streamingNotifier.getNotifier('tap-streaming-message');
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: SettingsProvider()),
+          ChangeNotifierProvider.value(value: AssistantProvider()),
+          ChangeNotifierProvider.value(value: TtsProvider()),
+          ChangeNotifierProvider.value(value: AskUserInteractionService()),
+          ChangeNotifierProvider.value(value: ToolApprovalService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MessageListView(
+              scrollController: scrollController,
+              listController: listController,
+              messages: messages,
+              byGroup: const {},
+              versionSelections: const {},
+              reasoning: const {},
+              reasoningSegments: const {},
+              contentSplits: const {},
+              toolParts: const {},
+              translations: const {},
+              selecting: false,
+              selectedItems: const {},
+              dividerPadding: EdgeInsets.zero,
+              isProcessingFiles: isProcessingFiles,
+              streamingContentNotifier: streamingNotifier,
+              onUserScrollIntent: () => userIntentCalls++,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(SuperListView));
+    await tester.pump();
+
+    expect(userIntentCalls, 0);
+
+    scrollController.dispose();
+    listController.dispose();
+    isProcessingFiles.dispose();
+    streamingNotifier.dispose();
+  });
+
+  testWidgets('已完成消息翻译期间部分译文立即可见', (tester) async {
+    final scrollController = ScrollController();
+    final listController = ListController();
+    final isProcessingFiles = ValueNotifier<bool>(false);
+    final streamingNotifier = StreamingContentNotifier();
+    final messages = <ChatMessage>[
+      ChatMessage(
+        id: 'translate-finished-message',
+        role: 'assistant',
+        content: 'initial finished content',
+        conversationId: 'conversation-1',
+      ),
+    ];
+    streamingNotifier.getNotifier('translate-finished-message');
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider.value(value: SettingsProvider()),
+          ChangeNotifierProvider.value(value: AssistantProvider()),
+          ChangeNotifierProvider.value(value: TtsProvider()),
+          ChangeNotifierProvider.value(value: AskUserInteractionService()),
+          ChangeNotifierProvider.value(value: ToolApprovalService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MessageListView(
+              scrollController: scrollController,
+              listController: listController,
+              messages: messages,
+              byGroup: const {},
+              versionSelections: const {},
+              reasoning: const {},
+              reasoningSegments: const {},
+              contentSplits: const {},
+              toolParts: const {},
+              translations: const {},
+              selecting: false,
+              selectedItems: const {},
+              dividerPadding: EdgeInsets.zero,
+              isProcessingFiles: isProcessingFiles,
+              streamingContentNotifier: streamingNotifier,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    streamingNotifier.updateTranslation(
+      'translate-finished-message',
+      'partial translation',
+    );
+    await tester.pump();
+
+    expect(find.text('partial translation'), findsOneWidget);
+
+    scrollController.dispose();
+    listController.dispose();
     isProcessingFiles.dispose();
     streamingNotifier.dispose();
   });


### PR DESCRIPTION
## Motivation
点击发送后界面“弹起”一下（Issue #352）：发送时键盘视口变化/输入框收缩与消息增长错帧，叠加 250-450ms easeOutCubic 滚动动画。上游 Kelivo 无此问题。

## What changed
- 滚动栈整体对齐上游：`ListView + scrollview_observer` → `SuperListView + ListController`，移植布局阶段钉底（positionAtBottomOnNextLayout / pinBottomDuringViewportResizeIfNeeded / settleAtBottomBeforeReveal）+ 生成结束 450ms 钉底窗口 + request token 防动画重启
- 消息级导航（上/下一消息、迷你地图）改为索引直达，动画中重读真实偏移消除估算高度跳变
- `ChatInputBar._handleSend` 提交前清空输入框（弹跳根因之一）；rejected 时原样回填文本/媒体与草稿
- 其余用户可见行为保持不变：显示设置参数补传、纯点击不登记滚动意图、已完成消息翻译增量保留
- 新增 MessageRenderModel 投影层，群聊页面同步适配，移除 scrollview_observer 依赖

## Verification
- `flutter pub get` / `dart format` / `dart analyze --fatal-infos lib test`: 0 issues
- `flutter test test/features/home`: 276 passed（含 2 个新回归测试：点击不打断流式跟随、已完成消息翻译逐字显示）
- `flutter test test/features/group_chat`: 36 passed

## Behavior notes
- 上一/下一按钮从“跳用户提问”改为“跳相邻消息”（与上游一致，按钮无文案改动）
- 发送请求飞行期间输入框显示为空，失败自动恢复
- 未覆盖：Android/iOS 实机与桌面运行验证（建议发布前按 #352 复现步骤人工验证）

Fixes #352
