### PR TITLE
fix(markdown): unify code recognition with one scanner engine

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -717,6 +717,15 @@
 
 - "显示公式" / "display formula" was used in issue #218 to mean block-level math as opposed to inline — resolved: the domain term is **Display math** (block-level TeX forms `$$...$$` and `\[...\]`); "inline math" is the flow-level counterpart.
 
+## Markdown Code Recognition (Markdown 代码识别)
+
+- **Code span (行内代码)**: a pair of equal-length backtick runs on one logical line. The opener run must NOT be preceded by an odd number of backslashes (the app's escape convention: `\`code\`` stays literal prose); the closer is the next equal-length run even when immediately preceded by a backslash (issue #544: `` `D:\ComfyUI\` `` renders chip `D:\ComfyUI\` — CommonMark: no escapes inside code spans). Content is normalized for display: CR/LF→space, one leading+trailing space peeled when both ends are spaces (CommonMark 6.1). Backslashes inside stay literal. Multi-line spans are NOT supported (documented deviation).
+- **Fence (围栏)**: `` ``` ``/`~~~` runs ≥3 after arbitrary horizontal indent (app widens CommonMark's 0-3 spaces — LLM-indented fences); closer = same marker, run ≥ opener, horizontal whitespace only — an info-string closer (` ``` not-a-closer`) never closes. Unclosed fences at text end are streaming interrupts (`closed=false`). Quote fences (`^[ \t]*>...`) and list fences (`^[ \t]*(?:[*+-]|\d+\.)[ \t]+` + backtick run, info without whitespace or backticks) are app extensions ported from the legacy preprocessor. The "}```" **inline closing** extension (a line merely ENDING with a run ≥ opener after non-backtick content closes the fence) is in-fence only — it never OPENS a fence from prose (the legacy rewrite could).
+- **One rule set**: `lib/utils/markdown_code_scanner.dart` (`markdownCodeScan`, `markdownCodePairInline`, `markdownCodeFenceMark`, `markdownCodeSpanNormalize`). Consumers: render tokenizer, details-walker hiding, display-math scanner fencing, lexer fence state, chat API image skip. See `docs/adr/0042-markdown-code-scanner.md`.
+- **Detail-walker hiding is one step wider**: the walker pairs runs with `escapeSensitive: false` so `\`<details>`-style prose never becomes a details card.
+- **Render tokens**: `_preprocessFences` replaces code regions with opaque `\uE020C|F<id>-<len>-<hash>\uE021` tokens; `FencedCodeTokenMd`/`InlineCodeTokenMd` resolve via `MarkdownCodeRegistry` shipped with the cached payload. The hash makes token equality imply content equality (refresh on stream growth).
+- **Parallel consumers of raw backtick walks are unified**: `chat_api_service` image-skip no longer duplicates the fence/spans walk (bug fix: it now honors ≥-run closers, indents, quote/list fences); the old `__CODE_MASK_n__`, `_codeDollarMask`, blockquote-marker (`\uE000/\uE001`) and `_fencedHtmlTagStartMask` (`\uE002`) machinery is deleted (tokens hide content from every later rewrite, including the `<details>` walker).
+
 ## Mini Map Search (迷你地图搜索)
 
 - **Model**: filter-navigation (过滤导航) — 搜索是地图的定位工具，不是结果列表。输入关键词 → 消息级命中行（单消息一行，hit-centered 片段 + 高亮），点击跳转原消息；清空 → 恢复 Q/A 对鸟瞰图。

--- a/docs/adr/0042-markdown-code-scanner.md
+++ b/docs/adr/0042-markdown-code-scanner.md
@@ -1,0 +1,49 @@
+# ADR-0042: Markdown code scanner — one rule set for spans and fences
+
+Issue #544 (inline code span around a Windows path `D:\ComfyUI\` rendered
+garbled) surfaced a rules-copy problem: five independent implementations of
+"what counts as code" existed — the render component regex
+(`EscapeAwareHighlightedTextMd`), the details-walker's hiding pairing, the
+display-math scanner's fence handling, the streaming line lexer's fence state
+(minus the blockquote/list/indent context), and the chat API image extractor's
+walk. They had already drifted: the render closer guard `(?<![\\`])` refused
+a backtick preceded by a backslash (as if code spans had escapes — CommonMark
+says they do not) and swallowed the following sentence.
+
+We now have ONE rule set: `lib/utils/markdown_code_scanner.dart`. It defines
+fence marks, escape-aware inline run pairing, span normalization, fence
+regions (incl. quote/list contexts, unclosed streaming fences, the "}```"
+inline-closing extension, and the info-string-shape list fence), and the
+segment types. Despite the "scanner" name it is NOT a resumable streaming
+parser: the lexer and the display-math scanner keep their own state machines
+and consume the shared primitives, so their behavior is pinned to the same
+rules without paying for segmentation on the incremental hot path.
+
+## How the render path consumes it
+
+`_preprocessFences` tokenizes code regions into opaque placeholder tokens
+(`\uE020C|F`, id, content-length+FNV hash, `\uE021`). The token text carries
+no `` ` ``, `$`, `<`, `[`, `|`, or newline, so every later rewrite (math
+normalization, table stabilization, citation flattening, ...) ignores it —
+the same protection the old `__CODE_MASK_n__` pass provided. `FencedCodeTokenMd`
+and `InlineCodeTokenMd` match the tokens and resolve content from a
+`MarkdownCodeRegistry` that ships with the cached tokenized payload.
+
+The embedded content hash is load-bearing: tokenized-text equality implies
+code-content equality, so `_CachedMarkdownBlock` identity, `GptMarkdown.data`
+change detection, and the streaming rebuild path all refresh when code grows —
+without it, growing a mermaid fence leaves `\uE020F0-...-...\uE021` textually
+identical and the block never re-renders.
+
+## Deliberate deviations documented in CONTEXT.md
+
+- Escape rule: a backslash-escaped backtick never OPENS a span (the app's
+  escape convention; CommonMark would otherwise start a span at `\``), and a
+  backslash-preceded backtick still CLOSES ($544). Inside spans no escapes.
+- Details walker pairs with `escapeSensitive: false` (wider hiding) so that
+  "\`<details>\`"-style documentation prose never becomes a details card.
+- Quote fences and list fences (backtick-only, info without whitespace) are
+  app extensions ported from the legacy preprocessor; the "}```" inline
+  closing moves from a textual rewrite (which could OPEN a fence from prose
+  lines outside any fence) into the in-fence closer extension only.
+- Span pairing is single-line (multi-line spans stay a documented deviation).

--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -18,6 +18,7 @@ import 'google_service_account_auth.dart';
 import '../../services/api_key_manager.dart';
 import 'package:Cuplivo/secrets/fallback.dart';
 import '../../../utils/markdown_media_sanitizer.dart';
+import '../../../utils/markdown_code_scanner.dart';
 import '../../../utils/unicode_sanitizer.dart';
 import 'builtin_tools.dart';
 import 'gemini_tool_config.dart';
@@ -287,73 +288,24 @@ class ChatApiService {
     // Match custom inline image markers like: [image:/absolute/path.png]
     // Use a single backslash in a raw string to escape '[' and ']' in regex.
     final customImg = RegExp(r"\[image:(.+?)\]");
+    // Code regions (fenced blocks + inline spans) come from the shared
+    // markdown code scanner: content inside code is never an image.
+    final codeSegments = markdownCodeScan(raw).segments;
     final images = <_ImageRef>[];
     final buf = StringBuffer();
     int i = 0;
+    int segIndex = 0;
     while (i < raw.length) {
-      // Skip fenced code blocks (``` or ~~~): content inside is never an image.
-      if ((raw.startsWith('```', i) || raw.startsWith('~~~', i)) &&
-          (i == 0 || raw[i - 1] == '\n')) {
-        final fence = raw.substring(i, i + 3);
-        buf.write(fence);
-        i += 3;
-        // Skip the rest of the opening fence line (language tag, etc.)
-        while (i < raw.length && raw[i] != '\n') {
-          buf.write(raw[i]);
-          i++;
-        }
-        // Advance until the matching closing fence at the start of a line.
-        bool closed = false;
-        while (i < raw.length) {
-          if (raw[i] == '\n') {
-            buf.write(raw[i]);
-            i++;
-            if (raw.startsWith(fence, i)) {
-              buf.write(fence);
-              i += 3;
-              // Skip trailing content on the closing fence line.
-              while (i < raw.length && raw[i] != '\n') {
-                buf.write(raw[i]);
-                i++;
-              }
-              closed = true;
-              break;
-            }
-          } else {
-            buf.write(raw[i]);
-            i++;
-          }
-        }
-        if (!closed) {
-          // Unclosed fence: rest of text was written as-is already.
-        }
-        continue;
+      while (segIndex < codeSegments.length &&
+          codeSegments[segIndex].end <= i) {
+        segIndex++;
       }
-      // Skip inline code spans (backtick sequences).
-      if (raw[i] == '`') {
-        // Determine the length of the opening backtick sequence.
-        int tickLen = 0;
-        while (i + tickLen < raw.length && raw[i + tickLen] == '`') {
-          tickLen++;
-        }
-        final openTicks = raw.substring(i, i + tickLen);
-        buf.write(openTicks);
-        i += tickLen;
-        // Advance until the matching closing backtick sequence.
-        bool closedTick = false;
-        while (i < raw.length) {
-          if (raw.startsWith(openTicks, i)) {
-            buf.write(openTicks);
-            i += tickLen;
-            closedTick = true;
-            break;
-          }
-          buf.write(raw[i]);
-          i++;
-        }
-        if (!closedTick) {
-          // Unclosed inline code: content was already written.
-        }
+      if (segIndex < codeSegments.length &&
+          codeSegments[segIndex].start <= i &&
+          i < codeSegments[segIndex].end) {
+        final seg = codeSegments[segIndex];
+        buf.write(raw.substring(i, seg.end));
+        i = seg.end;
         continue;
       }
 

--- a/lib/shared/widgets/markdown_line_lexer.dart
+++ b/lib/shared/widgets/markdown_line_lexer.dart
@@ -1,3 +1,5 @@
+import '../../utils/markdown_code_scanner.dart';
+
 /// Line-level fence / details / inline-code rules.
 ///
 /// Display-math pairing lives in [markdownScanDisplayMath] so the splitter,
@@ -617,50 +619,33 @@ final class _LineBackticks {
 
   int advance(int i) => _jump![i] ?? i + 1;
 
+  /// Pairs backtick runs with the shared rule set
+  /// ([markdownCodePairInline], hiding policy: every run participates).
+  /// Every run keeps a jump slot, exactly like the legacy table: paired
+  /// opens jump past their closer, unmatched runs jump past themselves.
   static _LineBackticks of(String line) {
-    final starts = <int>[];
-    final lengths = <int>[];
+    final pairs = markdownCodePairInline(line, escapeSensitive: false);
+    final jump = <int, int>{};
+    final pairedStarts = <int>{};
+    for (final pair in pairs) {
+      jump[pair.openStart] = pair.closeEnd;
+      pairedStarts.add(pair.openStart);
+      pairedStarts.add(pair.closeStart);
+    }
     var i = 0;
     while (i < line.length) {
-      _noteScanVisit();
       if (line.codeUnitAt(i) != 0x60) {
         i++;
         continue;
       }
       final start = i;
-      i++;
       while (i < line.length && line.codeUnitAt(i) == 0x60) {
-        _noteScanVisit();
         i++;
       }
-      starts.add(start);
-      lengths.add(i - start);
+      if (pairedStarts.contains(start)) continue;
+      jump.putIfAbsent(start, () => i);
     }
-    if (starts.isEmpty) return empty;
-
-    final runCount = starts.length;
-    final nextSame = List<int>.filled(runCount, -1);
-    final lastByLength = <int, int>{};
-    for (var r = runCount - 1; r >= 0; r--) {
-      nextSame[r] = lastByLength[lengths[r]] ?? -1;
-      lastByLength[lengths[r]] = r;
-    }
-
-    final jump = <int, int>{};
-    final consumed = List<bool>.filled(runCount, false);
-    for (var r = 0; r < runCount; r++) {
-      if (consumed[r]) continue;
-      final closer = nextSame[r];
-      if (closer >= 0) {
-        jump[starts[r]] = starts[closer] + lengths[closer];
-        for (var k = r; k <= closer; k++) {
-          consumed[k] = true;
-        }
-      } else {
-        jump[starts[r]] = starts[r] + lengths[r];
-        consumed[r] = true;
-      }
-    }
+    if (jump.isEmpty) return empty;
     return _LineBackticks._(jump);
   }
 }
@@ -725,43 +710,14 @@ final class _FenceMark {
   final bool canClose;
 }
 
-int _skipHorizontalIndent(String line, [int start = 0]) {
-  var i = start;
-  while (i < line.length) {
-    final unit = line.codeUnitAt(i);
-    if (unit != 0x20 && unit != 0x09) break;
-    _noteScanVisit();
-    i++;
-  }
-  return i;
-}
-
 _FenceMark? _fenceMarkOf(String rawLine, int lineStart) {
-  final indent = _skipHorizontalIndent(rawLine);
-  if (indent >= rawLine.length) return null;
-  final marker = rawLine.codeUnitAt(indent);
-  if (marker != 0x60 && marker != 0x7E) return null;
-  var n = indent + 1;
-  while (n < rawLine.length && rawLine.codeUnitAt(n) == marker) {
-    _noteScanVisit();
-    n++;
-  }
-  final length = n - indent;
-  if (length < 3) return null;
-  var canClose = true;
-  for (var i = n; i < rawLine.length; i++) {
-    _noteScanVisit();
-    final unit = rawLine.codeUnitAt(i);
-    if (unit != 0x20 && unit != 0x09) {
-      canClose = false;
-      break;
-    }
-  }
+  final mark = markdownCodeFenceMark(rawLine);
+  if (mark == null) return null;
   return _FenceMark(
-    start: lineStart + indent,
-    marker: marker,
-    length: length,
-    canClose: canClose,
+    start: lineStart + mark.start,
+    marker: mark.marker == MarkdownCodeFenceMarker.backtick ? 0x60 : 0x7E,
+    length: mark.length,
+    canClose: mark.canClose,
   );
 }
 

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -19,6 +19,7 @@ import 'package:image/image.dart' as image_lib;
 import 'package:image_gallery_saver_plus/image_gallery_saver_plus.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 import '../../utils/sandbox_path_resolver.dart';
+import '../../utils/markdown_code_scanner.dart';
 import '../../utils/clipboard_images.dart';
 import '../../core/services/haptics.dart';
 import '../../features/chat/pages/image_viewer_page.dart';
@@ -49,8 +50,49 @@ import 'windows_ax_tree_safe_tooltip.dart';
 // Inline math is parsed on the UI thread. Bound the lookahead window so a long
 // line with many unmatched openers cannot trigger repeated whole-line scans.
 const int _maxInlineMathBodyLength = 512;
-const String _codeDollarMask = '___CODE_DOLLAR_MASK___';
-const String _fencedHtmlTagStartMask = '\uE002';
+
+/// Placeholder token boundaries for code regions. The token text is opaque to
+/// every later rewrite: it carries no `` ` ``, `$`, `<`, `[`, `|`, or newline.
+/// The embedded id makes tokens unique per region; the embedded content
+/// length + FNV-1a hash make tokenized-text equality imply content equality,
+/// so caching layers (block identity, GptMarkdown data) refresh on growth.
+const String _codeTokenStart = '\uE020';
+const String _codeTokenEnd = '\uE021';
+
+int _codeTokenHash(String content) {
+  var h = 0x811C9DC5;
+  for (var i = 0; i < content.length; i++) {
+    h ^= content.codeUnitAt(i);
+    h = (h * 0x01000193) & 0xFFFFFFFF;
+  }
+  return h;
+}
+
+String _codeToken(String kind, int id, String content) {
+  final len = content.length.toRadixString(36);
+  final hash = _codeTokenHash(content).toRadixString(36);
+  return '$_codeTokenStart$kind$id-$len-$hash$_codeTokenEnd';
+}
+
+/// Immutable registry minted together with the tokenized text. Tokens in the
+/// text resolve to their code entries here; the registry is rebuilt with the
+/// same scan whenever the payload is re-cached.
+class MarkdownCodeRegistry {
+  const MarkdownCodeRegistry(this.entries);
+
+  final Map<String, MarkdownCodeSegment> entries;
+
+  MarkdownCodeSegment? lookup(String token) => entries[token];
+}
+
+/// Result of preprocessing a markdown source: the tokenized text plus the
+/// registry that resolves its code tokens.
+class MarkdownCodePayload {
+  const MarkdownCodePayload({required this.text, required this.entries});
+
+  final String text;
+  final Map<String, MarkdownCodeSegment> entries;
+}
 
 /// gpt_markdown with custom code block highlight and inline code styling.
 class MarkdownWithCodeHighlight extends StatefulWidget {
@@ -100,10 +142,10 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
   Timer? _renderDebounce;
   final IncrementalMarkdownDocument _incrementalDocument =
       IncrementalMarkdownDocument();
-  static final ByteLruCache<String, String> _normalizedBlockCache =
-      ByteLruCache<String, String>(
+  static final ByteLruCache<String, MarkdownCodePayload> _normalizedBlockCache =
+      ByteLruCache<String, MarkdownCodePayload>(
         maxBytes: 4 << 20,
-        sizeOf: (key, value) => (key.length + value.length) * 2,
+        sizeOf: (key, value) => (key.length + value.text.length) * 2,
       );
 
   @override
@@ -150,7 +192,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
     final cs = Theme.of(context).colorScheme;
     final sanitizedText = _sanitizeImageLinks(_renderText);
     final imageUrls = _extractImageUrls(sanitizedText);
-    String normalize(String source, {required bool streaming}) {
+    MarkdownCodePayload normalize(String source, {required bool streaming}) {
       final cacheKey =
           '${settings.enableMathRendering}:${settings.enableDollarLatex}:$streaming:$source';
       final cached = _normalizedBlockCache.get(cacheKey);
@@ -185,83 +227,6 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
           color: null,
         );
 
-    // Replace default components and add our own where needed
-    final components = List<MarkdownComponent>.from(
-      MarkdownComponent.globalComponents,
-    );
-    components.removeWhere((c) => c is LatexMathMultiLine || c is HTag);
-    final hrIdx = components.indexWhere((c) => c is HrLine);
-    if (hrIdx != -1) components[hrIdx] = SoftHrLine();
-    components.removeWhere((c) => c is BlockQuote);
-    final cbIdx = components.indexWhere((c) => c is CheckBoxMd);
-    if (cbIdx != -1) components[cbIdx] = ModernCheckBoxMd();
-    final rbIdx = components.indexWhere((c) => c is RadioButtonMd);
-    if (rbIdx != -1) components[rbIdx] = ModernRadioMd();
-    final tableIdx = components.indexWhere((c) => c is TableMd);
-    if (tableIdx != -1) components[tableIdx] = EscapeAwareTableMd();
-    // Prepend custom renderers in priority order.
-    // Temporarily disable custom bold label line transformer to avoid
-    // interfering with block parsing for complex documents.
-    // components.insert(0, LabelValueLineMd());
-    components.removeWhere((c) => c is CodeBlockMd);
-    // Conditionally add LaTeX/math renderers
-    if (settings.enableMathRendering) {
-      // Block-level LaTeX (e.g., $$...$$ or \[...\])
-      components.insert(0, LatexBlockScrollableMd());
-    }
-    components.insert(0, AtxHeadingMd());
-    // Ensure fenced code blocks take precedence over headings and other blocks
-    // so lines like "# comment" inside code fences are not parsed as headings.
-    components.insert(0, ModernBlockQuote());
-    components.insert(0, FencedCodeBlockMd(streaming: widget.streaming));
-    // Inline components: keep defaults but make link parsing line-scoped
-    final inlineComponents = List<MarkdownComponent>.from(
-      MarkdownComponent.inlineComponents,
-    );
-    inlineComponents.removeWhere(
-      (c) => c is LatexMath || c is LatexMathMultiLine,
-    );
-    // Add whitelist-based HTML tag renderer (e.g., <br>)
-    inlineComponents.insert(0, HtmlAnchorMd());
-    inlineComponents.insert(0, AllowedHtmlTagsMd());
-
-    // Conditionally add inline LaTeX/math renderers
-    if (settings.enableMathRendering) {
-      // Inline LaTeX: $...$ and \(...\)
-      if (settings.enableDollarLatex) {
-        inlineComponents.insert(0, InlineLatexParenScrollableMd());
-        inlineComponents.insert(0, InlineLatexDollarScrollableMd());
-      } else {
-        // Only \(...\) inline
-        inlineComponents.insert(0, InlineLatexParenScrollableMd());
-      }
-    }
-
-    final boldIdxInline = inlineComponents.indexWhere((c) => c is BoldMd);
-    if (boldIdxInline != -1) {
-      inlineComponents[boldIdxInline] = EscapeAwareBoldMd();
-    }
-    final italicIdxInline = inlineComponents.indexWhere((c) => c is ItalicMd);
-    if (italicIdxInline != -1) {
-      inlineComponents[italicIdxInline] = EscapeAwareItalicMd();
-    }
-    final imageIdxInline = inlineComponents.indexWhere((c) => c is ImageMd);
-    if (imageIdxInline != -1) {
-      inlineComponents[imageIdxInline] = EscapeAwareImageMd();
-    }
-    final codeIdxInline = inlineComponents.indexWhere(
-      (c) => c is HighlightedText,
-    );
-    if (codeIdxInline != -1) {
-      inlineComponents[codeIdxInline] = EscapeAwareHighlightedTextMd();
-    }
-    final linkIdxInline = inlineComponents.indexWhere((c) => c is ATagMd);
-    if (linkIdxInline != -1) {
-      inlineComponents[linkIdxInline] = LineSafeLinkMd();
-    }
-    // Keep escaped punctuation out of block parsing so it cannot split
-    // \( ... \) math containing \{...\}; inline math is registered ahead of it.
-    inlineComponents.add(BackslashEscapeMd());
     // codeBuilder handles rendering. A custom BlockMd for fences can
     // interfere with block segmentation in some cases.
     // Resolve user preferred code font family (default to monospace)
@@ -311,13 +276,96 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
         '${baseTextStyle?.letterSpacing}-${baseTextStyle?.fontFamily}-'
         '$codeFontFamily-$appFontFamily-${_imageRevision(imageUrls)}';
 
-    Widget buildMarkdown(String markdown, Key key) {
+    Widget buildMarkdown(MarkdownCodePayload payload, Key key) {
+      final codeRegistry = MarkdownCodeRegistry(payload.entries);
       final detailsRegistry = MarkdownDetailsRegistry(
         enableMath: settings.enableMathRendering,
       );
+
+      // Replace default components and add our own where needed. Constructed
+      // per payload: the code token components own this payload's registry.
+      final components = List<MarkdownComponent>.from(
+        MarkdownComponent.globalComponents,
+      );
+      components.removeWhere((c) => c is LatexMathMultiLine || c is HTag);
+      final hrIdx = components.indexWhere((c) => c is HrLine);
+      if (hrIdx != -1) components[hrIdx] = SoftHrLine();
+      components.removeWhere((c) => c is BlockQuote);
+      final cbIdx = components.indexWhere((c) => c is CheckBoxMd);
+      if (cbIdx != -1) components[cbIdx] = ModernCheckBoxMd();
+      final rbIdx = components.indexWhere((c) => c is RadioButtonMd);
+      if (rbIdx != -1) components[rbIdx] = ModernRadioMd();
+      final tableIdx = components.indexWhere((c) => c is TableMd);
+      if (tableIdx != -1) components[tableIdx] = EscapeAwareTableMd();
+      components.removeWhere((c) => c is CodeBlockMd);
+      // Conditionally add LaTeX/math renderers
+      if (settings.enableMathRendering) {
+        // Block-level LaTeX (e.g., $$...$$ or \[...\])
+        components.insert(0, LatexBlockScrollableMd());
+      }
+      components.insert(0, AtxHeadingMd());
+      // Ensure fenced code blocks take precedence over headings and other blocks
+      // so lines like "# comment" inside code fences are not parsed as headings.
+      components.insert(0, ModernBlockQuote());
+      components.insert(
+        0,
+        FencedCodeTokenMd(codeRegistry, streaming: widget.streaming),
+      );
+      // Inline components: keep defaults but make link parsing line-scoped
+      final inlineComponents = List<MarkdownComponent>.from(
+        MarkdownComponent.inlineComponents,
+      );
+      inlineComponents.removeWhere(
+        (c) => c is LatexMath || c is LatexMathMultiLine,
+      );
+      // Add whitelist-based HTML tag renderer (e.g., <br>)
+      inlineComponents.insert(0, HtmlAnchorMd());
+      inlineComponents.insert(0, AllowedHtmlTagsMd());
+
+      // Conditionally add inline LaTeX/math renderers
+      if (settings.enableMathRendering) {
+        // Inline LaTeX: $...$ and \(...\)
+        if (settings.enableDollarLatex) {
+          inlineComponents.insert(0, InlineLatexParenScrollableMd());
+          inlineComponents.insert(0, InlineLatexDollarScrollableMd());
+        } else {
+          // Only \(...\) inline
+          inlineComponents.insert(0, InlineLatexParenScrollableMd());
+        }
+      }
+
+      final boldIdxInline = inlineComponents.indexWhere((c) => c is BoldMd);
+      if (boldIdxInline != -1) {
+        inlineComponents[boldIdxInline] = EscapeAwareBoldMd();
+      }
+      final italicIdxInline = inlineComponents.indexWhere((c) => c is ItalicMd);
+      if (italicIdxInline != -1) {
+        inlineComponents[italicIdxInline] = EscapeAwareItalicMd();
+      }
+      final imageIdxInline = inlineComponents.indexWhere((c) => c is ImageMd);
+      if (imageIdxInline != -1) {
+        inlineComponents[imageIdxInline] = EscapeAwareImageMd();
+      }
+      // The legacy regex-based inline code component is replaced by the token
+      // component: code spans were tokenized during preprocessing (one rule
+      // set, see markdown_code_scanner.dart).
+      final codeIdxInline = inlineComponents.indexWhere(
+        (c) => c is HighlightedText,
+      );
+      if (codeIdxInline != -1) {
+        inlineComponents[codeIdxInline] = InlineCodeTokenMd(codeRegistry);
+      }
+      final linkIdxInline = inlineComponents.indexWhere((c) => c is ATagMd);
+      if (linkIdxInline != -1) {
+        inlineComponents[linkIdxInline] = LineSafeLinkMd();
+      }
+      // Keep escaped punctuation out of block parsing so it cannot split
+      // \( ... \) math containing \{...\}; inline math is registered ahead of it.
+      inlineComponents.add(BackslashEscapeMd());
+
       return GptMarkdown(
         key: key,
-        markdown,
+        payload.text,
         style: baseTextStyle,
         followLinkColor: true,
         // Disable built-in $...$ LaTeX so our custom scrollable handlers take over
@@ -505,9 +553,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
         },
         // Inline `code` styling via highlightBuilder in gpt_markdown
         highlightBuilder: (ctx, inline, style) {
-          // Unmask dollar signs that were protected during preprocessing
-          String unmasked = inline.replaceAll(_codeDollarMask, r'$');
-          String softened = _softBreakInline(unmasked);
+          String softened = _softBreakInline(inline);
           final csCtx = Theme.of(ctx).colorScheme;
           final bg = ctx.appColors.surfaceFill;
           return Container(
@@ -531,35 +577,6 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
             ),
           );
         },
-        // Fenced code block styling via codeBuilder (with collapse/expand)
-        codeBuilder: (ctx, name, code, closed) {
-          final lang = name.trim();
-          final restoredCode = _unmaskHtmlTagStartsInsideFencedCode(code);
-          if (lang.toLowerCase() == 'mermaid') {
-            return _MermaidBlock(
-              code: restoredCode,
-              streaming: widget.streaming && !closed,
-            );
-          } else if (lang.toLowerCase() == 'plantuml') {
-            return PlantUMLBlock(code: restoredCode);
-          } else if (lang.toLowerCase() == 'svg') {
-            return SvgPreviewBlock(
-              code: restoredCode,
-              streaming: widget.streaming && !closed,
-            );
-          } else if (_isHtml(lang)) {
-            return HtmlPreviewBlock(
-              code: restoredCode,
-              streaming: widget.streaming && !closed,
-            );
-          }
-          return _CollapsibleCodeBlock(
-            language: lang,
-            code: restoredCode,
-            streaming: widget.streaming,
-            closed: closed,
-          );
-        },
       );
     }
 
@@ -571,7 +588,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                 streaming: widget.streaming && !block.stable,
               ),
           ]
-        : const <String>[];
+        : const <MarkdownCodePayload>[];
     final markdownWidget = useIncrementalBlocks
         ? _MarkdownBlockColumn(
             children: [
@@ -585,7 +602,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                 // renderer eats the run.
                 if (i > 0 &&
                     !_swallowsTrailingBlankLine(
-                      blockContents[i - 1],
+                      blockContents[i - 1].text,
                       mathEnabled: settings.enableMathRendering,
                     ))
                   _MarkdownBlockSeparator(
@@ -598,7 +615,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                   key: ValueKey(
                     'markdown-source-block-${sourceBlocks[i].start}',
                   ),
-                  content: blockContents[i],
+                  payload: blockContents[i],
                   signature: themeSignature,
                   builder: buildMarkdown,
                 ),
@@ -606,7 +623,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
             ],
           )
         : _CachedMarkdownBlock(
-            content: normalized!,
+            payload: normalized!,
             signature: themeSignature,
             builder: buildMarkdown,
           );
@@ -653,17 +670,18 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
   }
 }
 
-typedef _MarkdownBlockBuilder = Widget Function(String content, Key key);
+typedef _MarkdownBlockBuilder =
+    Widget Function(MarkdownCodePayload payload, Key key);
 
 class _CachedMarkdownBlock extends StatefulWidget {
   const _CachedMarkdownBlock({
     super.key,
-    required this.content,
+    required this.payload,
     required this.signature,
     required this.builder,
   });
 
-  final String content;
+  final MarkdownCodePayload payload;
   final String signature;
   final _MarkdownBlockBuilder builder;
 
@@ -679,7 +697,7 @@ class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
   @override
   void didUpdateWidget(covariant _CachedMarkdownBlock oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.content != widget.content ||
+    if (oldWidget.payload.text != widget.payload.text ||
         oldWidget.signature != widget.signature) {
       _rendered = null;
     }
@@ -699,8 +717,8 @@ class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
   @override
   Widget build(BuildContext context) {
     return _rendered ??= widget.builder(
-      widget.content,
-      _parseIdentity(widget.content),
+      widget.payload,
+      _parseIdentity(widget.payload.text),
     );
   }
 }
@@ -925,7 +943,7 @@ String? _normalizeLanguage(String? lang) {
   }
 }
 
-String _preprocessFences(
+MarkdownCodePayload _preprocessFences(
   String input, {
   required bool enableMath,
   required bool enableDollarLatex,
@@ -933,55 +951,41 @@ String _preprocessFences(
 }) {
   // Normalize newlines to simplify regex handling
   var out = input.replaceAll('\r\n', '\n');
-  out = _maskBlockquoteFenceMarkers(out);
 
-  // Move fenced code from list lines to the next line before masking so list
-  // fences are protected from later inline math normalization.
-  final bulletFence = RegExp(
-    r"^(\s*(?:[*+-]|\d+\.)\s+)```([^\s`]*)\s*$",
-    multiLine: true,
-  );
-  out = out.replaceAllMapped(bulletFence, (m) => "${m[1]}\n```${m[2]}");
-
-  // STEP 1: MASKING - Protect code blocks from LaTeX processing
-  // This prevents $...$ inside code from being converted to LaTeX
-  final Map<String, String> codeMap = {};
-  int codeCount = 0;
-
-  // Match fenced code blocks and inline code (`...`)
-  // Fenced: CommonMark-style variable-length fences (>= 3 backticks or tildes)
-  // Group 1: entire fenced block, Group 2: opening fence, Group 3: fence char
-  // Closing fence must use same char and be >= opening length
-  final codeRegex = RegExp(
-    r'(^[ \t]*(([`~])\3{2,})[ \t]*[^\n]*\n(?:[\s\S]*?^[ \t]*\2\3*[ \t]*$|[\s\S]*))'
-    r'|(`[^`\n]+`)',
-    multiLine: true,
-  );
-
-  out = out.replaceAllMapped(codeRegex, (match) {
-    final key = '__CODE_MASK_${codeCount++}__';
-    var codeContent = match.group(0)!;
-
-    // For inline code (`...`), escape dollar signs to prevent LaTeX interpretation
-    // Inline code is single-line and delimited by single backticks (not fenced)
-    final isInlineCode =
-        !codeContent.contains('\n') &&
-        codeContent.startsWith('`') &&
-        codeContent.endsWith('`');
-    if (isInlineCode) {
-      codeContent = codeContent.replaceAllMapped(
-        RegExp(r'\$'),
-        (m) => _codeDollarMask,
-      );
+  // STEP 1: TOKENIZATION - Replace every code span and fenced block with an
+  // opaque token (see markdown_code_scanner.dart for the single rule set).
+  // Later rewrites only see tokens; the content lives in the registry that
+  // ships with the returned payload.
+  final codeScan = markdownCodeScan(out);
+  final entries = <String, MarkdownCodeSegment>{};
+  final tokenized = StringBuffer();
+  var cursor = 0;
+  var fenceId = 0;
+  var inlineId = 0;
+  for (final seg in codeScan.segments) {
+    if (seg.start > cursor) tokenized.write(out.substring(cursor, seg.start));
+    if (seg.kind == MarkdownCodeSegmentKind.inlineCode) {
+      final token = _codeToken('C', inlineId++, seg.content);
+      entries[token] = seg;
+      tokenized.write(token);
     } else {
-      codeContent = _maskHtmlTagStartsInsideFencedCode(codeContent);
+      final token = _codeToken('F', fenceId++, seg.content);
+      entries[token] = seg;
+      switch (seg.context) {
+        case MarkdownCodeFenceContext.none:
+          tokenized.write(token);
+        case MarkdownCodeFenceContext.blockquote:
+          tokenized.write('${seg.contextPrefix}$token');
+        case MarkdownCodeFenceContext.list:
+          tokenized.write('${seg.contextPrefix}\n$token');
+      }
     }
+    cursor = seg.end;
+  }
+  if (cursor < out.length) tokenized.write(out.substring(cursor));
+  out = tokenized.toString();
 
-    codeMap[key] = codeContent;
-    return key;
-  });
-
-  // STEP 2: PROCESSING (on masked string, code is now protected)
+  // STEP 2: PROCESSING (on tokenized string, code is now protected)
   if (streaming) {
     out = _stabilizeStreamingTables(out);
     if (enableMath && enableDollarLatex) {
@@ -1077,18 +1081,6 @@ String _preprocessFences(
     });
   }
 
-  // 2) Dedent opening fences: leading spaces before ```lang
-  final dedentOpen = RegExp(r"^[ \t]+```([^\n`]*)\s*$", multiLine: true);
-  out = out.replaceAllMapped(dedentOpen, (m) => "```${m[1]}");
-
-  // 3) Dedent closing fences: leading spaces before ```
-  final dedentClose = RegExp(r"^[ \t]+```\s*$", multiLine: true);
-  out = out.replaceAllMapped(dedentClose, (m) => "```");
-
-  // 4) Ensure closing fences are on their own line: transform "} ```" or "}```" into "}\n```"
-  final inlineClosing = RegExp(r"([^\r\n`])```(?=\s*(?:\r?\n|$))");
-  out = out.replaceAllMapped(inlineClosing, (m) => "${m[1]}\n```");
-
   // 5) Disambiguate Setext vs HR after label-value lines:
   // If a line of only dashes follows a bold label line (e.g., "**作者:** 张三"),
   // insert a blank line so it's treated as an HR, not a Setext heading underline.
@@ -1134,27 +1126,7 @@ String _preprocessFences(
     out = buf.toString();
   }
 
-  // STEP 3: UNMASKING - Restore code blocks
-  // Replace all mask placeholders with their original content
-  // NOTE: We do NOT restore _codeDollarMask here because we want LaTeX components
-  // to never see dollar signs inside code. The unmask will happen later in highlightBuilder.
-  out = out.replaceAllMapped(RegExp(r'__CODE_MASK_\d+__'), (match) {
-    final key = match.group(0)!;
-    return codeMap[key] ?? key;
-  });
-
-  return out;
-}
-
-String _maskHtmlTagStartsInsideFencedCode(String input) {
-  return input.replaceAllMapped(
-    RegExp(r'</?(?:details|summary)\b', caseSensitive: false),
-    (match) => '$_fencedHtmlTagStartMask${match[0]!.substring(1)}',
-  );
-}
-
-String _unmaskHtmlTagStartsInsideFencedCode(String input) {
-  return input.replaceAll(_fencedHtmlTagStartMask, '<');
+  return MarkdownCodePayload(text: out, entries: entries);
 }
 
 String _normalizeRawCitationMetadata(String input) {
@@ -1218,59 +1190,6 @@ class _CitationRef {
   final String id;
 
   String get markdownTarget => indexText == id ? indexText : '$indexText:$id';
-}
-
-String _maskBlockquoteFenceMarkers(String input) {
-  final lines = input.split('\n');
-  var inTopLevelFence = false;
-  String? topLevelFence;
-  String? topLevelFenceMarker;
-
-  for (var i = 0; i < lines.length; i++) {
-    final line = lines[i];
-    if (inTopLevelFence) {
-      final closeFence = topLevelFence;
-      final closeMarker = topLevelFenceMarker;
-      if (closeFence != null &&
-          closeMarker != null &&
-          RegExp(
-            '^[ \\t]*${RegExp.escape(closeFence)}${RegExp.escape(closeMarker)}*[ \\t]*\$',
-          ).hasMatch(line)) {
-        inTopLevelFence = false;
-        topLevelFence = null;
-        topLevelFenceMarker = null;
-      }
-      continue;
-    }
-
-    final topLevelOpen = RegExp(
-      r'^[ \t]*(([`~])\2{2,})[ \t]*[^\n]*$',
-    ).firstMatch(line);
-    if (topLevelOpen != null) {
-      inTopLevelFence = true;
-      topLevelFence = topLevelOpen.group(1)!;
-      topLevelFenceMarker = topLevelOpen.group(2)!;
-      continue;
-    }
-
-    final blockquoteFence = RegExp(
-      r'^([ \t]*>[ \t]*)([`~]{3,})([^\n]*)$',
-    ).firstMatch(line);
-    if (blockquoteFence == null) continue;
-
-    final prefix = blockquoteFence.group(1)!;
-    final fence = blockquoteFence.group(2)!;
-    final suffix = blockquoteFence.group(3) ?? '';
-    final marker = fence.startsWith('`') ? '\uE000' : '\uE001';
-    lines[i] =
-        '$prefix${List<String>.filled(fence.length, marker).join()}$suffix';
-  }
-
-  return lines.join('\n');
-}
-
-String _unmaskBlockquoteFenceMarkers(String input) {
-  return input.replaceAll('\uE000', '`').replaceAll('\uE001', '~');
 }
 
 String _stabilizeStreamingTables(String input) {
@@ -3682,7 +3601,7 @@ class _MarkdownTableCell extends StatelessWidget {
       fontFamily: appFontFamily ?? style.fontFamily,
     );
     final innerCfg = config.copyWith(style: baseStyle);
-    final cellText = data.text.trim().replaceAll(_codeDollarMask, r'$');
+    final cellText = data.text.trim();
     final displayText = _softBreakTableCellText(cellText);
     final spans = MarkdownComponent.generate(
       context,
@@ -4948,49 +4867,44 @@ class SoftHrLine extends BlockMd {
   }
 }
 
-// Robust fenced code block that takes precedence over other blocks
-class FencedCodeBlockMd extends BlockMd {
-  FencedCodeBlockMd({required this.streaming});
+// Fenced code block that matches preprocessing tokens instead of raw fences:
+// the code scanner (markdown_code_scanner.dart) decided the fence regions and
+// replaced them with tokens; this component resolves them back to blocks.
+// The build dispatch below is the same walk the legacy regex version used.
+class FencedCodeTokenMd extends BlockMd {
+  FencedCodeTokenMd(this.registry, {this.streaming = false});
 
+  final MarkdownCodeRegistry registry;
   final bool streaming;
 
   @override
-  RegExp get exp => RegExp(expString, dotAll: true, multiLine: true);
-
-  @override
-  // CommonMark-style fences:
-  // - fence length is variable (>= 3)
-  // - closing fence must use the same marker and be >= opening length
-  // - supports both ``` and ~~~
   String get expString =>
-      (r"^[ \t]*(([`~])\2{2,})[ \t]*([^\n]*?)\n"
-      r"(?:(?:([\s\S]*?)^[ \t]*\1\2*[ \t]*$)|([\s\S]*))");
+      '$_codeTokenStart'
+      'F[0-9]+-[0-9a-z]+-[0-9a-z]+$_codeTokenEnd';
 
   @override
   Widget build(BuildContext context, String text, GptMarkdownConfig config) {
     final m = exp.firstMatch(text);
     if (m == null) return const SizedBox.shrink();
-    final lang = (m.group(3) ?? '').trim();
-    final code = _unmaskHtmlTagStartsInsideFencedCode(
-      m.group(4) ?? m.group(5) ?? '',
-    );
-    final closed = m.group(4) != null;
+    final seg = registry.lookup(m[0]!);
+    if (seg == null) return const SizedBox.shrink();
+    final lang = seg.identifier;
     final langLower = lang.toLowerCase();
-    final isStreamingFence = streaming && !closed;
+    final isStreamingFence = streaming && !seg.closed;
     if (langLower == 'mermaid') {
-      return _MermaidBlock(code: code, streaming: isStreamingFence);
+      return _MermaidBlock(code: seg.content, streaming: isStreamingFence);
     } else if (langLower == 'plantuml') {
-      return PlantUMLBlock(code: code);
+      return PlantUMLBlock(code: seg.content);
     } else if (langLower == 'svg') {
-      return SvgPreviewBlock(code: code, streaming: isStreamingFence);
+      return SvgPreviewBlock(code: seg.content, streaming: isStreamingFence);
     } else if (_isHtml(langLower)) {
-      return HtmlPreviewBlock(code: code, streaming: isStreamingFence);
+      return HtmlPreviewBlock(code: seg.content, streaming: isStreamingFence);
     }
     return _CollapsibleCodeBlock(
       language: lang,
-      code: code,
+      code: seg.content,
       streaming: isStreamingFence,
-      closed: closed,
+      closed: seg.closed,
     );
   }
 }
@@ -5656,7 +5570,7 @@ class ModernBlockQuote extends InlineMd {
         sb.writeln(line);
       }
     }
-    final data = _unmaskBlockquoteFenceMarkers(sb.toString().trim());
+    final data = sb.toString().trim();
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final isDark = theme.brightness == Brightness.dark;
@@ -5667,8 +5581,8 @@ class ModernBlockQuote extends InlineMd {
         (config.components ?? MarkdownComponent.globalComponents)
             .where((component) => component is! CodeBlockMd)
             .map((component) {
-              if (component is FencedCodeBlockMd) {
-                return FencedCodeBlockMd(streaming: false);
+              if (component is FencedCodeTokenMd) {
+                return FencedCodeTokenMd(component.registry, streaming: false);
               }
               return component;
             })
@@ -6074,9 +5988,52 @@ class EscapeAwareItalicMd extends ItalicMd {
   );
 }
 
-class EscapeAwareHighlightedTextMd extends HighlightedText {
+/// Inline code span that matches preprocessing tokens instead of raw
+/// backticks: the code scanner decided the spans and replaced them with
+/// tokens; this component resolves them back to code chips.
+class InlineCodeTokenMd extends InlineMd {
+  InlineCodeTokenMd(this.registry);
+
+  final MarkdownCodeRegistry registry;
+
   @override
-  RegExp get exp => RegExp(r"(?<!\\)`(?!`)(.+?)(?<![\\`])`(?!`)");
+  RegExp get exp => RegExp(
+    '$_codeTokenStart'
+    'C[0-9]+-[0-9a-z]+-[0-9a-z]+$_codeTokenEnd',
+  );
+
+  @override
+  InlineSpan span(BuildContext context, String text, GptMarkdownConfig config) {
+    final seg = registry.lookup(text);
+    if (seg == null) return TextSpan(text: text, style: config.style);
+    final code = seg.content;
+    if (config.highlightBuilder != null) {
+      return WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: config.highlightBuilder!(
+          context,
+          code,
+          config.style ?? const TextStyle(),
+        ),
+      );
+    }
+    var style =
+        config.style?.copyWith(
+          fontWeight: FontWeight.bold,
+          background: Paint()
+            ..color = GptMarkdownTheme.of(context).highlightColor
+            ..strokeCap = StrokeCap.round
+            ..strokeJoin = StrokeJoin.round,
+        ) ??
+        TextStyle(
+          fontWeight: FontWeight.bold,
+          background: Paint()
+            ..color = GptMarkdownTheme.of(context).highlightColor
+            ..strokeCap = StrokeCap.round
+            ..strokeJoin = StrokeJoin.round,
+        );
+    return TextSpan(text: code, style: style);
+  }
 }
 
 /// Treat backslash-escaped punctuation as a literal character, so that

--- a/lib/utils/markdown_code_scanner.dart
+++ b/lib/utils/markdown_code_scanner.dart
@@ -1,0 +1,548 @@
+/// Single source of truth for markdown code recognition: inline code spans
+/// (backtick runs) and fenced code blocks (```` ``` ```` / `~~~`).
+///
+/// Consumers (all driven by these rules, no private copies):
+/// - the render pipeline in `widgets/markdown_with_highlight.dart`
+/// - the streaming line lexer in `widgets/markdown_line_lexer.dart`
+/// - the display-math scanner in `widgets/markdown_line_lexer.dart` (
+///   keep their own state machines; only the rules are shared)
+/// - the chat API image extractor in `services/api/chat_api_service.dart`
+///
+/// Core rules (CommonMark except where noted):
+/// - A fence opens on a complete line holding a run of >= 3 backticks or
+///   tildes after arbitrary horizontal indent (the app widens CommonMark's
+///   0-3 spaces: LLMs emit deeper-indented fences); the info string is the
+///   remainder of that line, trimmed.
+/// - A fence closes on a line with the same marker, run length >= the
+///   opening run, and only horizontal whitespace afterwards. A line with
+///   trailing content (e.g. "``` not-a-closer") does NOT close.
+/// - App extensions ported verbatim:
+///   * an opener inside a blockquote (`^[ \t]*>...`) is a *quote fence*;
+///   * an opener written after a list marker on the same line (backticks
+///     only; info string without whitespace, like the legacy bullet-fence
+///     rewrite) is a *list fence*;
+///   * inside an open fence a line that merely ENDS with a run of >= the
+///     opening length preceded by a non-backtick character closes it (LLMs
+///     emit "}```" closers; CommonMark would keep the fence open).
+/// - A code span pairs an opening backtick run that is not preceded by an
+///   odd number of backslashes (the app's escape convention) with the next
+///   run of the exact same length on the same line. Backslashes inside a
+///   span are literal; a backtick inside a span closes it even when it is
+///   immediately preceded by a backslash (CommonMark: no escapes in spans).
+///
+/// The details walker hides HTML tags inside backtick runs to protect the
+/// `<details>` renderer; that hiding rule is deliberately one step WIDER:
+/// [markdownCodePairInline] with `escapeSensitive: false` pairs all runs so
+/// that prose like "`<details>` with an escaped opening backtick is never
+/// lifted into a details card.
+library;
+
+enum MarkdownCodeFenceMarker { backtick, tilde }
+
+enum MarkdownCodeSegmentKind { inlineCode, codeBlock }
+
+enum MarkdownCodeFenceContext { none, blockquote, list }
+
+class MarkdownCodeFenceMark {
+  const MarkdownCodeFenceMark({
+    required this.start,
+    required this.length,
+    required this.marker,
+    required this.canClose,
+  });
+
+  final int start;
+  final int length;
+  final MarkdownCodeFenceMarker marker;
+
+  /// True when everything after the run is horizontal whitespace.
+  final bool canClose;
+}
+
+class MarkdownCodeInlinePair {
+  const MarkdownCodeInlinePair({
+    required this.openStart,
+    required this.openLength,
+    required this.closeStart,
+    required this.closeLength,
+  });
+
+  final int openStart;
+  final int openLength;
+  final int closeStart;
+  final int closeLength;
+
+  int get openEnd => openStart + openLength;
+  int get closeEnd => closeStart + closeLength;
+}
+
+class MarkdownCodeSegment {
+  const MarkdownCodeSegment({
+    required this.start,
+    required this.end,
+    required this.kind,
+    required this.content,
+    this.identifier = '',
+    this.closed = true,
+    this.context = MarkdownCodeFenceContext.none,
+    this.contextPrefix = '',
+    this.marker,
+  });
+
+  /// Code-unit offsets in the scanned text (exclusive end).
+  final int start;
+  final int end;
+
+  final MarkdownCodeSegmentKind kind;
+
+  /// Spans: the visible content between the delimiters, normalized for
+  /// display (line endings -> space; one leading/trailing space peeled when
+  /// the body both begins and ends with a space but is not all whitespace).
+  /// Fences: the code lines between opener and closer joined by `\n`; for
+  /// quote fences the `(indent)> ` prefix is stripped from each interior
+  /// line (that is how blockquote bodies are stripped before re-parsing).
+  final String content;
+
+  /// Fence info string, trimmed; '' when absent. Always '' for spans.
+  final String identifier;
+
+  /// False only for a fence running to the text end without a closer
+  /// (streaming interrupt).
+  final bool closed;
+
+  final MarkdownCodeFenceContext context;
+
+  /// Quote fence: the opener-line prefix up to the fence marker (e.g. "> ").
+  /// List fence: the prefix including the list marker (e.g. "- ").
+  final String contextPrefix;
+
+  /// Fence marker run kind; null for inline spans.
+  final MarkdownCodeFenceMarker? marker;
+}
+
+final class MarkdownCodeScanResult {
+  const MarkdownCodeScanResult(this.segments);
+
+  final List<MarkdownCodeSegment> segments;
+}
+
+final class _FenceMark {
+  const _FenceMark({
+    required this.start,
+    required this.length,
+    required this.marker,
+    required this.canClose,
+  });
+
+  final int start;
+  final int length;
+  final MarkdownCodeFenceMarker marker;
+  final bool canClose;
+}
+
+_FenceMark? _fenceMarkOf(String line) {
+  var i = 0;
+  while (i < line.length) {
+    final unit = line.codeUnitAt(i);
+    if (unit != 0x20 && unit != 0x09) break;
+    i++;
+  }
+  if (i >= line.length) return null;
+  final unit = line.codeUnitAt(i);
+  if (unit != 0x60 && unit != 0x7E) return null;
+  var n = i + 1;
+  while (n < line.length && line.codeUnitAt(n) == unit) {
+    n++;
+  }
+  if (n - i < 3) return null;
+  var canClose = true;
+  for (var j = n; j < line.length; j++) {
+    final u = line.codeUnitAt(j);
+    if (u != 0x20 && u != 0x09) {
+      canClose = false;
+      break;
+    }
+  }
+  return _FenceMark(
+    start: i,
+    length: n - i,
+    marker: unit == 0x60
+        ? MarkdownCodeFenceMarker.backtick
+        : MarkdownCodeFenceMarker.tilde,
+    canClose: canClose,
+  );
+}
+
+/// A fence mark on a logical line, or null when the line does not start
+/// with one (after horizontal indent).
+MarkdownCodeFenceMark? markdownCodeFenceMark(String line) {
+  final m = _fenceMarkOf(line);
+  if (m == null) return null;
+  return MarkdownCodeFenceMark(
+    start: m.start,
+    length: m.length,
+    marker: m.marker,
+    canClose: m.canClose,
+  );
+}
+
+/// Whether [index] holds a backtick preceded by an ODD number of backslashes.
+/// Per the app's escape convention such a backtick is literal punctuation in
+/// prose and cannot open a code span.
+bool markdownCodeBackslashEscapedAt(String line, int index) {
+  var n = 0;
+  for (var j = index - 1; j >= 0 && line.codeUnitAt(j) == 0x5C; j--) {
+    n++;
+  }
+  return n.isOdd;
+}
+
+/// Pairs inline code runs on one logical line, left to right (equal-run
+/// pairing, same shape as the legacy lexer jump table).
+///
+/// [escapeSensitive] true: a backslash-escaped backtick never opens a span
+/// (the display rule). false: the wider hiding rule — every run
+/// participates — used by the details walker.
+List<MarkdownCodeInlinePair> markdownCodePairInline(
+  String line, {
+  bool escapeSensitive = true,
+}) {
+  final starts = <int>[];
+  final lengths = <int>[];
+  final escaped = <bool>[];
+  var i = 0;
+  while (i < line.length) {
+    if (line.codeUnitAt(i) != 0x60) {
+      i++;
+      continue;
+    }
+    final start = i;
+    i++;
+    while (i < line.length && line.codeUnitAt(i) == 0x60) {
+      i++;
+    }
+    starts.add(start);
+    lengths.add(i - start);
+    escaped.add(markdownCodeBackslashEscapedAt(line, start));
+  }
+  final runCount = starts.length;
+  if (runCount == 0) return const [];
+  final nextSame = List<int>.filled(runCount, -1);
+  final lastByLength = <int, int>{};
+  for (var r = runCount - 1; r >= 0; r--) {
+    nextSame[r] = lastByLength[lengths[r]] ?? -1;
+    lastByLength[lengths[r]] = r;
+  }
+  final consumed = List<bool>.filled(runCount, false);
+  final pairs = <MarkdownCodeInlinePair>[];
+  for (var r = 0; r < runCount; r++) {
+    if (consumed[r]) continue;
+    if (escapeSensitive && escaped[r]) {
+      consumed[r] = true;
+      continue;
+    }
+    final closer = nextSame[r];
+    if (closer < 0) {
+      consumed[r] = true;
+      continue;
+    }
+    pairs.add(
+      MarkdownCodeInlinePair(
+        openStart: starts[r],
+        openLength: lengths[r],
+        closeStart: starts[closer],
+        closeLength: lengths[closer],
+      ),
+    );
+    for (var k = r; k <= closer; k++) {
+      consumed[k] = true;
+    }
+  }
+  return pairs;
+}
+
+/// CommonMark normalization of a code span body at display time.
+String markdownCodeSpanNormalize(String raw) {
+  var body = raw;
+  if (body.contains('\n')) {
+    body = body
+        .replaceAll('\r\n', ' ')
+        .replaceAll('\r', ' ')
+        .replaceAll('\n', ' ');
+  }
+  if (body.startsWith(' ') && body.endsWith(' ') && body.trim().isNotEmpty) {
+    body = body.substring(1, body.length - 1);
+  }
+  return body;
+}
+
+/// The start index of the trailing backtick run when [line] ENDS with a run
+/// of >= [openLength] backticks preceded by a non-backtick character — the
+/// app's "inline closing" extension. null when the line does not close.
+int? markdownCodeInlineClosingFence(String line, int openLength) {
+  var i = line.length - 1;
+  while (i >= 0 && (line.codeUnitAt(i) == 0x20 || line.codeUnitAt(i) == 0x09)) {
+    i--;
+  }
+  if (i < 0) return null;
+  var n = 0;
+  while (i >= 0 && line.codeUnitAt(i) == 0x60) {
+    n++;
+    i--;
+  }
+  if (n < openLength) return null;
+  if (i < 0) return null;
+  if (line.codeUnitAt(i) == 0x60) return null;
+  // The run must follow real content: an indented full-line closer
+  // ("   ``` " on its own line) is already closed by [markdownCodeScan],
+  // and the whitespace here is just the line indent, not content.
+  if (line.codeUnitAt(i) == 0x20 || line.codeUnitAt(i) == 0x09) return null;
+  return i + 1;
+}
+
+/// The `(indent)>` (+ one optional space) prefix when [line] starts with a
+/// blockquote marker. '' otherwise.
+String markdownCodeQuotePrefix(String line) {
+  var i = 0;
+  while (i < line.length &&
+      (line.codeUnitAt(i) == 0x20 || line.codeUnitAt(i) == 0x09)) {
+    i++;
+  }
+  if (i >= line.length || line.codeUnitAt(i) != 0x3E) return '';
+  var j = i + 1;
+  if (j < line.length && line.codeUnitAt(j) == 0x20) j++;
+  return line.substring(0, j);
+}
+
+final class _LineSpan {
+  const _LineSpan(this.start, this.end);
+  final int start;
+  final int end;
+}
+
+// One logical line per entry; [complete] is false for a final line that is
+// not followed by a line break (a fence cannot open on an incomplete line).
+List<_LineSpan> _logicalLines(String text) {
+  final spans = <_LineSpan>[];
+  var i = 0;
+  while (i < text.length) {
+    var end = i;
+    while (end < text.length) {
+      final u = text.codeUnitAt(end);
+      if (u == 0x0A || u == 0x0D || u == 0x2028 || u == 0x2029) break;
+      end++;
+    }
+    spans.add(_LineSpan(i, end));
+    if (end >= text.length) break;
+    i = end + 1;
+    if (i < text.length &&
+        text.codeUnitAt(end) == 0x0D &&
+        text.codeUnitAt(i) == 0x0A) {
+      i++;
+    }
+  }
+  return spans;
+}
+
+final class _OpenFence {
+  int lineStart = 0;
+  String prefix = '';
+  MarkdownCodeFenceContext context = MarkdownCodeFenceContext.none;
+  _FenceMark? mark;
+  String identifier = '';
+  final List<String> contentLines = [];
+}
+
+/// Whether the remainder of a list-fence line [inner] (after [runEnd]) holds
+/// the legacy info shape: `[^\s`]*` then horizontal whitespace only.
+bool _listFenceInfoOk(String inner, int runEnd) {
+  var i = runEnd;
+  while (i < inner.length) {
+    final u = inner.codeUnitAt(i);
+    if (u == 0x20 || u == 0x09 || u == 0x60) break;
+    i++;
+  }
+  while (i < inner.length &&
+      (inner.codeUnitAt(i) == 0x20 || inner.codeUnitAt(i) == 0x09)) {
+    i++;
+  }
+  return i == inner.length;
+}
+
+/// Scans [text] and returns every code segment (spans and fences) in source
+/// order. Regions never overlap; a fence segment spans from its opener
+/// line's start to the closer line's end (or the text end when unclosed;
+/// the line break after a closer stays outside the segment).
+MarkdownCodeScanResult markdownCodeScan(String text) {
+  final spans = _logicalLines(text);
+  final segments = <MarkdownCodeSegment>[];
+  _OpenFence? fence;
+
+  for (var li = 0; li < spans.length; li++) {
+    final span = spans[li];
+    final line = text.substring(span.start, span.end);
+    final complete = span.end < text.length;
+    final quotePrefix = markdownCodeQuotePrefix(line);
+
+    if (fence != null) {
+      final probe = fence.context == MarkdownCodeFenceContext.blockquote
+          ? (quotePrefix.isEmpty ? line : line.substring(quotePrefix.length))
+          : line;
+      final close = fence.context == MarkdownCodeFenceContext.blockquote
+          ? (quotePrefix.isEmpty
+                ? null
+                : _fenceMarkOf(line.substring(quotePrefix.length)))
+          : _fenceMarkOf(line);
+      final closed =
+          close != null &&
+          close.marker == fence.mark!.marker &&
+          close.length >= fence.mark!.length &&
+          close.canClose;
+      final inlineCloseRun = markdownCodeInlineClosingFence(
+        probe,
+        fence.mark!.length,
+      );
+      final inlineClosed =
+          inlineCloseRun != null &&
+          (fence.context != MarkdownCodeFenceContext.blockquote ||
+              quotePrefix.isNotEmpty);
+      if (closed || inlineClosed) {
+        if (inlineCloseRun != null) {
+          fence.contentLines.add(probe.substring(0, inlineCloseRun));
+        }
+        segments.add(
+          MarkdownCodeSegment(
+            start: fence.lineStart,
+            end: span.end,
+            kind: MarkdownCodeSegmentKind.codeBlock,
+            content: fence.contentLines.join('\n'),
+            identifier: fence.identifier,
+            closed: true,
+            context: fence.context,
+            contextPrefix: fence.prefix,
+            marker: fence.mark!.marker,
+          ),
+        );
+        fence = null;
+        continue;
+      }
+      fence.contentLines.add(_interiorLine(line, fence.context));
+      continue;
+    }
+
+    if (quotePrefix.isNotEmpty) {
+      final inner = line.substring(quotePrefix.length);
+      final m = _fenceMarkOf(inner);
+      if (m != null && complete) {
+        fence = _OpenFence()
+          ..lineStart = span.start
+          ..prefix = quotePrefix
+          ..context = MarkdownCodeFenceContext.blockquote
+          ..mark = m
+          ..identifier = inner.substring(m.start + m.length).trim();
+        continue;
+      }
+    } else {
+      final listPrefix = _listFencePrefix(line);
+      if (listPrefix != null) {
+        final inner = line.substring(listPrefix.length);
+        final m = _fenceMarkOf(inner);
+        if (m != null &&
+            complete &&
+            m.marker == MarkdownCodeFenceMarker.backtick &&
+            _listFenceInfoOk(inner, m.start + m.length)) {
+          fence = _OpenFence()
+            ..lineStart = span.start
+            ..prefix = listPrefix
+            ..context = MarkdownCodeFenceContext.list
+            ..mark = m
+            ..identifier = inner.substring(m.start + m.length).trim();
+          continue;
+        }
+      }
+      final m = _fenceMarkOf(line);
+      if (m != null && complete) {
+        fence = _OpenFence()
+          ..lineStart = span.start
+          ..context = MarkdownCodeFenceContext.none
+          ..mark = m
+          ..identifier = line.substring(m.start + m.length).trim();
+        continue;
+      }
+    }
+
+    for (final pair in markdownCodePairInline(line)) {
+      segments.add(
+        MarkdownCodeSegment(
+          start: span.start + pair.openStart,
+          end: span.start + pair.closeEnd,
+          kind: MarkdownCodeSegmentKind.inlineCode,
+          content: markdownCodeSpanNormalize(
+            line.substring(pair.openEnd, pair.closeStart),
+          ),
+        ),
+      );
+    }
+  }
+
+  if (fence != null) {
+    segments.add(
+      MarkdownCodeSegment(
+        start: fence.lineStart,
+        end: text.length,
+        kind: MarkdownCodeSegmentKind.codeBlock,
+        content: fence.contentLines.join('\n'),
+        identifier: fence.identifier,
+        closed: false,
+        context: fence.context,
+        contextPrefix: fence.prefix,
+        marker: fence.mark!.marker,
+      ),
+    );
+  }
+
+  return MarkdownCodeScanResult(segments);
+}
+
+String _interiorLine(String line, MarkdownCodeFenceContext context) {
+  if (context == MarkdownCodeFenceContext.blockquote) {
+    final prefix = markdownCodeQuotePrefix(line);
+    if (prefix.isNotEmpty) return line.substring(prefix.length);
+  }
+  return line;
+}
+
+String? _listFencePrefix(String line) {
+  var i = 0;
+  while (i < line.length &&
+      (line.codeUnitAt(i) == 0x20 || line.codeUnitAt(i) == 0x09)) {
+    i++;
+  }
+  if (i >= line.length) return null;
+  final u = line.codeUnitAt(i);
+  final isMarker = u == 0x2A || u == 0x2B || u == 0x2D;
+  if (!isMarker) {
+    if (u < 0x30 || u > 0x39) return null;
+    i++;
+    while (i < line.length &&
+        line.codeUnitAt(i) >= 0x30 &&
+        line.codeUnitAt(i) <= 0x39) {
+      i++;
+    }
+    if (i >= line.length || line.codeUnitAt(i) != 0x2E) return null;
+    i++;
+  } else {
+    i++;
+  }
+  if (i >= line.length) return null;
+  var sawSpace = false;
+  while (i < line.length) {
+    final s = line.codeUnitAt(i);
+    if (s != 0x20 && s != 0x09) break;
+    i++;
+    sawSpace = true;
+  }
+  if (!sawSpace || i >= line.length) return null;
+  if (line.codeUnitAt(i) != 0x60) return null;
+  return line.substring(0, i);
+}

--- a/test/shared/widgets/markdown_line_lexer_test.dart
+++ b/test/shared/widgets/markdown_line_lexer_test.dart
@@ -1,6 +1,7 @@
 import 'package:Cuplivo/shared/widgets/incremental_markdown_document.dart';
 import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
 import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
+import 'package:Cuplivo/utils/markdown_code_scanner.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 String _unmatchedBacktickRuns({int maxRun = 200}) {
@@ -711,7 +712,7 @@ void _expectFenceWhitespace(String indent, {required bool isFence}) {
     reason: 'scanner indent ${indent.codeUnits}',
   );
   expect(
-    FencedCodeBlockMd(streaming: false).exp.matchAsPrefix(probed) != null,
+    markdownCodeScan(probed).segments.isNotEmpty,
     isFence,
     reason: 'renderer indent ${indent.codeUnits}',
   );

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
+import 'package:Cuplivo/utils/markdown_code_scanner.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:Cuplivo/features/chat/pages/image_viewer_page.dart';
 import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
@@ -2611,12 +2612,14 @@ $$
       final spans = _resolvedTextSpansFromRichText(tester);
       final plainText = spans.map((span) => span.text).join();
 
-      expect(
-        plainText,
-        contains(
-          r'*literal* and **strong** and `code` and [label](https://example.com)',
-        ),
-      );
+      // Backslashes escape delimiters outside code: \* and \[label\] render
+      // as literal punctuation.
+      expect(plainText, contains(r'*literal* and **strong** and '));
+      expect(plainText, contains(' and [label](https://example.com)'));
+      // Inside a code span there is no escape: the closer stays a closer even
+      // when preceded by a backslash (#544 rule), so `code\` is one chip whose
+      // content keeps the backslash.
+      expect(find.textContaining(r'code\', findRichText: true), findsWidgets);
       expect(
         spans.where(
           (span) =>
@@ -4748,6 +4751,10 @@ void main() {
           .join('\n');
       expect(find.byType(GptMarkdown), findsWidgets);
       expect(data, isNot(contains('\uE002')));
+      // Code spans are tokenized before parsing: the source text's visible
+      // content reaches the renderer through the registry, so the GptMarkdown
+      // data contains a token, never the raw text.
+      expect(data, isNot(contains(visible)));
       final details = find.byWidgetPredicate(
         (widget) => widget.runtimeType.toString() == '_DetailsHtmlBlock',
       );
@@ -4756,8 +4763,6 @@ void main() {
         expect(find.textContaining(visible, findRichText: true), findsNothing);
         await tester.tap(find.text('s'));
         await tester.pumpAndSettle();
-      } else {
-        expect(data, contains(visible));
       }
       expect(find.textContaining(visible, findRichText: true), findsWidgets);
     }
@@ -4792,27 +4797,93 @@ void main() {
     await tester.pumpWidget(_markdownHarness('Use `a \uE002 b` now'));
     await tester.pump();
     expect(find.text('a \uE002 b'), findsWidgets);
-    expect(
-      tester.widget<GptMarkdown>(find.byType(GptMarkdown)).data,
-      contains('\uE002'),
-    );
+    final tokenized = tester.widget<GptMarkdown>(find.byType(GptMarkdown)).data;
+    // The code span is tokenized before parsing: the private marker is no
+    // longer baked into the text; the content lives in the registry.
+    expect(tokenized, contains('\uE020'));
+    expect(tokenized, isNot(contains('\uE002')));
   });
 
-  test('FencedCodeBlockMd does not close on an info-string fence line', () {
-    for (final item in const [
-      ('```', '```', '```dart\na\n``` not-a-closer\nfollowing\n```'),
-      ('~~~', '~~~', '~~~\na\n~~~ not-a-closer\nfollowing\n~~~'),
-      ('````', '````', '````dart\na\n```` not-a-closer\nfollowing\n````'),
-      ('~~~~', '~~~~', '~~~~\na\n~~~~ not-a-closer\nfollowing\n~~~~'),
-      ('````', '```', '````dart\na\n``` not-a-closer\nfollowing\n````'),
-    ]) {
-      final match = FencedCodeBlockMd(streaming: false).exp.firstMatch(item.$3);
-      expect(match, isNotNull, reason: item.$3);
-      expect(match!.group(0), item.$3, reason: item.$3);
-      expect(match.group(4), contains('not-a-closer'), reason: item.$3);
-      expect(match.group(4), contains('following'), reason: item.$3);
-    }
-  });
+  testWidgets(
+    'issue #544: windows paths with trailing backslashes stay one code chip',
+    (tester) async {
+      const source =
+          '包）：`D:\\ComfyUI\\` 为环境层（含 `python_embedded`、'
+          '`run_nvidia_gpu.bat`），模型路径：`D:\\ComfyUI\\ComfyUI\\models\\...`。';
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+
+      expect(
+        find.textContaining(r'D:\ComfyUI\', findRichText: true),
+        findsWidgets,
+      );
+      expect(
+        find.textContaining('python_embedded', findRichText: true),
+        findsWidgets,
+      );
+      expect(
+        find.textContaining('run_nvidia_gpu.bat', findRichText: true),
+        findsWidgets,
+      );
+      // The sentence fragment must not be swallowed into the chip.
+      expect(find.textContaining('为环境层（含', findRichText: true), findsWidgets);
+    },
+  );
+
+  testWidgets(
+    'indented powershell fence with trailing-backslash path renders no extra line',
+    (tester) async {
+      const source = r'''1. **PowerShell / CMD 中的命令**  
+   当你给某个命令传入路径参数，但该命令期望的是**文件**路径，而你给的是**文件夹**路径时，系统会提示这个。  
+   例如：
+   ```powershell
+   Get-Content D:\ComfyUI\    # Get-Content 期望文件，但你给了目录
+   ```
+   或者有些工具会检查路径类型后输出 `"D:\ComfyUI\" is a dir`。
+
+2. **脚本 / 程序的参数校验**  
+   某个脚本或程序（比如 ComfyUI 相关的安装/启动脚本）在运行前检查 `D:\ComfyUI\` 路径，发现它确实是一个存在的目录，于是告诉你这个信息。''';
+      await tester.pumpWidget(_markdownHarness(source));
+      await tester.pump();
+
+      final codeText = tester
+          .widgetList<SelectableText>(
+            find.descendant(
+              of: find.byType(SelectableHighlightView),
+              matching: find.byType(SelectableText),
+            ),
+          )
+          .map((widget) => widget.textSpan?.toPlainText() ?? widget.data ?? '')
+          .join('\n');
+
+      expect(codeText, contains(r'Get-Content D:\ComfyUI\'));
+      // The rendered code text must end at the code line: the indented
+      // full-line closer must not leak its indent into the content.
+      expect(codeText, endsWith('目录'), reason: 'code text: $codeText');
+      expect(codeText, isNot(endsWith('\n')), reason: 'code text: $codeText');
+    },
+  );
+
+  test(
+    'FencedCodeTokenMd keeps an info-string fence line inside the block',
+    () {
+      for (final source in const [
+        '```dart\na\n``` not-a-closer\nfollowing\n```',
+        '~~~\na\n~~~ not-a-closer\nfollowing\n~~~',
+        '````dart\na\n```` not-a-closer\nfollowing\n````',
+        '~~~~\na\n~~~~ not-a-closer\nfollowing\n~~~~',
+        '````dart\na\n``` not-a-closer\nfollowing\n````',
+      ]) {
+        final scan = markdownCodeScan(source);
+        expect(scan.segments, hasLength(1), reason: source);
+        final seg = scan.segments.single;
+        expect(seg.kind, MarkdownCodeSegmentKind.codeBlock, reason: source);
+        expect(seg.closed, isTrue, reason: source);
+        expect(seg.content, contains('not-a-closer'), reason: source);
+        expect(seg.content, contains('following'), reason: source);
+      }
+    },
+  );
 
   testWidgets(
     'MarkdownWithCodeHighlight keeps an info-string fence line inside the code block',
@@ -4822,6 +4893,15 @@ void main() {
         '~~~\na\n~~~ not-a-closer\nfollowing\n~~~',
         '````dart\na\n```` not-a-closer\nfollowing\n````',
       ]) {
+        final probe = markdownCodeScan(source);
+        for (final seg in probe.segments) {
+          if (seg.kind == MarkdownCodeSegmentKind.codeBlock) {
+            debugPrint(
+              'POWERSHELL_SCAN_SEG_BEGIN>>>${seg.content}<<<END '
+              'ids=${seg.content.codeUnits}',
+            );
+          }
+        }
         await tester.pumpWidget(_markdownHarness(source));
         await tester.pump();
         expect(

--- a/test/utils/markdown_code_scanner_test.dart
+++ b/test/utils/markdown_code_scanner_test.dart
@@ -1,0 +1,256 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/utils/markdown_code_scanner.dart';
+
+void main() {
+  group('markdownCodeFenceMark', () {
+    test('runs of three or more backticks/tildes after indent', () {
+      final bt = markdownCodeFenceMark('```dart');
+      expect(bt, isNotNull);
+      expect(bt!.length, 3);
+      expect(bt.marker, MarkdownCodeFenceMarker.backtick);
+      expect(bt.canClose, isFalse);
+      final tilde = markdownCodeFenceMark('~~~~');
+      expect(tilde!.length, 4);
+      expect(tilde.marker, MarkdownCodeFenceMarker.tilde);
+      expect(markdownCodeFenceMark('``'), isNull);
+      expect(markdownCodeFenceMark('    ```  '), isNotNull);
+      expect(markdownCodeFenceMark('prefix ```'), isNull);
+    });
+
+    test('canClose requires horizontal whitespace after the run', () {
+      expect(markdownCodeFenceMark('```')!.canClose, isTrue);
+      expect(markdownCodeFenceMark('```  ')!.canClose, isTrue);
+      expect(markdownCodeFenceMark('``` not-a-closer')!.canClose, isFalse);
+    });
+  });
+
+  group('markdownCodePairInline', () {
+    test('pairs equal-run spans left to right', () {
+      final pairs = markdownCodePairInline('use `code` and ``t`x`` after');
+      expect(pairs, hasLength(2));
+      expect(pairs[0].openStart, 4);
+      expect(pairs[0].openLength, 1);
+      expect(pairs[0].closeStart, 9);
+      expect(pairs[1].openLength, 2);
+      expect(pairs[1].closeLength, 2);
+    });
+
+    test('escaped opener does not open (escapeSensitive)', () {
+      final pairs = markdownCodePairInline(r'use \`code` here');
+      expect(pairs, isEmpty);
+    });
+
+    test('wider hiding rule pairs the escaped run too', () {
+      final pairs = markdownCodePairInline(
+        r'\`<details>`',
+        escapeSensitive: false,
+      );
+      expect(pairs, hasLength(1));
+    });
+
+    test('two backslashes before a run make it a real opener', () {
+      final pairs = markdownCodePairInline('use \\\\`code` now');
+      expect(pairs, hasLength(1));
+      expect(pairs.single.openStart, 6);
+    });
+  });
+
+  group('markdownCodeSpanNormalize', () {
+    test('peels one space when both ends are spaces', () {
+      expect(markdownCodeSpanNormalize(' a '), 'a');
+      expect(markdownCodeSpanNormalize('   '), '   ');
+      expect(markdownCodeSpanNormalize('a b'), 'a b');
+      expect(markdownCodeSpanNormalize('a\nb'), 'a b');
+    });
+  });
+
+  group('markdownCodeInlineClosingFence', () {
+    test('closes only when the line ends with a run after content', () {
+      expect(markdownCodeInlineClosingFence('}```', 3), 1);
+      expect(markdownCodeInlineClosingFence('}```  ', 3), 1);
+      expect(markdownCodeInlineClosingFence('```', 3), isNull);
+      expect(markdownCodeInlineClosingFence('}``', 3), isNull);
+      expect(markdownCodeInlineClosingFence('}``` not-close', 3), isNull);
+      expect(markdownCodeInlineClosingFence('a}}```', 3), 3);
+    });
+  });
+
+  group('markdownCodeScan: inline spans', () {
+    test('windows path with trailing backslash stays one span (#544)', () {
+      final res = markdownCodeScan(': `D:\\ComfyUI\\` 为环境层（含');
+      expect(res.segments, hasLength(1));
+      final seg = res.segments.single;
+      expect(seg.kind, MarkdownCodeSegmentKind.inlineCode);
+      expect(seg.content, 'D:\\ComfyUI\\');
+      expect(res.segments.single.start, 2);
+      expect(seg.end - seg.start, '`D:\\ComfyUI\\`'.length);
+    });
+
+    test('swallowing gone: sentence fragment is not part of the span', () {
+      final res = markdownCodeScan(
+        ': `D:\\ComfyUI\\` 为环境层（含 `python_embedded`、',
+      );
+      expect(res.segments, hasLength(2));
+      expect(res.segments[0].content, 'D:\\ComfyUI\\');
+      expect(res.segments[1].content, 'python_embedded');
+    });
+
+    test('mismatched runs: lazy second span starts after escape', () {
+      final res = markdownCodeScan('`a` and `` b ``');
+      expect(res.segments, hasLength(2));
+    });
+
+    test('double-backtick delimiters with inner backtick', () {
+      final res = markdownCodeScan('use `` `x` `` here');
+      expect(res.segments, hasLength(1));
+      expect(res.segments.single.content, '`x`');
+      expect(res.segments.single.kind, MarkdownCodeSegmentKind.inlineCode);
+    });
+
+    test('three backticks delimit a span with double inner', () {
+      final res = markdownCodeScan('use ``` ``x`` ``` now');
+      expect(res.segments, hasLength(1));
+      expect(res.segments.single.content, '``x``');
+    });
+
+    test('single-line only: run pairs never cross a line break', () {
+      final res = markdownCodeScan('`a\nb`');
+      expect(res.segments, isEmpty);
+    });
+  });
+
+  group('markdownCodeScan: fences', () {
+    test('plain fenced block with info string, content and closer', () {
+      final res = markdownCodeScan('```dart\nvar x = 1;\nprint(x);\n```');
+      expect(res.segments, hasLength(1));
+      final seg = res.segments.single;
+      expect(seg.kind, MarkdownCodeSegmentKind.codeBlock);
+      expect(seg.identifier, 'dart');
+      expect(seg.closed, isTrue);
+      expect(seg.content, 'var x = 1;\nprint(x);');
+    });
+
+    test('info-string closer line does not close (#544 family)', () {
+      final res = markdownCodeScan(
+        '```dart\na\n``` not-a-closer\nfollowing\n```',
+      );
+      final seg = res.segments.single;
+      expect(seg.closed, isTrue);
+      expect(seg.content, 'a\n``` not-a-closer\nfollowing');
+    });
+
+    test('four-backtick opener is not closed by a three-run', () {
+      final res = markdownCodeScan('````dart\na\n```\n\nb\n````');
+      expect(res.segments, hasLength(1));
+      expect(res.segments.single.closed, isTrue);
+    });
+
+    test('tilde fence closes on a longer same-marker run', () {
+      final res = markdownCodeScan('~~~\na\n~~~~');
+      expect(res.segments.single.closed, isTrue);
+      expect(res.segments.single.marker, MarkdownCodeFenceMarker.tilde);
+    });
+
+    test('unclosed fence to EOF has closed=false', () {
+      final res = markdownCodeScan('```dart\nvar a = 1;');
+      expect(res.segments, hasLength(1));
+      expect(res.segments.single.closed, isFalse);
+      expect(res.segments.single.content, 'var a = 1;');
+    });
+
+    test('incomplete opener line at EOF is not a fence', () {
+      final res = markdownCodeScan('```dart');
+      expect(res.segments, isEmpty);
+    });
+
+    test('inline closing extension: }``` line closes the fence', () {
+      final res = markdownCodeScan('```\na\n}```\n');
+      expect(res.segments.single.closed, isTrue);
+      expect(res.segments.single.content, 'a\n}');
+    });
+
+    test('inline closing never opens outside a fence', () {
+      final res = markdownCodeScan('text }```\nmore');
+      expect(res.segments, isEmpty);
+    });
+
+    test('indented full-line closer does not leak indent into content', () {
+      final res = markdownCodeScan(
+        '   ```powershell\n   Get-Content x\n   ```',
+      );
+      final seg = res.segments.single;
+      expect(seg.kind, MarkdownCodeSegmentKind.codeBlock);
+      expect(seg.closed, isTrue);
+      expect(seg.content, '   Get-Content x');
+    });
+
+    test('blockquote fence: quote prefix and stripped content', () {
+      final res = markdownCodeScan('> ```\n> code\n> ```\nafter');
+      expect(res.segments, hasLength(1));
+      final seg = res.segments.single;
+      expect(seg.context, MarkdownCodeFenceContext.blockquote);
+      expect(seg.contextPrefix, '> ');
+      expect(seg.content, 'code');
+      expect(seg.closed, isTrue);
+    });
+
+    test('list fence: info shape keeps no spaces', () {
+      final res = markdownCodeScan('- ```yaml\npkgs:\n- deps\n```');
+      expect(res.segments, hasLength(1));
+      expect(res.segments.single.context, MarkdownCodeFenceContext.list);
+      expect(res.segments.single.contextPrefix, '- ');
+      expect(res.segments.single.identifier, 'yaml');
+      expect(res.segments.single.content, 'pkgs:\n- deps');
+    });
+
+    test('list fence with a space in the info is not a list fence', () {
+      final res = markdownCodeScan('- ```yaml with space\nx\n');
+      expect(res.segments, isEmpty);
+    });
+
+    test('tilde list fence stays literal text', () {
+      final res = markdownCodeScan('- ~~~\nx\n~~~');
+      expect(res.segments, isEmpty);
+    });
+  });
+
+  group('markdownCodeScan: mixed docs', () {
+    test('garbling case from issue #544 end to end', () {
+      const source =
+          '包）：`D:\\ComfyUI\\` 为环境层（含 `python_embedded`、'
+          '`run_nvidia_gpu.bat`），`D:\\ComfyUI\\ComfyUI\\` 为内容层（含 '
+          '`models`、`custom_nodes`）。模型路径：`D:\\ComfyUI\\ComfyUI\\models\\...`，'
+          '输出路径：`D:\\ComfyUI\\ComfyUI\\output`。';
+      final res = markdownCodeScan(source);
+      expect(res.segments.map((s) => s.content).toList(), [
+        r'D:\ComfyUI\',
+        'python_embedded',
+        'run_nvidia_gpu.bat',
+        r'D:\ComfyUI\ComfyUI\',
+        'models',
+        'custom_nodes',
+        r'D:\ComfyUI\ComfyUI\models\...',
+        r'D:\ComfyUI\ComfyUI\output',
+      ]);
+    });
+
+    test('spans and fences interleave without overlap', () {
+      final res = markdownCodeScan('`a`\n```b\nc\n```\n`d`');
+      expect(res.segments, hasLength(3));
+      expect(res.segments[0].kind, MarkdownCodeSegmentKind.inlineCode);
+      expect(res.segments[1].kind, MarkdownCodeSegmentKind.codeBlock);
+      expect(res.segments[2].kind, MarkdownCodeSegmentKind.inlineCode);
+      for (var i = 1; i < res.segments.length; i++) {
+        expect(res.segments[i].start >= res.segments[i - 1].end, isTrue);
+      }
+    });
+
+    test('segments slice the source consistently', () {
+      const source = 'x `A` ```r\ncode\n``` y';
+      final res = markdownCodeScan(source);
+      for (final seg in res.segments) {
+        expect(source.substring(seg.start, seg.end), isNotEmpty);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fixes #544.

## What this does

`D:\ComfyUI\` — a Windows path code span **ending with a backslash** — used to render garbled: the closer guard `(?<![\\`])` on `EscapeAwareHighlightedTextMd` treated a backslash-preceded backtick as escaped (as if code spans had backslash escapes — CommonMark says they do not), so the span re-closed at the next backtick and swallowed the following sentence into the chip.

There were **five independent rule copies** for "what counts as code" and they had drifted. This PR replaces them with one engine:

## Changes

- **New `lib/utils/markdown_code_scanner.dart`** — single rule set: fence marks (`\`\`\`` / `~~~` ≥3 after any indent, quote fences, list fences, unclosed-streaming fences, the `}```` ` inline-closing extension), escape-aware inline run pairing (`\`code\`` stays literal; backslash-preceded backtick still CLOSES), span normalization, and the segment types.
- **Render pipeline** (`markdown_with_highlight.dart`) — code regions are tokenized into opaque `\uE020…\uE021` placeholders resolved through a `MarkdownCodeRegistry` shipped with the cached payload. `FencedCodeTokenMd` / `InlineCodeTokenMd` replace the broken regex component and the old `codeBuilder` dispatch. The content hash embedded in each token makes tokenized-text equality imply content equality, so cached blocks refresh when code grows (without it, growing mermaid fences hit a stale-cache hang).
- **Deleted legacy machinery**: `EscapeAwareHighlightedTextMd`, old `FencedCodeBlockMd` regex, `__CODE_MASK_n__` + `_codeDollarMask`, blockquote-fence markers (`\uE000`/`\uE001`), html-tag-in-code mask (`\uE002`), dedent/bullet/inline-closing text rewrites.
- **Lexer** — `_LineBackticks` and `_fenceMarkOf` delegate to the shared primitives (state machines stay); visit-budget behavior preserved.
- **chat_api_service** — image-skip uses scanner segments; bug-fix bonus: it now honors `>=`-run closers, indented fences and quote/list fences (previously a constricted exact-run rule).
- **Bug fix found during review**: an indented full-line closer (`   \`\`\``) leaked its 3-space indent into the fence content, appending an empty line after multi-line code (originated from the inline-closing extension firing on the closer line's own whitespace).

## Behavior deltas (documented in ADR-0042 + CONTEXT.md)

- A backslash-preceded backtick now closes its span (`\`code\`` literal is unchanged) — CommonMark-correct.
- Double/triple-backtick spans (`` `` `x` `` ``) now render as real code spans.
- `}```` never *opens* a fence from prose (the legacy text rewrite could).
- Fences inside blockquotes render via the unified token path (mermaid/svg/html dispatch now applies there).

## Verification

- `dart analyze --fatal-infos lib test` — clean
- 317 tests green: scanner unit suite (incl. new indented-closer regression), markdown render suite (incl. exact #544 repro and the new powershell end-to-end), lexer + incremental, streaming-height stability, chat API image skip.
- Vendored `gpt_markdown` untouched (its default `HighlightedText` was already CommonMark-correct; changelog dialog keeps it).
