### PR TITLE
sync(mcp): port upstream session reuse, discard heartbeat config, throttle GET reconnects

### DIFF
--- a/dependencies/mcp_client/lib/src/client/client.dart
+++ b/dependencies/mcp_client/lib/src/client/client.dart
@@ -22,12 +22,15 @@ class Client {
   final ClientCapabilities capabilities;
 
   /// Timeout for individual requests.
-  final Duration requestTimeout;
+  Duration _requestTimeout;
 
-  /// Optional sink for structured JSON-RPC-layer log events.
+  Duration get requestTimeout => _requestTimeout;
+
+  /// Optional sink for structured JSON-RPC-layer log events
+  /// ([McpLogEvent]); See [McpClientConfig.logListener].
   final McpLogListener? logListener;
 
-  /// Human-readable server label for log events; falls back to [name].
+  /// Human-readable server label used in log events ([McpLogEvent.server]).
   final String logServerLabel;
 
   /// Protocol version this client implements
@@ -35,6 +38,7 @@ class Client {
 
   /// Transport connection
   ClientTransport? _transport;
+  StreamSubscription<dynamic>? _transportMessageSubscription;
 
   /// Stream controller for handling incoming messages
   final _messageController = StreamController<JsonRpcMessage>.broadcast();
@@ -54,17 +58,16 @@ class Client {
 
   /// Map of request completion handlers by ID
   final _requestCompleters = <int, Completer<dynamic>>{};
+  Completer<void>? _pendingRequestsDrained;
 
   /// Method + tags per in-flight request id — kept so incoming
-  /// responses can be annotated in log events (JSON-RPC responses carry
-  /// no method). Client-initiated requests only.
+  /// responses can be paired with the emitted request in log events.
   final Map<dynamic, ({String method, Map<String, String>? tags})>
   _pendingInfo = {};
 
-  /// Method per in-flight SERVER-initiated request id (sampling,
+  /// Method per in-flight server-initiated request id (sampling,
   /// elicitation, roots). Separate namespace from [_pendingInfo]:
-  /// server ids come from the server's own counter (often 0,1,2...) and
-  /// would collide with client ids.
+  /// server requests have their own ids.
   final Map<dynamic, String> _serverPendingInfo = {};
 
   /// Map of notification handlers by method
@@ -118,35 +121,27 @@ class Client {
     required this.name,
     required this.version,
     this.capabilities = const ClientCapabilities(),
-    this.requestTimeout = const Duration(seconds: 30),
+    Duration requestTimeout = const Duration(seconds: 30),
     this.logListener,
     String? logServerLabel,
-  }) : logServerLabel = logServerLabel ?? name {
+  }) : _requestTimeout = requestTimeout,
+       logServerLabel = logServerLabel ?? name {
     // Default `roots/list` handler returns the locally registered roots.
     // Hosts may override with [onListRoots] for dynamic roots.
     _requestHandlers['roots/list'] =
         (_) async => {'roots': _roots.map((r) => r.toJson()).toList()};
-  }
-
-  void _emit({
-    required String direction,
-    required String kind,
-    dynamic id,
-    String? method,
-    Object? payload,
-    Map<String, String>? tags,
-  }) {
-    logListener?.call(
-      McpLogEvent(
-        server: logServerLabel,
-        direction: direction,
-        kind: kind,
-        id: id,
-        method: method,
-        payload: payload,
-        tags: tags,
-      ),
-    );
+    _messageController.stream.listen((message) async {
+      try {
+        await _processMessage(message);
+      } catch (error) {
+        _logger.debug('Error processing message: $error');
+        if (!_errorStreamController.isClosed) {
+          _errorStreamController.add(
+            McpError('Error processing message: $error'),
+          );
+        }
+      }
+    });
   }
 
   /// Connect the client to a transport
@@ -160,60 +155,15 @@ class Client {
     }
 
     _connecting = true;
-    _transport = transport;
-    // Listen with an explicit error handler: transports may push errors onto
-    // the message stream (e.g. authentication failures), and without onError
-    // they would surface as unhandled zone exceptions.
-    _transport!.onMessage.listen(
-      _handleMessage,
-      onError: (Object error) {
-        _logger.debug('Transport message stream error: $error');
-      },
-    );
-    _transport!.onClose
-        .then((_) {
-          // Only send disconnect event if we're still connected
-          if (_transport != null) {
-            _disconnectStreamController.add(DisconnectReason.transportClosed);
-            _onDisconnect();
-          }
-        })
-        .catchError((error) {
-          // Only handle error if we're still connected
-          if (_transport != null) {
-            _errorStreamController.add(McpError('Transport error: $error'));
-            _disconnectStreamController.add(DisconnectReason.transportError);
-            _onDisconnect();
-          }
-        });
-
-    // Set up message handling
-    _messageController.stream.listen((message) async {
-      try {
-        await _processMessage(message);
-      } catch (e) {
-        _logger.debug('Error processing message: $e');
-        _errorStreamController.add(McpError('Error processing message: $e'));
-      }
-    });
+    _attachTransport(transport);
 
     // Initialize the connection
     try {
       await initialize();
       _connecting = false;
 
-      // Emit connection event after successful initialization
-      if (_initialized && _serverInfo != null && _serverCapabilities != null) {
-        _connectStreamController.add(
-          ServerInfo(
-            name: _serverInfo!['name'] as String? ?? 'Unknown',
-            version: _serverInfo!['version'] as String? ?? 'Unknown',
-            capabilities: _serverCapabilities!.toJson(),
-            protocolVersion: protocolVersion,
-          ),
-        );
-        _emit(direction: 'receive', kind: 'lifecycle', payload: 'connected');
-      }
+      _emitConnected();
+      _emit(direction: 'receive', kind: 'lifecycle', payload: 'connected');
     } catch (e) {
       _connecting = false;
       _errorStreamController.add(McpError('Initialization error: $e'));
@@ -237,88 +187,107 @@ class Client {
     }
 
     _connecting = true;
-    int attempts = 0;
-
-    while (attempts < maxRetries) {
+    _attachTransport(transport);
+    for (var attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        _transport = transport;
-        _transport!.onMessage.listen(_handleMessage);
-        _transport!.onClose
-            .then((_) {
-              // Only send disconnect event if we're still connected
-              if (_transport != null) {
-                _disconnectStreamController.add(
-                  DisconnectReason.transportClosed,
-                );
-                _onDisconnect();
-              }
-            })
-            .catchError((error) {
-              // Only handle error if we're still connected
-              if (_transport != null) {
-                _errorStreamController.add(McpError('Transport error: $error'));
-                _disconnectStreamController.add(
-                  DisconnectReason.transportError,
-                );
-                _onDisconnect();
-              }
-            });
-
-        // Message handling setup
-        _messageController.stream.listen((message) async {
-          try {
-            await _processMessage(message);
-          } catch (e) {
-            _logger.debug('Error processing message: $e');
-            _errorStreamController.add(
-              McpError('Error processing message: $e'),
-            );
-          }
-        });
-
-        // Initialize connection
         await initialize();
         _connecting = false;
-
-        // Emit connection event after successful initialization
-        if (_initialized &&
-            _serverInfo != null &&
-            _serverCapabilities != null) {
-          _connectStreamController.add(
-            ServerInfo(
-              name: _serverInfo!['name'] as String? ?? 'Unknown',
-              version: _serverInfo!['version'] as String? ?? 'Unknown',
-              capabilities: _serverCapabilities!.toJson(),
-              protocolVersion: protocolVersion,
-            ),
-          );
-        }
-
-        return; // Successfully connected
+        _emitConnected();
+        _emit(direction: 'receive', kind: 'lifecycle', payload: 'connected');
+        return;
       } catch (e) {
-        // Clean up resources on failure
-        if (_transport != null) {
-          try {
-            _transport!.close();
-          } catch (_) {}
-          _transport = null;
-        }
-
-        attempts++;
-        if (attempts >= maxRetries) {
+        _initialized = false;
+        final transportClosed = !identical(_transport, transport);
+        if (attempt >= maxRetries || transportClosed) {
           _connecting = false;
-          _errorStreamController.add(
-            McpError('Failed to connect after $maxRetries attempts: $e'),
+          disconnect();
+          if (maxRetries == 1 || transportClosed) {
+            _errorStreamController.add(
+              e is McpError ? e : McpError('Connection failed: $e'),
+            );
+            rethrow;
+          }
+          final failure = McpError(
+            'Failed to connect after $maxRetries attempts: $e',
           );
-          throw McpError('Failed to connect after $maxRetries attempts: $e');
+          _errorStreamController.add(failure);
+          throw failure;
         }
 
         _logger.debug(
-          'Connection attempt $attempts failed: $e. Retrying in ${delay.inSeconds} seconds...',
+          'Connection attempt $attempt failed: $e. '
+          'Retrying in ${delay.inSeconds} seconds...',
         );
         await Future.delayed(delay);
       }
     }
+  }
+
+  void _attachTransport(ClientTransport transport) {
+    _transport = transport;
+    _transportMessageSubscription = transport.onMessage.listen(
+      _handleMessage,
+      onError: (Object error, StackTrace stackTrace) {
+        if (!_errorStreamController.isClosed) {
+          _errorStreamController.add(
+            error is McpError ? error : McpError('Transport error: $error'),
+          );
+        }
+      },
+    );
+    transport.onClose.then(
+      (_) {
+        if (identical(_transport, transport)) {
+          _disconnectStreamController.add(DisconnectReason.transportClosed);
+          _onDisconnect();
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (identical(_transport, transport)) {
+          if (!_errorStreamController.isClosed) {
+            _errorStreamController.add(
+              error is McpError ? error : McpError('Transport error: $error'),
+            );
+          }
+          _disconnectStreamController.add(DisconnectReason.transportError);
+          _onDisconnect();
+        }
+      },
+    );
+  }
+
+  void _emitConnected() {
+    if (_initialized && _serverInfo != null && _serverCapabilities != null) {
+      _connectStreamController.add(
+        ServerInfo(
+          name: _serverInfo!['name'] as String? ?? 'Unknown',
+          version: _serverInfo!['version'] as String? ?? 'Unknown',
+          capabilities: _serverCapabilities!.toJson(),
+          protocolVersion: protocolVersion,
+        ),
+      );
+    }
+  }
+
+  void _emit({
+    required String direction,
+    required String kind,
+    dynamic id,
+    String? method,
+    Object? payload,
+    Map<String, String>? tags,
+  }) {
+    logListener?.call(
+      McpLogEvent(
+        server: logServerLabel,
+        direction: direction,
+        kind: kind,
+        id: id,
+        method: method,
+        payload: payload,
+        tags: tags,
+      ),
+    );
   }
 
   /// Initialize the connection to the server
@@ -381,6 +350,39 @@ class Client {
   String? get negotiatedProtocolVersion => _negotiatedProtocolVersion;
   String? _negotiatedProtocolVersion;
 
+  String? get sessionId {
+    final transport = _transport;
+    return transport is StreamableHttpClientTransport
+        ? transport.sessionId
+        : null;
+  }
+
+  void setRequestTimeout(Duration timeout) {
+    if (timeout <= Duration.zero) return;
+    _requestTimeout = timeout;
+    final transport = _transport;
+    if (transport is StreamableHttpClientTransport) {
+      transport.setRequestTimeout(timeout);
+    }
+  }
+
+  Future<void> ping() async {
+    if (!_initialized) throw McpError('Client is not initialized');
+    await _sendRequest('ping', const {});
+  }
+
+  Future<void> terminateSession() async {
+    final transport = _transport;
+    if (transport is StreamableHttpClientTransport) {
+      await transport.terminateSession();
+    }
+  }
+
+  /// Completes once requests already issued through this client have settled.
+  /// New callers should stop routing work to the client before awaiting this.
+  Future<void> waitForPendingRequests() =>
+      _pendingRequestsDrained?.future ?? Future<void>.value();
+
   /// Validate protocol version compatibility
   void _validateProtocolVersion(String serverProtoVersion) {
     _logger.warning(
@@ -406,11 +408,7 @@ class Client {
   }
 
   /// List available tools on the server
-  ///
-  /// [logTags] — optional metadata attached to the emitted log event
-  /// (e.g. `{'reason': 'heartbeat'}` so consumers can suppress noisy
-  /// liveness checks).
-  Future<List<Tool>> listTools({Map<String, String>? logTags}) async {
+  Future<List<Tool>> listTools() async {
     if (!_initialized) {
       throw McpError('Client is not initialized');
     }
@@ -419,7 +417,7 @@ class Client {
       throw McpError('Server does not support tools');
     }
 
-    final response = await _sendRequest('tools/list', {}, logTags: logTags);
+    final response = await _sendRequest('tools/list', {});
     final toolsList = response['tools'] as List<dynamic>;
     return toolsList.map((tool) => Tool.fromJson(tool)).toList();
   }
@@ -894,6 +892,8 @@ class Client {
       final transport = _transport;
       _transport =
           null; // Clear reference before closing to avoid double events
+      unawaited(_transportMessageSubscription?.cancel());
+      _transportMessageSubscription = null;
       transport!.close();
       _onDisconnect();
     }
@@ -914,6 +914,8 @@ class Client {
   void _onDisconnect() {
     _transport = null;
     _initialized = false;
+    unawaited(_transportMessageSubscription?.cancel());
+    _transportMessageSubscription = null;
 
     // Complete any pending requests with an error
     for (final completer in _requestCompleters.values) {
@@ -922,6 +924,7 @@ class Client {
       }
     }
     _requestCompleters.clear();
+    _completePendingRequestsDrain();
     _pendingInfo.clear();
     _serverPendingInfo.clear();
     _emit(direction: 'receive', kind: 'lifecycle', payload: 'disconnected');
@@ -950,16 +953,7 @@ class Client {
       // Server-initiated request — sampling / elicitation / roots / etc.
       await _handleIncomingRequest(message);
     } else {
-      if (message.error != null) {
-        // An error response without an id is a failed fire-and-forget
-        // notification (e.g. a dead session) — worth surfacing in logs,
-        // not invisible debug noise.
-        _logger.warning(
-          'Ignoring unexpected error message without id: ${message.toJson()}',
-        );
-      } else {
-        _logger.debug('Ignoring unexpected message type: ${message.toJson()}');
-      }
+      _logger.debug('Ignoring unexpected message type: ${message.toJson()}');
     }
   }
 
@@ -974,14 +968,6 @@ class Client {
     if (method == null || id == null) {
       return;
     }
-    _serverPendingInfo[id] = method;
-    _emit(
-      direction: 'receive',
-      kind: 'request',
-      id: id,
-      method: method,
-      payload: request.params ?? const {},
-    );
     final handler = _requestHandlers[method];
     if (handler == null) {
       _sendErrorResult(
@@ -991,6 +977,14 @@ class Client {
       );
       return;
     }
+    _serverPendingInfo[id] = method;
+    _emit(
+      direction: 'receive',
+      kind: 'request',
+      id: id,
+      method: method,
+      payload: request.params ?? const {},
+    );
     try {
       final result = await handler(request.params ?? const {});
       _sendResultResponse(id, result);
@@ -1007,7 +1001,7 @@ class Client {
   void _sendResultResponse(dynamic id, Map<String, dynamic> result) {
     final transport = _transport;
     if (transport == null) return;
-    transport.send({'jsonrpc': '2.0', 'id': id, 'result': result});
+    _sendUntracked(transport, {'jsonrpc': '2.0', 'id': id, 'result': result});
     final method = _serverPendingInfo.remove(id);
     _emit(
       direction: 'send',
@@ -1027,7 +1021,7 @@ class Client {
   }) {
     final transport = _transport;
     if (transport == null) return;
-    transport.send({
+    _sendUntracked(transport, {
       'jsonrpc': '2.0',
       'id': id,
       'error': {
@@ -1058,7 +1052,7 @@ class Client {
       return;
     }
 
-    final completer = _requestCompleters.remove(id)!;
+    final completer = _removeRequestCompleter(id)!;
     final pending = _pendingInfo.remove(id);
 
     if (response.error != null) {
@@ -1127,6 +1121,9 @@ class Client {
 
     final id = _requestId++;
     final completer = Completer<dynamic>();
+    if (_requestCompleters.isEmpty) {
+      _pendingRequestsDrained = Completer<void>();
+    }
     _requestCompleters[id] = completer;
     _pendingInfo[id] = (method: method, tags: logTags);
 
@@ -1140,19 +1137,11 @@ class Client {
       'params': safeParams,
     };
 
-    _emit(
-      direction: 'send',
-      kind: 'request',
-      id: id,
-      method: method,
-      payload: safeParams,
-      tags: logTags,
-    );
-
+    late final TransportSendOperation operation;
     try {
-      _transport!.send(request);
+      operation = _transport!.send(request);
     } catch (e) {
-      _requestCompleters.remove(id);
+      _removeRequestCompleter(id);
       _pendingInfo.remove(id);
       final error = McpError('Failed to send request: $e');
       _errorStreamController.add(error);
@@ -1167,12 +1156,24 @@ class Client {
       throw error;
     }
 
+    _emit(
+      direction: 'send',
+      kind: 'request',
+      id: id,
+      method: method,
+      payload: safeParams,
+      tags: logTags,
+    );
+
     try {
       // Add timeout for requests
-      final result = await completer.future.timeout(
+      final result = await Future.any<dynamic>([
+        completer.future,
+        operation.done.then<dynamic>((_) => completer.future),
+      ]).timeout(
         requestTimeout,
         onTimeout: () {
-          _requestCompleters.remove(id);
+          _removeRequestCompleter(id);
           _pendingInfo.remove(id);
           final error = McpError('Request timed out: $method');
           _errorStreamController.add(error);
@@ -1189,13 +1190,29 @@ class Client {
       );
       return result;
     } catch (e) {
+      _removeRequestCompleter(id);
       if (e is! McpError) {
         final error = McpError('Request failed: $e');
         _errorStreamController.add(error);
         throw error;
       }
       rethrow;
+    } finally {
+      operation.cancel();
     }
+  }
+
+  Completer<dynamic>? _removeRequestCompleter(int id) {
+    final completer = _requestCompleters.remove(id);
+    _pendingInfo.remove(id);
+    if (_requestCompleters.isEmpty) _completePendingRequestsDrain();
+    return completer;
+  }
+
+  void _completePendingRequestsDrain() {
+    final drained = _pendingRequestsDrained;
+    if (drained != null && !drained.isCompleted) drained.complete();
+    _pendingRequestsDrained = null;
   }
 
   /// Send a JSON-RPC notification
@@ -1214,13 +1231,26 @@ class Client {
       'params': params,
     };
 
-    _transport!.send(notification);
+    _sendUntracked(_transport!, notification);
     _emit(
       direction: 'send',
       kind: 'notification',
       method: method,
       payload: params,
       tags: logTags,
+    );
+  }
+
+  void _sendUntracked(ClientTransport transport, dynamic message) {
+    final operation = transport.send(message);
+    unawaited(
+      operation.done.catchError((Object error, StackTrace stackTrace) {
+        if (!_errorStreamController.isClosed) {
+          _errorStreamController.add(
+            error is McpError ? error : McpError('Transport error: $error'),
+          );
+        }
+      }),
     );
   }
 }

--- a/dependencies/mcp_client/lib/src/models/models.dart
+++ b/dependencies/mcp_client/lib/src/models/models.dart
@@ -910,6 +910,152 @@ class McpError implements Exception {
   String toString() => 'McpError ${code != null ? '($code)' : ''}: $message';
 }
 
+/// Structured HTTP failure raised by HTTP-based MCP transports.
+@immutable
+class McpHttpError extends McpError {
+  final int statusCode;
+  final Duration? retryAfter;
+  final String? body;
+
+  /// The WWW-Authenticate challenge values returned by the failed request.
+  final List<String> wwwAuthenticate;
+
+  /// Whether the transport itself attached a non-empty session identifier.
+  final bool sessionIdPresent;
+
+  /// True only when the server rejected the request before accepting it.
+  /// A caller may retry after repairing the rejected session or credentials.
+  final bool canRetryRequest;
+
+  /// Background GET failures are not tied to a JSON-RPC request.
+  final bool isBackgroundRequest;
+
+  McpHttpError({
+    required this.statusCode,
+    required String message,
+    this.retryAfter,
+    this.body,
+    List<String> wwwAuthenticate = const [],
+    this.sessionIdPresent = false,
+    this.canRetryRequest = false,
+    this.isBackgroundRequest = false,
+  }) : wwwAuthenticate = List.unmodifiable(wwwAuthenticate),
+       super(message);
+
+  static Duration? parseRetryAfter(String? value, {DateTime? now}) {
+    if (value == null || value.isEmpty) return null;
+    if (RegExp(r'^[0-9]+$').hasMatch(value)) {
+      final seconds = int.tryParse(value);
+      return seconds == null ? null : Duration(seconds: seconds);
+    }
+
+    final date = _parseHttpDate(value, now ?? DateTime.now().toUtc());
+    if (date == null) return null;
+    final delay = date.difference((now ?? DateTime.now()).toUtc());
+    return delay.isNegative ? Duration.zero : delay;
+  }
+
+  static DateTime? _parseHttpDate(String value, DateTime now) {
+    final imf = RegExp(
+      r'^[A-Za-z]{3}, ([0-9]{2}) ([A-Za-z]{3}) ([0-9]{4}) '
+      r'([0-9]{2}):([0-9]{2}):([0-9]{2}) GMT$',
+    ).firstMatch(value);
+    if (imf != null) {
+      return _checkedUtcDate(
+        imf.group(3)!,
+        imf.group(2)!,
+        imf.group(1)!,
+        imf.group(4)!,
+        imf.group(5)!,
+        imf.group(6)!,
+      );
+    }
+
+    final rfc850 = RegExp(
+      r'^[A-Za-z]+, ([0-9]{2})-([A-Za-z]{3})-([0-9]{2}) '
+      r'([0-9]{2}):([0-9]{2}):([0-9]{2}) GMT$',
+    ).firstMatch(value);
+    if (rfc850 != null) {
+      final shortYear = int.parse(rfc850.group(3)!);
+      var year = (now.year ~/ 100) * 100 + shortYear;
+      if (year > now.year + 50) year -= 100;
+      return _checkedUtcDate(
+        year.toString(),
+        rfc850.group(2)!,
+        rfc850.group(1)!,
+        rfc850.group(4)!,
+        rfc850.group(5)!,
+        rfc850.group(6)!,
+      );
+    }
+
+    final asctime = RegExp(
+      r'^[A-Za-z]{3} ([A-Za-z]{3}) +([0-9]{1,2}) '
+      r'([0-9]{2}):([0-9]{2}):([0-9]{2}) ([0-9]{4})$',
+    ).firstMatch(value);
+    if (asctime == null) return null;
+    return _checkedUtcDate(
+      asctime.group(6)!,
+      asctime.group(1)!,
+      asctime.group(2)!,
+      asctime.group(3)!,
+      asctime.group(4)!,
+      asctime.group(5)!,
+    );
+  }
+
+  static DateTime? _checkedUtcDate(
+    String yearValue,
+    String monthValue,
+    String dayValue,
+    String hourValue,
+    String minuteValue,
+    String secondValue,
+  ) {
+    const months = <String, int>{
+      'Jan': 1,
+      'Feb': 2,
+      'Mar': 3,
+      'Apr': 4,
+      'May': 5,
+      'Jun': 6,
+      'Jul': 7,
+      'Aug': 8,
+      'Sep': 9,
+      'Oct': 10,
+      'Nov': 11,
+      'Dec': 12,
+    };
+    final year = int.tryParse(yearValue);
+    final month = months[monthValue];
+    final day = int.tryParse(dayValue);
+    final hour = int.tryParse(hourValue);
+    final minute = int.tryParse(minuteValue);
+    final second = int.tryParse(secondValue);
+    if (year == null ||
+        month == null ||
+        day == null ||
+        hour == null ||
+        minute == null ||
+        second == null ||
+        hour > 23 ||
+        minute > 59 ||
+        second > 59) {
+      return null;
+    }
+    final parsed = DateTime.utc(year, month, day, hour, minute, second);
+    if (parsed.year != year ||
+        parsed.month != month ||
+        parsed.day != day ||
+        parsed.hour != hour ||
+        parsed.minute != minute ||
+        parsed.second != second) {
+      return null;
+    }
+    return parsed;
+  }
+}
+
 /// JSON-RPC message
 @immutable
 class JsonRpcMessage {

--- a/dependencies/mcp_client/lib/src/transport/event_source.dart
+++ b/dependencies/mcp_client/lib/src/transport/event_source.dart
@@ -1,5 +1,7 @@
 library;
 
+export 'sse_parser.dart';
+
 /// Export the appropriate implementation based on platform
 export 'event_source_stub.dart'
     if (dart.library.io) 'event_source_io.dart'

--- a/dependencies/mcp_client/lib/src/transport/event_source_io.dart
+++ b/dependencies/mcp_client/lib/src/transport/event_source_io.dart
@@ -5,11 +5,9 @@ import 'dart:io';
 import '../../logger.dart';
 import '../models/models.dart';
 import 'event_source_stub.dart' as stub;
+import 'sse_parser.dart';
 
 final Logger _logger = Logger('mcp_client.event_source_io');
-final RegExp _eventDelimiter = RegExp(
-  r'\r\n\r\n|\r\n\n|\r\n\r|\n\r\n|\n\n|\n\r|\r\r\n|\r\r',
-);
 
 /// Native platform EventSource implementation using HttpClient
 class EventSource implements stub.EventSource {
@@ -17,7 +15,7 @@ class EventSource implements stub.EventSource {
   HttpClientRequest? _request;
   HttpClientResponse? _response;
   StreamSubscription? _subscription;
-  final _buffer = StringBuffer();
+  final SseParser _parser = SseParser();
   bool _isConnected = false;
 
   EventSource();
@@ -36,6 +34,8 @@ class EventSource implements stub.EventSource {
     Function(dynamic)? onMessage,
     Function(dynamic)? onError,
     Function(String?)? onEndpoint,
+    Function(SseEvent)? onEvent,
+    Function()? onDone,
   }) async {
     _logger.debug('EventSource connecting');
     if (_isConnected) {
@@ -64,8 +64,17 @@ class EventSource implements stub.EventSource {
 
       if (_response!.statusCode != 200) {
         final body = await _response!.transform(utf8.decoder).join();
-        throw McpError(
-          'Failed to connect to SSE endpoint: ${_response!.statusCode} - $body',
+        throw McpHttpError(
+          statusCode: _response!.statusCode,
+          message:
+              'Failed to connect to SSE endpoint: '
+              '${_response!.statusCode} - $body',
+          retryAfter: McpHttpError.parseRetryAfter(
+            _response!.headers.value('Retry-After'),
+          ),
+          body: body,
+          wwwAuthenticate: _response!.headers['WWW-Authenticate'] ?? const [],
+          isBackgroundRequest: true,
         );
       }
 
@@ -79,64 +88,14 @@ class EventSource implements stub.EventSource {
           try {
             // Log raw data for debugging
             _logger.debug('Raw SSE data: [$chunk]');
-            _buffer.write(chunk);
-
-            // Process SSE events
-            for (final event in _processBuffer()) {
-              _logger.debug(
-                'Processed SSE event: ${event.event}, data: ${event.data}',
-              );
-
-              if (event.event == 'endpoint' && event.data != null) {
-                _logger.debug('Received endpoint event: ${event.data}');
-                if (onEndpoint != null) {
-                  onEndpoint(event.data);
-                }
-              } else if (event.event == 'open' && onOpen != null) {
-                _logger.debug('Connection opened');
-                onOpen(event.data);
-              } else if (event.event == 'message' && event.data != null) {
-                _logger.debug('Received message data: ${event.data}');
-                // Try to parse as JSON
-                try {
-                  final message = jsonDecode(event.data!);
-                  _logger.debug('Parsed message: $message');
-                  if (onMessage != null) {
-                    onMessage(message);
-                  }
-                } catch (e) {
-                  _logger.debug('Failed to parse message as JSON: $e');
-                  // Pass raw data if JSON parsing fails
-                  if (onMessage != null) {
-                    onMessage(event.data);
-                  }
-                }
-              } else if (event.event == 'error' && event.data != null) {
-                _logger.error('Received error event: ${event.data}');
-                if (onError != null) {
-                  onError(event.data);
-                }
-              } else if (event.event == null && event.data != null) {
-                // Handle data without explicit event type
-                _logger.debug(
-                  'Received data without event type: ${event.data}',
-                );
-
-                // Check if it's an endpoint URL
-                if (event.data!.startsWith('http://') ||
-                    event.data!.startsWith('https://')) {
-                  _logger.debug('Detected endpoint URL: ${event.data}');
-                  if (onEndpoint != null) {
-                    onEndpoint(event.data);
-                  }
-                } else {
-                  // Treat as regular message
-                  if (onMessage != null) {
-                    onMessage(event.data);
-                  }
-                }
-              }
-            }
+            _dispatchEvents(
+              _parser.add(chunk),
+              onOpen: onOpen,
+              onMessage: onMessage,
+              onError: onError,
+              onEndpoint: onEndpoint,
+              onEvent: onEvent,
+            );
           } catch (e) {
             _logger.error('Error processing SSE data: $e');
             if (onError != null) {
@@ -154,6 +113,15 @@ class EventSource implements stub.EventSource {
         onDone: () {
           _logger.debug('EventSource stream closed');
           _isConnected = false;
+          _dispatchEvents(
+            _parser.close(),
+            onOpen: onOpen,
+            onMessage: onMessage,
+            onError: onError,
+            onEndpoint: onEndpoint,
+            onEvent: onEvent,
+          );
+          onDone?.call();
         },
       );
     } catch (e) {
@@ -166,41 +134,36 @@ class EventSource implements stub.EventSource {
     }
   }
 
-  /// Process the buffer to extract SSE events
-  List<SseEvent> _processBuffer() {
-    final events = <SseEvent>[];
-
-    while (true) {
-      final content = _buffer.toString();
-      final delimiter = _eventDelimiter.firstMatch(content);
-      if (delimiter == null) {
-        break;
-      }
-
-      final eventBlock = content.substring(0, delimiter.start);
-      _buffer
-        ..clear()
-        ..write(content.substring(delimiter.end));
-
-      String? eventType;
-      String? eventData;
-      String? eventId;
-
-      for (final line in eventBlock.split(RegExp(r'\r\n|\r|\n'))) {
-        if (line.startsWith('event:')) {
-          eventType = line.substring(6).trim();
-        } else if (line.startsWith('data:')) {
-          final data = line.substring(5).trim();
-          eventData = eventData == null ? data : '$eventData\n$data';
-        } else if (line.startsWith('id:')) {
-          eventId = line.substring(3).trim();
+  void _dispatchEvents(
+    List<SseEvent> events, {
+    required Function(String?)? onOpen,
+    required Function(dynamic)? onMessage,
+    required Function(dynamic)? onError,
+    required Function(String?)? onEndpoint,
+    required Function(SseEvent)? onEvent,
+  }) {
+    for (final event in events) {
+      onEvent?.call(event);
+      final data = event.data;
+      if (event.event == 'endpoint' && data != null) {
+        onEndpoint?.call(data);
+      } else if (event.event == 'open') {
+        onOpen?.call(data);
+      } else if (event.event == 'error' && data != null) {
+        onError?.call(data);
+      } else if (data != null) {
+        if (event.event == null &&
+            (data.startsWith('http://') || data.startsWith('https://'))) {
+          onEndpoint?.call(data);
+          continue;
+        }
+        try {
+          onMessage?.call(jsonDecode(data));
+        } catch (_) {
+          onMessage?.call(data);
         }
       }
-
-      events.add(SseEvent(event: eventType, data: eventData, id: eventId));
     }
-
-    return events;
   }
 
   @override
@@ -210,13 +173,4 @@ class EventSource implements stub.EventSource {
     _subscription?.cancel();
     _client?.close(force: true);
   }
-}
-
-/// SSE event data
-class SseEvent {
-  final String? event;
-  final String? data;
-  final String? id;
-
-  SseEvent({this.event, this.data, this.id});
 }

--- a/dependencies/mcp_client/lib/src/transport/event_source_stub.dart
+++ b/dependencies/mcp_client/lib/src/transport/event_source_stub.dart
@@ -1,3 +1,5 @@
+import 'sse_parser.dart';
+
 /// Abstract EventSource interface for cross-platform SSE support
 abstract class EventSource {
   /// Whether the connection is active
@@ -14,6 +16,8 @@ abstract class EventSource {
     Function(dynamic)? onMessage,
     Function(dynamic)? onError,
     Function(String?)? onEndpoint,
+    Function(SseEvent)? onEvent,
+    Function()? onDone,
   });
 
   /// Close the connection

--- a/dependencies/mcp_client/lib/src/transport/event_source_web.dart
+++ b/dependencies/mcp_client/lib/src/transport/event_source_web.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import '../../logger.dart';
 import '../models/models.dart';
 import 'event_source_stub.dart' as stub;
+import 'sse_parser.dart';
 
 final Logger _logger = Logger('mcp_client.event_source_web');
 
@@ -15,7 +16,7 @@ class EventSource implements stub.EventSource {
   StreamSubscription? _subscription;
   bool _isConnected = false;
   http.StreamedResponse? _response;
-  final _buffer = StringBuffer();
+  final SseParser _parser = SseParser();
 
   EventSource();
 
@@ -33,6 +34,8 @@ class EventSource implements stub.EventSource {
     Function(dynamic)? onMessage,
     Function(dynamic)? onError,
     Function(String?)? onEndpoint,
+    Function(SseEvent)? onEvent,
+    Function()? onDone,
   }) async {
     _logger.debug('EventSource connecting (web)');
     if (_isConnected) {
@@ -59,8 +62,20 @@ class EventSource implements stub.EventSource {
 
       if (_response!.statusCode != 200) {
         final body = await _response!.stream.transform(utf8.decoder).join();
-        throw McpError(
-          'Failed to connect to SSE endpoint: ${_response!.statusCode} - $body',
+        throw McpHttpError(
+          statusCode: _response!.statusCode,
+          message:
+              'Failed to connect to SSE endpoint: '
+              '${_response!.statusCode} - $body',
+          retryAfter: McpHttpError.parseRetryAfter(
+            _response!.headers['retry-after'],
+          ),
+          body: body,
+          wwwAuthenticate:
+              _response!.headers['www-authenticate'] == null
+                  ? const []
+                  : [_response!.headers['www-authenticate']!],
+          isBackgroundRequest: true,
         );
       }
 
@@ -77,8 +92,14 @@ class EventSource implements stub.EventSource {
             (String chunk) {
               try {
                 _logger.debug('Received SSE chunk: $chunk');
-                _buffer.write(chunk);
-                _processBuffer(onMessage, onEndpoint, onError);
+                _dispatchEvents(
+                  _parser.add(chunk),
+                  onOpen: onOpen,
+                  onMessage: onMessage,
+                  onError: onError,
+                  onEndpoint: onEndpoint,
+                  onEvent: onEvent,
+                );
               } catch (e) {
                 _logger.error('Error processing SSE chunk: $e');
                 if (onError != null) {
@@ -96,6 +117,15 @@ class EventSource implements stub.EventSource {
             onDone: () {
               _logger.debug('EventSource stream closed');
               _isConnected = false;
+              _dispatchEvents(
+                _parser.close(),
+                onOpen: onOpen,
+                onMessage: onMessage,
+                onError: onError,
+                onEndpoint: onEndpoint,
+                onEvent: onEvent,
+              );
+              onDone?.call();
             },
           );
     } catch (e) {
@@ -108,102 +138,35 @@ class EventSource implements stub.EventSource {
     }
   }
 
-  void _processBuffer(
-    Function(dynamic)? onMessage,
-    Function(String?)? onEndpoint,
-    Function(dynamic)? onError,
-  ) {
-    final content = _buffer.toString();
-
-    // Process all complete events (separated by double newline)
-    final eventBlocks = content.split(RegExp(r'(\r?\n){2}'));
-
-    if (eventBlocks.length < 2) {
-      // No complete event yet
-      return;
-    }
-
-    // Process complete events
-    for (int i = 0; i < eventBlocks.length - 1; i++) {
-      final eventBlock = eventBlocks[i];
-      if (eventBlock.isEmpty) continue;
-
-      final lines = eventBlock.split(RegExp(r'\r?\n'));
-      String? eventType;
-      String? eventData;
-
-      for (final line in lines) {
-        if (line.startsWith('event:')) {
-          eventType = line.substring(6).trim();
-        } else if (line.startsWith('data:')) {
-          final data = line.substring(5).trim();
-          if (eventData == null) {
-            eventData = data;
-          } else {
-            eventData = '$eventData\n$data';
-          }
+  void _dispatchEvents(
+    List<SseEvent> events, {
+    required Function(String?)? onOpen,
+    required Function(dynamic)? onMessage,
+    required Function(dynamic)? onError,
+    required Function(String?)? onEndpoint,
+    required Function(SseEvent)? onEvent,
+  }) {
+    for (final event in events) {
+      onEvent?.call(event);
+      final data = event.data;
+      if (event.event == 'endpoint' && data != null) {
+        onEndpoint?.call(data);
+      } else if (event.event == 'open') {
+        onOpen?.call(data);
+      } else if (event.event == 'error' && data != null) {
+        onError?.call(data);
+      } else if (data != null) {
+        if (event.event == null &&
+            (data.startsWith('http://') || data.startsWith('https://'))) {
+          onEndpoint?.call(data);
+          continue;
+        }
+        try {
+          onMessage?.call(jsonDecode(data));
+        } catch (_) {
+          onMessage?.call(data);
         }
       }
-
-      // Handle different event types
-      if (eventType == 'endpoint' && eventData != null) {
-        _logger.debug('Received endpoint event: $eventData');
-        if (onEndpoint != null) {
-          onEndpoint(eventData);
-        }
-      } else if ((eventType == 'message' || eventType == null) &&
-          eventData != null) {
-        _logger.debug('Received message data: $eventData');
-
-        // Check if it's an endpoint URL without event type
-        if (eventType == null && (eventData.startsWith('http://') || eventData.startsWith('https://'))) {
-          _logger.debug('Detected endpoint URL: $eventData');
-          if (onEndpoint != null) {
-            onEndpoint(eventData);
-          }
-        } else if (eventData.contains('"jsonrpc":"2.0"') ||
-            eventData.contains('"jsonrpc": "2.0"')) {
-          // Check if it's JSON-RPC data
-          try {
-            final jsonData = jsonDecode(eventData);
-            _logger.debug('Parsed JSON-RPC data: $jsonData');
-            if (onMessage != null) {
-              onMessage(jsonData);
-            }
-          } catch (e) {
-            _logger.debug('Failed to parse as JSON-RPC: $e');
-            if (onMessage != null) {
-              onMessage(eventData);
-            }
-          }
-        } else {
-          // Try to parse as JSON
-          try {
-            final message = jsonDecode(eventData);
-            _logger.debug('Parsed message: $message');
-            if (onMessage != null) {
-              onMessage(message);
-            }
-          } catch (e) {
-            _logger.debug('Failed to parse message as JSON: $e');
-            // Pass raw data if JSON parsing fails
-            if (onMessage != null) {
-              onMessage(eventData);
-            }
-          }
-        }
-      } else if (eventType == 'error' && eventData != null) {
-        _logger.error('Received error event: $eventData');
-        if (onError != null) {
-          onError(eventData);
-        }
-      }
-    }
-
-    // Keep the incomplete last block in buffer
-    _buffer.clear();
-    if (eventBlocks.isNotEmpty) {
-      _buffer.write(eventBlocks.last);
     }
   }
 

--- a/dependencies/mcp_client/lib/src/transport/sse_auth_transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/sse_auth_transport.dart
@@ -339,7 +339,15 @@ class SseAuthClientTransport implements ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) async {
+  TransportSendOperation send(dynamic message) {
+    final pending = _PendingAuthenticatedPost();
+    return TransportSendOperation(
+      _send(message, pending),
+      cancel: pending.cancel,
+    );
+  }
+
+  Future<void> _send(dynamic message, _PendingAuthenticatedPost pending) async {
     if (_isClosed) {
       _logger.debug('Attempted to send on closed authenticated transport');
       return;
@@ -351,20 +359,28 @@ class SseAuthClientTransport implements ClientTransport {
       );
     }
 
+    final client = HttpClient();
+    HttpClientRequest? request;
+    pending.client = client;
     try {
+      if (pending.cancelled) return;
       final jsonMessage = jsonEncode(message);
       _logger.debug('Sending authenticated message: $jsonMessage');
 
       final url = Uri.parse(_messageEndpoint!);
-      final client = HttpClient();
-      final request = await client.postUrl(url);
+      request = await client.postUrl(url);
+      pending.request = request;
+      if (pending.cancelled) {
+        request.abort();
+        return;
+      }
 
       // Set content type
       request.headers.contentType = ContentType.json;
 
       // Add authentication headers
       _baseHeaders.forEach((name, value) {
-        request.headers.add(name, value);
+        request!.headers.add(name, value);
       });
 
       // Add current OAuth token if available
@@ -388,7 +404,6 @@ class SseAuthClientTransport implements ClientTransport {
         _logger.debug(
           'Authentication error during send: ${response.statusCode} - $responseBody',
         );
-        client.close();
 
         // Try to refresh token if possible
         if (_oauthClient != null &&
@@ -396,55 +411,29 @@ class SseAuthClientTransport implements ClientTransport {
             !_isRefreshingToken) {
           await _refreshTokenIfNeeded();
           // Retry the send operation
-          return send(message);
+          await _send(message, pending);
+          return;
         } else {
-          _emitError(
+          throw McpError(
             'Authentication failed during send: ${response.statusCode}',
-            message: message,
           );
-        }
-      } else if (response.statusCode == 404) {
-        // 404 means the server no longer knows this session. Mirror
-        // SseClientTransport: surface it as a JSON-RPC "Session terminated"
-        // error on the message stream instead of throwing — `send` is
-        // `void async`, so a throw would escape as an unhandled exception.
-        final responseBody = await response.transform(utf8.decoder).join();
-        _logger.debug('Session terminated (404): $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {'code': 32600, 'message': 'Session terminated'},
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
         }
       } else {
         final responseBody = await response.transform(utf8.decoder).join();
         _logger.debug('Error response: $responseBody');
-        _emitError(
+        throw McpError(
           'Error sending authenticated message: ${response.statusCode}',
-          message: message,
         );
       }
-
-      client.close();
       _logger.debug('Authenticated message sent successfully');
     } catch (e) {
       _logger.debug('Error sending authenticated message: $e');
-      _emitError('Error sending authenticated message: $e', message: message);
+      rethrow;
+    } finally {
+      if (identical(pending.request, request)) pending.request = null;
+      if (identical(pending.client, client)) pending.client = null;
+      client.close(force: true);
     }
-  }
-
-  /// Route a send failure to the message stream as a JSON-RPC error, so a
-  /// `void async` send never throws (see [send]). Requests are failed by
-  /// the client through the error response's `id`; notifications without an
-  /// `id` are logged by the client and dropped.
-  void _emitError(String description, {required dynamic message}) {
-    if (_messageController.isClosed) return;
-    _messageController.add({
-      'jsonrpc': '2.0',
-      'error': {'code': -32603, 'message': description},
-      if (message is Map && message['id'] != null) 'id': message['id'],
-    });
   }
 
   @override
@@ -475,13 +464,26 @@ class SseAuthClientTransport implements ClientTransport {
   }
 }
 
+final class _PendingAuthenticatedPost {
+  bool cancelled = false;
+  HttpClient? client;
+  HttpClientRequest? request;
+
+  void cancel() {
+    if (cancelled) return;
+    cancelled = true;
+    request?.abort();
+    client?.close(force: true);
+  }
+}
+
 /// Authenticated EventSource implementation
 class AuthenticatedEventSource implements EventSource {
   HttpClient? _client;
   HttpClientRequest? _request;
   HttpClientResponse? _response;
   StreamSubscription? _subscription;
-  final _buffer = StringBuffer();
+  final SseParser _parser = SseParser();
   bool _isConnected = false;
 
   @override
@@ -498,6 +500,8 @@ class AuthenticatedEventSource implements EventSource {
     Function(dynamic)? onMessage,
     Function(dynamic)? onError,
     Function(String?)? onEndpoint,
+    Function(SseEvent)? onEvent,
+    Function()? onDone,
     Function(int, String)? onAuthFailure,
   }) async {
     _logger.debug('AuthenticatedEventSource connecting to: $url');
@@ -548,73 +552,19 @@ class AuthenticatedEventSource implements EventSource {
           try {
             final chunk = utf8.decode(data, allowMalformed: true);
             _logger.debug('Raw authenticated SSE data: [$chunk]');
-            _buffer.write(chunk);
-
-            // Process all events in buffer
-            final content = _buffer.toString();
-
-            // Check for JSON-RPC responses
-            if (content.contains('"jsonrpc":"2.0"') ||
-                content.contains('"jsonrpc": "2.0"')) {
-              _logger.debug(
-                'Detected JSON-RPC data in authenticated SSE stream',
-              );
-
-              try {
-                final jsonStart = content.indexOf('{');
-                final jsonEnd = content.lastIndexOf('}') + 1;
-
-                if (jsonStart >= 0 && jsonEnd > jsonStart) {
-                  final jsonStr = content.substring(jsonStart, jsonEnd);
-                  _logger.debug('Extracted authenticated JSON: $jsonStr');
-
-                  try {
-                    final jsonData = jsonDecode(jsonStr);
-                    _logger.debug(
-                      'Parsed authenticated JSON-RPC data: $jsonData',
-                    );
-
-                    // Clear processed data from buffer
-                    if (jsonEnd < content.length) {
-                      _buffer.clear();
-                      _buffer.write(content.substring(jsonEnd));
-                    } else {
-                      _buffer.clear();
-                    }
-
-                    // Forward to message handler
-                    if (onMessage != null) {
-                      onMessage(jsonData);
-                    }
-                    return;
-                  } catch (e) {
-                    _logger.debug(
-                      'JSON parse error in authenticated stream: $e',
-                    );
-                  }
+            for (final event in _parser.add(chunk)) {
+              onEvent?.call(event);
+              final eventData = event.data;
+              if (event.event == 'endpoint' && eventData != null) {
+                onOpen?.call(eventData);
+                onEndpoint?.call(eventData);
+              } else if (eventData != null) {
+                try {
+                  onMessage?.call(jsonDecode(eventData));
+                } catch (_) {
+                  onMessage?.call(eventData);
                 }
-              } catch (e) {
-                _logger.debug(
-                  'Error extracting JSON from authenticated stream: $e',
-                );
               }
-            }
-
-            // Process SSE events
-            final event = _processBuffer();
-            _logger.debug(
-              'Processed authenticated SSE event: ${event.event}, data: ${event.data}',
-            );
-
-            if (event.event == 'endpoint' && event.data != null) {
-              _logger.debug(
-                'Received authenticated endpoint event: ${event.data}',
-              );
-              if (onOpen != null) {
-                onOpen(event.data);
-              }
-            } else if (event.data != null && onMessage != null) {
-              onMessage(event.data);
             }
           } catch (e) {
             _logger.debug('Error processing authenticated SSE data: $e');
@@ -630,8 +580,13 @@ class AuthenticatedEventSource implements EventSource {
         onDone: () {
           _logger.debug('Authenticated EventSource stream closed');
           _isConnected = false;
-          if (onError != null) {
-            onError('Authenticated connection closed');
+          for (final event in _parser.close()) {
+            onEvent?.call(event);
+          }
+          if (onDone != null) {
+            onDone();
+          } else {
+            onError?.call('Authenticated connection closed');
           }
         },
       );
@@ -643,55 +598,6 @@ class AuthenticatedEventSource implements EventSource {
       }
       rethrow;
     }
-  }
-
-  _SseEvent _processBuffer() {
-    final content = _buffer.toString();
-    _logger.debug('_processBuffer authenticated content: [$content]');
-
-    if (content.isEmpty) {
-      return _SseEvent('', null);
-    }
-
-    final eventBlocks = content.split('\n\n');
-    _logger.debug(
-      '_processBuffer authenticated event blocks count: ${eventBlocks.length}',
-    );
-
-    if (eventBlocks.length < 2) {
-      return _SseEvent('', null);
-    }
-
-    final eventBlock = eventBlocks[0];
-    final lines = eventBlock.split('\n');
-
-    String currentEvent = '';
-    String? currentData;
-
-    for (final line in lines) {
-      final trimmedLine = line.trim();
-      _logger.debug('Processing authenticated line: [$trimmedLine]');
-
-      if (trimmedLine.startsWith('event:')) {
-        currentEvent = trimmedLine.substring(6).trim();
-        _logger.debug('Found authenticated event type: $currentEvent');
-      } else if (trimmedLine.startsWith('data:')) {
-        currentData = trimmedLine.substring(5).trim();
-        _logger.debug('Found authenticated event data: $currentData');
-      }
-    }
-
-    // Clear processed event from buffer
-    final remaining = eventBlocks.skip(1).join('\n\n');
-    _buffer.clear();
-    if (remaining.isNotEmpty) {
-      _buffer.write(remaining);
-    }
-
-    _logger.debug(
-      'Complete authenticated event found: $currentEvent, data: $currentData',
-    );
-    return _SseEvent(currentEvent, currentData);
   }
 
   @override
@@ -719,11 +625,4 @@ class AuthenticatedEventSource implements EventSource {
 
     _isConnected = false;
   }
-}
-
-class _SseEvent {
-  final String event;
-  final String? data;
-
-  _SseEvent(this.event, this.data);
 }

--- a/dependencies/mcp_client/lib/src/transport/sse_compressed_transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/sse_compressed_transport.dart
@@ -192,7 +192,15 @@ class SseCompressedClientTransport implements ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) async {
+  TransportSendOperation send(dynamic message) {
+    final pending = _PendingCompressedPost();
+    return TransportSendOperation(
+      _send(message, pending),
+      cancel: pending.cancel,
+    );
+  }
+
+  Future<void> _send(dynamic message, _PendingCompressedPost pending) async {
     if (_isClosed) {
       _logger.debug('Attempted to send on closed compressed transport');
       return;
@@ -204,7 +212,11 @@ class SseCompressedClientTransport implements ClientTransport {
       );
     }
 
+    final client = HttpClient();
+    HttpClientRequest? request;
+    pending.client = client;
     try {
+      if (pending.cancelled) return;
       final jsonMessage = jsonEncode(message);
       final shouldCompress = jsonMessage.length >= _compressionThreshold;
 
@@ -213,15 +225,19 @@ class SseCompressedClientTransport implements ClientTransport {
       );
 
       final url = Uri.parse(_messageEndpoint!);
-      final client = HttpClient();
-      final request = await client.postUrl(url);
+      request = await client.postUrl(url);
+      pending.request = request;
+      if (pending.cancelled) {
+        request.abort();
+        return;
+      }
 
       // Set content type
       request.headers.contentType = ContentType.json;
 
       // Add base headers
       _baseHeaders.forEach((name, value) {
-        request.headers.add(name, value);
+        request!.headers.add(name, value);
       });
 
       // Apply compression if needed and supported
@@ -247,50 +263,21 @@ class SseCompressedClientTransport implements ClientTransport {
         _logger.debug(
           'Compressed message delivery confirmation: $responseBody',
         );
-      } else if (response.statusCode == 404) {
-        // 404 means the server no longer knows this session. Mirror
-        // SseClientTransport: surface it as a JSON-RPC "Session terminated"
-        // error on the message stream instead of throwing — `send` is
-        // `void async`, so a throw would escape as an unhandled exception.
-        final responseBody = await _decompressResponse(response);
-        _logger.debug('Session terminated (404): $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {'code': 32600, 'message': 'Session terminated'},
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
       } else {
         final responseBody = await _decompressResponse(response);
         _logger.debug('Error response: $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {
-              'code': -32603,
-              'message':
-                  'Error sending compressed message: ${response.statusCode}',
-            },
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
+        throw McpError(
+          'Error sending compressed message: ${response.statusCode}',
+        );
       }
-
-      client.close();
       _logger.debug('Compressed message sent successfully');
     } catch (e) {
       _logger.debug('Error sending compressed message: $e');
-      if (!_messageController.isClosed) {
-        _messageController.add({
-          'jsonrpc': '2.0',
-          'error': {
-            'code': -32603,
-            'message': 'Error sending compressed message: $e',
-          },
-          if (message is Map && message['id'] != null) 'id': message['id'],
-        });
-      }
+      rethrow;
+    } finally {
+      if (identical(pending.request, request)) pending.request = null;
+      if (identical(pending.client, client)) pending.client = null;
+      client.close(force: true);
     }
   }
 
@@ -375,6 +362,19 @@ class SseCompressedClientTransport implements ClientTransport {
     if (!_closeCompleter.isCompleted) {
       _closeCompleter.complete();
     }
+  }
+}
+
+final class _PendingCompressedPost {
+  bool cancelled = false;
+  HttpClient? client;
+  HttpClientRequest? request;
+
+  void cancel() {
+    if (cancelled) return;
+    cancelled = true;
+    request?.abort();
+    client?.close(force: true);
   }
 }
 

--- a/dependencies/mcp_client/lib/src/transport/sse_heartbeat_transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/sse_heartbeat_transport.dart
@@ -419,7 +419,15 @@ class SseHeartbeatClientTransport implements ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) async {
+  TransportSendOperation send(dynamic message) {
+    final pending = _PendingHeartbeatPost();
+    return TransportSendOperation(
+      _send(message, pending),
+      cancel: pending.cancel,
+    );
+  }
+
+  Future<void> _send(dynamic message, _PendingHeartbeatPost pending) async {
     if (_isClosed) {
       _logger.debug('Attempted to send on closed heartbeat transport');
       return;
@@ -436,22 +444,30 @@ class SseHeartbeatClientTransport implements ClientTransport {
       throw McpError('Cannot send message: Connection is disconnected');
     }
 
+    final client = HttpClient();
+    HttpClientRequest? request;
+    pending.client = client;
     try {
+      if (pending.cancelled) return;
       final jsonMessage = jsonEncode(message);
       _logger.debug(
         'Sending heartbeat message: ${jsonMessage.substring(0, 100)}...',
       );
 
       final url = Uri.parse(_messageEndpoint!);
-      final client = HttpClient();
-      final request = await client.postUrl(url);
+      request = await client.postUrl(url);
+      pending.request = request;
+      if (pending.cancelled) {
+        request.abort();
+        return;
+      }
 
       // Set content type
       request.headers.contentType = ContentType.json;
 
       // Add base headers
       _baseHeaders.forEach((name, value) {
-        request.headers.add(name, value);
+        request!.headers.add(name, value);
       });
 
       // Send the request
@@ -462,37 +478,13 @@ class SseHeartbeatClientTransport implements ClientTransport {
       if (response.statusCode == 200) {
         final responseBody = await response.transform(utf8.decoder).join();
         _logger.debug('Heartbeat message delivery confirmation: $responseBody');
-      } else if (response.statusCode == 404) {
-        // 404 means the server no longer knows this session. Mirror
-        // SseClientTransport: surface it as a JSON-RPC "Session terminated"
-        // error on the message stream instead of throwing — `send` is
-        // `void async`, so a throw would escape as an unhandled exception.
-        final responseBody = await response.transform(utf8.decoder).join();
-        _logger.debug('Session terminated (404): $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {'code': 32600, 'message': 'Session terminated'},
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
       } else {
         final responseBody = await response.transform(utf8.decoder).join();
         _logger.debug('Error response: $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {
-              'code': -32603,
-              'message':
-                  'Error sending heartbeat message: ${response.statusCode}',
-            },
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
+        throw McpError(
+          'Error sending heartbeat message: ${response.statusCode}',
+        );
       }
-
-      client.close();
       _logger.debug('Heartbeat message sent successfully');
     } catch (e) {
       _logger.debug('Error sending heartbeat message: $e');
@@ -503,16 +495,11 @@ class SseHeartbeatClientTransport implements ClientTransport {
         _updateHealth(ConnectionHealth.degraded);
       }
 
-      if (!_messageController.isClosed) {
-        _messageController.add({
-          'jsonrpc': '2.0',
-          'error': {
-            'code': -32603,
-            'message': 'Error sending heartbeat message: $e',
-          },
-          if (message is Map && message['id'] != null) 'id': message['id'],
-        });
-      }
+      rethrow;
+    } finally {
+      if (identical(pending.request, request)) pending.request = null;
+      if (identical(pending.client, client)) pending.client = null;
+      client.close(force: true);
     }
   }
 
@@ -543,6 +530,19 @@ class SseHeartbeatClientTransport implements ClientTransport {
     }
 
     _updateHealth(ConnectionHealth.disconnected);
+  }
+}
+
+final class _PendingHeartbeatPost {
+  bool cancelled = false;
+  HttpClient? client;
+  HttpClientRequest? request;
+
+  void cancel() {
+    if (cancelled) return;
+    cancelled = true;
+    request?.abort();
+    client?.close(force: true);
   }
 }
 

--- a/dependencies/mcp_client/lib/src/transport/sse_parser.dart
+++ b/dependencies/mcp_client/lib/src/transport/sse_parser.dart
@@ -1,0 +1,123 @@
+/// One parsed SSE event block.
+final class SseEvent {
+  final String? event;
+  final String? data;
+  final String? id;
+  final bool hasId;
+  final Duration? retry;
+
+  const SseEvent({
+    this.event,
+    this.data,
+    this.id,
+    this.hasId = false,
+    this.retry,
+  });
+}
+
+/// Incremental WHATWG event-stream parser shared by every transport.
+final class SseParser {
+  String _buffer = '';
+  String? _event;
+  final List<String> _data = [];
+  String? _id;
+  bool _hasId = false;
+  Duration? _retry;
+  bool _firstLine = true;
+
+  List<SseEvent> add(String chunk) {
+    _buffer += chunk;
+    return _drain(finalChunk: false);
+  }
+
+  List<SseEvent> close() => _drain(finalChunk: true);
+
+  List<SseEvent> _drain({required bool finalChunk}) {
+    final events = <SseEvent>[];
+    while (_buffer.isNotEmpty) {
+      var end = -1;
+      for (var index = 0; index < _buffer.length; index++) {
+        final unit = _buffer.codeUnitAt(index);
+        if (unit == 0x0a || unit == 0x0d) {
+          end = index;
+          break;
+        }
+      }
+      if (end < 0) {
+        if (finalChunk) {
+          _processLine(_buffer, events);
+          _buffer = '';
+        }
+        break;
+      }
+      if (!finalChunk &&
+          _buffer.codeUnitAt(end) == 0x0d &&
+          end + 1 == _buffer.length) {
+        break;
+      }
+
+      final line = _buffer.substring(0, end);
+      var delimiterLength = 1;
+      if (_buffer.codeUnitAt(end) == 0x0d &&
+          end + 1 < _buffer.length &&
+          _buffer.codeUnitAt(end + 1) == 0x0a) {
+        delimiterLength = 2;
+      }
+      _buffer = _buffer.substring(end + delimiterLength);
+      _processLine(line, events);
+    }
+    return events;
+  }
+
+  void _processLine(String rawLine, List<SseEvent> events) {
+    var line = rawLine;
+    if (_firstLine) {
+      _firstLine = false;
+      if (line.startsWith('\ufeff')) line = line.substring(1);
+    }
+    if (line.isEmpty) {
+      if (_event != null || _data.isNotEmpty || _hasId || _retry != null) {
+        events.add(
+          SseEvent(
+            event: _event == null || _event!.isEmpty ? null : _event,
+            data: _data.isEmpty ? null : _data.join('\n'),
+            id: _id,
+            hasId: _hasId,
+            retry: _retry,
+          ),
+        );
+      }
+      _event = null;
+      _data.clear();
+      _id = null;
+      _hasId = false;
+      _retry = null;
+      return;
+    }
+    if (line.startsWith(':')) return;
+
+    final colon = line.indexOf(':');
+    final field = colon < 0 ? line : line.substring(0, colon);
+    var value = colon < 0 ? '' : line.substring(colon + 1);
+    if (value.startsWith(' ')) value = value.substring(1);
+
+    switch (field) {
+      case 'event':
+        _event = value;
+      case 'data':
+        _data.add(value);
+      case 'id':
+        if (!value.contains('\u0000')) {
+          _id = value;
+          _hasId = true;
+        }
+      case 'retry':
+        if (value.isNotEmpty && RegExp(r'^[0-9]+$').hasMatch(value)) {
+          final milliseconds = int.tryParse(value);
+          if (milliseconds != null) {
+            _retry = Duration(milliseconds: milliseconds);
+          }
+        }
+    }
+  }
+}

--- a/dependencies/mcp_client/lib/src/transport/streamable_http_transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/streamable_http_transport.dart
@@ -1,9 +1,10 @@
-/// Streamable HTTP transport for MCP 2025-03-26
+/// Streamable HTTP transport for MCP 2025-03-26 and later.
 library;
 
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
@@ -17,46 +18,20 @@ import 'transport.dart';
 
 final Logger _logger = Logger('mcp_client.streamable_http_transport');
 
-/// HTTP transport configuration
 @immutable
 class StreamableHttpTransportConfig {
-  /// Base URL for the MCP server
   final String baseUrl;
-
-  /// OAuth configuration (optional)
   final OAuthConfig? oauthConfig;
-
-  /// Previously obtained OAuth token (optional). Injected before the first
-  /// request so persisted tokens survive app restarts.
-  final OAuthToken? oauthToken;
-
-  /// Called whenever the internal token manager refreshes the token.
-  /// The host application persists the new token here.
-  final Function(OAuthToken token)? onTokenRefreshed;
-
-  /// Additional headers to send with requests
   final Map<String, String> headers;
-
-  /// Request timeout
   final Duration timeout;
-
-  /// SSE read timeout (longer for streaming)
   final Duration sseReadTimeout;
-
-  /// Maximum number of concurrent requests
   final int maxConcurrentRequests;
-
-  /// Whether to use HTTP/2 if available
   final bool useHttp2;
-
-  /// Whether to terminate session on close
   final bool terminateOnClose;
 
   const StreamableHttpTransportConfig({
     required this.baseUrl,
     this.oauthConfig,
-    this.oauthToken,
-    this.onTokenRefreshed,
     this.headers = const {},
     this.timeout = const Duration(seconds: 30),
     this.sseReadTimeout = const Duration(minutes: 5),
@@ -66,26 +41,53 @@ class StreamableHttpTransportConfig {
   });
 }
 
-/// Streamable HTTP client transport for MCP
 class StreamableHttpClientTransport implements ClientTransport {
+  static const Duration _minimumReconnectDelay = Duration(seconds: 1);
+  static const Duration _defaultReconnectDelay = Duration(seconds: 1);
+  static const Duration _authenticationRetryDelay = Duration(minutes: 5);
+
+  /// Ceiling for the exponential backoff applied after consecutive lost
+  /// GET streams (see [_runGetStream]).
+  static const Duration _getStreamBackoffCap = Duration(seconds: 30);
+
+  /// After this many consecutive GET-stream failures the background stream
+  /// is given up until the next POST-driven session recovery (a fresh
+  /// session re-arms [_startGetStream]).
+  static const int _maxGetStreamReconnects = 4;
+
+  static const Set<String> _reservedHeaders = {
+    'accept',
+    'content-type',
+    'last-event-id',
+    'mcp-protocol-version',
+    'mcp-session-id',
+  };
+
   final StreamableHttpTransportConfig config;
   final http.Client _httpClient;
   final HttpOAuthClient? _oauthClient;
   final OAuthTokenManager? _tokenManager;
-
   final StreamController<dynamic> _messageController =
-      StreamController.broadcast();
+      StreamController<dynamic>.broadcast();
   final Completer<void> _closeCompleter = Completer<void>();
+  final Semaphore _requestSemaphore;
+  final Set<_PostRequestTask> _postTasks = {};
+  final Completer<void> _closedSignal = Completer<void>();
 
   bool _isClosed = false;
-  final Semaphore _requestSemaphore;
   String _baseUrl;
+  Duration _requestTimeout;
   String? _sessionId;
   String? _protocolVersion;
-  final Map<int, Completer<dynamic>> _pendingRequests = {};
-  EventSource? _eventSource;
-  StreamSubscription? _sseSubscription;
-  bool _getStreamActive = false;
+  EventSource? _getEventSource;
+  Future<void>? _getTask;
+  String? _getLastEventId;
+  Duration _getSseRetry = _defaultReconnectDelay;
+
+  /// Consecutive GET-stream terminations without a single delivered event.
+  /// Drives the exponential backoff and the reconnect cap that keep a
+  /// broken server from being hammered at a flat 1s (Kelivo #937).
+  int _getStreamFailures = 0;
 
   StreamableHttpClientTransport._({
     required this.config,
@@ -96,16 +98,9 @@ class StreamableHttpClientTransport implements ClientTransport {
        _oauthClient = oauthClient,
        _tokenManager = tokenManager,
        _baseUrl = config.baseUrl,
+       _requestTimeout = config.timeout,
        _requestSemaphore = Semaphore(config.maxConcurrentRequests);
 
-  /// Spec 2025-06-18+: record the negotiated MCP protocol version so
-  /// every post-handshake HTTP request carries
-  /// `MCP-Protocol-Version: <version>`.
-  void setProtocolVersion(String version) {
-    _protocolVersion = version;
-  }
-
-  /// Create a new Streamable HTTP transport
   static Future<StreamableHttpClientTransport> create({
     required String baseUrl,
     OAuthConfig? oauthConfig,
@@ -116,42 +111,31 @@ class StreamableHttpClientTransport implements ClientTransport {
     int? maxConcurrentRequests,
     bool? useHttp2,
     http.Client? httpClient,
-    bool terminateOnClose = true, // Default: true for backward compatibility
+    bool terminateOnClose = true,
   }) async {
     final config = StreamableHttpTransportConfig(
       baseUrl: baseUrl,
       oauthConfig: oauthConfig,
-      oauthToken: oauthToken,
-      onTokenRefreshed: onTokenRefreshed,
       headers: headers ?? const {},
       timeout: timeout ?? const Duration(seconds: 30),
       maxConcurrentRequests: maxConcurrentRequests ?? 10,
       useHttp2: useHttp2 ?? true,
       terminateOnClose: terminateOnClose,
     );
-
-    final client =
-        httpClient ??
-        (config.useHttp2
-            ? http.Client()
-            : // Use default client
-            http.Client());
-
-    HttpOAuthClient? oauthClient;
-    OAuthTokenManager? tokenManager;
-
-    if (oauthConfig != null) {
-      oauthClient = HttpOAuthClient(config: oauthConfig, httpClient: client);
-      tokenManager = OAuthTokenManager(oauthClient);
-      if (oauthToken != null) {
-        tokenManager.setToken(oauthToken);
-      }
-      if (onTokenRefreshed != null) {
-        tokenManager.onTokenRefresh =
-            (oldToken, newToken) => onTokenRefreshed(newToken);
-      }
+    final client = httpClient ?? http.Client();
+    final oauthClient =
+        oauthConfig == null
+            ? null
+            : HttpOAuthClient(config: oauthConfig, httpClient: client);
+    final tokenManager =
+        oauthClient == null ? null : OAuthTokenManager(oauthClient);
+    if (oauthToken != null) {
+      tokenManager?.setToken(oauthToken);
     }
-
+    if (onTokenRefreshed != null) {
+      tokenManager?.onTokenRefresh =
+          (oldToken, newToken) => onTokenRefreshed(newToken);
+    }
     return StreamableHttpClientTransport._(
       config: config,
       httpClient: client,
@@ -166,423 +150,522 @@ class StreamableHttpClientTransport implements ClientTransport {
   @override
   Future<void> get onClose => _closeCompleter.future;
 
-  /// Emit a message to [onMessage], dropping events that race with [close].
-  ///
-  /// Requests can still be in flight when [close] closes the stream
-  /// controller; a late response or error must not throw
-  /// "Cannot add new events after calling close".
-  void _emit(dynamic message) {
-    if (_isClosed || _messageController.isClosed) return;
-    _messageController.add(message);
-  }
-
-  /// Emit an error to [onMessage], dropping errors that race with [close].
-  void _emitError(dynamic error) {
-    if (_isClosed || _messageController.isClosed) return;
-    _messageController.addError(error);
-  }
-
-  /// Get the base URL
   String get baseUrl => _baseUrl;
-
-  /// Get the maximum concurrent requests
   int get maxConcurrentRequests => config.maxConcurrentRequests;
-
-  /// Check if HTTP/2 is enabled
   bool get useHttp2 => config.useHttp2;
-
-  /// Get the OAuth configuration
   OAuthConfig? get oauthConfig => config.oauthConfig;
-
-  /// Get the current session ID
   String? get sessionId => _sessionId;
 
-  /// Send a JSON-RPC message
-  @override
-  void send(dynamic message) {
-    if (_isClosed) return;
+  void setRequestTimeout(Duration timeout) {
+    if (timeout > Duration.zero) _requestTimeout = timeout;
+  }
 
-    // Check if this is the initialized notification
-    if (message is Map &&
-        message['method'] == 'notifications/initialized' &&
-        !_getStreamActive) {
+  void setProtocolVersion(String version) {
+    _protocolVersion = version;
+  }
+
+  @override
+  TransportSendOperation send(dynamic message) {
+    if (_isClosed) {
+      return TransportSendOperation(
+        Future<void>.error(McpError('Transport is closed')),
+      );
+    }
+
+    if (message is Map && message['method'] == 'notifications/initialized') {
       _startGetStream();
     }
 
-    _sendRequest(message).catchError((error) {
-      _emitError(error);
+    final requestId =
+        message is Map && message['method'] != null && message['id'] is int
+            ? message['id'] as int
+            : null;
+    final task = _PostRequestTask(requestId);
+    _postTasks.add(task);
+    final done = _sendRequest(message, task).whenComplete(() {
+      _postTasks.remove(task);
     });
+    return TransportSendOperation(done, cancel: task.cancel);
   }
 
-  /// Send HTTP request with proper authentication
-  Future<void> _sendRequest(dynamic message) async {
-    // Check if transport is closed before sending
-    if (_isClosed) {
-      _logger.debug('Transport closed, ignoring request');
-      return;
-    }
-
+  Future<void> _sendRequest(dynamic message, _PostRequestTask task) async {
     await _requestSemaphore.acquire();
-
     try {
-      final headers = <String, String>{
-        'Content-Type': 'application/json',
-        // StreamableHTTP standard requires accepting both content types
-        'Accept': 'application/json, text/event-stream',
-        ...config.headers,
-      };
+      if (_isClosed || task.cancelled) return;
+      final sessionIdPresent = _sessionId?.isNotEmpty == true;
+      final request = http.AbortableRequest(
+        'POST',
+        Uri.parse(_baseUrl),
+        abortTrigger: task.cancelledFuture,
+      )..body = jsonEncode(message);
+      request.headers.addAll(
+        await _requestHeaders(
+          accept: 'application/json, text/event-stream',
+          contentType: 'application/json',
+          includeSession: true,
+        ),
+      );
 
-      // Add session ID if available
-      if (_sessionId != null) {
-        headers['MCP-Session-Id'] = _sessionId!;
+      final response = await _sendWithRedirects(request);
+      _captureSessionId(response.headers['mcp-session-id']);
+
+      if (response.statusCode == 202) {
+        await _drainResponse(response);
+        return;
+      }
+      if (response.statusCode >= 400) {
+        throw await _httpError(
+          response,
+          sessionIdPresent: sessionIdPresent,
+          canRetryRequest: response.statusCode == 404 && sessionIdPresent,
+        );
       }
 
-      // Spec 2025-06-18+: every post-handshake HTTP request MUST carry
-      // the negotiated protocol version. Older revisions ignore this
-      // header. Set via [setProtocolVersion] after initialize.
-      if (_protocolVersion != null &&
-          McpProtocol.requiresProtocolHeader(_protocolVersion!)) {
-        headers['MCP-Protocol-Version'] = _protocolVersion!;
+      final contentType = response.headers['content-type']?.toLowerCase() ?? '';
+      if (contentType.startsWith('application/json')) {
+        final body = await response.stream.bytesToString();
+        if (body.isNotEmpty) _dispatchJson(body, task);
+        return;
       }
-
-      // Add OAuth token if available
-      if (_tokenManager != null) {
+      if (contentType.startsWith('text/event-stream')) {
+        bool received;
         try {
-          final token = await _tokenManager.getAccessToken();
-          headers['Authorization'] = 'Bearer $token';
-        } on OAuthError catch (e) {
-          if (e.error == 'no_valid_token') {
-            // Send 401 to trigger OAuth flow
-            _emit({
-              'jsonrpc': '2.0',
-              'error': {
-                'code': -32001,
-                'message': 'Authentication required',
-                'data': {'oauth_error': e.toJson()},
-              },
-              if (message is Map && message['id'] != null) 'id': message['id'],
-            });
+          received = await _consumeSse(response.stream, task);
+        } catch (_) {
+          if (_canResumePost(task)) {
+            await _resumePost(task);
             return;
           }
           rethrow;
         }
-      }
-
-      final body = jsonEncode(message);
-      final uri = Uri.parse(_baseUrl);
-
-      // Store request ID if this is a request
-      int? requestId;
-      if (message is Map && message['id'] != null) {
-        requestId = message['id'] as int;
-        _pendingRequests[requestId] = Completer<dynamic>();
-      }
-
-      // Build a streamed request so SSE responses can be read live.
-      //
-      // FastMCP routes server-initiated requests
-      // (`sampling/createMessage`, `elicitation/create`) on the in-flight
-      // POST's SSE response stream — not the standalone GET stream — and
-      // those requests fire mid-tool-call. Buffering the body via
-      // `httpClient.post(...).bodyBytes` deadlocks: the server holds the
-      // SSE response open waiting for our reply to a server-initiated
-      // request, but we can't see the request until the stream closes.
-      // Streaming the response while it's open lets us dispatch each SSE
-      // event the moment it arrives.
-      final request = http.Request('POST', uri)..body = body;
-      headers.forEach((k, v) => request.headers[k] = v);
-
-      final response = await _sendWithRedirects(request);
-
-      // Extract session ID from response headers
-      final newSessionId = response.headers['mcp-session-id'];
-      if (newSessionId != null && newSessionId != _sessionId) {
-        _sessionId = newSessionId;
-        _logger.debug('Received session ID: $_sessionId');
-      }
-
-      if (response.statusCode == 202) {
-        // 202 Accepted - no immediate response expected
-        _logger.debug('Received 202 Accepted');
-        // Drain any stray bytes so the connection can be released.
-        await response.stream.drain<void>();
-        return;
-      }
-
-      if (response.statusCode == 404) {
-        // Session terminated
-        if (requestId != null) {
-          _emit({
-            'jsonrpc': '2.0',
-            'id': requestId,
-            'error': {'code': 32600, 'message': 'Session terminated'},
-          });
-        }
-        await response.stream.drain<void>();
-        return;
-      }
-
-      if (response.statusCode == 401) {
-        // Authentication required - trigger OAuth flow
-        _emit({
-          'jsonrpc': '2.0',
-          'error': {
-            'code': -32001,
-            'message': 'Authentication required',
-            'data': {
-              'www_authenticate': response.headers['www-authenticate'],
-              'oauth_config_hint': config.oauthConfig?.toJson(),
-            },
-          },
-          if (requestId != null) 'id': requestId,
-        });
-        await response.stream.drain<void>();
-        return;
-      }
-
-      if (response.statusCode >= 400) {
-        // Buffer the error body for the exception message.
-        final errorBody = await response.stream.bytesToString();
-        throw McpError(
-          'HTTP ${response.statusCode}: ${response.reasonPhrase}'
-          '${errorBody.isEmpty ? '' : ' — $errorBody'}',
-        );
-      }
-
-      // Check content type
-      final contentType = response.headers['content-type']?.toLowerCase() ?? '';
-
-      if (contentType.startsWith('application/json')) {
-        // Direct JSON response - read the entire body, decode as UTF-8.
-        final responseBody = await response.stream.bytesToString();
-        if (responseBody.isNotEmpty) {
-          final responseMessage = jsonDecode(responseBody);
-          _emit(responseMessage);
-        }
-      } else if (contentType.startsWith('text/event-stream')) {
-        // SSE response — process each event as it arrives so
-        // server-initiated requests embedded in this stream don't have
-        // to wait for the whole tool call to finish.
-        await _handleStreamedSseResponse(response, requestId);
-      } else {
-        _logger.warning('Unexpected content type: $contentType');
-        // Try to parse as JSON anyway - read full body
-        final responseBody = await response.stream.bytesToString();
-        if (responseBody.isNotEmpty) {
-          try {
-            final responseMessage = jsonDecode(responseBody);
-            _emit(responseMessage);
-          } catch (e) {
-            _logger.error('Failed to parse response: $e');
+        if (task.requestId != null && !received && !task.cancelled) {
+          if (task.lastEventId == null) {
+            throw McpError(
+              'POST SSE ended before the final response; result is unknown',
+            );
           }
+          await _resumePost(task);
+        }
+        return;
+      }
+
+      final body = await response.stream.bytesToString();
+      if (body.isNotEmpty) {
+        try {
+          _dispatchJson(body, task);
+        } catch (_) {
+          throw McpError('Unexpected HTTP response content type: $contentType');
         }
       }
+    } on http.RequestAbortedException {
+      if (!task.cancelled) rethrow;
     } finally {
       _requestSemaphore.release();
     }
+  }
+
+  bool _canResumePost(_PostRequestTask task) =>
+      !_isClosed &&
+      !task.cancelled &&
+      !task.responseReceived &&
+      task.requestId != null &&
+      task.lastEventId != null;
+
+  Future<void> _resumePost(_PostRequestTask task) async {
+    while (!_isClosed && !task.cancelled && !task.responseReceived) {
+      await _waitForRetry(_boundedRetry(task.sseRetry), task.cancelledFuture);
+      if (_isClosed || task.cancelled) return;
+
+      final request = http.AbortableRequest(
+        'GET',
+        Uri.parse(_baseUrl),
+        abortTrigger: task.cancelledFuture,
+      );
+      request.headers.addAll(
+        await _requestHeaders(
+          accept: 'text/event-stream',
+          includeSession: true,
+          lastEventId: task.lastEventId,
+        ),
+      );
+
+      try {
+        final response = await _sendWithRedirects(request);
+        if (response.statusCode == 200) {
+          final received = await _consumeSse(response.stream, task);
+          if (received) return;
+          continue;
+        }
+
+        final error = await _httpError(
+          response,
+          sessionIdPresent: _sessionId?.isNotEmpty == true,
+          canRetryRequest: false,
+        );
+        if (_isRetryableStatus(error.statusCode)) {
+          await _waitForRetry(_httpRetryDelay(error), task.cancelledFuture);
+          continue;
+        }
+        throw error;
+      } on http.RequestAbortedException {
+        if (!task.cancelled) rethrow;
+      } on McpHttpError {
+        rethrow;
+      } catch (_) {
+        await _waitForRetry(_boundedRetry(task.sseRetry), task.cancelledFuture);
+      }
+    }
+  }
+
+  Future<bool> _consumeSse(
+    Stream<List<int>> byteStream,
+    _PostRequestTask task,
+  ) async {
+    final parser = SseParser();
+    await for (final chunk in byteStream.transform(utf8.decoder)) {
+      for (final event in parser.add(chunk)) {
+        if (_applyPostEvent(event, task)) return true;
+      }
+    }
+    for (final event in parser.close()) {
+      if (_applyPostEvent(event, task)) return true;
+    }
+    return task.responseReceived;
+  }
+
+  bool _applyPostEvent(SseEvent event, _PostRequestTask task) {
+    if (event.hasId) {
+      task.lastEventId =
+          event.id == null || event.id!.isEmpty ? null : event.id;
+    }
+    if (event.retry != null) task.sseRetry = event.retry!;
+    final data = event.data;
+    if (data == null || data == '[DONE]') return false;
+    try {
+      final decoded = jsonDecode(data);
+      _messageController.add(decoded);
+      if (_isResponseFor(decoded, task.requestId)) {
+        task.responseReceived = true;
+        return true;
+      }
+    } catch (_) {
+      _logger.debug('Failed to parse SSE data: $data');
+    }
+    return false;
+  }
+
+  void _dispatchJson(String body, _PostRequestTask task) {
+    final decoded = jsonDecode(body);
+    _messageController.add(decoded);
+    if (_isResponseFor(decoded, task.requestId)) {
+      task.responseReceived = true;
+    }
+  }
+
+  bool _isResponseFor(dynamic message, int? requestId) {
+    return requestId != null &&
+        message is Map &&
+        message['id'] == requestId &&
+        message['method'] == null &&
+        (message.containsKey('result') || message.containsKey('error'));
+  }
+
+  void _startGetStream() {
+    if (_isClosed || _sessionId == null || _getTask != null) return;
+    final task = _runGetStream();
+    _getTask = task;
+    unawaited(
+      task.whenComplete(() {
+        if (identical(_getTask, task)) _getTask = null;
+      }),
+    );
+  }
+
+  Future<void> _runGetStream() async {
+    while (!_isClosed && _sessionId != null) {
+      final done = Completer<void>();
+      final eventSource = EventSource();
+      _getEventSource = eventSource;
+      Object? streamError;
+      try {
+        await eventSource.connect(
+          _baseUrl,
+          headers: await _requestHeaders(
+            accept: 'text/event-stream',
+            includeSession: true,
+            lastEventId: _getLastEventId,
+          ),
+          onMessage: (message) {
+            if (!_messageController.isClosed) {
+              _messageController.add(message);
+            }
+          },
+          onEvent: (event) {
+            // Any delivered event proves the server is alive again.
+            _getStreamFailures = 0;
+            if (event.hasId) {
+              _getLastEventId =
+                  event.id == null || event.id!.isEmpty ? null : event.id;
+            }
+            if (event.retry != null) _getSseRetry = event.retry!;
+          },
+          onError: (error) {
+            streamError = error;
+            if (!done.isCompleted) done.complete();
+          },
+          onDone: () {
+            if (!done.isCompleted) done.complete();
+          },
+        );
+        await Future.any<void>([done.future, _closedSignal.future]);
+      } catch (error) {
+        streamError = error;
+      } finally {
+        if (identical(_getEventSource, eventSource)) {
+          _getEventSource = null;
+        }
+        eventSource.close();
+      }
+      if (_isClosed) return;
+
+      _getStreamFailures++;
+      var delay = _boundedRetry(_getSseRetry);
+      final error = streamError;
+      if (error is McpHttpError) {
+        final backgroundError = McpHttpError(
+          statusCode: error.statusCode,
+          message: error.message,
+          retryAfter: error.retryAfter,
+          body: error.body,
+          wwwAuthenticate: error.wwwAuthenticate,
+          sessionIdPresent: _sessionId?.isNotEmpty == true,
+          isBackgroundRequest: true,
+        );
+        if (!_messageController.isClosed) {
+          _messageController.addError(backgroundError);
+        }
+        if (backgroundError.statusCode == 404 &&
+            backgroundError.sessionIdPresent) {
+          _failTransport(backgroundError);
+          return;
+        }
+        if (backgroundError.statusCode == 401 ||
+            backgroundError.statusCode == 403) {
+          // Credentials are burned: space retries 5 minutes apart is fine.
+          delay = _authenticationRetryDelay;
+          _getStreamFailures = 0;
+        } else if (_isRetryableStatus(backgroundError.statusCode)) {
+          delay = _httpRetryDelay(backgroundError);
+        } else {
+          return;
+        }
+      }
+
+      // Escalate flat / server-agnostic delays exponentially so a broken
+      // server cannot be hammered at a fixed 1s (Kelivo #937). Delays that
+      // already exceed the cap (e.g. the 5-minute auth wait, a server
+      // retry:) are left alone.
+      if (delay < _getStreamBackoffCap) {
+        final shift = (_getStreamFailures - 1).clamp(0, 5);
+        final escalation = Duration(seconds: 1 << shift);
+        if (escalation > delay) delay = escalation;
+        if (delay > _getStreamBackoffCap) delay = _getStreamBackoffCap;
+      }
+
+      if (_getStreamFailures > _maxGetStreamReconnects) {
+        _logger.debug(
+          'GET stream failed $_getStreamFailures times; giving up on it '
+          'until the next request rebuilds the session',
+        );
+        return;
+      }
+      await _waitForRetry(delay, _closedSignal.future);
+    }
+  }
+
+  Future<Map<String, String>> _requestHeaders({
+    required String accept,
+    String? contentType,
+    required bool includeSession,
+    String? lastEventId,
+  }) async {
+    final headers = <String, String>{};
+    for (final entry in config.headers.entries) {
+      if (!_reservedHeaders.contains(entry.key.toLowerCase())) {
+        headers[entry.key] = entry.value;
+      }
+    }
+    headers['Accept'] = accept;
+    if (contentType != null) headers['Content-Type'] = contentType;
+    if (includeSession && _sessionId?.isNotEmpty == true) {
+      headers['MCP-Session-Id'] = _sessionId!;
+    }
+    if (_protocolVersion != null &&
+        McpProtocol.requiresProtocolHeader(_protocolVersion!)) {
+      headers['MCP-Protocol-Version'] = _protocolVersion!;
+    }
+    if (lastEventId != null) headers['Last-Event-ID'] = lastEventId;
+    if (_tokenManager != null) {
+      headers['Authorization'] =
+          'Bearer ${await _tokenManager.getAccessToken()}';
+    }
+    return headers;
   }
 
   Future<http.StreamedResponse> _sendWithRedirects(
     http.Request request, {
     int redirectCount = 0,
   }) async {
-    final response = await _httpClient.send(request).timeout(config.timeout);
-    if (!_isPreserveMethodRedirect(response.statusCode)) {
+    final response = await _httpClient.send(request).timeout(_requestTimeout);
+    if (response.statusCode != 307 && response.statusCode != 308) {
       return response;
     }
-
     final location = response.headers['location'];
-    if (location == null || location.trim().isEmpty) {
-      return response;
-    }
+    if (location == null || location.trim().isEmpty) return response;
     if (redirectCount >= 5) {
-      await response.stream.drain<void>();
+      await _drainResponse(response);
       throw McpError('Too many HTTP redirects while connecting to MCP server');
     }
 
-    final currentUri = request.url;
-    final redirectedUri = currentUri.resolve(location);
-    await response.stream.drain<void>();
-
+    final redirectedUri = request.url.resolve(location);
+    if (!_isSameOrigin(request.url, redirectedUri)) {
+      await _drainResponse(response);
+      throw McpError(
+        'Refusing cross-origin or protocol-downgrade MCP redirect: '
+        '${request.url} -> $redirectedUri',
+      );
+    }
+    await _drainResponse(response);
     _baseUrl = redirectedUri.toString();
-    final redirectedRequest =
-        http.Request(request.method, redirectedUri)
-          ..bodyBytes = request.bodyBytes
-          ..followRedirects = request.followRedirects
-          ..maxRedirects = request.maxRedirects
-          ..persistentConnection = request.persistentConnection;
-    request.headers.forEach((key, value) {
-      redirectedRequest.headers[key] = value;
-    });
+    final redirected = http.AbortableRequest(
+      request.method,
+      redirectedUri,
+      abortTrigger:
+          request is http.AbortableRequest ? request.abortTrigger : null,
+    )..bodyBytes = request.bodyBytes;
+    redirected.headers.addAll(request.headers);
+    return _sendWithRedirects(redirected, redirectCount: redirectCount + 1);
+  }
 
-    return _sendWithRedirects(
-      redirectedRequest,
-      redirectCount: redirectCount + 1,
+  bool _isSameOrigin(Uri source, Uri target) =>
+      source.scheme.toLowerCase() == target.scheme.toLowerCase() &&
+      source.host.toLowerCase() == target.host.toLowerCase() &&
+      _effectivePort(source) == _effectivePort(target);
+
+  int _effectivePort(Uri uri) {
+    if (uri.hasPort) return uri.port;
+    return uri.scheme.toLowerCase() == 'https' ? 443 : 80;
+  }
+
+  Future<void> _drainResponse(http.StreamedResponse response) =>
+      response.stream.drain<void>().timeout(_requestTimeout);
+
+  Future<McpHttpError> _httpError(
+    http.StreamedResponse response, {
+    required bool sessionIdPresent,
+    required bool canRetryRequest,
+  }) async {
+    final body = await response.stream.bytesToString();
+    return McpHttpError(
+      statusCode: response.statusCode,
+      message:
+          'HTTP ${response.statusCode}: ${response.reasonPhrase}'
+          '${body.isEmpty ? '' : ' — $body'}',
+      retryAfter: McpHttpError.parseRetryAfter(response.headers['retry-after']),
+      body: body,
+      wwwAuthenticate:
+          response.headers['www-authenticate'] == null
+              ? const []
+              : [response.headers['www-authenticate']!],
+      sessionIdPresent: sessionIdPresent,
+      canRetryRequest: canRetryRequest || response.statusCode == 401,
     );
   }
 
-  bool _isPreserveMethodRedirect(int statusCode) =>
-      statusCode == 307 || statusCode == 308;
+  bool _isRetryableStatus(int statusCode) =>
+      statusCode == 408 || statusCode == 429 || statusCode >= 500;
 
-  /// Handle a streamed SSE response from a POST request, dispatching
-  /// each event as it arrives. Required for cases where the server
-  /// embeds server-initiated requests (`sampling/createMessage`,
-  /// `elicitation/create`) in the response stream and waits for the
-  /// client's reply before producing the final tool result — buffering
-  /// the body would deadlock.
-  Future<void> _handleStreamedSseResponse(
-    http.StreamedResponse response,
-    int? requestId,
-  ) async {
-    _logger.debug('Handling streamed SSE response');
-    final lineStream = response.stream
-        .transform(utf8.decoder)
-        .transform(const LineSplitter());
+  Duration _httpRetryDelay(McpHttpError error) =>
+      _boundedRetry(error.retryAfter ?? _defaultReconnectDelay);
 
-    await for (final line in lineStream) {
-      if (!line.startsWith('data:')) continue;
-      final data = line.substring(5).trim();
-      if (data.isEmpty || data == '[DONE]') continue;
-      try {
-        final decoded = jsonDecode(data);
-        _emit(decoded);
-      } catch (e) {
-        _logger.debug('Failed to parse SSE data: $data');
-      }
+  Duration _boundedRetry(Duration delay) =>
+      delay < _minimumReconnectDelay ? _minimumReconnectDelay : delay;
+
+  Future<void> _waitForRetry(Duration delay, Future<void> cancellation) async {
+    await Future.any<void>([Future<void>.delayed(delay), cancellation]);
+  }
+
+  void _captureSessionId(String? value) {
+    if (value != null && value.trim().isNotEmpty) {
+      _sessionId = value;
     }
   }
 
-  /// Start GET stream for server-initiated messages
-  void _startGetStream() {
-    if (_getStreamActive || _sessionId == null) return;
-
-    _getStreamActive = true;
-    _logger.debug('Starting GET stream for session: $_sessionId');
-
-    _establishGetStream().catchError((error) {
-      _logger.error('GET stream error: $error');
-      _getStreamActive = false;
-    });
+  void _failTransport(Object error) {
+    if (_isClosed) return;
+    _isClosed = true;
+    if (!_closedSignal.isCompleted) _closedSignal.complete();
+    for (final task in _postTasks.toList()) {
+      task.cancel();
+    }
+    _getEventSource?.close();
+    _httpClient.close();
+    _oauthClient?.close();
+    _tokenManager?.dispose();
+    if (!_messageController.isClosed) _messageController.close();
+    if (!_closeCompleter.isCompleted) _closeCompleter.completeError(error);
   }
 
-  /// Establish SSE GET stream
-  Future<void> _establishGetStream() async {
+  Future<void> terminateSession() async {
+    if (_sessionId?.isNotEmpty != true || _isClosed) return;
+    final request = http.Request('DELETE', Uri.parse(_baseUrl));
+    request.headers.addAll(
+      await _requestHeaders(
+        accept: 'application/json, text/event-stream',
+        includeSession: true,
+      ),
+    );
     try {
-      final uri = Uri.parse(_baseUrl);
-
-      // Set up headers
-      final headers = <String, String>{
-        'Accept': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        ...config.headers,
-      };
-
-      if (_sessionId != null) {
-        headers['MCP-Session-Id'] = _sessionId!;
+      final response = await _sendWithRedirects(request);
+      await _drainResponse(response);
+      if (response.statusCode != 200 &&
+          response.statusCode != 204 &&
+          response.statusCode != 405) {
+        _logger.warning('Session termination failed: ${response.statusCode}');
       }
-
-      // Add OAuth token if available
-      if (_tokenManager != null) {
-        try {
-          final token = await _tokenManager.getAccessToken();
-          headers['Authorization'] = 'Bearer $token';
-        } catch (e) {
-          _logger.debug('Failed to add OAuth token to GET stream: $e');
-        }
-      }
-
-      // Create EventSource instance
-      _eventSource = EventSource();
-
-      // Connect to SSE endpoint
-      await _eventSource!.connect(
-        uri.toString(),
-        headers: headers,
-        onOpen: (_) {
-          _logger.debug('GET SSE connection established');
-        },
-        onMessage: (data) {
-          if (data is Map) {
-            _logger.debug('Received SSE message: $data');
-            _emit(data);
-          } else if (data is String) {
-            try {
-              final message = jsonDecode(data);
-              _logger.debug('Received SSE message: $message');
-              _emit(message);
-            } catch (e) {
-              _logger.debug('Failed to parse SSE message: $data');
-            }
-          }
-        },
-        onError: (error) {
-          _logger.error('GET stream error: $error');
-          _getStreamActive = false;
-        },
-      );
-    } catch (e) {
-      _logger.error('Failed to establish GET stream: $e');
-      _getStreamActive = false;
-      rethrow;
+    } catch (error) {
+      _logger.warning('Session termination failed: $error');
     }
   }
 
   @override
   void close() {
     if (_isClosed) return;
+    final termination =
+        config.terminateOnClose && _sessionId != null
+            ? terminateSession()
+            : null;
     _isClosed = true;
-
-    // Terminate session if configured
-    if (config.terminateOnClose && _sessionId != null) {
-      _terminateSession().catchError((error) {
-        _logger.debug('Failed to terminate session: $error');
-      });
+    if (!_closedSignal.isCompleted) _closedSignal.complete();
+    for (final task in _postTasks.toList()) {
+      task.cancel();
     }
+    _getEventSource?.close();
+    if (termination == null) {
+      _closeHttpResources();
+    } else {
+      unawaited(termination.whenComplete(_closeHttpResources));
+    }
+    if (!_messageController.isClosed) _messageController.close();
+    if (!_closeCompleter.isCompleted) _closeCompleter.complete();
+  }
 
-    // Close GET stream
-    _sseSubscription?.cancel();
-    _eventSource?.close();
-
-    // Clear pending requests without completing them with error
-    // to avoid unhandled exceptions during shutdown
-    _pendingRequests.clear();
-
-    _messageController.close();
+  void _closeHttpResources() {
     _httpClient.close();
     _oauthClient?.close();
     _tokenManager?.dispose();
-
-    if (!_closeCompleter.isCompleted) {
-      _closeCompleter.complete();
-    }
   }
 
-  /// Terminate the session
-  Future<void> _terminateSession() async {
-    if (_sessionId == null) return;
-
-    try {
-      final headers = <String, String>{
-        'MCP-Session-Id': _sessionId!,
-        ...config.headers,
-      };
-
-      final uri = Uri.parse(_baseUrl);
-      final response = await _httpClient
-          .delete(uri, headers: headers)
-          .timeout(Duration(seconds: 5));
-
-      if (response.statusCode == 405) {
-        _logger.debug('Server does not allow session termination');
-      } else if (response.statusCode != 200 && response.statusCode != 204) {
-        _logger.warning('Session termination failed: ${response.statusCode}');
-      }
-    } catch (e) {
-      _logger.warning('Session termination failed: $e');
-    }
-  }
-
-  /// Initiate OAuth authentication flow
   Future<OAuthToken> authenticateWithOAuth({
     required List<String> scopes,
     String? state,
@@ -590,31 +673,40 @@ class StreamableHttpClientTransport implements ClientTransport {
     if (_oauthClient == null) {
       throw StateError('OAuth not configured for this transport');
     }
-
     final authUrl = await _oauthClient.getAuthorizationUrl(
       scopes: scopes,
       state: state,
     );
-
-    // In a real implementation, you would:
-    // 1. Open the auth URL in a browser
-    // 2. Handle the redirect
-    // 3. Extract the authorization code
-    // 4. Exchange it for a token
-
     throw UnimplementedError(
       'OAuth flow requires platform-specific implementation. '
       'Authorization URL: $authUrl',
     );
   }
 
-  /// Set OAuth token manually
   void setOAuthToken(OAuthToken token) {
     _tokenManager?.setToken(token);
   }
 }
 
-/// Semaphore for controlling concurrent requests
+final class _PostRequestTask {
+  final int? requestId;
+  final Completer<void> _cancelled = Completer<void>();
+  bool cancelled = false;
+  bool responseReceived = false;
+  String? lastEventId;
+  Duration sseRetry = const Duration(seconds: 1);
+
+  _PostRequestTask(this.requestId);
+
+  Future<void> get cancelledFuture => _cancelled.future;
+
+  void cancel() {
+    if (cancelled) return;
+    cancelled = true;
+    if (!_cancelled.isCompleted) _cancelled.complete();
+  }
+}
+
 class Semaphore {
   final int maxCount;
   int _currentCount;
@@ -627,7 +719,6 @@ class Semaphore {
       _currentCount--;
       return;
     }
-
     final completer = Completer<void>();
     _waitQueue.add(completer);
     return completer.future;
@@ -635,8 +726,7 @@ class Semaphore {
 
   void release() {
     if (_waitQueue.isNotEmpty) {
-      final completer = _waitQueue.removeFirst();
-      completer.complete();
+      _waitQueue.removeFirst().complete();
     } else {
       _currentCount++;
     }

--- a/dependencies/mcp_client/lib/src/transport/transport.dart
+++ b/dependencies/mcp_client/lib/src/transport/transport.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:io' show Process, HttpClient;
+import 'dart:io' show Process, HttpClient, HttpClientRequest;
 
 import '../../logger.dart';
 import '../models/models.dart';
@@ -9,6 +9,22 @@ import 'event_source.dart';
 import 'stdio_launch.dart';
 
 final Logger _logger = Logger('mcp_client.transport');
+
+/// One transport send, with failure and cancellation scoped to that send.
+final class TransportSendOperation {
+  final Future<void> done;
+  final void Function() _cancel;
+
+  TransportSendOperation(this.done, {void Function()? cancel})
+    : _cancel = cancel ?? _noop;
+
+  factory TransportSendOperation.completed() =>
+      TransportSendOperation(Future<void>.value());
+
+  void cancel() => _cancel();
+
+  static void _noop() {}
+}
 
 /// Abstract base class for client transport implementations
 abstract class ClientTransport {
@@ -19,7 +35,7 @@ abstract class ClientTransport {
   Future<void> get onClose;
 
   /// Send a message through the transport
-  void send(dynamic message);
+  TransportSendOperation send(dynamic message);
 
   /// Close the transport
   void close();
@@ -174,7 +190,7 @@ class StdioClientTransport implements ClientTransport {
 
   // Add message to queue and process it
   @override
-  void send(dynamic message) {
+  TransportSendOperation send(dynamic message) {
     try {
       final jsonMessage = jsonEncode(message);
       _logger.debug('Queueing message: $jsonMessage');
@@ -184,6 +200,7 @@ class StdioClientTransport implements ClientTransport {
 
       // Start processing queue if not already doing so
       _processMessageQueue();
+      return TransportSendOperation.completed();
     } catch (e) {
       _logger.debug('Error encoding message: $e');
       _logger.debug('Original message: $message');
@@ -241,6 +258,7 @@ class SseClientTransport implements ClientTransport {
   final _messageController = StreamController<dynamic>.broadcast();
   final _closeCompleter = Completer<void>();
   final EventSource _eventSource = EventSource();
+  final HttpClient _httpClient = HttpClient();
   String? _messageEndpoint;
   StreamSubscription? _subscription;
   bool _isClosed = false;
@@ -253,9 +271,24 @@ class SseClientTransport implements ClientTransport {
     required String serverUrl,
     Map<String, String>? headers,
   }) async {
+    final safeHeaders =
+        headers == null
+            ? null
+            : Map<String, String>.fromEntries(
+              headers.entries.where(
+                (entry) =>
+                    !const {
+                      'accept',
+                      'content-type',
+                      'last-event-id',
+                      'mcp-protocol-version',
+                      'mcp-session-id',
+                    }.contains(entry.key.toLowerCase()),
+              ),
+            );
     final transport = SseClientTransport._internal(
       serverUrl: serverUrl,
-      headers: headers,
+      headers: safeHeaders,
     );
 
     try {
@@ -273,7 +306,7 @@ class SseClientTransport implements ClientTransport {
 
       await transport._eventSource.connect(
         sseUrlWithSession,
-        headers: headers,
+        headers: safeHeaders,
         onMessage: (data) {
           // This is crucial - forward messages to the controller
           if (data is Map &&
@@ -298,6 +331,9 @@ class SseClientTransport implements ClientTransport {
           if (!endpointCompleter.isCompleted && endpoint != null) {
             endpointCompleter.complete(endpoint);
           }
+        },
+        onDone: () {
+          transport._handleClosure();
         },
       );
 
@@ -355,8 +391,27 @@ class SseClientTransport implements ClientTransport {
   }
 
   void _handleError(dynamic error) {
+    _closeResources();
     if (!_closeCompleter.isCompleted) {
       _closeCompleter.completeError(error);
+    }
+  }
+
+  void _handleClosure() {
+    _closeResources();
+    if (!_closeCompleter.isCompleted) {
+      _closeCompleter.complete();
+    }
+  }
+
+  void _closeResources() {
+    if (_isClosed) return;
+    _isClosed = true;
+    _subscription?.cancel();
+    _eventSource.close();
+    _httpClient.close(force: true);
+    if (!_messageController.isClosed) {
+      _messageController.close();
     }
   }
 
@@ -368,36 +423,49 @@ class SseClientTransport implements ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) async {
+  TransportSendOperation send(dynamic message) {
     if (_isClosed) {
-      _logger.debug('Attempted to send on closed transport');
-      return;
-    }
-
-    if (_messageEndpoint == null) {
-      throw McpError(
-        'Cannot send message: SSE connection not fully established',
+      return TransportSendOperation(
+        Future<void>.error(McpError('Transport is closed')),
       );
     }
 
-    try {
+    if (_messageEndpoint == null) {
+      return TransportSendOperation(
+        Future<void>.error(
+          McpError('Cannot send message: SSE connection not fully established'),
+        ),
+      );
+    }
+
+    HttpClientRequest? activeRequest;
+    var cancelled = false;
+    final done = Future<void>.sync(() async {
       final jsonMessage = jsonEncode(message);
       _logger.debug('Sending message: $jsonMessage');
 
       final url = Uri.parse(_messageEndpoint!);
-      final client = HttpClient();
-      final request = await client.postUrl(url);
+      final request = await _httpClient.postUrl(url);
+      activeRequest = request;
+      if (cancelled) {
+        request.abort();
+        return;
+      }
 
-      // Set headers
+      // Keep Content-Type charset-free for legacy SSE endpoints. Encode the
+      // body as UTF-8 bytes so non-Latin-1 tool arguments are not rejected by
+      // dart:io's default ISO-8859-1 write() encoding.
+      final bytes = utf8.encode(jsonMessage);
       request.headers.set('Content-Type', 'application/json');
       if (headers != null) {
         headers!.forEach((name, value) {
-          request.headers.add(name, value);
+          if (name.toLowerCase() != 'mcp-session-id') {
+            request.headers.set(name, value);
+          }
         });
       }
-
-      // Send the request
-      request.write(jsonMessage);
+      request.contentLength = bytes.length;
+      request.add(bytes);
       final response = await request.close();
 
       // Check for successful delivery (200 OK or 202 Accepted)
@@ -407,72 +475,53 @@ class SseClientTransport implements ClientTransport {
           'Message delivery confirmation (${response.statusCode}): $responseBody',
         );
         // Don't forward this to message controller, actual response comes via SSE
-      } else if (response.statusCode == 404) {
-        // 404 means the server no longer knows this session. Mirror the
-        // StreamableHttpClientTransport behavior: surface it as a JSON-RPC
-        // "Session terminated" error on the message stream instead of
-        // throwing, so fire-and-forget notifications don't end up as
-        // unhandled exceptions. Requests are failed by the client through
-        // the error response's `id`.
-        final responseBody = await response.transform(utf8.decoder).join();
-        _logger.debug('Session terminated (404): $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {'code': 32600, 'message': 'Session terminated'},
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
       } else {
-        // Any non-200/202 response is routed back as a JSON-RPC error
-        // message instead of throwing: `send` is declared `void async`, so a
-        // thrown error would escape as an unhandled exception (the client
-        // cannot await or catch it). Requests are failed by the client
-        // through the error response's `id`; notifications without an `id`
-        // are dropped after a debug log.
         final responseBody = await response.transform(utf8.decoder).join();
         _logger.debug('Error response: $responseBody');
-        if (!_messageController.isClosed) {
-          _messageController.add({
-            'jsonrpc': '2.0',
-            'error': {
-              'code': -32603,
-              'message': 'Error sending message: ${response.statusCode}',
-            },
-            if (message is Map && message['id'] != null) 'id': message['id'],
-          });
-        }
+        final sessionIdPresent = _endpointHasSessionId(url);
+        throw McpHttpError(
+          statusCode: response.statusCode,
+          message: 'HTTP ${response.statusCode}: $responseBody',
+          retryAfter: McpHttpError.parseRetryAfter(
+            response.headers.value('Retry-After'),
+          ),
+          body: responseBody,
+          wwwAuthenticate: response.headers['WWW-Authenticate'] ?? const [],
+          sessionIdPresent: sessionIdPresent,
+          canRetryRequest:
+              (response.statusCode == 404 && sessionIdPresent) ||
+              response.statusCode == 401,
+        );
       }
 
-      // Close the HTTP client
-      client.close();
       _logger.debug('Message sent successfully');
-    } catch (e) {
-      // Same rationale as the non-200/202 branch above: this `void async`
-      // method must never throw, or the error escapes as an unhandled
-      // exception (e.g. a connection dropped mid-response).
-      _logger.debug('Error sending message: $e');
-      if (!_messageController.isClosed) {
-        _messageController.add({
-          'jsonrpc': '2.0',
-          'error': {'code': -32603, 'message': 'Error sending message: $e'},
-          if (message is Map && message['id'] != null) 'id': message['id'],
-        });
+    });
+    return TransportSendOperation(
+      done,
+      cancel: () {
+        cancelled = true;
+        activeRequest?.abort();
+      },
+    );
+  }
+
+  bool _endpointHasSessionId(Uri endpoint) {
+    for (final entry in endpoint.queryParameters.entries) {
+      final key = entry.key.toLowerCase().replaceAll('-', '_');
+      if ((key == 'session_id' ||
+              key == 'sessionid' ||
+              key == 'mcp_session_id') &&
+          entry.value.trim().isNotEmpty) {
+        return true;
       }
     }
+    return false;
   }
 
   @override
   void close() {
-    if (_isClosed) return;
-    _isClosed = true;
-
     _logger.debug('Closing SseClientTransport');
-    _subscription?.cancel();
-    _eventSource.close();
-    if (!_messageController.isClosed) {
-      _messageController.close();
-    }
+    _closeResources();
     if (!_closeCompleter.isCompleted) {
       _closeCompleter.complete();
     }

--- a/dependencies/mcp_client/test/mcp_client_test.dart
+++ b/dependencies/mcp_client/test/mcp_client_test.dart
@@ -707,27 +707,5 @@ void main() {
       expect(disconnectEvents.length, equals(1));
       expect(disconnectEvents[0], equals(DisconnectReason.clientDisconnected));
     });
-
-    test('errors on the message stream are handled, not unhandled', () async {
-      mockTransport.queueResponse({
-        'jsonrpc': McpProtocol.jsonRpcVersion,
-        'id': 1,
-        'result': {
-          'protocolVersion': McpProtocol.v2025_03_26,
-          'serverInfo': {'name': 'Mock Server', 'version': '1.0.0'},
-          'capabilities': {},
-        },
-      });
-
-      await client.connect(mockTransport);
-
-      // Transports push errors onto the message stream (e.g. OAuth auth
-      // failures). Without an onError handler on the client's subscription
-      // these become unhandled zone exceptions, failing this test.
-      mockTransport.sendMockError(McpError('auth failure'));
-      mockTransport.sendMockError(StateError('boom'));
-
-      await Future<void>.delayed(const Duration(milliseconds: 10));
-    });
   });
 }

--- a/dependencies/mcp_client/test/mock_transport.dart
+++ b/dependencies/mcp_client/test/mock_transport.dart
@@ -35,15 +35,6 @@ class MockTransport implements ClientTransport {
     }
   }
 
-  /// Push an error onto the message stream, as transports do for
-  /// authentication failures. The client must handle it (no unhandled
-  /// zone exception).
-  void sendMockError(Object error) {
-    if (!_closed) {
-      _messageController.addError(error);
-    }
-  }
-
   @override
   Stream<dynamic> get onMessage => _messageController.stream;
 
@@ -51,7 +42,7 @@ class MockTransport implements ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) {
+  TransportSendOperation send(dynamic message) {
     if (_closed) {
       throw McpError('Transport is closed');
     }
@@ -78,6 +69,7 @@ class MockTransport implements ClientTransport {
         }
       }
     }
+    return TransportSendOperation.completed();
   }
 
   /// Schedule a response to be sent asynchronously

--- a/dependencies/mcp_client/test/sse_transport_io_test.dart
+++ b/dependencies/mcp_client/test/sse_transport_io_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:mcp_client/mcp_client.dart';
@@ -10,6 +11,29 @@ import 'package:test/test.dart';
 
 void main() {
   group('Native SSE transport', () {
+    test('shared parser preserves opaque IDs and rejects malformed retry', () {
+      final parser = SseParser();
+      final events = <SseEvent>[
+        ...parser.add(
+          'id:  opaque\t \r'
+          'retry:  0 \r'
+          'data: {}\r\r',
+        ),
+        ...parser.close(),
+      ];
+
+      expect(events, hasLength(1));
+      expect(events.single.id, ' opaque\t ');
+      expect(events.single.retry, isNull);
+
+      final invalidId = SseParser();
+      final nulEvents = <SseEvent>[
+        ...invalidId.add('id: bad\u0000id\rdata: {}\r\r'),
+        ...invalidId.close(),
+      ];
+      expect(nulEvents.single.hasId, isFalse);
+    });
+
     test(
       'keeps an event intact when its fields arrive in separate chunks',
       () async {
@@ -67,21 +91,30 @@ void main() {
 
       server.listen((request) async {
         if (request.method == 'GET') {
+          // bufferOutput=false: dart:io buffers HttpResponse writes until the
+          // response closes; SSE needs each flush to reach the socket
+          // immediately.
+          request.response.bufferOutput = false;
           request.response.headers.contentType = ContentType(
             'text',
             'event-stream',
           );
-          request.response.write(
-            'event: endpoint\n'
-            'data: /messages/?session_id=server-session\n\n',
+          request.response.add(
+            utf8.encode(
+              'event: endpoint\n'
+              'data: /messages/?session_id=server-session\n\n',
+            ),
           );
-          await request.response.close();
+          await request.response.flush();
+          // Keep the event stream open until teardown — closing it ends
+          // the session by design (legacy SSE session = open GET).
           return;
         }
 
         receivedContentType.complete(
           request.headers.value(HttpHeaders.contentTypeHeader),
         );
+        await request.drain<void>();
         request.response.statusCode = HttpStatus.accepted;
         await request.response.close();
       });
@@ -89,131 +122,81 @@ void main() {
       transport = await SseClientTransport.create(
         serverUrl: 'http://${server.address.address}:${server.port}/sse',
       );
-      transport.send({'jsonrpc': '2.0', 'id': 1, 'method': 'initialize'});
+      final send = transport.send({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'initialize',
+      });
 
       expect(
-        await receivedContentType.future.timeout(const Duration(seconds: 5)),
+        await receivedContentType.future.timeout(const Duration(seconds: 1)),
         'application/json',
       );
+      await send.done;
     });
 
-    test(
-      '404 on message POST is surfaced as a session-terminated error',
-      () async {
-        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-        SseClientTransport? transport;
+    test('sends Unicode tool arguments as UTF-8 JSON', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final received =
+          Completer<({String? contentType, int? length, String body})>();
+      SseClientTransport? transport;
 
-        addTearDown(() async {
-          transport?.close();
-          await server.close(force: true);
-        });
+      addTearDown(() async {
+        transport?.close();
+        await server.close(force: true);
+      });
 
-        server.listen((request) async {
-          if (request.method == 'GET') {
-            request.response.headers.contentType = ContentType(
-              'text',
-              'event-stream',
-            );
-            request.response.write(
+      server.listen((request) async {
+        if (request.method == 'GET') {
+          // bufferOutput=false: dart:io buffers HttpResponse writes until the
+          // response closes; SSE needs each flush to reach the socket
+          // immediately.
+          request.response.bufferOutput = false;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          request.response.add(
+            utf8.encode(
               'event: endpoint\n'
-              'data: /messages?session_id=server-session\n\n',
-            );
-            await request.response.close();
-            return;
-          }
+              'data: /messages/?session_id=server-session\n\n',
+            ),
+          );
+          await request.response.flush();
+          // Hold the stream open until teardown (see fix above).
+          return;
+        }
 
-          await request.drain<void>();
-          request.response.statusCode = HttpStatus.notFound;
-          await request.response.close();
-        });
+        final body = await utf8.decoder.bind(request).join();
+        received.complete((
+          contentType: request.headers.value(HttpHeaders.contentTypeHeader),
+          length: request.headers.contentLength,
+          body: body,
+        ));
+        request.response.statusCode = HttpStatus.accepted;
+        await request.response.close();
+      });
 
-        transport = await SseClientTransport.create(
-          serverUrl: 'http://${server.address.address}:${server.port}/sse',
-        );
-
-        final received = <dynamic>[];
-        final receivedError = Completer<void>();
-        final subscription = transport.onMessage.listen((m) {
-          received.add(m);
-          if (m is Map &&
-              m['error'] is Map &&
-              (m['error'] as Map)['code'] == 32600 &&
-              (m['error'] as Map)['message'] == 'Session terminated' &&
-              m['id'] == 7 &&
-              !receivedError.isCompleted) {
-            receivedError.complete();
-          }
-        });
-        addTearDown(subscription.cancel);
-
-        // Must not throw: a dead session is a routine condition, not an
-        // unhandled exception.
-        transport.send({'jsonrpc': '2.0', 'id': 7, 'method': 'ping'});
-
-        await receivedError.future.timeout(const Duration(seconds: 5));
-        expect(received, isNotEmpty);
-      },
-    );
-
-    test(
-      'authenticated transport: 404 on message POST is surfaced as a session-terminated error',
-      () async {
-        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-        SseAuthClientTransport? transport;
-
-        addTearDown(() async {
-          transport?.close();
-          await server.close(force: true);
-        });
-
-        server.listen((request) async {
-          if (request.method == 'GET') {
-            request.response.headers.contentType = ContentType(
-              'text',
-              'event-stream',
-            );
-            request.response.write(
-              'event: endpoint\n'
-              'data: /messages?session_id=server-session\n\n',
-            );
-            await request.response.close();
-            return;
-          }
-
-          await request.drain<void>();
-          request.response.statusCode = HttpStatus.notFound;
-          await request.response.close();
-        });
-
-      transport = await SseAuthClientTransport.create(
+      transport = await SseClientTransport.create(
         serverUrl: 'http://${server.address.address}:${server.port}/sse',
       );
+      const query = '中文搜索';
+      final message = {
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'tools/call',
+        'params': {
+          'name': 'diary_write',
+          'arguments': {'content': query},
+        },
+      };
+      final send = transport.send(message);
 
-      // The AuthenticatedEventSource reports the clean close of the SSE GET
-      // stream as an error, which the transport forwards to onClose. The
-      // client normally awaits onClose with a catchError; acknowledge it in
-      // the test so it is not left unhandled.
-      unawaited(transport.onClose.catchError((Object _) {}));
-
-        final receivedError = Completer<void>();
-        final subscription = transport.onMessage.listen((m) {
-          if (m is Map &&
-              m['error'] is Map &&
-              (m['error'] as Map)['code'] == 32600 &&
-              (m['error'] as Map)['message'] == 'Session terminated' &&
-              m['id'] == 7 &&
-              !receivedError.isCompleted) {
-            receivedError.complete();
-          }
-        });
-        addTearDown(subscription.cancel);
-
-        // Must not throw: a dead session is a routine condition, not an
-        // unhandled exception.
-        transport.send({'jsonrpc': '2.0', 'id': 7, 'method': 'ping'});
-
-        await receivedError.future.timeout(const Duration(seconds: 5));
-      },
-    );
+      final posted = await received.future.timeout(const Duration(seconds: 1));
+      expect(posted.contentType, 'application/json');
+      expect(posted.length, utf8.encode(posted.body).length);
+      expect(jsonDecode(posted.body), message);
+      await send.done;
+    });
   });
 }

--- a/dependencies/mcp_client/test/streamable_http_close_race_test.dart
+++ b/dependencies/mcp_client/test/streamable_http_close_race_test.dart
@@ -36,7 +36,22 @@ void main() {
     );
     addTearDown(transport.close);
 
-    transport.send({'jsonrpc': '2.0', 'id': 1, 'method': 'ping'});
+    // Invariants of the redesigned transport: send errors are delivered on
+    // the operation's `done` future — the message stream is only for
+    // server-sent messages — and no late error is pushed onto a closed
+    // broadcast controller.
+    final operation = transport.send({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'ping',
+    });
+    final errorReceived = Completer<Object>();
+    operation.done.then<void>(
+      (_) {},
+      onError: (Object e, StackTrace _) {
+        if (!errorReceived.isCompleted) errorReceived.complete(e);
+      },
+    );
     await client.requestStarted.future;
 
     // Close the transport while the request is still in flight, then let
@@ -46,6 +61,7 @@ void main() {
     transport.close();
     client.release.complete();
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
+    final err = await errorReceived.future.timeout(const Duration(seconds: 5));
+    expect(err, isA<http.ClientException>());
   });
 }

--- a/dependencies/mcp_client/test/streamable_http_get_stream_throttle_test.dart
+++ b/dependencies/mcp_client/test/streamable_http_get_stream_throttle_test.dart
@@ -1,0 +1,179 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:mcp_client/mcp_client.dart';
+import 'package:test/test.dart';
+
+/// Regression for Kelivo #937 ("MCP反复连接" — the client hammered a server
+/// with ~1 request/second of GET-stream reconnects when the server closed
+/// the stream).
+///
+/// Verifies that the background GET stream:
+///  - reconnects with exponentially growing gaps (1s, 2s, 4s, ...),
+///  - stops after a bounded number of consecutive failures instead of
+///    retrying forever at a flat interval.
+void main() {
+  test('GET stream reconnect is throttled and capped after failures', () async {
+    final server = await ThrottleMockServer.start();
+    addTearDown(server.close);
+
+    late StreamableHttpClientTransport transport;
+    transport = await StreamableHttpClientTransport.create(
+      baseUrl: server.url,
+      terminateOnClose: false,
+    );
+    addTearDown(transport.close);
+
+    final responses = transport.onMessage.listen((_) {}, onError: (_) {});
+    addTearDown(responses.cancel);
+
+    // Establish the session (the transport captures MCP-Session-Id from the
+    // initialize response).
+    final initializeDone = Completer<void>();
+    final initialized = transport.onMessage.listen((message) {
+      if (message is Map && message['id'] == 1) {
+        if (!initializeDone.isCompleted) initializeDone.complete();
+      }
+    });
+    addTearDown(initialized.cancel);
+
+    transport.send({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'initialize',
+      'params': {
+        'protocolVersion': McpProtocol.defaultVersion,
+        'clientInfo': {'name': 'test', 'version': '1.0.0'},
+        'capabilities': <String, dynamic>{},
+      },
+    });
+    await initializeDone.future.timeout(const Duration(seconds: 5));
+
+    // The initialized notification is what arms the background GET stream.
+    transport.send({'jsonrpc': '2.0', 'method': 'notifications/initialized'});
+
+    // Allow the cap sequence to run: 1s, 2s, 4s, 8s gaps (5 GETs total)
+    // then the loop must stop.
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    await _waitUntil(() => server.getTimes.length >= 3);
+    final firstGaps = <int>[
+      server.getTimes[1].difference(server.getTimes[0]).inMilliseconds,
+      server.getTimes[2].difference(server.getTimes[1]).inMilliseconds,
+    ];
+
+    // No flat 1s retry storm: the second gap must be significantly larger
+    // than the first (exponential backoff).
+    expect(
+      firstGaps[1],
+      greaterThanOrEqualTo((firstGaps[0] * 1.5).round()),
+      reason: 'expected exponential backoff, got gaps $firstGaps',
+    );
+
+    await _waitUntil(() => server.getTimes.length >= 4);
+    final thirdGap =
+        server.getTimes[3].difference(server.getTimes[2]).inMilliseconds;
+    expect(
+      thirdGap,
+      greaterThanOrEqualTo((firstGaps[1] * 1.5).round()),
+      reason: 'expected further exponential growth, got gap $thirdGap',
+    );
+
+    // Run past the last scheduled reconnect (8s after GET #4) and assert the
+    // loop gave up: no further GETs arrive and the count stays bounded.
+    await Future<void>.delayed(const Duration(seconds: 10));
+    final after = server.getTimes.length;
+    await Future<void>.delayed(const Duration(seconds: 4));
+    expect(
+      server.getTimes.length,
+      after,
+      reason: 'GET stream kept reconnecting after the failure cap',
+    );
+    expect(
+      after,
+      lessThanOrEqualTo(6),
+      reason: 'cap not applied: ${server.getTimes.length} GETs',
+    );
+  }, timeout: const Timeout(Duration(seconds: 45)));
+}
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('condition was not met');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+}
+
+/// Streamable-HTTP mock whose GET stream answers 200 and then closes
+/// immediately — the exact server shape that used to produce the 1s
+/// reconnect storm.
+class ThrottleMockServer {
+  final HttpServer _server;
+  final List<DateTime> getTimes = [];
+  late final Future<void> _serving;
+
+  ThrottleMockServer._(this._server) {
+    _serving = _serve();
+  }
+
+  static Future<ThrottleMockServer> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return ThrottleMockServer._(server);
+  }
+
+  String get url => 'http://${_server.address.address}:${_server.port}/mcp';
+
+  Future<void> close() async {
+    await _server.close(force: true);
+    await _serving.timeout(const Duration(seconds: 1), onTimeout: () {});
+  }
+
+  Future<void> _serve() async {
+    await for (final request in _server) {
+      if (request.method == 'GET') {
+        getTimes.add(DateTime.now());
+        request.response.bufferOutput = false;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        request.response.write(': connected\n\n');
+        await request.response.flush();
+        await request.response.close();
+        continue;
+      }
+
+      final body = await utf8.decoder.bind(request).join();
+      final message = jsonDecode(body) as Map<String, dynamic>;
+      if (message['method'] == 'initialize') {
+        request.response.headers.set('MCP-Session-Id', 'session-1');
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': message['id'],
+            'result': {
+              'protocolVersion': McpProtocol.defaultVersion,
+              'serverInfo': {'name': 'ThrottleMock', 'version': '1.0.0'},
+              'capabilities': <String, dynamic>{},
+            },
+          }),
+        );
+        await request.response.close();
+        continue;
+      }
+
+      request.response.statusCode = HttpStatus.accepted;
+      await request.response.close();
+    }
+  }
+}

--- a/dependencies/mcp_client/test/streamable_http_oauth_refresh_timeout_test.dart
+++ b/dependencies/mcp_client/test/streamable_http_oauth_refresh_timeout_test.dart
@@ -27,6 +27,10 @@ void main() {
       await request.response.close();
     });
 
+    addTearDown(() async {
+      await server.close(force: true);
+    });
+
     final transport = await StreamableHttpClientTransport.create(
       baseUrl: 'http://${server.address.address}:${server.port}/mcp',
       oauthConfig: OAuthConfig(
@@ -41,25 +45,25 @@ void main() {
         expiresIn: 3600,
         issuedAt: DateTime.now().subtract(const Duration(hours: 2)),
       ),
+      terminateOnClose: false,
     );
+    addTearDown(transport.close);
 
+    // The refresh must time out (~15s) instead of hanging the request; the
+    // error surfaces on the send operation's `done`.
     final errorReceived = Completer<Object>();
-    final sub = transport.onMessage.listen(
+    final operation = transport.send({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'initialize',
+    });
+    operation.done.then<void>(
       (_) {},
       onError: (Object e, StackTrace _) {
         if (!errorReceived.isCompleted) errorReceived.complete(e);
       },
     );
 
-    addTearDown(() async {
-      sub.cancel();
-      transport.close();
-      await server.close(force: true);
-    });
-
-    transport.send({'jsonrpc': '2.0', 'id': 1, 'method': 'initialize'});
-
-    // The refresh must time out (~15s) instead of hanging the request.
     final err = await errorReceived.future.timeout(const Duration(seconds: 30));
     expect(err, isA<TimeoutException>());
     expect(tokenEndpointHits, 1);

--- a/lib/core/providers/mcp_provider.dart
+++ b/lib/core/providers/mcp_provider.dart
@@ -19,6 +19,29 @@ enum McpTransportType { sse, http, stdio, inmemory }
 /// Connection status for an MCP server.
 enum McpStatus { idle, connecting, connected, error }
 
+class _Cooldown {
+  final DateTime startedAt;
+  final DateTime until;
+
+  const _Cooldown({required this.startedAt, required this.until});
+}
+
+/// Per-server connection record. Holds the live client and every piece of
+/// connection state so connect/disconnect/recover can coalesce, dedupe
+/// concurrent attempts, and distinguish stale generations after a reload.
+class _ServerConnection {
+  mcp.Client? client;
+  Future<bool>? connectFuture;
+  int generation = 0;
+  McpStatus status = McpStatus.idle;
+  String? error;
+  _Cooldown? cooldown;
+  Future<void>? refreshFuture;
+  bool refreshDirty = false;
+}
+
+enum _ToolRefreshOutcome { success, sessionExpired, failed }
+
 class McpParamSpec {
   final String name;
   final bool required;
@@ -225,7 +248,6 @@ class McpServerConfig {
   final List<String> args;
   final Map<String, String> env;
   final String? workingDirectory;
-  final int? heartbeatIntervalSeconds; // null = use default (12s)
   final String
   toolPrefix; // optional prefix prepended to all tool names from this server
   // OAuth (HTTP/SSE only). Null = no OAuth, static headers apply.
@@ -245,7 +267,6 @@ class McpServerConfig {
     this.args = const [],
     this.env = const {},
     this.workingDirectory,
-    this.heartbeatIntervalSeconds,
     this.toolPrefix = '',
     this.oauth,
     this.oauthToken,
@@ -264,8 +285,6 @@ class McpServerConfig {
     Map<String, String>? env,
     String? workingDirectory,
     bool clearWorkingDirectory = false,
-    int? heartbeatIntervalSeconds,
-    bool clearHeartbeatIntervalSeconds = false,
     String? toolPrefix,
     McpOAuthConfig? oauth,
     bool clearOauth = false,
@@ -285,9 +304,6 @@ class McpServerConfig {
     workingDirectory: clearWorkingDirectory
         ? null
         : (workingDirectory ?? this.workingDirectory),
-    heartbeatIntervalSeconds: clearHeartbeatIntervalSeconds
-        ? null
-        : (heartbeatIntervalSeconds ?? this.heartbeatIntervalSeconds),
     toolPrefix: toolPrefix ?? this.toolPrefix,
     oauth: clearOauth ? null : (oauth ?? this.oauth),
     oauthToken: clearOauthToken ? null : (oauthToken ?? this.oauthToken),
@@ -310,8 +326,6 @@ class McpServerConfig {
     if (transport == McpTransportType.stdio) 'env': env,
     if (transport == McpTransportType.stdio && workingDirectory != null)
       'workingDirectory': workingDirectory,
-    if (heartbeatIntervalSeconds != null)
-      'heartbeatIntervalSeconds': heartbeatIntervalSeconds,
     if (toolPrefix.isNotEmpty) 'toolPrefix': toolPrefix,
     if (oauth != null) 'oauth': oauth!.toJson(),
     if (oauthToken != null) 'oauthToken': oauthToken!.toJson(),
@@ -333,7 +347,6 @@ class McpServerConfig {
             )
             .toList() ??
         const <McpToolConfig>[];
-    final heartbeatIntervalSeconds = json['heartbeatIntervalSeconds'] as int?;
     final toolPrefix = (json['toolPrefix'] as String?) ?? '';
     final oauth = json['oauth'] is Map
         ? McpOAuthConfig.fromJson(
@@ -360,7 +373,6 @@ class McpServerConfig {
             ? envAny.map((k, v) => MapEntry(k.toString(), v.toString()))
             : const <String, String>{},
         workingDirectory: (json['workingDirectory'] as String?)?.trim(),
-        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
         toolPrefix: toolPrefix,
         oauth: oauth,
         oauthToken: oauthToken,
@@ -372,7 +384,6 @@ class McpServerConfig {
         name: json['name'] as String? ?? '',
         transport: McpTransportType.inmemory,
         tools: tools,
-        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
         toolPrefix: toolPrefix,
         oauth: oauth,
         oauthToken: oauthToken,
@@ -390,7 +401,6 @@ class McpServerConfig {
               (k, v) => MapEntry(k.toString(), v.toString()),
             )) ??
             const {},
-        heartbeatIntervalSeconds: heartbeatIntervalSeconds,
         toolPrefix: toolPrefix,
         oauth: oauth,
         oauthToken: oauthToken,
@@ -428,24 +438,25 @@ class McpProvider extends ChangeNotifier {
   /// Provider-agnostic OAuth flow orchestration (see ADR-0015).
   final OAuthFlowService oauthFlowService;
 
-  final Map<String, mcp.Client> _clients = {};
-  final Map<String, McpStatus> _status = {}; // id -> status
-  final Map<String, String> _errors = {}; // id -> last error
+  final Map<String, _ServerConnection> _connections = {};
   List<McpServerConfig> _servers = [];
-  // Reconnect bookkeeping to avoid duplicate concurrent retries
-  final Set<String> _reconnecting = <String>{};
-  // Heartbeat timers for live-connection health checks
-  final Map<String, Timer> _heartbeats = <String, Timer>{};
+  Future<void> _serverMutationTail = Future<void>.value();
   Duration _requestTimeout = const Duration(seconds: 30);
+  bool _disposed = false;
 
   final McpStdioCommandResolver _stdioCommandResolver =
       McpStdioCommandResolver();
 
   List<McpServerConfig> get servers => List.unmodifiable(_servers);
-  McpStatus statusFor(String id) => _status[id] ?? McpStatus.idle;
-  String? errorFor(String id) => _errors[id];
-  bool isConnected(String id) =>
-      _clients.containsKey(id) && statusFor(id) == McpStatus.connected;
+  McpStatus statusFor(String id) => _connections[id]?.status ?? McpStatus.idle;
+  String? errorFor(String id) => _connections[id]?.error;
+  bool isConnected(String id) {
+    final state = _connections[id];
+    return state?.client?.isConnected == true &&
+        state?.status == McpStatus.connected;
+  }
+
+  bool isInCooldown(String id) => _activeCooldown(_connections[id]) != null;
   List<McpServerConfig> get connectedServers => _servers
       .where((s) => statusFor(s.id) == McpStatus.connected)
       .toList(growable: false);
@@ -453,7 +464,7 @@ class McpProvider extends ChangeNotifier {
   int get requestTimeoutSeconds => _requestTimeout.inSeconds;
 
   Future<void> _load() async {
-    await _reloadServersFromPrefs();
+    await _serializeServerMutation(_reloadServersFromPrefs);
   }
 
   /// Re-reads `mcp_servers_v1` / `mcp_request_timeout_ms_v1` from
@@ -490,10 +501,9 @@ class McpProvider extends ChangeNotifier {
     }
     // initialize statuses
     for (final s in _servers) {
-      _status[s.id] = McpStatus.idle;
-      _errors.remove(s.id);
+      _connections.putIfAbsent(s.id, _ServerConnection.new);
     }
-    notifyListeners();
+    _notify();
 
     // Auto-connect enabled servers. Skip OAuth servers that have not been
     // authorized yet — connecting them would fail with "no token yet" and
@@ -513,18 +523,21 @@ class McpProvider extends ChangeNotifier {
   /// holds the restored ones. This disconnects every live client, rebuilds
   /// the list from disk, and reconnects enabled servers.
   Future<void> reloadFromPrefs() async {
-    for (final id in _clients.keys.toList()) {
-      try {
-        await disconnect(id);
-      } catch (e) {
-        debugPrint('[MCP/Reload] disconnect $id failed: $e');
+    await _serializeServerMutation(() async {
+      for (final id in _connections.keys.toList()) {
+        try {
+          final state = _connections[id];
+          if (state?.client != null) {
+            await disconnect(id);
+          }
+        } catch (e) {
+          debugPrint('[MCP/Reload] disconnect $id failed: $e');
+        }
       }
-    }
-    _servers = <McpServerConfig>[];
-    _status.clear();
-    _errors.clear();
-    _reconnecting.clear();
-    await _reloadServersFromPrefs();
+      _connections.clear();
+      _servers = <McpServerConfig>[];
+      await _reloadServersFromPrefs();
+    });
   }
 
   /// Retired built-in MCP servers, removed on load and import:
@@ -551,9 +564,26 @@ class McpProvider extends ChangeNotifier {
     await prefs.setInt(_prefsTimeoutKey, _requestTimeout.inMilliseconds);
   }
 
-  Future<void> _persistTimeout() async {
+  Future<void> _persistServers(List<McpServerConfig> servers) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_prefsTimeoutKey, _requestTimeout.inMilliseconds);
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode(servers.map((e) => e.toJson()).toList()),
+    );
+  }
+
+  Future<void> _persistTimeout(Duration timeout) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_prefsTimeoutKey, timeout.inMilliseconds);
+  }
+
+  Future<T> _serializeServerMutation<T>(Future<T> Function() operation) {
+    final result = _serverMutationTail.then((_) => operation());
+    _serverMutationTail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    return result;
   }
 
   /// Export current MCP servers as a user-friendly JSON structure.
@@ -828,14 +858,13 @@ class McpProvider extends ChangeNotifier {
 
     // Replace and reset statuses
     _servers = next;
-    _status.clear();
-    _errors.clear();
+    _connections.clear();
     for (final s in _servers) {
-      _status[s.id] = McpStatus.idle;
+      _connections[s.id] = _ServerConnection();
     }
 
     await _persist();
-    notifyListeners();
+    _notify();
 
     // Auto-connect enabled servers
     for (final s in _servers.where((e) => e.enabled)) {
@@ -861,7 +890,6 @@ class McpProvider extends ChangeNotifier {
     List<String> args = const <String>[],
     Map<String, String> env = const <String, String>{},
     String? workingDirectory,
-    int? heartbeatIntervalSeconds,
     String toolPrefix = '',
     McpOAuthConfig? oauth,
   }) async {
@@ -879,14 +907,15 @@ class McpProvider extends ChangeNotifier {
       workingDirectory: (workingDirectory?.trim().isNotEmpty ?? false)
           ? workingDirectory!.trim()
           : null,
-      heartbeatIntervalSeconds: heartbeatIntervalSeconds,
       toolPrefix: toolPrefix,
       oauth: oauth,
     );
-    _servers = [..._servers, cfg];
-    _status[id] = McpStatus.idle;
-    await _persist();
-    notifyListeners();
+    await _serializeServerMutation(() async {
+      _servers = [..._servers, cfg];
+      _connections[id] = _ServerConnection();
+      await _persist();
+      _notify();
+    });
     // Skip the automatic connect when OAuth is configured but not yet
     // authorized — it would fail with "no token yet" and leave a stale
     // error state. The connection happens after authorization completes.
@@ -901,24 +930,29 @@ class McpProvider extends ChangeNotifier {
   /// list and persists. Used by [TrashRestoreCoordinator].
   void restoreServer(McpServerConfig config) {
     _servers = [..._servers, config];
-    _status[config.id] = McpStatus.idle;
+    _connections.putIfAbsent(config.id, _ServerConnection.new);
     _persist();
-    notifyListeners();
+    _notify();
   }
 
   Future<void> updateServer(McpServerConfig updated) async {
-    final idx = _servers.indexWhere((e) => e.id == updated.id);
-    if (idx < 0) return;
-    _servers = List<McpServerConfig>.of(_servers)..[idx] = updated;
-    await _persist();
-    notifyListeners();
-    if (!updated.enabled) {
-      await disconnect(updated.id);
-    } else {
-      // Always reconnect after saving to apply changes (url/transport/name)
-      await disconnect(updated.id);
-      unawaited(connect(updated.id));
-    }
+    await _serializeServerMutation(() async {
+      final idx = _servers.indexWhere((e) => e.id == updated.id);
+      if (idx < 0) return;
+      _servers = List<McpServerConfig>.of(_servers)..[idx] = updated;
+      await _persist();
+      _notify();
+      if (!updated.enabled) {
+        // The disabled state is already persisted. Tear down the old
+        // connection in the background so settings UI does not wait on a
+        // remote session DELETE or a connection attempt finishing.
+        unawaited(disconnect(updated.id));
+      } else {
+        // Always reconnect after saving to apply changes (url/transport/name)
+        await disconnect(updated.id);
+        unawaited(connect(updated.id));
+      }
+    });
   }
 
   /// Starts the OAuth authorization flow for [serverId].
@@ -988,7 +1022,7 @@ class McpProvider extends ChangeNotifier {
         _servers = List<McpServerConfig>.of(_servers)
           ..[idx] = current.copyWith(oauth: updated);
         await _persist();
-        notifyListeners();
+        _notify();
       }
     }
     return result;
@@ -1016,7 +1050,7 @@ class McpProvider extends ChangeNotifier {
     _servers = List<McpServerConfig>.of(_servers)
       ..[idx] = server.copyWith(oauthToken: token);
     await _persist();
-    notifyListeners();
+    _notify();
     if (server.enabled) {
       // The connection may have failed earlier with "no token yet" —
       // reconnect now that the token is persisted.
@@ -1032,7 +1066,7 @@ class McpProvider extends ChangeNotifier {
     _servers = List<McpServerConfig>.of(_servers)
       ..[idx] = _servers[idx].copyWith(clearOauthToken: true);
     await _persist();
-    notifyListeners();
+    _notify();
   }
 
   /// Cancels an in-flight OAuth flow (PKCE verifier discarded).
@@ -1048,7 +1082,7 @@ class McpProvider extends ChangeNotifier {
     _servers = List<McpServerConfig>.of(_servers)
       ..[idx] = _servers[idx].copyWith(oauthToken: token);
     unawaited(_persist());
-    notifyListeners();
+    _notify();
   }
 
   Future<void> removeServer(String id) async {
@@ -1072,19 +1106,21 @@ class McpProvider extends ChangeNotifier {
     }
     await disconnect(id);
     _servers = _servers.where((e) => e.id != id).toList(growable: false);
-    _status.remove(id);
+    _connections.remove(id);
     await _persist();
-    notifyListeners();
+    _notify();
   }
 
   Future<void> reorderServers(int oldIndex, int newIndex) async {
     if (oldIndex == newIndex) return;
     if (oldIndex < 0 || oldIndex >= _servers.length) return;
     if (newIndex < 0 || newIndex >= _servers.length) return;
-    final moved = _servers.removeAt(oldIndex);
-    _servers.insert(newIndex, moved);
-    notifyListeners();
-    await _persist();
+    await _serializeServerMutation(() async {
+      final moved = _servers.removeAt(oldIndex);
+      _servers.insert(newIndex, moved);
+      _notify();
+      await _persist();
+    });
   }
 
   Future<void> setToolEnabled(
@@ -1092,15 +1128,17 @@ class McpProvider extends ChangeNotifier {
     String toolName,
     bool enabled,
   ) async {
-    final idx = _servers.indexWhere((e) => e.id == serverId);
-    if (idx < 0) return;
-    final server = _servers[idx];
-    final tools = server.tools
-        .map((t) => t.name == toolName ? t.copyWith(enabled: enabled) : t)
-        .toList();
-    _servers[idx] = server.copyWith(tools: tools);
-    await _persist();
-    notifyListeners();
+    await _serializeServerMutation(() async {
+      final idx = _servers.indexWhere((e) => e.id == serverId);
+      if (idx < 0) return;
+      final server = _servers[idx];
+      final tools = server.tools
+          .map((t) => t.name == toolName ? t.copyWith(enabled: enabled) : t)
+          .toList();
+      _servers[idx] = server.copyWith(tools: tools);
+      await _persist();
+      _notify();
+    });
   }
 
   /// Set whether a tool requires user approval before execution.
@@ -1109,25 +1147,26 @@ class McpProvider extends ChangeNotifier {
     String toolName,
     bool needsApproval,
   ) async {
-    final idx = _servers.indexWhere((e) => e.id == serverId);
-    if (idx < 0) return;
-    final server = _servers[idx];
-    final tools = server.tools
-        .map(
-          (t) =>
-              t.name == toolName ? t.copyWith(needsApproval: needsApproval) : t,
-        )
-        .toList();
-    _servers[idx] = server.copyWith(tools: tools);
-    await _persist();
-    notifyListeners();
+    await _serializeServerMutation(() async {
+      final idx = _servers.indexWhere((e) => e.id == serverId);
+      if (idx < 0) return;
+      final server = _servers[idx];
+      final tools = server.tools
+          .map(
+            (t) => t.name == toolName
+                ? t.copyWith(needsApproval: needsApproval)
+                : t,
+          )
+          .toList();
+      _servers[idx] = server.copyWith(tools: tools);
+      await _persist();
+      _notify();
+    });
   }
 
-  /// Check if a tool (by name) requires approval across all connected servers.
-  /// Conservative: returns true if ANY connected server marks the tool as needing approval.
+  /// Conservative: require approval if any enabled cached tool requires it.
   bool toolNeedsApproval(String toolName) {
     for (final s in _servers) {
-      if (statusFor(s.id) != McpStatus.connected) continue;
       if (!s.enabled) continue;
       for (final t in s.tools) {
         if (t.name == toolName && t.enabled && t.needsApproval) return true;
@@ -1137,148 +1176,236 @@ class McpProvider extends ChangeNotifier {
   }
 
   Future<void> connect(String id) async {
-    final server = _servers.firstWhere(
-      (e) => e.id == id,
-      orElse: () => throw StateError('Server not found'),
-    );
-    // If already connected, try a ping by listing tools quickly; else return
-    if (_clients.containsKey(id)) {
-      // Already connected; update status just in case
-      _status[id] = McpStatus.connected;
-      _errors.remove(id);
-      notifyListeners();
-      return;
+    await _connect(id);
+  }
+
+  Future<bool> _connect(String id) {
+    final server = getById(id);
+    if (server == null || !server.enabled || _disposed) {
+      return Future<bool>.value(false);
     }
-    _status[id] = McpStatus.connecting;
-    _errors.remove(id);
-    notifyListeners();
+    final state = _connections.putIfAbsent(id, _ServerConnection.new);
+    final active = state.connectFuture;
+    if (active != null) return active;
+    if (_activeCooldown(state) != null) return Future<bool>.value(false);
+    if (state.client?.isConnected == true) {
+      state.status = McpStatus.connected;
+      state.error = null;
+      _notify();
+      unawaited(refreshTools(id));
+      return Future<bool>.value(true);
+    }
 
+    return _beginConnect(id, server, state);
+  }
+
+  Future<bool> _beginConnect(
+    String id,
+    McpServerConfig server,
+    _ServerConnection state, {
+    Future<bool>? waitFor,
+  }) {
+    state.status = McpStatus.connecting;
+    state.error = null;
+    final generation = state.generation;
+    _notify();
+    late final Future<bool> future;
+    future =
+        (() async {
+          if (waitFor != null) {
+            try {
+              await waitFor;
+            } catch (_) {}
+          }
+          if (_disposed ||
+              state.generation != generation ||
+              getById(id)?.enabled != true) {
+            return false;
+          }
+          return _performConnect(id, server, state, generation);
+        })().whenComplete(() {
+          if (identical(state.connectFuture, future)) {
+            state.connectFuture = null;
+          }
+        });
+    state.connectFuture = future;
+    return future.then((connected) {
+      if (connected && !_disposed) unawaited(refreshTools(id));
+      return connected;
+    });
+  }
+
+  Future<bool> _performConnect(
+    String id,
+    McpServerConfig server,
+    _ServerConnection state,
+    int generation,
+  ) async {
+    mcp.Client? client;
+    final startedAt = DateTime.now();
     try {
-      // Log connect intent and parameters
-      // debugPrint('[MCP/Connect] id=$id name=${server.name} transport=${server.transport.name}');
-      // debugPrint('[MCP/Connect] url=${server.url}');
-      // if (server.headers.isNotEmpty) {
-      //   debugPrint('[MCP/Headers] ${server.headers.length} headers:');
-      //   server.headers.forEach((k, v) {
-      //     final masked = _maskIfSensitive(k, v);
-      //     debugPrint('  - $k: $masked');
-      //   });
-      // } else {
-      //   debugPrint('[MCP/Headers] (none)');
-      // }
-
       final clientConfig = mcp.McpClient.simpleConfig(
         name: 'Cuplivo MCP',
         version: '1.0.0',
-        // Turn on library-internal verbose logs
         enableDebugLogging: false,
         requestTimeout: _requestTimeout,
         logListener: McpLogBridge.onEvent,
         logServerLabel: server.name,
-      );
+      ).copyWith(maxRetries: 1);
 
       // In-memory builtin server path — all built-in in-memory engines
       // (fetch, filesystem, subagent) have been retired; refuse any
       // in-memory id as a safety net.
       if (server.transport == McpTransportType.inmemory) {
-        _status[id] = McpStatus.error;
-        _errors[id] = 'Unsupported in-memory MCP server: ${server.id}';
-        notifyListeners();
-        return;
+        throw StateError('Unsupported in-memory MCP server: ${server.id}');
       }
 
-      final mergedHeaders = <String, String>{...server.headers};
-      final oauthConfig = server.oauth?.toLibraryConfig();
-      final transportConfig = await () async {
-        if (server.transport == McpTransportType.sse) {
-          if (oauthConfig != null && server.oauthToken == null) {
-            throw StateError(
-              'OAuth server "${server.name}" has no token yet. '
-              'Authorize it first (edit → OAuth section → 开始授权).',
-            );
-          }
-          return mcp.TransportConfig.sse(
-            serverUrl: server.url,
-            headers: mergedHeaders.isEmpty ? null : mergedHeaders,
-            oauthConfig: oauthConfig,
-            oauthToken: server.oauthToken,
-            onTokenRefreshed: (token) => _persistOAuthToken(id, token),
-          );
-        } else if (server.transport == McpTransportType.http) {
-          if (oauthConfig != null && server.oauthToken == null) {
-            throw StateError(
-              'OAuth server "${server.name}" has no token yet. '
-              'Authorize it first (edit → OAuth section → 开始授权).',
-            );
-          }
-          return mcp.TransportConfig.streamableHttp(
-            baseUrl: server.url,
-            headers: mergedHeaders.isEmpty ? null : mergedHeaders,
-            timeout: _requestTimeout,
-            oauthConfig: oauthConfig,
-            oauthToken: server.oauthToken,
-            onTokenRefreshed: (token) => _persistOAuthToken(id, token),
-          );
-        } else {
-          // STDIO; only supported on desktop
-          if (!_isDesktopPlatform()) {
-            throw StateError('STDIO transport not supported on this platform');
-          }
-          final cmd = server.command;
-          if (cmd == null || cmd.isEmpty) {
-            throw StateError('STDIO command is empty');
-          }
-          final mergedEnv = await _stdioCommandResolver
-              .resolveEnvironmentWithPath(server.env);
-          final commandExists = await _stdioCommandResolver.commandExists(
-            cmd,
-            mergedEnv,
-          );
-          if (!commandExists) {
-            throw StateError(
-              'Command "$cmd" not found in PATH. '
-              'Ensure the command is installed and accessible.',
-            );
-          }
-          return mcp.TransportConfig.stdio(
-            command: cmd,
-            arguments: server.args,
-            workingDirectory: server.workingDirectory,
-            environment: mergedEnv.isEmpty ? null : mergedEnv,
-          );
-        }
-      }();
-
-      // debugPrint('[MCP/Connect] creating client (enableDebugLogging=true) ...');
-      final clientResult = await mcp.McpClient.createAndConnect(
+      final transportConfig = await _transportConfig(server, id);
+      final result = await mcp.McpClient.createAndConnect(
         config: clientConfig,
         transportConfig: transportConfig,
       );
+      client = result.fold((value) => value, (error) => throw error);
+      final connectedClient = client;
+      if (connectedClient == null) {
+        throw StateError('MCP client was not created');
+      }
 
-      final client = clientResult.fold((c) => c, (err) => throw err);
-      _clients[id] = client;
-      _status[id] = McpStatus.connected;
-      _errors.remove(id);
-      // debugPrint('[MCP/Connected] id=$id (${server.name})');
-      notifyListeners();
+      if (_disposed ||
+          state.generation != generation ||
+          getById(id)?.enabled != true) {
+        await connectedClient.terminateSession();
+        connectedClient.dispose();
+        return false;
+      }
 
-      // Try to refresh tools once connected
-      // debugPrint('[MCP/Tools] refreshing tools for id=$id ...');
-      await refreshTools(id);
-      // debugPrint('[MCP/Tools] refresh done for id=$id');
-
-      // Start/refresh heartbeat for this connection
-      _startHeartbeat(
-        id,
-        interval: Duration(seconds: server.heartbeatIntervalSeconds ?? 12),
-      );
-    } catch (e) {
-      // debugPrint('[MCP/Error] connect failed for id=$id (${server.name})');
-      // _logMcpException('connect', serverId: id, error: e, stack: st);
-      _status[id] = McpStatus.error;
-      _errors[id] = e.toString();
-      notifyListeners();
+      state.client = connectedClient;
+      state.status = McpStatus.connected;
+      state.error = null;
+      _clearCooldownAfterSuccess(state, startedAt);
+      _attachClient(id, state, connectedClient, generation);
+      _notify();
+      return true;
+    } catch (error) {
+      client?.dispose();
+      if (_disposed || state.generation != generation) return false;
+      if (error is mcp.McpHttpError && _requiresCooldown(error)) {
+        _enterCooldown(state, error.retryAfter);
+      }
+      state.status = McpStatus.error;
+      state.error = error.toString();
+      _notify();
+      return false;
     }
+  }
+
+  Future<mcp.TransportConfig> _transportConfig(
+    McpServerConfig server,
+    String id,
+  ) async {
+    final headers = server.headers.isEmpty ? null : server.headers;
+    final oauthConfig = server.oauth?.toLibraryConfig();
+    if (server.transport == McpTransportType.sse) {
+      if (oauthConfig != null && server.oauthToken == null) {
+        throw StateError(
+          'OAuth server "${server.name}" has no token yet. '
+          'Authorize it first (edit → OAuth section → 开始授权).',
+        );
+      }
+      return mcp.TransportConfig.sse(
+        serverUrl: server.url,
+        headers: headers,
+        oauthConfig: oauthConfig,
+        oauthToken: server.oauthToken,
+        onTokenRefreshed: (token) => _persistOAuthToken(id, token),
+      );
+    }
+    if (server.transport == McpTransportType.http) {
+      if (oauthConfig != null && server.oauthToken == null) {
+        throw StateError(
+          'OAuth server "${server.name}" has no token yet. '
+          'Authorize it first (edit → OAuth section → 开始授权).',
+        );
+      }
+      return mcp.TransportConfig.streamableHttp(
+        baseUrl: server.url,
+        headers: headers,
+        timeout: _requestTimeout,
+        oauthConfig: oauthConfig,
+        oauthToken: server.oauthToken,
+        onTokenRefreshed: (token) => _persistOAuthToken(id, token),
+        terminateOnClose: false,
+      );
+    }
+    if (!_isDesktopPlatform()) {
+      throw StateError('STDIO transport not supported on this platform');
+    }
+    final command = server.command;
+    if (command == null || command.isEmpty) {
+      throw StateError('STDIO command is empty');
+    }
+    final environment = await _stdioCommandResolver.resolveEnvironmentWithPath(
+      server.env,
+    );
+    if (!await _stdioCommandResolver.commandExists(command, environment)) {
+      throw StateError(
+        'Command "$command" not found in PATH. '
+        'Ensure the command is installed and accessible.',
+      );
+    }
+    return mcp.TransportConfig.stdio(
+      command: command,
+      arguments: server.args,
+      workingDirectory: server.workingDirectory,
+      environment: environment.isEmpty ? null : environment,
+    );
+  }
+
+  void _attachClient(
+    String id,
+    _ServerConnection state,
+    mcp.Client client,
+    int generation,
+  ) {
+    client.onDisconnect.listen((_) {
+      if (_disposed ||
+          state.generation != generation ||
+          !identical(state.client, client)) {
+        return;
+      }
+      state.client = null;
+      state.status = McpStatus.idle;
+      state.error = null;
+      _notify();
+    });
+    client.onError.listen((error) {
+      if (_disposed ||
+          state.generation != generation ||
+          !identical(state.client, client)) {
+        return;
+      }
+      if (error is mcp.McpHttpError &&
+          error.isBackgroundRequest &&
+          error.statusCode == 404 &&
+          error.sessionIdPresent) {
+        unawaited(_recoverExpiredSession(id, state, client));
+      } else if (error is mcp.McpHttpError && _requiresCooldown(error)) {
+        _enterCooldown(state, error.retryAfter);
+        _notify();
+      } else if (error is mcp.McpHttpError &&
+          (error.statusCode == 401 || error.statusCode == 403)) {
+        _enterCooldown(state, const Duration(minutes: 5));
+        _notify();
+      }
+    });
+    client.onToolsListChanged(() {
+      if (_disposed ||
+          state.generation != generation ||
+          !identical(state.client, client)) {
+        return;
+      }
+      unawaited(refreshTools(id));
+    });
   }
 
   Future<void> updateRequestTimeout(
@@ -1287,98 +1414,43 @@ class McpProvider extends ChangeNotifier {
   }) async {
     if (duration.inMilliseconds <= 0) return;
     if (duration == _requestTimeout) return;
+    await _persistTimeout(duration);
     _requestTimeout = duration;
-    await _persistTimeout();
-    notifyListeners();
+    _notify();
     if (reconnectActive) {
-      for (final id in _clients.keys.toList()) {
-        if (_servers.any((s) => s.id == id && s.enabled)) {
-          unawaited(reconnect(id));
-        }
+      for (final state in _connections.values) {
+        state.client?.setRequestTimeout(duration);
       }
     }
   }
 
-  Future<void> disconnect(String id) async {
-    final client = _clients.remove(id);
-    try {
-      // debugPrint('[MCP/Disconnect] id=$id ...');
-      client?.disconnect();
-      // debugPrint('[MCP/Disconnect] id=$id done');
-    } catch (e) {
-      // debugPrint('[MCP/Error] disconnect failed for id=$id');
-      // _logMcpException('disconnect', serverId: id, error: e, stack: st);
-    }
-    _status[id] = McpStatus.idle;
-    _errors.remove(id);
-    _stopHeartbeat(id);
-    notifyListeners();
-  }
+  Future<void> disconnect(String id, {bool terminateSession = true}) async {
+    final state = _connections.putIfAbsent(id, _ServerConnection.new);
+    state.generation++;
+    final active = state.connectFuture;
+    final client = state.client;
+    state.client = null;
+    state.status = McpStatus.idle;
+    state.error = null;
+    state.cooldown = null;
+    state.refreshDirty = false;
+    _notify();
 
-  Future<void> reconnect(String id) async {
-    await disconnect(id);
-    await connect(id);
-  }
-
-  Future<void> _reconnectWithBackoff(String id, {int maxAttempts = 3}) async {
-    if (_reconnecting.contains(id)) return;
-    _reconnecting.add(id);
-    try {
-      for (int attempt = 1; attempt <= maxAttempts; attempt++) {
-        await reconnect(id);
-        if (isConnected(id)) return;
-        // progressive backoff: 600ms, 1200ms, 2400ms
-        final delayMs = 600 * (1 << (attempt - 1));
-        await Future.delayed(Duration(milliseconds: delayMs));
-      }
-    } finally {
-      _reconnecting.remove(id);
-    }
-  }
-
-  void _startHeartbeat(
-    String id, {
-    Duration interval = const Duration(seconds: 12),
-  }) {
-    _stopHeartbeat(id);
-    _heartbeats[id] = Timer.periodic(interval, (t) async {
-      // Heartbeat only when we think we're connected
-      if (!isConnected(id)) return;
-      final client = _clients[id];
-      if (client == null) return;
+    if (active != null) {
       try {
-        // A lightweight call to verify liveness
-        // listTools is relatively cheap and available
-        final fut = client.listTools(logTags: {'reason': 'heartbeat'});
-        // Add a soft timeout to avoid piling up
-        await fut.timeout(const Duration(seconds: 6));
-      } catch (e) {
-        // Rate-limited? Server is alive — skip this tick, don't reconnect.
-        if (_isRateLimitError(e)) return;
-        // debugPrint('[MCP/Heartbeat] liveness check failed id=$id');
-        // Consider connection lost; mark error and try auto-reconnect
-        _status[id] = McpStatus.error;
-        _errors[id] = e.toString();
-        notifyListeners();
-        await _reconnectWithBackoff(id, maxAttempts: 3);
-        // If reconnected, restart heartbeat (connect() also starts it)
-        if (!isConnected(id)) {
-          // keep error state; next heartbeat tick will be a no-op
-        }
-      }
-    });
+        await active;
+      } catch (_) {}
+    }
+    if (client != null) {
+      if (terminateSession) await client.terminateSession();
+      client.dispose();
+    }
   }
 
-  void _stopHeartbeat(String id) {
-    _heartbeats.remove(id)?.cancel();
-  }
-
-  /// Returns true if the error indicates rate-limiting (429, MCP -32106).
-  /// Rate-limited responses prove the server is alive — skip heartbeat retry.
-  bool _isRateLimitError(Object e) {
-    if (e is mcp.McpError && e.code == -32106) return true;
-    final msg = e.toString().toLowerCase();
-    return msg.contains('429') || msg.contains('rate limit');
+  Future<bool> reconnect(String id) async {
+    if (_activeCooldown(_connections[id]) != null) return false;
+    await disconnect(id, terminateSession: true);
+    return _connect(id);
   }
 
   McpToolConfig? _toolConfig(String serverId, String toolName) {
@@ -1667,33 +1739,135 @@ class McpProvider extends ChangeNotifier {
     return const [];
   }
 
-  Future<void> refreshTools(String id) async {
-    final client = _clients[id];
-    if (client == null) return;
-    try {
-      // debugPrint('[MCP/Tools] listTools() ...');
-      final tools = await client.listTools();
-      // The client may have been disconnected or replaced while listTools was
-      // in flight (e.g. restore reload rebuilt the server list). Never write
-      // a stale tool refresh back to disk — it would clobber the restored
-      // mcp_servers_v1 with the pre-restore list (assistant changes trigger
-      // this refresh, and restore reloads assistants).
-      if (!identical(_clients[id], client)) return;
-      // debugPrint('[MCP/Tools] listTools() returned ${tools.length} tools');
-      // Preserve enabled state from existing config
-      final idx = _servers.indexWhere((e) => e.id == id);
-      if (idx < 0) return;
-      final existing = _servers[idx].tools;
-      final existingMap = {for (final t in existing) t.name: t};
+  Future<void> refreshTools(String id) {
+    final state = _connections[id];
+    if (state?.client == null || _disposed) return Future<void>.value();
+    state!.refreshDirty = true;
+    final active = state.refreshFuture;
+    if (active != null) return active;
 
-      List<McpToolConfig> merged = [];
-      for (final t in tools) {
-        final prior = existingMap[t.name];
+    final future = _drainToolRefresh(id, state);
+    state.refreshFuture = future;
+    return future.whenComplete(() {
+      if (!identical(state.refreshFuture, future)) return;
+      state.refreshFuture = null;
+      if (state.refreshDirty && !_disposed) {
+        unawaited(refreshTools(id));
+      }
+    });
+  }
+
+  Future<void> _drainToolRefresh(String id, _ServerConnection state) async {
+    var sessionRecoveries = 0;
+    while (state.refreshDirty && !_disposed) {
+      state.refreshDirty = false;
+      final failedClient = state.client;
+      final outcome = await _refreshToolsOnce(id, state);
+      if (outcome == _ToolRefreshOutcome.sessionExpired &&
+          sessionRecoveries++ == 0 &&
+          failedClient != null &&
+          await _recoverExpiredSession(id, state, failedClient) != null) {
+        state.refreshDirty = true;
+        continue;
+      }
+      if (outcome != _ToolRefreshOutcome.success) return;
+    }
+  }
+
+  Future<_ToolRefreshOutcome> _refreshToolsOnce(
+    String id,
+    _ServerConnection state,
+  ) async {
+    final client = state.client;
+    if (client == null) return _ToolRefreshOutcome.failed;
+    final generation = state.generation;
+
+    if (client.serverCapabilities?.tools != true) {
+      await _persistToolList(id, state, client, const <mcp.Tool>[]);
+      if (_disposed ||
+          state.generation != generation ||
+          !identical(state.client, client)) {
+        return _ToolRefreshOutcome.failed;
+      }
+      state.status = McpStatus.connected;
+      state.error = null;
+      _notify();
+      return _ToolRefreshOutcome.success;
+    }
+
+    for (var attempt = 0; attempt < 3; attempt++) {
+      final cooldown = _activeCooldown(state);
+      if (cooldown != null) {
+        await Future<void>.delayed(cooldown.until.difference(DateTime.now()));
+      }
+      if (_disposed ||
+          state.generation != generation ||
+          !identical(state.client, client)) {
+        return _ToolRefreshOutcome.failed;
+      }
+
+      final startedAt = DateTime.now();
+      try {
+        final tools = await client.listTools();
+        if (_disposed ||
+            state.generation != generation ||
+            !identical(state.client, client)) {
+          return _ToolRefreshOutcome.failed;
+        }
+        await _persistToolList(id, state, client, tools);
+        if (_disposed ||
+            state.generation != generation ||
+            !identical(state.client, client)) {
+          return _ToolRefreshOutcome.failed;
+        }
+        state.status = McpStatus.connected;
+        state.error = null;
+        _clearCooldownAfterSuccess(state, startedAt);
+        _notify();
+        return _ToolRefreshOutcome.success;
+      } catch (error) {
+        if (_isRejectedSession(error)) {
+          return _ToolRefreshOutcome.sessionExpired;
+        }
+        if (error is mcp.McpHttpError && _requiresCooldown(error)) {
+          _enterCooldown(state, error.retryAfter);
+        }
+        if (_isSafeTransient(error) && attempt < 2) {
+          if (_activeCooldown(state) == null) {
+            await Future<void>.delayed(Duration(seconds: attempt == 0 ? 1 : 4));
+          }
+          continue;
+        }
+        state.status = McpStatus.error;
+        state.error = error.toString();
+        _notify();
+        return _ToolRefreshOutcome.failed;
+      }
+    }
+    return _ToolRefreshOutcome.failed;
+  }
+
+  Future<void> _persistToolList(
+    String id,
+    _ServerConnection state,
+    mcp.Client client,
+    List<mcp.Tool> tools,
+  ) async {
+    await _serializeServerMutation(() async {
+      if (!identical(state.client, client)) return;
+      final index = _servers.indexWhere((server) => server.id == id);
+      if (index < 0) return;
+      final existing = {
+        for (final tool in _servers[index].tools) tool.name: tool,
+      };
+      final merged = <McpToolConfig>[];
+      for (final tool in tools) {
+        final prior = existing[tool.name];
         // Extract params from inputSchema if present
         final params = <McpParamSpec>[];
+        final js = tool.inputSchema;
         Map<String, dynamic>? schemaJson;
         try {
-          final js = t.inputSchema;
           schemaJson = js;
           final props =
               (js['properties'] as Map?)?.cast<String, dynamic>() ??
@@ -1724,27 +1898,24 @@ class McpProvider extends ChangeNotifier {
             );
           });
         } catch (_) {}
-
         merged.add(
           McpToolConfig(
             enabled: prior?.enabled ?? true,
-            name: t.name,
-            description: t.description,
+            name: tool.name,
+            description: tool.description,
             params: params,
             schema: schemaJson,
             needsApproval:
-                prior?.needsApproval ?? _defaultToolNeedsApproval(id, t.name),
+                prior?.needsApproval ??
+                _defaultToolNeedsApproval(id, tool.name),
           ),
         );
       }
-
-      _servers[idx] = _servers[idx].copyWith(tools: merged);
-      await _persist();
-      notifyListeners();
-    } catch (e) {
-      // debugPrint('[MCP/Tools] listTools() failed for id=$id');
-      // ignore tool refresh errors; status stays connected
-    }
+      final next = List<McpServerConfig>.of(_servers)
+        ..[index] = _servers[index].copyWith(tools: merged);
+      await _persistServers(next);
+      _servers = next;
+    });
   }
 
   /// Default approval flag for a tool when its config is first created.
@@ -1760,8 +1931,7 @@ class McpProvider extends ChangeNotifier {
     final cfg = getById(id);
     if (cfg == null || !cfg.enabled) return;
     if (isConnected(id)) return;
-    // Try a few times with short backoff in case server blips
-    await _reconnectWithBackoff(id, maxAttempts: 3);
+    await _connect(id);
   }
 
   Future<mcp.CallToolResult?> callTool(
@@ -1769,64 +1939,188 @@ class McpProvider extends ChangeNotifier {
     String toolName,
     Map<String, dynamic> args,
   ) async {
+    await ensureConnected(serverId);
+    final state = _connections[serverId];
+    if (state == null) return null;
+    final cooldown = _activeCooldown(state);
+    if (cooldown != null) {
+      return _toolError(
+        'MCP server is temporarily unavailable; retry after '
+        '${cooldown.until.difference(DateTime.now()).inSeconds + 1} seconds.',
+      );
+    }
+    final client = state.client;
+    if (client == null) return null;
+    // Normalize arguments based on tool schema (best-effort)
+    final normalized = _normalizeArgsForTool(serverId, toolName, args);
+    final startedAt = DateTime.now();
     try {
-      await ensureConnected(serverId);
-      var client = _clients[serverId];
-      if (client == null) return null;
-      // Normalize arguments based on tool schema (best-effort)
-      final normalized = _normalizeArgsForTool(serverId, toolName, args);
-      // if (normalized != args) {
-      //   debugPrint('[MCP/Call] serverId=$serverId tool=$toolName args(normalized)=${jsonEncode(normalized)}');
-      // } else {
-      //   debugPrint('[MCP/Call] serverId=$serverId tool=$toolName args=${jsonEncode(args)}');
-      // }
       final result = await client.callTool(toolName, normalized);
-      // Detailed call timing/content logging disabled
+      _clearCooldownAfterSuccess(state, startedAt);
       return result;
-    } catch (e) {
-      // debugPrint('[MCP/Call/Error] serverId=$serverId tool=$toolName');
-
-      // If this is a parameter validation error from the server, do NOT disconnect.
-      try {
-        if (e is mcp.McpError && (e.code == -32602)) {
-          // Keep connection healthy status; surface error to caller via null
-          _errors[serverId] = e.toString();
-          // debugPrint('[MCP/Call] invalid arguments; skipping reconnect');
-          return null;
-        }
-      } catch (_) {}
-
-      _status[serverId] = McpStatus.error;
-      _errors[serverId] = e.toString();
-      notifyListeners();
-      // Auto-reconnect a few times and try once more
-      try {
-        await _reconnectWithBackoff(serverId, maxAttempts: 3);
-        if (!isConnected(serverId)) return null;
-        final client = _clients[serverId];
-        if (client == null) return null;
-        // debugPrint('[MCP/Call] retry serverId=$serverId tool=$toolName');
-        final normalized = _normalizeArgsForTool(serverId, toolName, args);
-        final result = await client.callTool(toolName, normalized);
-        // Detailed retry logging disabled
-        // Mark healthy again
-        _status[serverId] = McpStatus.connected;
-        _errors.remove(serverId);
-        notifyListeners();
-        return result;
-      } catch (e2) {
-        // debugPrint('[MCP/Call/RetryError] serverId=$serverId tool=$toolName');
-        // Keep error state; give up
-        return null;
+    } catch (error) {
+      if (error is mcp.McpError && error.code == -32602) {
+        return _toolError(error.toString());
       }
+      if (error is mcp.McpHttpError && _requiresCooldown(error)) {
+        _enterCooldown(state, error.retryAfter);
+        _notify();
+        if (error.statusCode == 429) {
+          return _toolError('MCP server rate limited this request.');
+        }
+      }
+      if (_isRejectedSession(error)) {
+        final replacement = await _recoverExpiredSession(
+          serverId,
+          state,
+          client,
+        );
+        if (replacement != null) {
+          try {
+            return await replacement.callTool(toolName, normalized);
+          } catch (retryError) {
+            if (retryError is mcp.McpHttpError &&
+                _requiresCooldown(retryError)) {
+              _enterCooldown(state, retryError.retryAfter);
+              _notify();
+              if (retryError.statusCode == 429) {
+                return _toolError('MCP server rate limited this request.');
+              }
+            }
+            if (retryError is mcp.McpError && retryError.code != null) {
+              return _toolError(retryError.toString());
+            }
+            return _toolError(
+              'The MCP tool request may have been executed, but its result is '
+              'unknown. It was not retried. $retryError',
+            );
+          }
+        }
+      }
+      if (error is mcp.McpError && error.code != null) {
+        return _toolError(error.toString());
+      }
+      return _toolError(
+        'The MCP tool request may have been executed, but its result is '
+        'unknown. It was not retried. $error',
+      );
     }
   }
 
+  Future<mcp.Client?> _recoverExpiredSession(
+    String id,
+    _ServerConnection state,
+    mcp.Client failedClient,
+  ) async {
+    if (_disposed || getById(id)?.enabled != true) return null;
+    if (!identical(state.client, failedClient)) {
+      final active = state.connectFuture;
+      if (active != null) {
+        try {
+          await active;
+        } catch (_) {}
+      }
+      final current = state.client;
+      return current?.isConnected == true ? current : null;
+    }
+
+    final previousConnect = state.connectFuture;
+    state.generation++;
+    state.client = null;
+    state.status = McpStatus.connecting;
+    state.error = null;
+    state.cooldown = null;
+
+    final server = getById(id);
+    if (server == null || !server.enabled || _disposed) {
+      failedClient.dispose();
+      return null;
+    }
+    try {
+      final connected = await _beginConnect(
+        id,
+        server,
+        state,
+        waitFor: previousConnect,
+      );
+      await failedClient.waitForPendingRequests();
+      return connected ? state.client : null;
+    } finally {
+      failedClient.dispose();
+    }
+  }
+
+  _Cooldown? _activeCooldown(_ServerConnection? state) {
+    final cooldown = state?.cooldown;
+    if (cooldown == null) return null;
+    if (!cooldown.until.isAfter(DateTime.now())) {
+      state!.cooldown = null;
+      return null;
+    }
+    return cooldown;
+  }
+
+  void _enterCooldown(_ServerConnection state, Duration? retryAfter) {
+    const minimum = Duration(seconds: 1);
+    var delay = retryAfter ?? const Duration(seconds: 30);
+    if (delay < minimum) delay = minimum;
+    final now = DateTime.now();
+    final until = now.add(delay);
+    final current = _activeCooldown(state);
+    state.cooldown = _Cooldown(
+      startedAt: now,
+      until: current != null && current.until.isAfter(until)
+          ? current.until
+          : until,
+    );
+  }
+
+  void _clearCooldownAfterSuccess(
+    _ServerConnection state,
+    DateTime requestStartedAt,
+  ) {
+    final cooldown = state.cooldown;
+    if (cooldown == null || !requestStartedAt.isAfter(cooldown.startedAt)) {
+      return;
+    }
+    state.cooldown = null;
+  }
+
+  bool _requiresCooldown(mcp.McpHttpError error) =>
+      error.statusCode == 429 ||
+      (error.statusCode >= 500 && error.retryAfter != null);
+
+  bool _isRejectedSession(Object error) =>
+      error is mcp.McpHttpError &&
+      error.statusCode == 404 &&
+      error.sessionIdPresent &&
+      error.canRetryRequest;
+
+  bool _isSafeTransient(Object error) {
+    if (error is mcp.McpHttpError) {
+      return error.statusCode == 408 ||
+          error.statusCode == 429 ||
+          error.statusCode >= 500;
+    }
+    if (error is! mcp.McpError || error.code != null) return false;
+    final message = error.message.toLowerCase();
+    return message.contains('timed out') ||
+        message.contains('transport') ||
+        message.contains('socket') ||
+        message.contains('connection') ||
+        message.contains('handshake');
+  }
+
+  mcp.CallToolResult _toolError(String message) =>
+      mcp.CallToolResult([mcp.TextContent(text: message)], isError: true);
+
+  void _notify() {
+    if (!_disposed) notifyListeners();
+  }
+
   List<McpToolConfig> getEnabledToolsForServers(Set<String> serverIds) {
-    // Only expose tools for servers that are both selected AND currently connected
     final tools = <McpToolConfig>[];
     for (final s in _servers.where((s) => serverIds.contains(s.id))) {
-      if (statusFor(s.id) != McpStatus.connected) continue;
       if (!s.enabled) continue;
       tools.addAll(s.tools.where((t) => t.enabled));
     }
@@ -1835,11 +2129,14 @@ class McpProvider extends ChangeNotifier {
 
   @override
   void dispose() {
-    // Clean up timers
-    for (final t in _heartbeats.values) {
-      t.cancel();
+    if (_disposed) return;
+    _disposed = true;
+    for (final state in _connections.values) {
+      state.generation++;
+      state.client?.dispose();
+      state.client = null;
     }
-    _heartbeats.clear();
+    _connections.clear();
     super.dispose();
   }
 

--- a/lib/core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart
+++ b/lib/core/services/mcp/kelivo_filesystem/kelivo_filesystem_server.dart
@@ -1937,15 +1937,20 @@ class KelivoFilesystemInMemoryClientTransport implements mcp.ClientTransport {
   Future<void> get onClose => _closeCompleter.future;
 
   @override
-  void send(dynamic message) {
-    if (_closed) return;
-    Future.microtask(() async {
+  mcp.TransportSendOperation send(dynamic message) {
+    if (_closed) {
+      return mcp.TransportSendOperation(
+        Future<void>.error(mcp.McpError('Transport is closed')),
+      );
+    }
+    final done = Future<void>.sync(() async {
       final resp = await _server.handleMessage(message);
       if (_closed) return;
       if (resp != null) {
         _messageController.add(resp);
       }
     });
+    return mcp.TransportSendOperation(done);
   }
 
   @override

--- a/lib/core/services/mcp/mcp_tool_service.dart
+++ b/lib/core/services/mcp/mcp_tool_service.dart
@@ -42,11 +42,7 @@ class McpToolService extends ChangeNotifier {
     if (selected.isEmpty) return null;
 
     // Find a server that has this tool enabled
-    final connected = mcpProvider.connectedServers
-        .where((s) => selected.contains(s.id))
-        .toList();
-    // debugPrint('[MCP/Call/Select] connectedAndSelected=${connected.map((s)=>s.id).join(',')}');
-    for (final s in connected) {
+    for (final s in _routingServers(mcpProvider, selected)) {
       final has = s.tools.any((t) => t.enabled && t.name == toolName);
       if (has) {
         // debugPrint('[MCP/Call/Select] using server=${s.id} name=${s.name} transport=${s.transport.name}');
@@ -66,12 +62,9 @@ class McpToolService extends ChangeNotifier {
   }) async {
     // Attempt call via selected server
     final selected = chat.getConversationMcpServers(conversationId).toSet();
-    final connected = mcpProvider.connectedServers
-        .where((s) => selected.contains(s.id))
-        .toList();
     mcp.CallToolResult? res;
     McpServerConfig? usedServer;
-    for (final s in connected) {
+    for (final s in _routingServers(mcpProvider, selected)) {
       final has = s.tools.any((t) => t.enabled && t.name == toolName);
       if (!has) continue;
       usedServer = s;
@@ -80,16 +73,12 @@ class McpToolService extends ChangeNotifier {
     }
     if (res == null) {
       if (usedServer != null) {
-        final errMsg = mcpProvider.errorFor(usedServer.id) ?? 'Unknown error';
-        final schema = usedServer.tools
-            .firstWhere((t) => t.name == toolName)
-            .schema;
+        final errMsg =
+            mcpProvider.errorFor(usedServer.id) ?? 'MCP server is unavailable.';
         return _renderToolErrorForModel(
           serverName: usedServer.name,
           toolName: toolName,
-          arguments: arguments,
           errorMessage: errMsg,
-          schema: schema,
         );
       }
       return '';
@@ -179,12 +168,12 @@ class McpToolService extends ChangeNotifier {
     // debugPrint('[MCP/Call/Select] assistant=${assistantId ?? a?.id ?? '(current)'} tool=$toolName selectedServers=${selected.join(',')}');
     if (selected.isEmpty) return '';
 
-    var candidates = mcpProvider.connectedServers.where(
-      (s) => selected.contains(s.id),
-    );
+    var candidates = _routingServers(mcpProvider, selected);
     // If targetServerId is given, try only that server
     if (targetServerId != null) {
-      candidates = candidates.where((s) => s.id == targetServerId);
+      candidates = candidates
+          .where((s) => s.id == targetServerId)
+          .toList(growable: false);
     }
     for (final s in candidates) {
       final has = s.tools.any((t) => t.enabled && t.name == toolName);
@@ -192,14 +181,12 @@ class McpToolService extends ChangeNotifier {
         // debugPrint('[MCP/Call/Select] using server=${s.id} name=${s.name} transport=${s.transport.name}');
         final res = await mcpProvider.callTool(s.id, toolName, arguments);
         if (res == null) {
-          final errMsg = mcpProvider.errorFor(s.id) ?? 'Unknown error';
-          final schema = s.tools.firstWhere((t) => t.name == toolName).schema;
+          final errMsg =
+              mcpProvider.errorFor(s.id) ?? 'MCP server is unavailable.';
           return _renderToolErrorForModel(
             serverName: s.name,
             toolName: toolName,
-            arguments: arguments,
             errorMessage: errMsg,
-            schema: schema,
           );
         }
         final buf = StringBuffer();
@@ -269,24 +256,41 @@ class McpToolService extends ChangeNotifier {
     return '';
   }
 
+  /// Routed server candidates: connected servers first (usable now), then
+  /// any enabled selected server (so reconnecting/error servers still get
+  /// tried through [McpProvider.callTool], which surfaces unavailable
+  /// errors precisely instead of silently skipping them).
+  Iterable<McpServerConfig> _routingServers(
+    McpProvider provider,
+    Set<String> selected,
+  ) sync* {
+    for (final server in provider.servers) {
+      if (server.enabled &&
+          selected.contains(server.id) &&
+          provider.statusFor(server.id) == McpStatus.connected) {
+        yield server;
+      }
+    }
+    for (final server in provider.servers) {
+      if (server.enabled &&
+          selected.contains(server.id) &&
+          provider.statusFor(server.id) != McpStatus.connected) {
+        yield server;
+      }
+    }
+  }
+
   String _renderToolErrorForModel({
     required String serverName,
     required String toolName,
-    required Map<String, dynamic> arguments,
     required String errorMessage,
-    Map<String, dynamic>? schema,
   }) {
-    // Provide a concise JSON for the model to self-correct and retry
     final map = <String, dynamic>{
       'type': 'tool_error',
-      'error': 'invalid_arguments',
+      'error': 'tool_unavailable',
       'message': errorMessage,
       'tool': toolName,
       'server': serverName,
-      'lastArguments': arguments,
-      if (schema != null && schema.isNotEmpty) 'parametersSchema': schema,
-      'instruction':
-          'Revise arguments to satisfy parametersSchema, then call the same tool again.',
     };
     return const JsonEncoder.withIndent('  ').convert(map);
   }

--- a/lib/desktop/setting/mcp_edit_dialog.dart
+++ b/lib/desktop/setting/mcp_edit_dialog.dart
@@ -57,7 +57,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
   McpTransportType _transport = McpTransportType.http;
   final _urlCtrl = TextEditingController();
   final List<_HeaderEntry> _headers = [];
-  int _heartbeatIntervalSeconds = 12;
   // STDIO fields (desktop only)
   final _cmdCtrl = TextEditingController();
   final _argsCtrl = TextEditingController(); // space-separated args
@@ -81,7 +80,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
       _nameCtrl.text = server.name;
       _transport = server.transport;
       _urlCtrl.text = server.url;
-      _heartbeatIntervalSeconds = server.heartbeatIntervalSeconds ?? 12;
       _toolPrefixCtrl.text = server.toolPrefix;
       server.headers.forEach((k, v) {
         _headers.add(
@@ -221,9 +219,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           if (h.key.text.trim().isNotEmpty)
             h.key.text.trim(): h.value.text.trim(),
       },
-      heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
-          ? null
-          : _heartbeatIntervalSeconds,
       toolPrefix: _toolPrefixCtrl.text.trim(),
       oauth: oauth,
     );
@@ -292,8 +287,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
             env: env,
             workingDirectory: clearing ? null : cwd,
             clearWorkingDirectory: clearing,
-            heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
-            clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
             toolPrefix: toolPrefix,
           ),
         );
@@ -306,9 +299,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           args: args,
           env: env,
           workingDirectory: cwd.isEmpty ? null : cwd,
-          heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
-              ? null
-              : _heartbeatIntervalSeconds,
           toolPrefix: toolPrefix,
         );
       }
@@ -333,8 +323,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
             transport: _transport,
             url: url,
             headers: headers,
-            heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
-            clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
             toolPrefix: toolPrefix,
             oauth: oauth,
             clearOauth: oauth == null,
@@ -354,8 +342,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
             transport: _transport,
             url: url,
             headers: headers,
-            heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
-            clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
             toolPrefix: toolPrefix,
             oauth: oauth,
             clearOauth: oauth == null,
@@ -369,9 +355,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           transport: _transport,
           url: url,
           headers: headers,
-          heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
-              ? null
-              : _heartbeatIntervalSeconds,
           toolPrefix: toolPrefix,
           oauth: oauth,
         );
@@ -938,26 +921,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
           ),
           if (_advancedExpanded) ...[
             const SizedBox(height: 12),
-            Text(
-              l10n.mcpServerEditSheetHeartbeatLabel,
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: AppFontWeights.semibold,
-              ),
-            ),
-            const SizedBox(height: 6),
-            _heartbeatPicker(),
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Text(
-                l10n.mcpServerEditSheetHeartbeatHint,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: cs.onSurface.withValues(alpha: 0.7),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
             _labeledField(
               label: l10n.mcpServerEditSheetToolPrefixLabel,
               controller: _toolPrefixCtrl,
@@ -1204,20 +1167,6 @@ class _DesktopMcpEditDialogState extends State<_DesktopMcpEditDialog>
     // Simple whitespace split; users can provide quoted args as a single token for now.
     // For advanced quoting, consider a shell-like parser later.
     return text.split(RegExp(r"\s+")).where((e) => e.isNotEmpty).toList();
-  }
-
-  static const _heartbeatOptions = [12, 30, 60, 120, 300];
-
-  Widget _heartbeatPicker() {
-    final labels = _heartbeatOptions.map((s) => '${s}s').toList();
-    final idx = _heartbeatOptions.indexOf(_heartbeatIntervalSeconds);
-    final selected = idx >= 0 ? idx : 0;
-    return _SegChoiceBar(
-      labels: labels,
-      selectedIndex: selected,
-      onSelected: (i) =>
-          setState(() => _heartbeatIntervalSeconds = _heartbeatOptions[i]),
-    );
   }
 
   @override

--- a/lib/features/mcp/pages/mcp_page.dart
+++ b/lib/features/mcp/pages/mcp_page.dart
@@ -116,8 +116,10 @@ class McpPage extends StatelessWidget {
                         child: ElevatedButton.icon(
                           onPressed: () async {
                             final mcpProvider = ctx.read<McpProvider>();
-                            await mcpProvider.reconnect(serverId);
-                            if (ctx.mounted) {
+                            final connected = await mcpProvider.reconnect(
+                              serverId,
+                            );
+                            if (connected && ctx.mounted) {
                               Navigator.of(ctx).pop();
                             }
                           },

--- a/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
+++ b/lib/features/mcp/widgets/mcp_server_edit_sheet.dart
@@ -62,7 +62,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
   McpTransportType _transport = McpTransportType.http;
   final _urlCtrl = TextEditingController();
   final List<_HeaderEntry> _headers = [];
-  int _heartbeatIntervalSeconds = 12;
   final _toolPrefixCtrl = TextEditingController();
   bool _advancedExpanded = false;
   // OAuth section: shared logic lives in McpOAuthSectionController
@@ -83,7 +82,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
       _nameCtrl.text = server.name;
       _transport = server.transport;
       _urlCtrl.text = server.url;
-      _heartbeatIntervalSeconds = server.heartbeatIntervalSeconds ?? 12;
       _toolPrefixCtrl.text = server.toolPrefix;
       server.headers.forEach((k, v) {
         _headers.add(
@@ -190,9 +188,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
           if (h.key.text.trim().isNotEmpty)
             h.key.text.trim(): h.value.text.trim(),
       },
-      heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
-          ? null
-          : _heartbeatIntervalSeconds,
       toolPrefix: _toolPrefixCtrl.text.trim(),
       oauth: oauth,
     );
@@ -334,20 +329,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
     );
   }
 
-  static const _heartbeatOptions = [12, 30, 60, 120, 300];
-
-  Widget _heartbeatPicker() {
-    final labels = _heartbeatOptions.map((s) => '${s}s').toList();
-    final idx = _heartbeatOptions.indexOf(_heartbeatIntervalSeconds);
-    final selected = idx >= 0 ? idx : 0;
-    return _SegChoiceBar(
-      labels: labels,
-      selectedIndex: selected,
-      onSelected: (i) =>
-          setState(() => _heartbeatIntervalSeconds = _heartbeatOptions[i]),
-    );
-  }
-
   Widget _basicForm() {
     final l10n = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
@@ -460,26 +441,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
           ),
           if (_advancedExpanded) ...[
             const SizedBox(height: 12),
-            Text(
-              l10n.mcpServerEditSheetHeartbeatLabel,
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: AppFontWeights.semibold,
-              ),
-            ),
-            const SizedBox(height: 6),
-            _heartbeatPicker(),
-            Padding(
-              padding: const EdgeInsets.only(top: 4),
-              child: Text(
-                l10n.mcpServerEditSheetHeartbeatHint,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: cs.onSurface.withValues(alpha: 0.7),
-                ),
-              ),
-            ),
-            const SizedBox(height: 12),
             _inputRow(
               label: l10n.mcpServerEditSheetToolPrefixLabel,
               controller: _toolPrefixCtrl,
@@ -589,8 +550,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
           transport: _transport,
           url: url,
           headers: headers,
-          heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
-          clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
           toolPrefix: toolPrefix,
           oauth: oauth,
           clearOauth: oauth == null,
@@ -610,8 +569,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
           transport: _transport,
           url: url,
           headers: headers,
-          heartbeatIntervalSeconds: _heartbeatIntervalSeconds,
-          clearHeartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12,
           toolPrefix: toolPrefix,
           oauth: oauth,
           clearOauth: oauth == null,
@@ -625,9 +582,6 @@ class _McpServerEditSheetState extends State<_McpServerEditSheet>
         transport: _transport,
         url: url,
         headers: headers,
-        heartbeatIntervalSeconds: _heartbeatIntervalSeconds == 12
-            ? null
-            : _heartbeatIntervalSeconds,
         toolPrefix: toolPrefix,
         oauth: oauth,
       );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1599,8 +1599,6 @@
   "mcpServerEditSheetNameLabel": "Name",
   "mcpServerEditSheetTransportLabel": "Transport",
   "mcpServerEditSheetSseRetryHint": "If SSE fails, try a few times",
-  "mcpServerEditSheetHeartbeatLabel": "Heartbeat Interval",
-  "mcpServerEditSheetHeartbeatHint": "If you encounter frequent 429 (rate limit) errors, try increasing this interval.",
   "mcpServerEditSheetAdvancedLabel": "Advanced Settings",
   "mcpServerEditSheetUrlLabel": "Server URL",
   "mcpServerEditSheetCustomHeadersTitle": "Custom Headers",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6794,18 +6794,6 @@ abstract class AppLocalizations {
   /// **'If SSE fails, try a few times'**
   String get mcpServerEditSheetSseRetryHint;
 
-  /// No description provided for @mcpServerEditSheetHeartbeatLabel.
-  ///
-  /// In en, this message translates to:
-  /// **'Heartbeat Interval'**
-  String get mcpServerEditSheetHeartbeatLabel;
-
-  /// No description provided for @mcpServerEditSheetHeartbeatHint.
-  ///
-  /// In en, this message translates to:
-  /// **'If you encounter frequent 429 (rate limit) errors, try increasing this interval.'**
-  String get mcpServerEditSheetHeartbeatHint;
-
   /// No description provided for @mcpServerEditSheetAdvancedLabel.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3745,13 +3745,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mcpServerEditSheetSseRetryHint => 'If SSE fails, try a few times';
 
   @override
-  String get mcpServerEditSheetHeartbeatLabel => 'Heartbeat Interval';
-
-  @override
-  String get mcpServerEditSheetHeartbeatHint =>
-      'If you encounter frequent 429 (rate limit) errors, try increasing this interval.';
-
-  @override
   String get mcpServerEditSheetAdvancedLabel => 'Advanced Settings';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3611,12 +3611,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mcpServerEditSheetSseRetryHint => '如果SSE连接失败，请多试几次';
 
   @override
-  String get mcpServerEditSheetHeartbeatLabel => '心跳间隔';
-
-  @override
-  String get mcpServerEditSheetHeartbeatHint => '若频繁遇到 429 (限流) 错误，建议延长心跳间隔。';
-
-  @override
   String get mcpServerEditSheetAdvancedLabel => '高级设置';
 
   @override
@@ -12201,12 +12195,6 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get mcpServerEditSheetSseRetryHint => '如果SSE连接失败，请多试几次';
 
   @override
-  String get mcpServerEditSheetHeartbeatLabel => '心跳间隔';
-
-  @override
-  String get mcpServerEditSheetHeartbeatHint => '若频繁遇到 429 (限流) 错误，建议延长心跳间隔。';
-
-  @override
   String get mcpServerEditSheetAdvancedLabel => '高级设置';
 
   @override
@@ -20788,12 +20776,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get mcpServerEditSheetSseRetryHint => '如果SSE連線失敗，請多試幾次';
-
-  @override
-  String get mcpServerEditSheetHeartbeatLabel => '心跳間隔';
-
-  @override
-  String get mcpServerEditSheetHeartbeatHint => '若頻繁遇到 429 (限流) 錯誤，建議延長心跳間隔。';
 
   @override
   String get mcpServerEditSheetAdvancedLabel => '進階設定';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1222,8 +1222,6 @@
   "mcpServerEditSheetNameLabel": "名称",
   "mcpServerEditSheetTransportLabel": "传输类型",
   "mcpServerEditSheetSseRetryHint": "如果SSE连接失败，请多试几次",
-  "mcpServerEditSheetHeartbeatLabel": "心跳间隔",
-  "mcpServerEditSheetHeartbeatHint": "若频繁遇到 429 (限流) 错误，建议延长心跳间隔。",
   "mcpServerEditSheetAdvancedLabel": "高级设置",
   "mcpServerEditSheetUrlLabel": "服务器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自定义请求头",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1257,8 +1257,6 @@
   "mcpServerEditSheetNameLabel": "名称",
   "mcpServerEditSheetTransportLabel": "传输类型",
   "mcpServerEditSheetSseRetryHint": "如果SSE连接失败，请多试几次",
-  "mcpServerEditSheetHeartbeatLabel": "心跳间隔",
-  "mcpServerEditSheetHeartbeatHint": "若频繁遇到 429 (限流) 错误，建议延长心跳间隔。",
   "mcpServerEditSheetAdvancedLabel": "高级设置",
   "mcpServerEditSheetUrlLabel": "服务器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自定义请求头",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1212,8 +1212,6 @@
   "mcpServerEditSheetNameLabel": "名稱",
   "mcpServerEditSheetTransportLabel": "傳輸類型",
   "mcpServerEditSheetSseRetryHint": "如果SSE連線失敗，請多試幾次",
-  "mcpServerEditSheetHeartbeatLabel": "心跳間隔",
-  "mcpServerEditSheetHeartbeatHint": "若頻繁遇到 429 (限流) 錯誤，建議延長心跳間隔。",
   "mcpServerEditSheetAdvancedLabel": "進階設定",
   "mcpServerEditSheetUrlLabel": "伺服器地址",
   "mcpServerEditSheetCustomHeadersTitle": "自訂請求標頭",

--- a/test/core/providers/mcp_provider_remote_session_test.dart
+++ b/test/core/providers/mcp_provider_remote_session_test.dart
@@ -1,0 +1,597 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:Cuplivo/core/providers/mcp_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mcp_client/mcp_client.dart' as mcp;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = null;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('safe refresh retries once and merges notification bursts', () async {
+    final server = await _MockMcpServer.start(
+      failFirstToolsList: true,
+      sendToolsChangedBurst: true,
+    );
+    final provider = _provider();
+    addTearDown(provider.dispose);
+
+    final id = await provider.addServer(
+      enabled: true,
+      name: 'Remote',
+      transport: McpTransportType.http,
+      url: server.url,
+    );
+    await _waitUntil(
+      () => provider.getById(id)?.tools.length == 1,
+      label: 'initial tools: ${server._counts}',
+    );
+    await _waitUntil(() => server.burstSent, label: 'notification burst');
+    await _waitUntil(
+      () => server.count('tools/list') >= 3,
+      label: 'coalesced refresh: ${server._counts}',
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(server.count('initialize'), 1);
+    expect(server.count('tools/list'), 3);
+    expect(server.maxConcurrentToolsList, 1);
+    expect(
+      server.toolsListRequestTimes[1].difference(
+        server.toolsListRequestTimes[0],
+      ),
+      greaterThanOrEqualTo(const Duration(milliseconds: 1900)),
+    );
+
+    server.coordinateCooldown = true;
+    final olderSuccess = provider.callTool(id, 'slow-success', const {});
+    await _waitUntil(
+      () => server.count('tools/call') == 1,
+      label: 'older tool call',
+    );
+    final limited = await provider.callTool(id, 'limited', const {});
+    final callsAfterLimit = server.count('tools/call');
+    expect((await olderSuccess)?.isError, isFalse);
+    expect(provider.isInCooldown(id), isTrue);
+    final blocked = await provider.callTool(id, 'echo', const {});
+
+    expect(limited?.isError, isTrue);
+    expect(blocked?.isError, isTrue);
+    expect(provider.isInCooldown(id), isTrue);
+    expect(server.count('tools/call'), callsAfterLimit);
+    expect(server.count('initialize'), 1);
+    await server.close();
+  }, timeout: const Timeout(Duration(seconds: 12)));
+
+  test('unknown tool result is never replayed after a socket drop', () async {
+    final server = await _MockMcpServer.start(dropFirstToolResponse: true);
+    final provider = _provider();
+    addTearDown(provider.dispose);
+
+    final id = await provider.addServer(
+      enabled: true,
+      name: 'Remote',
+      transport: McpTransportType.http,
+      url: server.url,
+    );
+    await _waitUntil(
+      () => provider.getById(id)?.tools.length == 1,
+      label: 'initial tools: ${server._counts}',
+    );
+
+    final result = await provider.callTool(id, 'side-effect', const {});
+
+    expect(result?.isError, isTrue);
+    expect(
+      (result!.content.single as mcp.TextContent).text,
+      contains('result is unknown'),
+    );
+    expect(server.count('tools/call'), 1);
+    expect(server.count('initialize'), 1);
+    await server.close();
+  }, timeout: const Timeout(Duration(seconds: 8)));
+
+  test('connect and manual reconnect are single-flight', () async {
+    final firstInitializeGate = Completer<void>();
+    final server = await _MockMcpServer.start(
+      firstInitializeGate: firstInitializeGate,
+    );
+    final provider = _provider();
+    addTearDown(provider.dispose);
+
+    final id = await provider.addServer(
+      enabled: true,
+      name: 'Remote',
+      transport: McpTransportType.http,
+      url: server.url,
+    );
+    await _waitUntil(
+      () => server.count('initialize') == 1,
+      label: 'first initialize: ${server._counts}',
+    );
+
+    final reconnect = provider.reconnect(id);
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    expect(server.count('initialize'), 1);
+    firstInitializeGate.complete();
+
+    expect(
+      await reconnect.timeout(
+        const Duration(seconds: 3),
+        onTimeout: () => throw StateError(
+          'reconnect stuck: initialize=${server.count('initialize')} '
+          'delete=${server.deleteCount} status=${provider.statusFor(id)}',
+        ),
+      ),
+      isTrue,
+    );
+    await _waitUntil(
+      () => provider.getById(id)?.tools.length == 1,
+      label: 'reconnected tools: ${server._counts}',
+    );
+    expect(server.count('initialize'), 2);
+    expect(server.maxConcurrentInitialize, 1);
+    expect(server.deleteCount, 1);
+    await server.close();
+  }, timeout: const Timeout(Duration(seconds: 8)));
+
+  test('GET 404 replaces the expired session once', () async {
+    final server = await _MockMcpServer.start(expireFirstGet: true);
+    final provider = _provider();
+    addTearDown(provider.dispose);
+
+    final id = await provider.addServer(
+      enabled: true,
+      name: 'Remote',
+      transport: McpTransportType.http,
+      url: server.url,
+    );
+    await _waitUntil(
+      () => server.count('initialize') == 2,
+      label: 'replacement initialize',
+    );
+    await _waitUntil(
+      () => provider.getById(id)?.tools.length == 1,
+      label: 'replacement tools',
+    );
+
+    expect(server.count('initialize'), 2);
+    expect(server.deleteCount, 0);
+    await server.close();
+  }, timeout: const Timeout(Duration(seconds: 8)));
+
+  test(
+    'concurrent session 404 responses share one replacement connection',
+    () async {
+      final server = await _MockMcpServer.start(
+        rejectFirstSessionToolCalls: true,
+      );
+      final provider = _provider();
+      addTearDown(provider.dispose);
+
+      final id = await provider.addServer(
+        enabled: true,
+        name: 'Remote',
+        transport: McpTransportType.http,
+        url: server.url,
+      );
+      await _waitUntil(
+        () => provider.getById(id)?.tools.length == 1,
+        label: 'initial tools',
+      );
+
+      final results = await Future.wait([
+        provider.callTool(id, 'echo', const {'value': 'a'}),
+        provider.callTool(id, 'echo', const {'value': 'b'}),
+      ]);
+
+      expect(results, everyElement(isNotNull));
+      expect(results.map((result) => result!.isError), everyElement(isFalse));
+      expect(server.count('initialize'), 2);
+      expect(server.count('tools/call'), 4);
+      await server.close();
+    },
+    timeout: const Timeout(Duration(seconds: 8)),
+  );
+
+  test(
+    'server without tools capability stays connected with an empty list',
+    () async {
+      final server = await _MockMcpServer.start(supportsTools: false);
+      final provider = _provider();
+      addTearDown(provider.dispose);
+
+      final id = await provider.addServer(
+        enabled: true,
+        name: 'Resources only',
+        transport: McpTransportType.http,
+        url: server.url,
+      );
+      await _waitUntil(
+        () => provider.statusFor(id) == McpStatus.connected,
+        label: 'resources-only connection',
+      );
+
+      expect(provider.getById(id)?.tools, isEmpty);
+      expect(provider.errorFor(id), isNull);
+      expect(server.count('tools/list'), 0);
+      await server.close();
+    },
+    timeout: const Timeout(Duration(seconds: 8)),
+  );
+
+  test(
+    'disabling returns before remote session termination finishes',
+    () async {
+      final deleteRelease = Completer<void>();
+      final server = await _MockMcpServer.start(deleteRelease: deleteRelease);
+      final provider = _provider();
+      addTearDown(provider.dispose);
+
+      final id = await provider.addServer(
+        enabled: true,
+        name: 'Remote',
+        transport: McpTransportType.http,
+        url: server.url,
+      );
+      await _waitUntil(
+        () => provider.getById(id)?.tools.length == 1,
+        label: 'initial tools',
+      );
+
+      final disabling = provider.updateServer(
+        provider.getById(id)!.copyWith(enabled: false),
+      );
+      await _waitUntil(
+        () => server.deleteCount == 1,
+        label: 'session termination request',
+      );
+      await disabling.timeout(const Duration(milliseconds: 500));
+
+      expect(provider.getById(id)?.enabled, isFalse);
+      expect(provider.statusFor(id), McpStatus.idle);
+      expect(deleteRelease.isCompleted, isFalse);
+      if (!deleteRelease.isCompleted) deleteRelease.complete();
+      await server.close();
+    },
+    timeout: const Timeout(Duration(seconds: 8)),
+  );
+
+  test(
+    'cached tools reconnect lazily and preserve validation errors',
+    () async {
+      final server = await _MockMcpServer.start();
+      final provider = _provider();
+      addTearDown(provider.dispose);
+
+      final id = await provider.addServer(
+        enabled: true,
+        name: 'Remote',
+        transport: McpTransportType.http,
+        url: server.url,
+      );
+      await _waitUntil(
+        () => provider.getById(id)?.tools.length == 1,
+        label: 'initial tools',
+      );
+      await provider.setToolNeedsApproval(id, 'echo', true);
+
+      final invalid = await provider.callTool(id, 'invalid', const {});
+      expect(invalid?.isError, isTrue);
+      expect(
+        (invalid!.content.single as mcp.TextContent).text,
+        contains('missing value'),
+      );
+
+      await provider.disconnect(id, terminateSession: false);
+      expect(provider.getEnabledToolsForServers({id}), hasLength(1));
+      expect(provider.toolNeedsApproval('echo'), isTrue);
+
+      final reconnected = await provider.callTool(id, 'echo', const {});
+      expect(reconnected?.isError, isFalse);
+      expect(server.count('initialize'), 2);
+      await server.close();
+    },
+    timeout: const Timeout(Duration(seconds: 8)),
+  );
+}
+
+/// Constructs the provider the same way [McpProvider] is used in the app
+/// (SharedPreferences-backed persistence, no UI context).
+McpProvider _provider() {
+  final provider = McpProvider(
+    contextProvider: () => throw UnimplementedError(),
+  );
+  return provider;
+}
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+  String label = 'condition',
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('$label was not met');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+}
+
+class _MockMcpServer {
+  final HttpServer _server;
+  final bool failFirstToolsList;
+  final bool sendToolsChangedBurst;
+  final bool dropFirstToolResponse;
+  final bool expireFirstGet;
+  final bool rejectFirstSessionToolCalls;
+  final bool supportsTools;
+  final Completer<void>? firstInitializeGate;
+  final Completer<void>? deleteRelease;
+  final Map<String, int> _counts = {};
+  final List<HttpResponse> _openStreams = [];
+  late final Future<void> _serving;
+  HttpResponse? _publicStream;
+  bool _toolsListSucceeded = false;
+  bool _burstSent = false;
+  int _activeInitialize = 0;
+  int _activeToolsList = 0;
+  int maxConcurrentInitialize = 0;
+  int maxConcurrentToolsList = 0;
+  int deleteCount = 0;
+  int _getCount = 0;
+  final List<HttpResponse> _expiredToolResponses = [];
+  final List<DateTime> toolsListRequestTimes = [];
+  bool coordinateCooldown = false;
+
+  bool get burstSent => _burstSent;
+
+  _MockMcpServer._(
+    this._server, {
+    required this.failFirstToolsList,
+    required this.sendToolsChangedBurst,
+    required this.dropFirstToolResponse,
+    required this.expireFirstGet,
+    required this.rejectFirstSessionToolCalls,
+    required this.supportsTools,
+    required this.firstInitializeGate,
+    required this.deleteRelease,
+  }) {
+    _serving = _serve();
+  }
+
+  static Future<_MockMcpServer> start({
+    bool failFirstToolsList = false,
+    bool sendToolsChangedBurst = false,
+    bool dropFirstToolResponse = false,
+    bool expireFirstGet = false,
+    bool rejectFirstSessionToolCalls = false,
+    bool supportsTools = true,
+    Completer<void>? firstInitializeGate,
+    Completer<void>? deleteRelease,
+  }) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _MockMcpServer._(
+      server,
+      failFirstToolsList: failFirstToolsList,
+      sendToolsChangedBurst: sendToolsChangedBurst,
+      dropFirstToolResponse: dropFirstToolResponse,
+      expireFirstGet: expireFirstGet,
+      rejectFirstSessionToolCalls: rejectFirstSessionToolCalls,
+      supportsTools: supportsTools,
+      firstInitializeGate: firstInitializeGate,
+      deleteRelease: deleteRelease,
+    );
+  }
+
+  String get url => 'http://${_server.address.address}:${_server.port}/mcp';
+
+  int count(String method) => _counts[method] ?? 0;
+
+  Future<void> close() async {
+    for (final response in _openStreams) {
+      unawaited(response.close());
+    }
+    await _server.close(force: true);
+    await _serving.timeout(const Duration(seconds: 1), onTimeout: () {});
+  }
+
+  Future<void> _serve() async {
+    await for (final request in _server) {
+      if (request.method == 'GET') {
+        _getCount++;
+        if (expireFirstGet && _getCount == 1) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          continue;
+        }
+        request.response.bufferOutput = false;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        request.response.write(': connected\n\n');
+        await request.response.flush();
+        _publicStream = request.response;
+        _openStreams.add(request.response);
+        unawaited(_maybeSendBurst());
+        continue;
+      }
+      if (request.method == 'DELETE') {
+        deleteCount++;
+        await request.drain<void>();
+        if (deleteRelease != null) await deleteRelease!.future;
+        request.response.statusCode = HttpStatus.noContent;
+        await request.response.close();
+        continue;
+      }
+
+      final body = await utf8.decoder.bind(request).join();
+      final message = jsonDecode(body) as Map<String, dynamic>;
+      final method = message['method']?.toString();
+      if (method != null) _counts[method] = count(method) + 1;
+
+      switch (method) {
+        case 'initialize':
+          await _handleInitialize(request, message);
+        case 'tools/list':
+          await _handleToolsList(request, message);
+        case 'tools/call':
+          await _handleToolCall(request, message);
+        default:
+          request.response.statusCode = HttpStatus.accepted;
+          await request.response.close();
+      }
+    }
+  }
+
+  Future<void> _handleInitialize(
+    HttpRequest request,
+    Map<String, dynamic> message,
+  ) async {
+    _activeInitialize++;
+    if (_activeInitialize > maxConcurrentInitialize) {
+      maxConcurrentInitialize = _activeInitialize;
+    }
+    if (count('initialize') == 1 && firstInitializeGate != null) {
+      await firstInitializeGate!.future;
+    }
+    request.response.headers.set(
+      'MCP-Session-Id',
+      'session-${count('initialize')}',
+    );
+    _writeJson(request.response, {
+      'jsonrpc': '2.0',
+      'id': message['id'],
+      'result': {
+        'protocolVersion': mcp.McpProtocol.defaultVersion,
+        'serverInfo': {'name': 'Mock', 'version': '1.0.0'},
+        'capabilities': supportsTools
+            ? {'tools': <String, dynamic>{}}
+            : {'resources': <String, dynamic>{}},
+      },
+    });
+    await request.response.close();
+    _activeInitialize--;
+  }
+
+  Future<void> _handleToolsList(
+    HttpRequest request,
+    Map<String, dynamic> message,
+  ) async {
+    toolsListRequestTimes.add(DateTime.now());
+    _activeToolsList++;
+    if (_activeToolsList > maxConcurrentToolsList) {
+      maxConcurrentToolsList = _activeToolsList;
+    }
+    try {
+      if (failFirstToolsList && count('tools/list') == 1) {
+        request.response.statusCode = HttpStatus.serviceUnavailable;
+        request.response.headers.set(HttpHeaders.retryAfterHeader, '2');
+        await request.response.close();
+        return;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      _toolsListSucceeded = true;
+      await _maybeSendBurst();
+      _writeJson(request.response, {
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'result': {
+          'tools': [
+            {
+              'name': 'echo',
+              'description': 'echo',
+              'inputSchema': {'type': 'object'},
+            },
+          ],
+        },
+      });
+      await request.response.close();
+    } finally {
+      _activeToolsList--;
+    }
+  }
+
+  Future<void> _handleToolCall(
+    HttpRequest request,
+    Map<String, dynamic> message,
+  ) async {
+    final toolName = (message['params'] as Map?)?['name']?.toString();
+    if (rejectFirstSessionToolCalls &&
+        request.headers.value('MCP-Session-Id') == 'session-1') {
+      _expiredToolResponses.add(request.response);
+      if (_expiredToolResponses.length == 2) {
+        for (final response in _expiredToolResponses) {
+          response.statusCode = HttpStatus.notFound;
+          await response.close();
+        }
+      }
+      return;
+    }
+    if (toolName == 'invalid') {
+      _writeJson(request.response, {
+        'jsonrpc': '2.0',
+        'id': message['id'],
+        'error': {'code': -32602, 'message': 'missing value'},
+      });
+      await request.response.close();
+      return;
+    }
+    if (coordinateCooldown && toolName == 'limited') {
+      request.response.statusCode = HttpStatus.tooManyRequests;
+      request.response.headers.set(HttpHeaders.retryAfterHeader, '1');
+      await request.response.close();
+      return;
+    }
+    if (coordinateCooldown && toolName == 'slow-success') {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    if (dropFirstToolResponse && count('tools/call') == 1) {
+      final socket = await request.response.detachSocket(writeHeaders: false);
+      socket.destroy();
+      return;
+    }
+    _writeJson(request.response, {
+      'jsonrpc': '2.0',
+      'id': message['id'],
+      'result': {
+        'content': [
+          {'type': 'text', 'text': 'ok'},
+        ],
+        'isError': false,
+      },
+    });
+    await request.response.close();
+  }
+
+  Future<void> _maybeSendBurst() async {
+    final stream = _publicStream;
+    if (!sendToolsChangedBurst ||
+        !_toolsListSucceeded ||
+        _burstSent ||
+        stream == null) {
+      return;
+    }
+    _burstSent = true;
+    for (var index = 0; index < 10; index++) {
+      stream.write(
+        'data: ${jsonEncode({'jsonrpc': '2.0', 'method': 'notifications/tools/list_changed'})}\n\n',
+      );
+    }
+    await stream.flush();
+  }
+
+  void _writeJson(HttpResponse response, Object value) {
+    response.headers.contentType = ContentType.json;
+    response.write(jsonEncode(value));
+  }
+}


### PR DESCRIPTION
## Summary

Syncs upstream Kelivo's MCP connection fixes into Cuplivo and removes the old per-server heartbeat-connection feature:

- **`fix(mcp): reuse remote sessions safely`** (upstream `f5c65d46`) — single-flight connects, session-expiry recovery, cooldowns, coalesced tool refreshes
- **`fix(mcp): avoid blocking when disabling servers`** (upstream `0c6b8d1c`)
- **`fix(mcp): send SSE tool calls as UTF-8 bytes`** (upstream `0c2e782a`)
- **Reconnect storm fix** — bounded exponential backoff + failure cap for the background GET stream (upstream report: [Chevey339/kelivo#937](https://github.com/Chevey339/kelivo/issues/937), still open upstream)

## What changed

### vendored `mcp_client`
- New cancellable `TransportSendOperation` send contract; `Client` session API (`ping`, `terminateSession`, `waitForPendingRequests`, `setRequestTimeout`, `onDisconnect`/`onError`/`onToolsListChanged`)
- Rewritten streamable-HTTP transport: POST resume, Retry-After handling, 404 session-expiry recovery, redirects; UTF-8 legacy-SSE sends
- Shared `SseParser` refactor; `McpHttpError` model
- Kept Cuplivo-only surfaces: JSON-RPC log bridge and OAuth hooks (token refresh bound, refresh-before-connect, `onTokenRefreshed` persistence)

### MCP provider
- `_ServerConnection` state machine (connect dedupe, generation guards, cooldowns on 429/5xx/401/403, `_recoverExpiredSession` on 404, drain-based `refreshTools`)
- `callTool` returns precise `tool_error` results instead of reconnect storms
- Preserved: SharedPreferences persistence, backup/restore reload, trash restore, OAuth flows, retired-server cleanup
- **Discarded**: per-server heartbeat interval (model/JSON, timers, mobile + desktop UI, 2 l10n keys). Old persisted configs are tolerated — the key is simply ignored, heartbeat uses library defaults.

### Other
- `mcp_tool_service`: connected-first routing + `tool_unavailable` model errors (upstream semantics)
- Tests: ported upstream 8-test remote-session suite; adapted close-race / OAuth-timeout / SSE-IO tests; new GET-stream throttle regression test

## Verification

- `dependencies/mcp_client` (own dir): `dart analyze` clean, `dart test -p vm` → 109/109 (web suites not run — no Chrome locally, pre-existing)
- Root: `dart analyze --fatal-infos lib test` clean, `flutter gen-l10n` (no untranslated entries)
- MCP test subset: 47/47 (remote-session, reload, oauth-config, log bridge)

## Notes

- The GET-reconnect backoff is a deliberate, documented divergence from upstream (fixes #937 locally; upstream is still open). Revert in favor of upstream's own fix once they land one.
- Not run: full root test suite (CI validates), desktop app launch (desktop changes are dialog-only).
