### PR TITLE
fix(sandbox): avoid mobile runtime crashes and overhead

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -25,6 +25,11 @@ jobs:
           java-version: '17'
           cache: 'gradle'
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -34,6 +39,12 @@ jobs:
 
       - name: Flutter pub get
         run: flutter pub get
+
+      - name: Node jitless fetch polyfill regression
+        run: >
+          node --jitless --no-experimental-fetch
+          --require ./ios/sandbox/resources/node-fetch-jitless-polyfill.js
+          ./ios/sandbox/tests/node_fetch_jitless_polyfill_test.js
 
       - name: Dart format (changed files only)
         shell: bash

--- a/android/app/src/main/kotlin/com/cup11/cuplivo/RootfsExtractor.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/RootfsExtractor.kt
@@ -121,6 +121,7 @@ object RootfsExtractor {
   /** Pull-based ustar reader that follows GNU long-name and PAX records. */
   private class TarStream(private val source: InputStream) {
     private val block = ByteArray(BLOCK_BYTES)
+    private val payloadBuffer = ByteArray(COPY_CHUNK)
 
     /**
      * Returns the next concrete entry, or null at the end of the archive.
@@ -252,13 +253,12 @@ object RootfsExtractor {
 
     fun drainInto(out: OutputStream, size: Long) {
       var remaining = size
-      val chunk = ByteArray(COPY_CHUNK)
       while (remaining > 0) {
         alive()
-        val want = minOf(chunk.size.toLong(), remaining).toInt()
-        val read = source.read(chunk, 0, want)
+        val want = minOf(payloadBuffer.size.toLong(), remaining).toInt()
+        val read = source.read(payloadBuffer, 0, want)
         if (read < 0) throw EOFException("Tar payload ended early")
-        out.write(chunk, 0, read)
+        out.write(payloadBuffer, 0, read)
         remaining -= read
       }
     }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B15A000000000000000000A4 /* CuplivoLinuxSandboxPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B7 /* CuplivoLinuxSandboxPlugin.swift */; };
 		B15A000000000000000000A5 /* CuplivoSandboxRootfsInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B8 /* CuplivoSandboxRootfsInstaller.swift */; };
 		B15A000000000000000000A6 /* alpine-rootfs.zip in Resources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000B9 /* alpine-rootfs.zip */; };
+		B15A000000000000000000A7 /* node-fetch-jitless-polyfill.js in Resources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000BD /* node-fetch-jitless-polyfill.js */; };
 		B15A000000000000000000CA /* BackgroundKeepAliveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15A000000000000000000CB /* BackgroundKeepAliveManager.swift */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +115,7 @@
 		B15A000000000000000000B8 /* CuplivoSandboxRootfsInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuplivoSandboxRootfsInstaller.swift; sourceTree = "<group>"; };
 		B15A000000000000000000CB /* BackgroundKeepAliveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundKeepAliveManager.swift; sourceTree = "<group>"; };
 		B15A000000000000000000B9 /* alpine-rootfs.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; name = "alpine-rootfs.zip"; path = "sandbox/resources/alpine-rootfs.zip"; sourceTree = SOURCE_ROOT; };
+		B15A000000000000000000BD /* node-fetch-jitless-polyfill.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "node-fetch-jitless-polyfill.js"; path = "sandbox/resources/node-fetch-jitless-polyfill.js"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +183,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				CB99E8CD1E59B0861193D1F0 /* Pods */,
 				2EE6D5FD27723C6C9804D147 /* Frameworks */,
+				B15A000000000000000000BD /* node-fetch-jitless-polyfill.js */,
 			);
 			sourceTree = "<group>";
 		};
@@ -382,6 +385,7 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				B15A000000000000000000A6 /* alpine-rootfs.zip in Resources */,
+				B15A000000000000000000A7 /* node-fetch-jitless-polyfill.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
+++ b/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
@@ -37,6 +37,15 @@ enum {
 static const NSTimeInterval kDrainGraceSeconds = 1.0;
 /// Grace period for the exit notification to arrive after a timeout kill.
 static const NSTimeInterval kKillGraceSeconds = 2.0;
+static const char *kNodeFetchPolyfillGuestPath =
+    "/lib/cuplivo-fetch-jitless-polyfill.js";
+
+static BOOL CuplivoGuestFileExists(const char *path) {
+    struct fd *fd = generic_open(path, O_RDONLY_, 0);
+    if (IS_ERR(fd)) return NO;
+    fd_close(fd);
+    return YES;
+}
 
 #pragma mark - Execution context
 
@@ -519,8 +528,19 @@ static dispatch_queue_t _readerQueue;
     ENVP_APPEND("NO_COLOR=1");
     ENVP_APPEND("PYTHONMALLOC=malloc");
     ENVP_APPEND("PYTHONDONTWRITEBYTECODE=1");
-    // V8 cannot JIT under emulation; node honours NODE_OPTIONS.
-    ENVP_APPEND("NODE_OPTIONS=--jitless --max-old-space-size=512");
+    // V8 cannot JIT under emulation. --no-experimental-fetch prevents Node
+    // 22 from loading undici's WASM llhttp parser; when the bundled fallback
+    // is present, it restores fetch through core http/https instead.
+    if (CuplivoGuestFileExists(kNodeFetchPolyfillGuestPath)) {
+        ENVP_APPEND("NODE_OPTIONS=--jitless --no-experimental-fetch "
+                    "--require=/lib/cuplivo-fetch-jitless-polyfill.js "
+                    "--max-old-space-size=512");
+    } else {
+        NSLog(@"CuplivoISHExecutor: node fetch polyfill unavailable; "
+              "disabling built-in fetch to avoid undici WASM crash");
+        ENVP_APPEND("NODE_OPTIONS=--jitless --no-experimental-fetch "
+                    "--max-old-space-size=512");
+    }
     // Go tuning (ported from OpenMinis): cap the scheduler to one core-pair
     // so it does not spin extra threads under the interpreter, and disable
     // async preemption which is expensive under emulation.

--- a/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
+++ b/ios/Runner/iSHSandbox/CuplivoISHExecutor.m
@@ -52,6 +52,7 @@ static const NSTimeInterval kKillGraceSeconds = 2.0;
 @property (nonatomic, readonly) CuplivoISHBoundedData *stdoutData;
 @property (nonatomic, readonly) CuplivoISHBoundedData *stderrData;
 @property (nonatomic, readonly) dispatch_semaphore_t waitSemaphore;
+@property (nonatomic, readonly) dispatch_group_t readersGroup;
 @property (atomic) int exitCode;
 @property (atomic) BOOL exited;
 @property (atomic) BOOL cancelled;
@@ -240,6 +241,7 @@ toCircularOffset:(NSUInteger)offset {
         _stdoutData = [[CuplivoISHBoundedData alloc] init];
         _stderrData = [[CuplivoISHBoundedData alloc] init];
         _waitSemaphore = dispatch_semaphore_create(0);
+        _readersGroup = dispatch_group_create();
         _stdoutPipe[0] = _stdoutPipe[1] = -1;
         _stderrPipe[0] = _stderrPipe[1] = -1;
         _exitCode = -1;
@@ -592,18 +594,18 @@ static dispatch_queue_t _readerQueue;
             dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kKillGraceSeconds * NSEC_PER_SEC)));
     }
 
-    // Let readers drain remaining pipe data before decoding.
-    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:kDrainGraceSeconds];
-    while ((!ctx.stdoutReaderDone || !ctx.stderrReaderDone) &&
-           [deadline timeIntervalSinceNow] > 0) {
-        [NSThread sleepForTimeInterval:0.05];
-    }
+    // Let readers drain remaining pipe data before decoding. This must be a
+    // completion wait, not a polling loop on _execQueue: the latter made the
+    // next shell command wait in 50ms increments after every exit.
+    BOOL readersDrained = dispatch_group_wait(
+        ctx.readersGroup,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDrainGraceSeconds * NSEC_PER_SEC))) == 0;
 
     // A guest child that inherited the pipes keeps the write ends open, so
     // the readers stay blocked after the shell task exited. Reap those
     // descendants first: their fds close, the readers hit EOF and terminate
     // on their own.
-    if (ctx.exited || !ctx.stdoutReaderDone || !ctx.stderrReaderDone) {
+    if (ctx.exited || !readersDrained) {
         // The shell may already have exited while a background child either
         // owns the pipe or redirected its output elsewhere. Keep the original
         // process-group id so that child is still terminated after the shell
@@ -612,15 +614,13 @@ static dispatch_queue_t _readerQueue;
     }
     // Last resort: closing the read ends unblocks the poll() loops (kqueue
     // based on Darwin). Only then join the readers.
-    if (!ctx.stdoutReaderDone || !ctx.stderrReaderDone) {
+    if (!readersDrained) {
         [ctx closePipeEnds];
-        NSDate *closeDeadline = [NSDate dateWithTimeIntervalSinceNow:1.0];
-        while ((!ctx.stdoutReaderDone || !ctx.stderrReaderDone) &&
-               [closeDeadline timeIntervalSinceNow] > 0) {
-            [NSThread sleepForTimeInterval:0.05];
-        }
+        readersDrained = dispatch_group_wait(
+            ctx.readersGroup,
+            dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kDrainGraceSeconds * NSEC_PER_SEC))) == 0;
     }
-    if (!ctx.stdoutReaderDone || !ctx.stderrReaderDone) {
+    if (!readersDrained) {
         NSLog(@"CuplivoISHExecutor: reader(s) still alive for request %@ "
               "(stdout=%d stderr=%d); decoding captured data anyway",
               requestId, ctx.stdoutReaderDone, ctx.stderrReaderDone);
@@ -693,18 +693,19 @@ static dispatch_queue_t _readerQueue;
 
     ctx.exitCode = exitCode;
     ctx.exited = YES;
-    // Give pipe readers a moment to drain before waking the waiter.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(200 * NSEC_PER_MSEC)),
-                   dispatch_get_main_queue(), ^{
-        dispatch_semaphore_signal(ctx.waitSemaphore);
-    });
+    // Wake the executor as soon as the process exits. It separately waits on
+    // readersGroup with a bounded drain grace, so every successful command no
+    // longer pays an unconditional 200ms latency tax.
+    dispatch_semaphore_signal(ctx.waitSemaphore);
 }
 
 #pragma mark - Pipe reading
 
 + (void)startReaderForPipe:(int)fd context:(CuplivoISHExecutionContext *)ctx isStdErr:(BOOL)isStdErr {
+    dispatch_group_enter(ctx.readersGroup);
     dispatch_async(_readerQueue, ^{
         [self readPipe:fd context:ctx isStdErr:isStdErr];
+        dispatch_group_leave(ctx.readersGroup);
     });
 }
 
@@ -747,14 +748,39 @@ static dispatch_queue_t _readerQueue;
 
 #pragma mark - Kill
 
-static BOOL CuplivoTaskIsDescendantOf(struct task *t, pid_t_ rootPid) {
-    int hops = 0;
-    while (t != NULL && hops < MAX_PID) {
-        if (t->pid == rootPid) return YES;
-        t = t->parent;
-        hops++;
+static void CuplivoSignalThreadGroup(struct tgroup *group, int signal,
+                                     struct siginfo_ info) {
+    struct task *task;
+    list_for_each_entry(&group->threads, task, group_links) {
+        send_signal(task, signal, info);
     }
-    return NO;
+}
+
+/// Signals descendants that moved to a different process group. The original
+/// group is handled separately, so this avoids signalling its tasks twice.
+static void CuplivoSignalTaskTreeOutsideProcessGroup(
+    struct task *task, pid_t_ pgid, int signal, struct siginfo_ info) {
+    if (task->group->pgid != pgid && task_is_leader(task)) {
+        CuplivoSignalThreadGroup(task->group, signal, info);
+    }
+    struct task *child;
+    list_for_each_entry(&task->children, child, siblings) {
+        CuplivoSignalTaskTreeOutsideProcessGroup(child, pgid, signal, info);
+    }
+}
+
+/// Signal all threads in a process group directly through iSH's pgroup list.
+/// Scanning the whole 32K PID table under pids_lock made timeout/cancellation
+/// stalls proportional to the maximum PID instead of the command's process
+/// tree size.
+static void CuplivoSignalProcessGroup(pid_t_ pgid, int signal, struct siginfo_ info) {
+    struct pid *groupPid = pid_get((dword_t)pgid);
+    if (groupPid == NULL) return;
+
+    struct tgroup *group;
+    list_for_each_entry(&groupPid->pgroup, group, pgroup) {
+        CuplivoSignalThreadGroup(group, signal, info);
+    }
 }
 
 /// SIGTERM the process group (pgid match or ancestry), then SIGKILL
@@ -778,14 +804,11 @@ static BOOL CuplivoTaskIsDescendantOf(struct task *t, pid_t_ rootPid) {
         unlock(&pids_lock);
         return;
     }
-    for (int i = 2; i < MAX_PID; i++) {
-        struct task *t = pid_get_task(i);
-        if (!t) continue;
-        BOOL byPgid = (t->group->pgid == pgid);
-        BOOL byAncestry = rootTask && CuplivoTaskIsDescendantOf(t, (pid_t_)pid);
-        if (byPgid || byAncestry) {
-            send_signal(t, rootTask ? SIGTERM_ : SIGKILL_, info);
-        }
+    int immediateSignal = rootTask ? SIGTERM_ : SIGKILL_;
+    CuplivoSignalProcessGroup(pgid, immediateSignal, info);
+    if (rootTask != NULL) {
+        CuplivoSignalTaskTreeOutsideProcessGroup(rootTask, pgid,
+                                                  immediateSignal, info);
     }
     unlock(&pids_lock);
 
@@ -807,15 +830,11 @@ static BOOL CuplivoTaskIsDescendantOf(struct task *t, pid_t_ rootPid) {
             unlock(&pids_lock);
             return;
         }
-        for (int i = 2; i < MAX_PID; i++) {
-            struct task *t = pid_get_task(i);
-            if (!t) continue;
-            BOOL byPgid = (capturedPgid != 0 && t->group->pgid == capturedPgid);
-            BOOL byAncestry = CuplivoTaskIsDescendantOf(t, (pid_t_)capturedPid);
-            if (byPgid || byAncestry) {
-                send_signal(t, SIGKILL_, info);
-            }
+        if (capturedPgid != 0) {
+            CuplivoSignalProcessGroup(capturedPgid, SIGKILL_, info);
         }
+        CuplivoSignalTaskTreeOutsideProcessGroup(still, capturedPgid,
+                                                  SIGKILL_, info);
         unlock(&pids_lock);
     });
 }

--- a/ios/Runner/iSHSandbox/CuplivoISHKernel.m
+++ b/ios/Runner/iSHSandbox/CuplivoISHKernel.m
@@ -37,6 +37,8 @@
 NSNotificationName const CuplivoISHProcessExitedNotification = @"CuplivoISHProcessExited";
 
 static NSString *const kDnsSubdir = @"CuplivoSandbox/dns";
+static NSString *const kNodeFetchPolyfillResource = @"node-fetch-jitless-polyfill";
+static NSString *const kNodeFetchPolyfillGuestPath = @"/lib/cuplivo-fetch-jitless-polyfill.js";
 
 // Fallback nameservers appended after the system resolver servers. System
 // DNS may be absent (airplane mode) or unusable from the guest (a loopback
@@ -180,6 +182,11 @@ static void cuplivo_handle_process_exit(struct task *task, int code) {
     // 3. Device nodes.
     [self createDeviceNodes];
 
+    // Node runs with --jitless in iSH, which removes WebAssembly and makes
+    // Node 22's undici fetch crash while loading its llhttp WASM parser.
+    // Install the bundled non-WASM fetch implementation before commands run.
+    [self installNodeJitlessFetchPolyfill];
+
     // 4. Mount proc and devpts.
     do_mount(&procfs, "proc", "/proc", "", 0);
     do_mount(&devptsfs, "devpts", "/dev/pts", "", 0);
@@ -220,6 +227,50 @@ static void cuplivo_handle_process_exit(struct task *task, int code) {
     generic_mknodat(AT_PWD, "/dev/random", S_IFCHR | 0666, dev_make(MEM_MAJOR, DEV_RANDOM_MINOR));
     generic_mknodat(AT_PWD, "/dev/urandom", S_IFCHR | 0666, dev_make(MEM_MAJOR, DEV_URANDOM_MINOR));
     NSLog(@"CuplivoISHKernel: device nodes created");
+}
+
+- (void)installNodeJitlessFetchPolyfill {
+    NSURL *resource = [[NSBundle mainBundle]
+        URLForResource:kNodeFetchPolyfillResource withExtension:@"js"];
+    if (resource == nil) {
+        NSLog(@"CuplivoISHKernel: node fetch polyfill bundle resource missing");
+        return;
+    }
+
+    NSError *readError = nil;
+    NSData *contents = [NSData dataWithContentsOfURL:resource
+                                              options:0
+                                                error:&readError];
+    if (contents == nil) {
+        NSLog(@"CuplivoISHKernel: node fetch polyfill read failed: %@", readError);
+        return;
+    }
+
+    struct fd *fd = generic_open(kNodeFetchPolyfillGuestPath.UTF8String,
+                                 O_WRONLY_ | O_CREAT_ | O_TRUNC_, 0644);
+    if (IS_ERR(fd)) {
+        NSLog(@"CuplivoISHKernel: node fetch polyfill guest write open failed: %ld",
+              PTR_ERR(fd));
+        return;
+    }
+
+    const char *bytes = contents.bytes;
+    size_t offset = 0;
+    const size_t length = contents.length;
+    while (offset < length) {
+        ssize_t written = fd->ops->write(fd, bytes + offset, length - offset);
+        if (written <= 0) {
+            NSLog(@"CuplivoISHKernel: node fetch polyfill guest write failed: %zd",
+                  written);
+            break;
+        }
+        offset += (size_t)written;
+    }
+    fd_close(fd);
+
+    if (offset == length) {
+        NSLog(@"CuplivoISHKernel: installed node fetch polyfill");
+    }
 }
 
 - (void)mountDnsConfig {

--- a/ios/Runner/iSHSandbox/CuplivoISHKernel.m
+++ b/ios/Runner/iSHSandbox/CuplivoISHKernel.m
@@ -39,6 +39,8 @@ NSNotificationName const CuplivoISHProcessExitedNotification = @"CuplivoISHProce
 static NSString *const kDnsSubdir = @"CuplivoSandbox/dns";
 static NSString *const kNodeFetchPolyfillResource = @"node-fetch-jitless-polyfill";
 static NSString *const kNodeFetchPolyfillGuestPath = @"/lib/cuplivo-fetch-jitless-polyfill.js";
+static NSString *const kNodeFetchPolyfillGuestTempPath =
+    @"/lib/.cuplivo-fetch-jitless-polyfill.js.tmp";
 
 // Fallback nameservers appended after the system resolver servers. System
 // DNS may be absent (airplane mode) or unusable from the guest (a loopback
@@ -245,11 +247,15 @@ static void cuplivo_handle_process_exit(struct task *task, int code) {
         NSLog(@"CuplivoISHKernel: node fetch polyfill read failed: %@", readError);
         return;
     }
+    if (contents.length == 0) {
+        NSLog(@"CuplivoISHKernel: node fetch polyfill bundle resource is empty");
+        return;
+    }
 
-    struct fd *fd = generic_open(kNodeFetchPolyfillGuestPath.UTF8String,
+    struct fd *fd = generic_open(kNodeFetchPolyfillGuestTempPath.UTF8String,
                                  O_WRONLY_ | O_CREAT_ | O_TRUNC_, 0644);
     if (IS_ERR(fd)) {
-        NSLog(@"CuplivoISHKernel: node fetch polyfill guest write open failed: %ld",
+        NSLog(@"CuplivoISHKernel: node fetch polyfill guest temp write open failed: %ld",
               PTR_ERR(fd));
         return;
     }
@@ -268,9 +274,29 @@ static void cuplivo_handle_process_exit(struct task *task, int code) {
     }
     fd_close(fd);
 
-    if (offset == length) {
-        NSLog(@"CuplivoISHKernel: installed node fetch polyfill");
+    if (offset != length) {
+        int unlinkErr = generic_unlinkat(AT_PWD, kNodeFetchPolyfillGuestTempPath.UTF8String);
+        if (unlinkErr < 0) {
+            NSLog(@"CuplivoISHKernel: node fetch polyfill temp cleanup failed: %d", unlinkErr);
+        }
+        return;
     }
+
+    int renameErr = generic_renameat(AT_PWD,
+                                     kNodeFetchPolyfillGuestTempPath.UTF8String,
+                                     AT_PWD,
+                                     kNodeFetchPolyfillGuestPath.UTF8String);
+    if (renameErr < 0) {
+        NSLog(@"CuplivoISHKernel: node fetch polyfill guest install rename failed: %d",
+              renameErr);
+        int unlinkErr = generic_unlinkat(AT_PWD, kNodeFetchPolyfillGuestTempPath.UTF8String);
+        if (unlinkErr < 0) {
+            NSLog(@"CuplivoISHKernel: node fetch polyfill temp cleanup failed: %d", unlinkErr);
+        }
+        return;
+    }
+
+    NSLog(@"CuplivoISHKernel: installed node fetch polyfill");
 }
 
 - (void)mountDnsConfig {

--- a/ios/sandbox/resources/node-fetch-jitless-polyfill.js
+++ b/ios/sandbox/resources/node-fetch-jitless-polyfill.js
@@ -1,0 +1,131 @@
+"use strict";
+// Adapted from OpenMinis/ish-arm64 RootfsPatch (GPL-3.0-or-later; see
+// ios/sandbox/NOTICE). This is intentionally small: iSH cannot expose
+// WebAssembly while Node runs with --jitless, so Node's undici fetch crashes
+// while lazily loading its llhttp WASM parser.
+
+if (typeof globalThis.WebAssembly === "undefined") {
+  let implementation = null;
+
+  function lazyImplementation() {
+    if (implementation) return implementation;
+
+    const http = require("http");
+    const https = require("https");
+    const {URL} = require("url");
+    const zlib = require("zlib");
+
+    class Response {
+      constructor(body, status, statusText, headers, url) {
+        this._body = body;
+        this.status = status;
+        this.statusText = statusText;
+        this.ok = status >= 200 && status < 300;
+        this.url = url;
+        this._headers = headers;
+        this.headers = {
+          get: (key) => headers[key.toLowerCase()] || null,
+          has: (key) => key.toLowerCase() in headers,
+          entries: () => Object.entries(headers),
+          forEach: (callback) =>
+            Object.entries(headers).forEach(([key, value]) => callback(value, key)),
+        };
+      }
+
+      async text() {
+        return this._body.toString("utf8");
+      }
+
+      async json() {
+        return JSON.parse(this._body.toString("utf8"));
+      }
+
+      async arrayBuffer() {
+        return this._body.buffer.slice(
+          this._body.byteOffset,
+          this._body.byteOffset + this._body.byteLength,
+        );
+      }
+
+      clone() {
+        return new Response(
+          this._body,
+          this.status,
+          this.statusText,
+          this._headers,
+          this.url,
+        );
+      }
+    }
+
+    implementation = function fetch(input, init) {
+      return new Promise((resolve, reject) => {
+        const url =
+          typeof input === "string" ? new URL(input) : new URL(input.url || input);
+        const options = Object.assign({}, init || {});
+        const protocol = url.protocol === "https:" ? https : http;
+        const requestOptions = {
+          hostname: url.hostname,
+          port: url.port || (url.protocol === "https:" ? 443 : 80),
+          path: url.pathname + url.search,
+          method: (options.method || "GET").toUpperCase(),
+          headers: Object.assign({}, options.headers || {}),
+        };
+        const request = protocol.request(requestOptions, (response) => {
+          if (
+            response.statusCode >= 301 &&
+            response.statusCode <= 308 &&
+            response.headers.location
+          ) {
+            implementation(new URL(response.headers.location, url).href, init).then(
+              resolve,
+              reject,
+            );
+            return;
+          }
+
+          const chunks = [];
+          let stream = response;
+          const encoding = response.headers["content-encoding"];
+          if (encoding === "gzip") stream = response.pipe(zlib.createGunzip());
+          else if (encoding === "deflate") stream = response.pipe(zlib.createInflate());
+          else if (encoding === "br") stream = response.pipe(zlib.createBrotliDecompress());
+          stream.on("data", (chunk) => chunks.push(chunk));
+          stream.on("end", () => {
+            resolve(
+              new Response(
+                Buffer.concat(chunks),
+                response.statusCode,
+                response.statusMessage,
+                response.headers,
+                url.href,
+              ),
+            );
+          });
+          stream.on("error", reject);
+        });
+        request.on("error", reject);
+        if (options.body) {
+          request.write(
+            typeof options.body === "string" ? options.body : JSON.stringify(options.body),
+          );
+        }
+        request.end();
+      });
+    };
+    return implementation;
+  }
+
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    get() {
+      const fetch = lazyImplementation();
+      Object.defineProperty(globalThis, "fetch", {
+        value: fetch,
+        writable: true,
+        configurable: true,
+      });
+      return fetch;
+    },
+  });
+}

--- a/ios/sandbox/resources/node-fetch-jitless-polyfill.js
+++ b/ios/sandbox/resources/node-fetch-jitless-polyfill.js
@@ -14,6 +14,48 @@ if (typeof globalThis.WebAssembly === "undefined") {
     const https = require("https");
     const {URL} = require("url");
     const zlib = require("zlib");
+    const bodyHeaders = new Set([
+      "content-encoding",
+      "content-language",
+      "content-length",
+      "content-location",
+      "content-type",
+      "transfer-encoding",
+    ]);
+    const crossOriginHeaders = new Set([
+      "authorization",
+      "cookie",
+      "cookie2",
+      "host",
+      "proxy-authorization",
+    ]);
+
+    function removeHeaders(headers, names) {
+      Object.keys(headers).forEach((key) => {
+        if (names.has(key.toLowerCase())) delete headers[key];
+      });
+    }
+
+    function optionsForRedirect(url, redirectUrl, options, statusCode) {
+      const redirected = Object.assign({}, options, {
+        headers: Object.assign({}, options.headers || {}),
+      });
+      const method = (redirected.method || "GET").toUpperCase();
+      const switchToGet =
+        (statusCode === 303 && method !== "GET" && method !== "HEAD") ||
+        ((statusCode === 301 || statusCode === 302) && method === "POST");
+
+      if (switchToGet) {
+        redirected.method = "GET";
+        delete redirected.body;
+        removeHeaders(redirected.headers, bodyHeaders);
+      }
+      if (url.origin !== redirectUrl.origin) {
+        removeHeaders(redirected.headers, crossOriginHeaders);
+      }
+
+      return redirected;
+    }
 
     class Response {
       constructor(body, status, statusText, headers, url) {
@@ -77,7 +119,11 @@ if (typeof globalThis.WebAssembly === "undefined") {
             response.statusCode <= 308 &&
             response.headers.location
           ) {
-            implementation(new URL(response.headers.location, url).href, init).then(
+            const redirectUrl = new URL(response.headers.location, url);
+            implementation(
+              redirectUrl.href,
+              optionsForRedirect(url, redirectUrl, options, response.statusCode),
+            ).then(
               resolve,
               reject,
             );

--- a/ios/sandbox/tests/node_fetch_jitless_polyfill_test.js
+++ b/ios/sandbox/tests/node_fetch_jitless_polyfill_test.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const http = require("node:http");
+
+function startServer(handler) {
+  const server = http.createServer(handler);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+function stopServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function serverUrl(server, path) {
+  const {port} = server.address();
+  return `http://127.0.0.1:${port}${path}`;
+}
+
+function readBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    request.on("error", reject);
+  });
+}
+
+async function testCrossOriginCredentialsAreStripped() {
+  let targetHeaders;
+  const target = await startServer((request, response) => {
+    targetHeaders = request.headers;
+    response.end("ok");
+  });
+  const source = await startServer((request, response) => {
+    response.writeHead(302, {location: serverUrl(target, "/target")});
+    response.end();
+  });
+
+  try {
+    const response = await globalThis.fetch(serverUrl(source, "/start"), {
+      headers: {
+        Authorization: "Bearer review-secret",
+        Cookie: "session=review-secret",
+        Cookie2: "legacy=review-secret",
+        Host: "stale-origin.example",
+        "Proxy-Authorization": "Basic review-secret",
+      },
+    });
+    assert.equal(await response.text(), "ok");
+    assert.equal(targetHeaders.authorization, undefined);
+    assert.equal(targetHeaders.cookie, undefined);
+    assert.equal(targetHeaders.cookie2, undefined);
+    assert.equal(targetHeaders.host, new URL(serverUrl(target, "/")).host);
+    assert.equal(targetHeaders["proxy-authorization"], undefined);
+  } finally {
+    await stopServer(source);
+    await stopServer(target);
+  }
+}
+
+async function testSameOriginCredentialsAreRetained() {
+  let targetHeaders;
+  const server = await startServer((request, response) => {
+    if (request.url === "/start") {
+      response.writeHead(302, {location: "/target"});
+      response.end();
+      return;
+    }
+
+    targetHeaders = request.headers;
+    response.end("ok");
+  });
+
+  try {
+    const response = await globalThis.fetch(serverUrl(server, "/start"), {
+      headers: {Authorization: "Bearer same-origin-secret"},
+    });
+    assert.equal(await response.text(), "ok");
+    assert.equal(targetHeaders.authorization, "Bearer same-origin-secret");
+  } finally {
+    await stopServer(server);
+  }
+}
+
+async function testPostRedirectBecomesGet(statusCode) {
+  let targetRequest;
+  const server = await startServer(async (request, response) => {
+    if (request.url === "/start") {
+      await readBody(request);
+      response.writeHead(statusCode, {location: "/target"});
+      response.end();
+      return;
+    }
+
+    targetRequest = {
+      body: await readBody(request),
+      headers: request.headers,
+      method: request.method,
+    };
+    response.end("ok");
+  });
+
+  try {
+    const response = await globalThis.fetch(serverUrl(server, "/start"), {
+      body: "payload",
+      headers: {"Content-Type": "text/plain"},
+      method: "POST",
+    });
+    assert.equal(await response.text(), "ok");
+    assert.equal(targetRequest.method, "GET");
+    assert.equal(targetRequest.body, "");
+    assert.equal(targetRequest.headers["content-type"], undefined);
+    assert.equal(targetRequest.headers["content-length"], undefined);
+  } finally {
+    await stopServer(server);
+  }
+}
+
+async function testPostRedirectIsPreserved(statusCode) {
+  let targetRequest;
+  const server = await startServer(async (request, response) => {
+    if (request.url === "/start") {
+      await readBody(request);
+      response.writeHead(statusCode, {location: "/target"});
+      response.end();
+      return;
+    }
+
+    targetRequest = {
+      body: await readBody(request),
+      headers: request.headers,
+      method: request.method,
+    };
+    response.end("ok");
+  });
+
+  try {
+    const response = await globalThis.fetch(serverUrl(server, "/start"), {
+      body: "payload",
+      headers: {"Content-Type": "text/plain"},
+      method: "POST",
+    });
+    assert.equal(await response.text(), "ok");
+    assert.equal(targetRequest.method, "POST");
+    assert.equal(targetRequest.body, "payload");
+    assert.equal(targetRequest.headers["content-type"], "text/plain");
+  } finally {
+    await stopServer(server);
+  }
+}
+
+async function main() {
+  assert.equal(typeof globalThis.WebAssembly, "undefined");
+  assert.equal(typeof globalThis.fetch, "function");
+
+  await testCrossOriginCredentialsAreStripped();
+  await testSameOriginCredentialsAreRetained();
+  await testPostRedirectBecomesGet(301);
+  await testPostRedirectBecomesGet(302);
+  await testPostRedirectBecomesGet(303);
+  await testPostRedirectIsPreserved(307);
+  await testPostRedirectIsPreserved(308);
+
+  console.log("node fetch jitless polyfill regression tests passed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/lib/core/services/workspace/linux_sandbox_service.dart
+++ b/lib/core/services/workspace/linux_sandbox_service.dart
@@ -160,6 +160,19 @@ class SandboxInstallProgress {
   });
 }
 
+/// A single readiness check and command probe for every sandbox dependency.
+/// The workspace dependency panel refreshes all rows together, so launching a
+/// guest shell once is materially cheaper than probing each command separately.
+class SandboxDependencyStatusSnapshot {
+  SandboxDependencyStatusSnapshot({
+    required this.hasRuntime,
+    required Map<String, bool> installed,
+  }) : installed = Map<String, bool>.unmodifiable(installed);
+
+  final bool hasRuntime;
+  final Map<String, bool> installed;
+}
+
 /// One staged package-manager operation inside the sandbox rootfs.
 class PackageInstallStep {
   /// 'recover' (self-heal package state), 'update' or 'install'.
@@ -568,6 +581,87 @@ class LinuxSandboxService {
     );
   }
 
+  static const String _dependencyProbePrefix = '__cuplivo_dependency__:';
+
+  static const Map<String, String> _dependencyProbes = <String, String>{
+    WorkspaceDependencyIds.python: 'command -v python3 >/dev/null 2>&1',
+    WorkspaceDependencyIds.nodejs: 'command -v node >/dev/null 2>&1',
+    WorkspaceDependencyIds.git: 'command -v git >/dev/null 2>&1',
+    // The Office install is a toolchain; LibreOffice alone is insufficient.
+    WorkspaceDependencyIds.office:
+        'command -v soffice >/dev/null 2>&1 && '
+        'command -v pandoc >/dev/null 2>&1 && '
+        'command -v pdftoppm >/dev/null 2>&1',
+    WorkspaceDependencyIds.buildEssential: 'command -v gcc >/dev/null 2>&1',
+  };
+
+  /// A fixed shell script: no model or user input enters this command.
+  static String dependencyProbeCommand() {
+    final buffer = StringBuffer();
+    for (final entry in _dependencyProbes.entries) {
+      buffer.writeln(
+        'if ${entry.value}; then '
+        "printf '%s\\n' '$_dependencyProbePrefix${entry.key}=1'; "
+        'else '
+        "printf '%s\\n' '$_dependencyProbePrefix${entry.key}=0'; "
+        'fi',
+      );
+    }
+    return buffer.toString();
+  }
+
+  @visibleForTesting
+  static Map<String, bool> parseDependencyProbeOutput(String stdout) {
+    final statuses = <String, bool>{
+      for (final id in _dependencyProbes.keys) id: false,
+    };
+    for (final line in stdout.split(RegExp(r'\r?\n'))) {
+      if (!line.startsWith(_dependencyProbePrefix)) continue;
+      final payload = line.substring(_dependencyProbePrefix.length);
+      final separator = payload.indexOf('=');
+      if (separator <= 0) continue;
+      final id = payload.substring(0, separator);
+      if (!statuses.containsKey(id)) continue;
+      statuses[id] = payload.substring(separator + 1) == '1';
+    }
+    return statuses;
+  }
+
+  Future<SandboxDependencyStatusSnapshot> dependencyStatus(
+    String workspaceHostPath,
+  ) async {
+    final installed = <String, bool>{
+      for (final id in WorkspaceDependencyIds.ordered) id: false,
+    };
+    final rootfs = await hasRootfs(workspaceHostPath);
+    installed[WorkspaceDependencyIds.base] = rootfs;
+    final runtime = await hasRuntime();
+    if (!rootfs || !runtime) {
+      return SandboxDependencyStatusSnapshot(
+        hasRuntime: runtime,
+        installed: installed,
+      );
+    }
+
+    final result = await exec(
+      workspaceHostPath: workspaceHostPath,
+      command: dependencyProbeCommand(),
+      timeoutSeconds: 15,
+    );
+    if (result.exitCode == 0) {
+      installed.addAll(parseDependencyProbeOutput(result.stdout));
+    } else {
+      debugPrint(
+        'LinuxSandboxService.dependencyStatus probe failed '
+        '(exit ${result.exitCode}): ${result.stderr}',
+      );
+    }
+    return SandboxDependencyStatusSnapshot(
+      hasRuntime: runtime,
+      installed: installed,
+    );
+  }
+
   Future<bool> isDependencyInstalled(
     String workspaceHostPath,
     String depId,
@@ -578,19 +672,7 @@ class LinuxSandboxService {
     }
     final status = await statusFor(workspaceHostPath);
     if (status != SandboxStatus.ready) return false;
-    final probe = switch (depId) {
-      WorkspaceDependencyIds.python => 'command -v python3 >/dev/null 2>&1',
-      WorkspaceDependencyIds.nodejs => 'command -v node >/dev/null 2>&1',
-      WorkspaceDependencyIds.git => 'command -v git >/dev/null 2>&1',
-      // The office step installs a whole toolchain; LibreOffice alone is not
-      // enough, so require every component the document skills rely on.
-      WorkspaceDependencyIds.office =>
-        'command -v soffice >/dev/null 2>&1 && '
-            'command -v pandoc >/dev/null 2>&1 && '
-            'command -v pdftoppm >/dev/null 2>&1',
-      WorkspaceDependencyIds.buildEssential => 'command -v gcc >/dev/null 2>&1',
-      _ => null,
-    };
+    final probe = _dependencyProbes[depId];
     if (probe == null) return false;
     final r = await exec(
       workspaceHostPath: workspaceHostPath,

--- a/lib/core/services/workspace/workspace_tools_service.dart
+++ b/lib/core/services/workspace/workspace_tools_service.dart
@@ -18,6 +18,14 @@ import 'workspace_path_presentation.dart';
 class WorkspaceToolsService {
   const WorkspaceToolsService._();
 
+  static const String shellToolDescription =
+      'Run a shell command inside the Linux sandbox for the bound workspace. '
+      'Prefer the workspace filesystem tools for file reads, writes, search, '
+      'moves, archives, and downloads; use shell only when Linux command or '
+      'package semantics are required. Working directory defaults to '
+      '/workspace (the workspace root). Output is truncated. Requires base '
+      'dependency installed.';
+
   /// Workspace root plus the Android SAF mounts owned by this workspace.
   static List<FilesystemMount> combinedMounts(
     WorkspaceProvider workspaces,
@@ -118,11 +126,7 @@ class WorkspaceToolsService {
     'type': 'function',
     'function': {
       'name': WorkspaceToolNames.shell,
-      'description':
-          'Run a shell command inside the Linux sandbox for the bound '
-          'workspace. Working directory defaults to /workspace (the '
-          'workspace root). Output is truncated. Requires base dependency '
-          'installed.',
+      'description': shellToolDescription,
       'parameters': {
         'type': 'object',
         'properties': {

--- a/lib/features/workspace/pages/workspace_detail_page.dart
+++ b/lib/features/workspace/pages/workspace_detail_page.dart
@@ -119,17 +119,13 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
     setState(() => _depStatusLoading = true);
     try {
       final svc = LinuxSandboxService.instance;
-      final runtime = await svc.hasRuntime();
-      final next = <String, bool>{};
-      for (final id in WorkspaceDependencyIds.ordered) {
-        next[id] = await svc.isDependencyInstalled(host, id);
-      }
+      final snapshot = await svc.dependencyStatus(host);
       if (!mounted) return;
       setState(() {
-        _hasRuntime = runtime;
+        _hasRuntime = snapshot.hasRuntime;
         _depInstalled
           ..clear()
-          ..addAll(next);
+          ..addAll(snapshot.installed);
         _depStatusLoading = false;
       });
     } catch (e) {

--- a/test/core/services/workspace/linux_sandbox_service_bound_output_test.dart
+++ b/test/core/services/workspace/linux_sandbox_service_bound_output_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:Cuplivo/core/models/workspace.dart';
 import 'package:Cuplivo/core/services/workspace/linux_sandbox_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -46,6 +47,40 @@ void main() {
       final out = LinuxSandboxService.boundOutput(value);
       expectValidUtf16(out);
       expect(() => jsonEncode(out), returnsNormally);
+    });
+  });
+
+  group('LinuxSandboxService dependency probe', () {
+    test('probes every non-base dependency in one fixed shell command', () {
+      final command = LinuxSandboxService.dependencyProbeCommand();
+
+      expect(command, contains('command -v python3'));
+      expect(command, contains('command -v node'));
+      expect(command, contains('command -v git'));
+      expect(command, contains('command -v soffice'));
+      expect(command, contains('command -v gcc'));
+      for (final depId in WorkspaceDependencyIds.ordered.skip(1)) {
+        expect(command, contains('__cuplivo_dependency__:$depId=1'));
+        expect(command, contains('__cuplivo_dependency__:$depId=0'));
+      }
+    });
+
+    test('parses complete, partial, and malformed probe output safely', () {
+      final parsed = LinuxSandboxService.parseDependencyProbeOutput('''
+__cuplivo_dependency__:python=1
+__cuplivo_dependency__:nodejs=0
+ordinary command output
+__cuplivo_dependency__:office=unexpected
+__cuplivo_dependency__:unknown=1
+__cuplivo_dependency__:git=1
+''');
+
+      expect(parsed[WorkspaceDependencyIds.python], isTrue);
+      expect(parsed[WorkspaceDependencyIds.nodejs], isFalse);
+      expect(parsed[WorkspaceDependencyIds.git], isTrue);
+      expect(parsed[WorkspaceDependencyIds.office], isFalse);
+      expect(parsed[WorkspaceDependencyIds.buildEssential], isFalse);
+      expect(parsed.containsKey('unknown'), isFalse);
     });
   });
 }

--- a/test/core/services/workspace/workspace_tools_service_test.dart
+++ b/test/core/services/workspace/workspace_tools_service_test.dart
@@ -106,4 +106,19 @@ void main() {
       );
     });
   });
+
+  test(
+    'shell definition directs file operations to native workspace tools',
+    () {
+      expect(WorkspaceToolsService.shellToolDescription, contains('Prefer'));
+      expect(
+        WorkspaceToolsService.shellToolDescription,
+        contains('filesystem'),
+      );
+      expect(
+        WorkspaceToolsService.shellToolDescription,
+        contains('package semantics'),
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary
- keep Node running with `--jitless` on iOS, while providing a lazy core-HTTP fetch polyfill and disabling the undici/WASM fetch path that otherwise terminates Node
- remove the unconditional iOS post-exit delay and pipe-reader polling; wait for readers through a bounded dispatch group instead
- signal iSH process groups and escaped descendant groups directly, avoiding two full `MAX_PID` scans during timeout or cancellation
- batch workspace dependency probes into one guest-shell invocation and direct models to the existing native workspace filesystem tools first
- reuse Android tar extraction buffer instead of allocating one 64 KiB byte array per archive entry

## Second verification and scope
- #357 is confirmed: Node 22.23.2 with `--jitless` prints `WebAssembly: undefined`, reports the normal network rejection, then terminates in undici while compiling llhttp WASM. The iOS resource polyfill preserves `--jitless`, serves basic fetch through core `http`/`https`, and avoids that termination.
- Addresses the confirmed missing native-tool preference from #360. A full native media/ffmpeg offload layer remains a separate iOS architecture task.
- Addresses the high-impact, low-risk #369 items: iOS fixed exit wait/polling, iOS PID-table scans, Android tar buffer churn, and sequential dependency probes.

## Validation
- `dart format lib/core/services/workspace/linux_sandbox_service.dart lib/core/services/workspace/workspace_tools_service.dart lib/features/workspace/pages/workspace_detail_page.dart test/core/services/workspace/linux_sandbox_service_bound_output_test.dart test/core/services/workspace/workspace_tools_service_test.dart`
- `flutter test test/core/services/workspace/linux_sandbox_service_bound_output_test.dart test/core/services/workspace/workspace_tools_service_test.dart`
- `dart analyze --fatal-infos lib test`
- Node v22.23.2: polyfill syntax check, successful local HTTP fetch, failed localhost request rejection, and continued process execution with the exact `NODE_OPTIONS` injected on iOS

## Not run
- No local iOS/Android build or device test, per request. iSH lifecycle/cancellation and the bundled-resource install should be exercised on an iOS device.