### PR TITLE
fix(web-fetch): allow fake-IP DNS answers through the SSRF guard

### DIFF
--- a/lib/core/services/fetch/web_fetch_target_guard.dart
+++ b/lib/core/services/fetch/web_fetch_target_guard.dart
@@ -10,6 +10,11 @@ import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 /// (169.254.169.254) — and in download mode write those bytes into
 /// `@workspaces`. Every direct connection is validated before a socket is
 /// opened, and each redirect hop is re-validated.
+///
+/// DNS-layer limits (see also [resolvedBlockReason]): under a fake-IP proxy,
+/// answers cannot distinguish virtual from real hosts; IPv6 fake-IP ranges
+/// (user-configured `fake-ip-range6`, ULA space) are deliberately not
+/// exempted since fc00::/7 is also a genuine internal range.
 class WebFetchTargetGuard {
   WebFetchTargetGuard._();
 
@@ -66,9 +71,11 @@ class WebFetchTargetGuard {
       // default to this range): the OS resolves the public hostname into a
       // synthetic loopback-like address that the proxy then rewrites in
       // software. Treating these as blocked would reject every ordinary
-      // public site under such a proxy. Real SSRF targets (RFC 1918,
-      // loopback, link-local, metadata) still resolve to their own ranges
-      // even under fake-IP, so blocking them is unaffected.
+      // public site under such a proxy. Tradeoff: under a fake-IP proxy,
+      // internal-only hostnames (e.g. intranet.corp.com) also resolve to
+      // fake addresses and are routed to the real internal host by the
+      // proxy, so hostname-level SSRF protection is inherently limited —
+      // only literal-IP URLs and `localhost` stay hard-blocked.
       if (_isBlockedAddress(address, allowFakeIpRange: true)) {
         return '${url.host} resolves to $address, a loopback/private/'
             'link-local/metadata address and not an allowed web_fetch target';
@@ -105,6 +112,7 @@ class WebFetchTargetGuard {
           raw[11] == 0xff) {
         return _isBlockedAddress(
           InternetAddress.fromRawAddress(raw.sublist(12)),
+          allowFakeIpRange: allowFakeIpRange,
         );
       }
       return false;

--- a/lib/core/services/fetch/web_fetch_target_guard.dart
+++ b/lib/core/services/fetch/web_fetch_target_guard.dart
@@ -37,6 +37,12 @@ class WebFetchTargetGuard {
     return null;
   }
 
+  /// Resolver hook so tests can inject synthetic DNS answer sets without
+  /// depending on the real network. Defaults to the platform resolver.
+  @visibleForTesting
+  static Future<List<InternetAddress>> Function(String host) redirectResolve =
+      (String host) => InternetAddress.lookup(host);
+
   /// Returns a rejection reason when [url]'s hostname resolves to a blocked
   /// address, otherwise null. Best-effort: DNS failures are not treated as
   /// blocked (the connection itself will surface the real error). Only
@@ -48,13 +54,22 @@ class WebFetchTargetGuard {
     }
     final List<InternetAddress> addresses;
     try {
-      addresses = await InternetAddress.lookup(url.host);
+      addresses = await redirectResolve(url.host);
     } catch (e) {
       debugPrint('[web_fetch] DNS lookup failed for ${url.host}: $e');
       return null;
     }
     for (final address in addresses) {
-      if (_isBlockedAddress(address)) {
+      // DNS answers that fall inside the fake-IP range (198.18.0.0/15,
+      // IANA benchmark space) are NOT real targets. They are virtual
+      // addresses injected by a fake-IP proxy (Clash / mihomo / sing-box
+      // default to this range): the OS resolves the public hostname into a
+      // synthetic loopback-like address that the proxy then rewrites in
+      // software. Treating these as blocked would reject every ordinary
+      // public site under such a proxy. Real SSRF targets (RFC 1918,
+      // loopback, link-local, metadata) still resolve to their own ranges
+      // even under fake-IP, so blocking them is unaffected.
+      if (_isBlockedAddress(address, allowFakeIpRange: true)) {
         return '${url.host} resolves to $address, a loopback/private/'
             'link-local/metadata address and not an allowed web_fetch target';
       }
@@ -62,7 +77,10 @@ class WebFetchTargetGuard {
     return null;
   }
 
-  static bool _isBlockedAddress(InternetAddress address) {
+  static bool _isBlockedAddress(
+    InternetAddress address, {
+    bool allowFakeIpRange = false,
+  }) {
     if (address.isLoopback || address.isLinkLocal) return true;
     if (address.rawAddress.isEmpty) return true;
     if (address.type == InternetAddressType.IPv6) {
@@ -102,7 +120,12 @@ class WebFetchTargetGuard {
     if (a == 169 && b == 254) return true; // link-local / metadata
     if (a == 172 && b >= 16 && b <= 31) return true; // 172.16/12
     if (a == 192 && b == 168) return true; // 192.168/16
-    if (a == 198 && (b == 18 || b == 19)) return true; // benchmark
+    // 198.18.0.0/15 is the IANA benchmark block. Its only real-world use is
+    // the fake-IP range of Clash / mihomo / sing-box proxies, so answers in
+    // DNS lookups are virtual injected addresses, not real internal hosts.
+    // Only let those through when the address came from a resolved lookup;
+    // an explicit literal IP in that range is still rejected below.
+    if (a == 198 && (b == 18 || b == 19) && !allowFakeIpRange) return true;
     if (a >= 224) return true; // multicast + reserved
     return false;
   }

--- a/test/core/services/fetch/web_fetch_target_guard_test.dart
+++ b/test/core/services/fetch/web_fetch_target_guard_test.dart
@@ -29,6 +29,8 @@ void main() {
         '169.254.169.254',
         '100.64.0.1',
         '0.0.0.0',
+        '198.18.1.1',
+        '198.19.255.255',
         '[::1]',
         '[fe80::1]',
         '[fc00::1]',
@@ -77,6 +79,51 @@ void main() {
         Uri.parse('http://127.0.0.1/path'),
       );
       expect(reason, isNull); // literal path is handled by literalBlockReason
+    });
+
+    test('fake-IP DNS answers (198.18/15) are allowed through the resolver',
+        () async {
+      // A fake-IP proxy resolves a public hostname into a synthetic address
+      // inside 198.18.0.0/15. This must NOT be reported as blocked, otherwise
+      // every ordinary page fails under Clash / mihomo / sing-box.
+      final original = WebFetchTargetGuard.redirectResolve;
+      WebFetchTargetGuard.redirectResolve = (_) async => [
+        InternetAddress('198.18.1.1'),
+      ];
+      addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+      final reason = await WebFetchTargetGuard.resolvedBlockReason(
+        Uri.parse('http://fake-ip.example.com/path'),
+      );
+      expect(reason, isNull,
+          reason: 'fake-IP range must not trip the SSRF guard');
+    });
+
+    test('resolver still blocks RFC1918 even when allowed fake-IP range',
+        () async {
+      // The fake-IP exemption only relaxes the 198.18/15 benchmark block;
+      // genuine private-address answers must remain blocked.
+      final original = WebFetchTargetGuard.redirectResolve;
+      WebFetchTargetGuard.redirectResolve = (_) async => [
+        InternetAddress('10.0.0.5'),
+      ];
+      addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+      final reason = await WebFetchTargetGuard.resolvedBlockReason(
+        Uri.parse('http://internal.example.com/path'),
+      );
+      expect(reason, isNotNull,
+          reason: 'RFC1918 answer must still be blocked after fake-IP fix');
+    });
+
+    test('resolver blocks metadata and loopback answers', () async {
+      final original = WebFetchTargetGuard.redirectResolve;
+      WebFetchTargetGuard.redirectResolve = (_) async => [
+        InternetAddress('169.254.169.254'),
+      ];
+      addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+      final reason = await WebFetchTargetGuard.resolvedBlockReason(
+        Uri.parse('http://metadata.example.com/path'),
+      );
+      expect(reason, isNotNull);
     });
   });
 

--- a/test/core/services/fetch/web_fetch_target_guard_test.dart
+++ b/test/core/services/fetch/web_fetch_target_guard_test.dart
@@ -34,6 +34,7 @@ void main() {
         '[::1]',
         '[fe80::1]',
         '[fc00::1]',
+        '[::ffff:198.18.1.1]',
       ]) {
         final reason = WebFetchTargetGuard.literalBlockReason(
           Uri.parse('http://$host/path'),
@@ -81,38 +82,70 @@ void main() {
       expect(reason, isNull); // literal path is handled by literalBlockReason
     });
 
-    test('fake-IP DNS answers (198.18/15) are allowed through the resolver',
-        () async {
-      // A fake-IP proxy resolves a public hostname into a synthetic address
-      // inside 198.18.0.0/15. This must NOT be reported as blocked, otherwise
-      // every ordinary page fails under Clash / mihomo / sing-box.
-      final original = WebFetchTargetGuard.redirectResolve;
-      WebFetchTargetGuard.redirectResolve = (_) async => [
-        InternetAddress('198.18.1.1'),
-      ];
-      addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
-      final reason = await WebFetchTargetGuard.resolvedBlockReason(
-        Uri.parse('http://fake-ip.example.com/path'),
-      );
-      expect(reason, isNull,
-          reason: 'fake-IP range must not trip the SSRF guard');
-    });
+    test(
+      'fake-IP DNS answers (198.18/15) are allowed through the resolver',
+      () async {
+        // A fake-IP proxy resolves a public hostname into a synthetic address
+        // inside 198.18.0.0/15. This must NOT be reported as blocked, otherwise
+        // every ordinary page fails under Clash / mihomo / sing-box.
+        final original = WebFetchTargetGuard.redirectResolve;
+        WebFetchTargetGuard.redirectResolve = (_) async => [
+          InternetAddress('198.18.1.1'),
+        ];
+        addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+        final reason = await WebFetchTargetGuard.resolvedBlockReason(
+          Uri.parse('http://fake-ip.example.com/path'),
+        );
+        expect(
+          reason,
+          isNull,
+          reason: 'fake-IP range must not trip the SSRF guard',
+        );
+      },
+    );
 
-    test('resolver still blocks RFC1918 even when allowed fake-IP range',
-        () async {
-      // The fake-IP exemption only relaxes the 198.18/15 benchmark block;
-      // genuine private-address answers must remain blocked.
-      final original = WebFetchTargetGuard.redirectResolve;
-      WebFetchTargetGuard.redirectResolve = (_) async => [
-        InternetAddress('10.0.0.5'),
-      ];
-      addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
-      final reason = await WebFetchTargetGuard.resolvedBlockReason(
-        Uri.parse('http://internal.example.com/path'),
-      );
-      expect(reason, isNotNull,
-          reason: 'RFC1918 answer must still be blocked after fake-IP fix');
-    });
+    test(
+      'IPv4-mapped fake-IP DNS answer is allowed through the resolver',
+      () async {
+        // The fake-IP exemption must apply to the IPv6-mapped form
+        // (::ffff:198.18.x.x) too, otherwise resolvers returning mapped answers
+        // still trip the guard.
+        final original = WebFetchTargetGuard.redirectResolve;
+        WebFetchTargetGuard.redirectResolve = (_) async => [
+          InternetAddress('::ffff:198.18.1.1'),
+        ];
+        addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+        final reason = await WebFetchTargetGuard.resolvedBlockReason(
+          Uri.parse('http://fake-ip.example.com/path'),
+        );
+        expect(
+          reason,
+          isNull,
+          reason: 'mapped fake-IP range must not trip the SSRF guard',
+        );
+      },
+    );
+
+    test(
+      'resolver still blocks RFC1918 even when allowed fake-IP range',
+      () async {
+        // The fake-IP exemption only relaxes the 198.18/15 benchmark block;
+        // genuine private-address answers must remain blocked.
+        final original = WebFetchTargetGuard.redirectResolve;
+        WebFetchTargetGuard.redirectResolve = (_) async => [
+          InternetAddress('10.0.0.5'),
+        ];
+        addTearDown(() => WebFetchTargetGuard.redirectResolve = original);
+        final reason = await WebFetchTargetGuard.resolvedBlockReason(
+          Uri.parse('http://internal.example.com/path'),
+        );
+        expect(
+          reason,
+          isNotNull,
+          reason: 'RFC1918 answer must still be blocked after fake-IP fix',
+        );
+      },
+    );
 
     test('resolver blocks metadata and loopback answers', () async {
       final original = WebFetchTargetGuard.redirectResolve;


### PR DESCRIPTION
## Summary

Fixes #547.

When the user routes the app through a **fake-IP proxy** (Clash / mihomo / sing-box, which all default to the `198.18.0.0/15` IANA benchmark block for synthetic virtual addresses), the OS resolves every public hostname into one of these fake addresses. The SSRF guard's `resolvedBlockReason` treated that range as blocked, so every ordinary `web_fetch` / workspace download failed with:

> `example.com resolves to 198.18.1.1, a loopback/private/... address and not an allowed web_fetch target`

### What changed

- `WebFetchTargetGuard._isBlockedAddress` now takes an `allowFakeIpRange` flag.
- **DNS-lookup answers** set it to `true` (`resolvedBlockReason`): addresses inside `198.18.0.0/15` are **allowed through**. These are virtual proxy-injected addresses, not real internal hosts.
- **Literal IPs** keep it `false` (`literalBlockReason`): an explicit `http://198.18.x.x/...` URL is **still rejected**.
- RFC 1918 / loopback / link-local / CGNAT / cloud-metadata / multicast ranges remain blocked in both paths, so real SSRF protection is unchanged.
- Added a test-injectable resolver hook (`WebFetchTargetGuard.redirectResolve`) so the DNS path is covered without hitting the real network.

### Known tradeoff (acknowledged in review)

Hostname-level SSRF protection is **inherently limited** under a fake-IP proxy: in mihomo fake-IP blacklist mode, internal-only hostnames (e.g. `intranet.corp.com`) also resolve to fake addresses and are routed to the real internal host by the proxy — there is no way for the DNS layer to distinguish them from public names. Only literal-IP URLs, `localhost`, and proxy-side filtering remain as barriers in this scenario.

Similarly, IPv6 fake-IP ranges (`fake-ip-range6`, ULA space) are deliberately **not** exempted: `fc00::/7` is also a genuine internal range, so exempting it wholesale would open a real SSRF hole. Users on IPv6 fake-IP would still see #547 for AAAA answers.

### Follow-up fixes (2nd commit)

- Corrected the misleading comment that claimed blocking was "unaffected" under fake-IP (it wasn't).
- Propagated `allowFakeIpRange` through the IPv4-mapped `::ffff:` recursion so mapped DNS answers behave like plain IPv4.
- Documented the IPv6 ULA boundary in the class doc.
- Tests: mapped fake-IP DNS answer allowed through resolver; mapped literal `::ffff:198.18.1.1` still blocked.

### Tests

Four new tests in `web_fetch_target_guard_test.dart`:
1. literal `198.18.0.0/15` URLs are still blocked;
2. fake-IP DNS answers (`198.18.1.1`) pass the resolver;
3. RFC 1918 answers stay blocked after the fake-IP exemption;
4. metadata/loopback answers stay blocked.

Plus:
5. IPv4-mapped fake-IP DNS answer (`::ffff:198.18.1.1`) passes the resolver;
6. mapped literal `[::ffff:198.18.1.1]` still blocked.
