### PR TITLE
fix(markdown): keep display math source intact and scale formulas to fit export

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -1017,7 +1017,37 @@ String _preprocessFences(
   // Skips $$...$$ blocks, which are handled separately.
   // NOW SAFE: Code blocks are masked, so $variables in code won't be converted.
   if (enableMath && enableDollarLatex) {
-    out = _replaceInlineDollarMath(out);
+    // Renderable display math is masked too: _replaceInlineDollarMath is
+    // line-agnostic and cannot tell a literal dollar inside a $$...$$ body
+    // from an inline delimiter, so a body like "\text{ costs }$5$" had its
+    // dollars rewritten to "\( ... \)" — corrupting both the rendered formula
+    // and the Copy LaTeX export (issue #500). Only spans the shared scanner
+    // accepts are masked, so "$$" kept literally in prose (pinned by the
+    // $a$$b$$c$ tests) is never swallowed.
+    final mathScan = markdownScanDisplayMath(out);
+    if (mathScan.spans.isNotEmpty) {
+      final Map<String, String> displayMathMap = {};
+      int displayMathCount = 0;
+      final buf = StringBuffer();
+      var cursor = 0;
+      for (final span in mathScan.spans) {
+        buf.write(out.substring(cursor, span.start));
+        final key = '__DISPLAY_MATH_MASK_${displayMathCount++}__';
+        displayMathMap[key] = out.substring(span.start, span.end);
+        buf.write(key);
+        cursor = span.end;
+      }
+      buf.write(out.substring(cursor));
+      out = _replaceInlineDollarMath(buf.toString());
+      out = out.replaceAllMapped(RegExp(r'__DISPLAY_MATH_MASK_\d+__'), (
+        match,
+      ) {
+        final key = match.group(0)!;
+        return displayMathMap[key] ?? key;
+      });
+    } else {
+      out = _replaceInlineDollarMath(out);
+    }
   }
 
   // Ensure display-math blocks stay as standalone blocks even when generated inline.
@@ -5010,21 +5040,28 @@ class LatexBlockScrollableMd extends BlockMd {
     if (body.isEmpty) return const SizedBox.shrink();
 
     final math = _LatexMathBlock(body: body, style: config.style);
-    // Wrap in horizontal scroll to avoid overflow and center within available width
+    // Wrap in horizontal scroll to avoid overflow and center within available
+    // width. A static capture (message image export via ExportCaptureScope)
+    // has no way to scroll: a formula wider than the export canvas would be
+    // clipped, so the capture instead scales the whole formula down to fit.
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          return SelectionContainer.disabled(
-            child: SingleChildScrollView(
+          final Widget content;
+          if (ExportCaptureScope.of(context)) {
+            content = FittedBox(fit: BoxFit.scaleDown, child: math);
+          } else {
+            content = SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               primary: false,
               child: ConstrainedBox(
                 constraints: BoxConstraints(minWidth: constraints.maxWidth),
                 child: Center(child: math),
               ),
-            ),
-          );
+            );
+          }
+          return SelectionContainer.disabled(child: content);
         },
       ),
     );

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3971,7 +3971,7 @@ void main() {
   );
 
   testWidgets(
-    'MarkdownWithCodeHighlight keeps single-$ literals inside display math '
+    'MarkdownWithCodeHighlight keeps single-\$ literals inside display math '
     'export',
     (tester) async {
       markdownMathTargetPlatformOverride = TargetPlatform.android;
@@ -3993,7 +3993,7 @@ void main() {
 
       const source = r'''
 $$
-\\text{total } $x+y$ \\text{ yuan}
+\text{total } $x+y$ \text{ yuan}
 $$
 ''';
       await tester.pumpWidget(_markdownHarness(source, width: 360));
@@ -4047,10 +4047,10 @@ $$
 
       const source = r'''
 $$
-\\begin{aligned}
-E &= mc^2 \\\\
+\begin{aligned}
+E &= mc^2 \\
 p &= mv
-\\end{aligned}
+\end{aligned}
 $$
 ''';
       await tester.pumpWidget(_markdownHarness(source, width: 360));

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3971,6 +3971,141 @@ void main() {
   );
 
   testWidgets(
+    'MarkdownWithCodeHighlight keeps single-$ literals inside display math '
+    'export',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      String? clipboardText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              final data = Map<String, dynamic>.from(call.arguments as Map);
+              clipboardText = data['text'] as String?;
+            }
+            return null;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      const source = r'''
+$$
+\\text{total } $x+y$ \\text{ yuan}
+$$
+''';
+      await tester.pumpWidget(_markdownHarness(source, width: 360));
+      await tester.pump();
+
+      // The renderer receives the original body: the single-$ literals inside
+      // the display-math body were never rewritten to \( ... \).
+      final renderedData = tester
+          .widgetList<GptMarkdown>(find.byType(GptMarkdown))
+          .map((widget) => widget.data)
+          .join('\n');
+      expect(renderedData, contains(r'$x+y$'));
+      expect(renderedData, isNot(contains(r'\(x+y\)')));
+
+      await tester.longPress(
+        find.byType(Math),
+        warnIfMissed: false, // Math's RenderLine is paint-only; the gesture
+        // lands on the enclosing export GestureDetector.
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy LaTeX'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      // Copy LaTeX hands back the model-emitted source, stray dollars intact.
+      expect(clipboardText, r'\text{total } $x+y$ \text{ yuan}');
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight copies multi-line aligned LaTeX with rows '
+    'intact',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      String? clipboardText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              final data = Map<String, dynamic>.from(call.arguments as Map);
+              clipboardText = data['text'] as String?;
+            }
+            return null;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      const source = r'''
+$$
+\\begin{aligned}
+E &= mc^2 \\\\
+p &= mv
+\\end{aligned}
+$$
+''';
+      await tester.pumpWidget(_markdownHarness(source, width: 360));
+      await tester.pump();
+
+      await tester.longPress(find.byType(Math), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy LaTeX'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      const expected =
+          '\\begin{aligned}\nE &= mc^2 \\\\\np &= mv\n\\end{aligned}';
+      expect(clipboardText, expected);
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight copies bracket-delimited LaTeX source',
+    (tester) async {
+      markdownMathTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => markdownMathTargetPlatformOverride = null);
+
+      String? clipboardText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+            if (call.method == 'Clipboard.setData') {
+              final data = Map<String, dynamic>.from(call.arguments as Map);
+              clipboardText = data['text'] as String?;
+            }
+            return null;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+
+      await tester.pumpWidget(
+        _markdownHarness(r'\[E_{tot} = \sum_i q_i\]', width: 360),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.byType(Math), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy LaTeX'));
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(clipboardText, r'E_{tot} = \sum_i q_i');
+    },
+  );
+
+  testWidgets(
     'MarkdownWithCodeHighlight opens math menu on desktop right click',
     (tester) async {
       markdownMathTargetPlatformOverride = TargetPlatform.windows;
@@ -4227,6 +4362,80 @@ void main() {
 
       expect(find.text('Copy LaTeX'), findsOneWidget);
       expect(find.text('SELECTION_TOOLBAR_MARKER'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight scales an oversized formula to fit message export',
+    (tester) async {
+      // Far wider than the 320px export canvas: the formula must be captured
+      // complete (scaled down), not truncated at a scroll viewport.
+      final wideTex =
+          r'\[' + List.generate(40, (i) => 'x_{${i + 1}}').join(' + ') + r'\]';
+
+      await tester.pumpWidget(
+        _settingsHarness(
+          onSettingsReady: (_) {},
+          child: SizedBox(
+            width: 320,
+            child: ExportCaptureScope(
+              enabled: true,
+              child: MarkdownWithCodeHighlight(text: wideTex),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(_findMathWidget(), findsOneWidget);
+      // The formula is oversized input: wider than the export canvas.
+      final mathBox = tester.renderObject<RenderBox>(_findMathWidget());
+      expect(mathBox.size.width, greaterThan(320));
+      // Message export has no scroll interaction: the scroll viewport that
+      // clips the formula must be gone during capture.
+      expect(
+        find.ancestor(
+          of: _findMathWidget(),
+          matching: find.byType(SingleChildScrollView),
+        ),
+        findsNothing,
+      );
+      // The full formula stays in the capture via a scale-down fit.
+      final fitters = find.ancestor(
+        of: _findMathWidget(),
+        matching: find.byType(FittedBox),
+      );
+      expect(fitters, findsOneWidget);
+      expect(tester.widget<FittedBox>(fitters).fit, BoxFit.scaleDown);
+      expect(
+        tester.renderObject<RenderBox>(fitters).size.width,
+        lessThanOrEqualTo(320),
+      );
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight keeps the scrollable viewport for wide formulas in chat',
+    (tester) async {
+      final wideTex =
+          r'\[' + List.generate(40, (i) => 'x_{${i + 1}}').join(' + ') + r'\]';
+
+      await tester.pumpWidget(_markdownHarness(wideTex, width: 320));
+      await tester.pump();
+
+      expect(_findMathWidget(), findsOneWidget);
+      // Chat keeps horizontal scroll interaction; no export fit wrapper.
+      expect(
+        find.ancestor(
+          of: _findMathWidget(),
+          matching: find.byType(SingleChildScrollView),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.ancestor(of: _findMathWidget(), matching: find.byType(FittedBox)),
+        findsNothing,
+      );
     },
   );
 


### PR DESCRIPTION
## Summary

Fixes #500 （公式导出仍然存在问题）— two distinct export defects in math rendering, both now covered by regression tests.

## Defect 1: single-`$` literals inside display math corrupted both rendering and Copy LaTeX export

`_preprocessFences` ran `_replaceInlineDollarMath` over the whole document *including* `$$...$$` bodies. That converter is line-agnostic and cannot tell a literal dollar inside a display-math body from an inline delimiter, so a body like `\text{ costs }$5$` had its dollars rewritten to `\( ... \)` — corrupting the rendered formula and the LaTeX handed to the clipboard.

**Fix:** before the inline-$ pass, scan display spans with the shared `markdownScanDisplayMath` scanner, mask them out, run `_replaceInlineDollarMath` on the remainder, then unmask verbatim. Only spans the shared scanner accepts are masked, so `$$` kept literally in prose (pinned by the existing `$a$$b$$c$` tests) is never swallowed.

## Defect 2: wide formulas clipped in message image export

Display math renders inside a horizontal `SingleChildScrollView`. Static capture (`ExportCaptureScope`, used by message image export) has no way to scroll, so any formula wider than the export canvas was truncated at the viewport edge.

**Fix:** during capture, swap the scroll viewport for `FittedBox(fit: BoxFit.scaleDown)` so the whole formula scales down to fit the canvas; normal chat keeps the interactive scrollable viewport unchanged.

## Tests

5 regression tests added (clipboard mocked via `SystemChannels.platform`, no new deps):

- single-$ literals survive preprocessing and Copy LaTeX returns the model-emitted source intact;
- multi-line `aligned` block copies with rows and `\\` separators intact;
- bracket-delimited `\[ ... \]` copies its inner source;
- oversized formula scales to fit under `ExportCaptureScope` (no scroll viewport during capture);
- chat view keeps the horizontal scroll viewport (no FittedBox).

Second commit fixes over-escaped TeX fixtures in the first-round tests (doubled backslashes inside raw strings made both copy tests fail as written); expectations untouched.

## Verification

> ⚠️ Honest disclosure: this Linux sandbox has no Flutter/Dart SDK — the suite was **not executed** here. Verified instead: referenced symbols exist (`markdownScanDisplayMath`, `ExportCaptureScope.of`), and every TeX expectation was byte-level decoded and checked (raw-string fixtures vs. escaped literals, incl. real newlines and `\\` row breaks in the aligned case). Please run `flutter test test/shared/widgets/markdown_with_highlight_test.dart` and `dart analyze lib test` in CI before merge.

Fixes #500