### PR TITLE
fix(search): multi-key rotation deadlock — error keys never recovered

### DIFF
--- a/lib/core/services/api_key_manager.dart
+++ b/lib/core/services/api_key_manager.dart
@@ -34,16 +34,21 @@ class ApiKeyManager {
 
     final now = DateTime.now().millisecondsSinceEpoch;
     final cooldownMs = config.failureRecoveryTimeMinutes * 60 * 1000;
+    // An error key becomes selectable again once its cooldown has elapsed;
+    // the next failure re-marks it error with a fresh [updatedAt] (new
+    // cooldown), while success flips it back to active.
     final available = enabled.where((k) {
-      if (k.status == ApiKeyStatus.disabled) return false;
       if (k.status == ApiKeyStatus.error) {
-        final since = now - (k.updatedAt);
-        if (since < cooldownMs) return false;
+        return now - k.updatedAt >= cooldownMs;
       }
       return k.status == ApiKeyStatus.active;
     }).toList();
 
     if (available.isEmpty) {
+      final probe = _recoveryProbe(enabled, config);
+      if (probe != null) {
+        return KeySelectionResult(probe, 'escalation_all_error');
+      }
       return const KeySelectionResult(null, 'no_available_keys');
     }
 
@@ -73,6 +78,26 @@ class ApiKeyManager {
     }
 
     return KeySelectionResult(chosen, 'strategy_${strategy.name}');
+  }
+
+  /// When every enabled key is inside its failure cooldown, re-admit the key
+  /// whose cooldown is closest to expiry (its failure is the oldest) as a
+  /// single probe, so a recovering provider resumes without user intervention.
+  /// Escalation is gated by [KeyManagementConfig.enableAutoRecovery]. Callers
+  /// that persist the updated key (e.g. `SearchToolService._runWithKeyRotation`)
+  /// refresh [ApiKeyConfig.updatedAt] on a probe failure, so consecutive probes
+  /// rotate across keys instead of hammering one.
+  static ApiKeyConfig? _recoveryProbe(
+    List<ApiKeyConfig> enabled,
+    KeyManagementConfig config,
+  ) {
+    if (!config.enableAutoRecovery) return null;
+    final candidates = enabled
+        .where((k) => k.status == ApiKeyStatus.error)
+        .toList();
+    if (candidates.isEmpty) return null;
+    candidates.sort((a, b) => a.updatedAt.compareTo(b.updatedAt));
+    return candidates.first;
   }
 
   ApiKeyConfig updateKeyStatus(

--- a/lib/core/services/search/providers/bing_search_service.dart
+++ b/lib/core/services/search/providers/bing_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class BingSearchService extends SearchService<BingLocalOptions> {
+  BingSearchService({super.client});
+
   @override
   String get name => 'Bing (Local)';
 

--- a/lib/core/services/search/providers/bocha_search_service.dart
+++ b/lib/core/services/search/providers/bocha_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class BochaSearchService extends SearchService<BochaOptions> {
+  BochaSearchService({super.client});
+
   @override
   String get name => 'Bocha';
 

--- a/lib/core/services/search/providers/brave_search_service.dart
+++ b/lib/core/services/search/providers/brave_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class BraveSearchService extends SearchService<BraveOptions> {
+  BraveSearchService({super.client});
+
   @override
   String get name => 'Brave Search';
 

--- a/lib/core/services/search/providers/duckduckgo_search_service.dart
+++ b/lib/core/services/search/providers/duckduckgo_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class DuckDuckGoSearchService extends SearchService<DuckDuckGoOptions> {
+  DuckDuckGoSearchService({super.client});
+
   @override
   String get name => 'DuckDuckGo';
 

--- a/lib/core/services/search/providers/exa_search_service.dart
+++ b/lib/core/services/search/providers/exa_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class ExaSearchService extends SearchService<ExaOptions> {
+  ExaSearchService({super.client});
+
   @override
   String get name => 'Exa';
 

--- a/lib/core/services/search/providers/jina_search_service.dart
+++ b/lib/core/services/search/providers/jina_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class JinaSearchService extends SearchService<JinaOptions> {
+  JinaSearchService({super.client});
+
   @override
   String get name => 'Jina';
 

--- a/lib/core/services/search/providers/linkup_search_service.dart
+++ b/lib/core/services/search/providers/linkup_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class LinkUpSearchService extends SearchService<LinkUpOptions> {
+  LinkUpSearchService({super.client});
+
   @override
   String get name => 'LinkUp';
 

--- a/lib/core/services/search/providers/metaso_search_service.dart
+++ b/lib/core/services/search/providers/metaso_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class MetasoSearchService extends SearchService<MetasoOptions> {
+  MetasoSearchService({super.client});
+
   @override
   String get name => 'Metaso (秘塔)';
 

--- a/lib/core/services/search/providers/ollama_search_service.dart
+++ b/lib/core/services/search/providers/ollama_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class OllamaSearchService extends SearchService<OllamaOptions> {
+  OllamaSearchService({super.client});
+
   @override
   String get name => 'Ollama';
 

--- a/lib/core/services/search/providers/perplexity_search_service.dart
+++ b/lib/core/services/search/providers/perplexity_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class PerplexitySearchService extends SearchService<PerplexityOptions> {
+  PerplexitySearchService({super.client});
+
   @override
   String get name => 'Perplexity';
 

--- a/lib/core/services/search/providers/searxng_search_service.dart
+++ b/lib/core/services/search/providers/searxng_search_service.dart
@@ -4,6 +4,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class SearXNGSearchService extends SearchService<SearXNGOptions> {
+  SearXNGSearchService({super.client});
+
   @override
   String get name => 'SearXNG';
 

--- a/lib/core/services/search/providers/tavily_search_service.dart
+++ b/lib/core/services/search/providers/tavily_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class TavilySearchService extends SearchService<TavilyOptions> {
+  TavilySearchService({super.client});
+
   @override
   String get name => 'Tavily';
 

--- a/lib/core/services/search/providers/zhipu_search_service.dart
+++ b/lib/core/services/search/providers/zhipu_search_service.dart
@@ -5,6 +5,8 @@ import '../../../../l10n/app_localizations.dart';
 import '../search_service.dart';
 
 class ZhipuSearchService extends SearchService<ZhipuOptions> {
+  ZhipuSearchService({super.client});
+
   @override
   String get name => 'Zhipu (智谱)';
 

--- a/lib/core/services/search/search_service.dart
+++ b/lib/core/services/search/search_service.dart
@@ -61,49 +61,53 @@ abstract class SearchService<T extends SearchServiceOptions> {
     throw UnsupportedError('$name does not provide native web fetch');
   }
 
-  // Factory method to get service instance based on options type
-  static SearchService getService(SearchServiceOptions options) {
+  // Factory method to get service instance based on options type. Tests may
+  // inject a mock [client]; production callers use the shared default.
+  static SearchService getService(
+    SearchServiceOptions options, {
+    http.Client? client,
+  }) {
     switch (options) {
       case BingLocalOptions _:
-        return BingSearchService() as SearchService;
+        return BingSearchService(client: client) as SearchService;
       case TavilyOptions _:
-        return TavilySearchService() as SearchService;
+        return TavilySearchService(client: client) as SearchService;
       case ExaOptions _:
-        return ExaSearchService() as SearchService;
+        return ExaSearchService(client: client) as SearchService;
       case ZhipuOptions _:
-        return ZhipuSearchService() as SearchService;
+        return ZhipuSearchService(client: client) as SearchService;
       case SearXNGOptions _:
-        return SearXNGSearchService() as SearchService;
+        return SearXNGSearchService(client: client) as SearchService;
       case LinkUpOptions _:
-        return LinkUpSearchService() as SearchService;
+        return LinkUpSearchService(client: client) as SearchService;
       case BraveOptions _:
-        return BraveSearchService() as SearchService;
+        return BraveSearchService(client: client) as SearchService;
       case MetasoOptions _:
-        return MetasoSearchService() as SearchService;
+        return MetasoSearchService(client: client) as SearchService;
       case OllamaOptions _:
-        return OllamaSearchService() as SearchService;
+        return OllamaSearchService(client: client) as SearchService;
       case JinaOptions _:
-        return JinaSearchService() as SearchService;
+        return JinaSearchService(client: client) as SearchService;
       case BochaOptions _:
-        return BochaSearchService() as SearchService;
+        return BochaSearchService(client: client) as SearchService;
       case PerplexityOptions _:
-        return PerplexitySearchService() as SearchService;
+        return PerplexitySearchService(client: client) as SearchService;
       case DuckDuckGoOptions _:
-        return DuckDuckGoSearchService() as SearchService;
+        return DuckDuckGoSearchService(client: client) as SearchService;
       case SerperOptions _:
-        return SerperSearchService() as SearchService;
+        return SerperSearchService(client: client) as SearchService;
       case GrokOptions _:
-        return GrokSearchService() as SearchService;
+        return GrokSearchService(client: client) as SearchService;
       case QueritOptions _:
-        return QueritSearchService() as SearchService;
+        return QueritSearchService(client: client) as SearchService;
       case StepFunOptions _:
-        return StepFunSearchService() as SearchService;
+        return StepFunSearchService(client: client) as SearchService;
       case FirecrawlOptions _:
-        return FirecrawlSearchService() as SearchService;
+        return FirecrawlSearchService(client: client) as SearchService;
       case TinyFishOptions _:
-        return TinyFishSearchService() as SearchService;
+        return TinyFishSearchService(client: client) as SearchService;
       case DoubaoOptions _:
-        return DoubaoSearchService() as SearchService;
+        return DoubaoSearchService(client: client) as SearchService;
       default:
         return BingSearchService() as SearchService;
     }

--- a/lib/core/services/search/search_tool_service.dart
+++ b/lib/core/services/search/search_tool_service.dart
@@ -140,8 +140,9 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
 
   static Future<String> executeSearch(
     String query,
-    SettingsProvider settings,
-  ) async {
+    SettingsProvider settings, {
+    http.Client? searchClient,
+  }) async {
     final services = settings.searchServices;
     if (services.isEmpty) {
       return jsonEncode({'error': 'No search services configured'});
@@ -152,7 +153,10 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
       services.length - 1,
     );
     final serviceOptions = services[selectedIndex];
-    final service = SearchService.getService(serviceOptions);
+    final service = SearchService.getService(
+      serviceOptions,
+      client: searchClient,
+    );
     final manager = ApiKeyManager();
 
     // Keyless services (BingLocal, DuckDuckGo, SearXNG) or providers whose
@@ -164,6 +168,7 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
     // Keyed services: rotate keys on failure, retry transparently.
     final config = serviceOptions.keyManagement ?? const KeyManagementConfig();
     final beforeJson = serviceOptions.toJson();
+    String? lastError;
     final result = await _runWithKeyRotation<String>(
       serviceOptions,
       manager,
@@ -174,6 +179,7 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
         service,
         serviceOptions,
         apiKeyOverride: apiKey,
+        onError: (error) => lastError = error,
       ),
       failureCode: 'search_failed',
     );
@@ -188,7 +194,10 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
       beforeJson,
     );
 
-    return result ?? jsonEncode({'error': 'All search keys failed'});
+    return result ??
+        jsonEncode({
+          'error': 'All search keys failed${_errorSuffix(lastError)}',
+        });
   }
 
   static Future<String> executeFetch(
@@ -542,6 +551,7 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
     SearchService service,
     SearchServiceOptions serviceOptions, {
     String? apiKeyOverride,
+    void Function(String error)? onError,
   }) async {
     try {
       final result = await service.search(
@@ -568,6 +578,7 @@ Best Practice: (1) Use keywords rather than a complete sentence for `query`; (2)
       });
     } catch (e) {
       debugPrint('[search_web] ${service.name} search failed: $e');
+      onError?.call(e.toString());
       return null;
     }
   }

--- a/test/api_key_manager_test.dart
+++ b/test/api_key_manager_test.dart
@@ -19,6 +19,7 @@ ProviderConfig _provider({
   required String id,
   required List<ApiKeyConfig> keys,
   LoadBalanceStrategy strategy = LoadBalanceStrategy.roundRobin,
+  KeyManagementConfig? keyManagement,
 }) {
   return ProviderConfig(
     id: id,
@@ -29,7 +30,7 @@ ProviderConfig _provider({
     providerType: ProviderKind.openai,
     multiKeyEnabled: true,
     apiKeys: keys,
-    keyManagement: KeyManagementConfig(strategy: strategy),
+    keyManagement: keyManagement ?? KeyManagementConfig(strategy: strategy),
   );
 }
 
@@ -134,6 +135,116 @@ void main() {
       final result = ApiKeyManager().selectForProvider(provider);
 
       expect(result.key?.key, 'idle');
+    });
+
+    test('error key is selectable again once its cooldown has elapsed', () {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final key = _key(
+        'key_a',
+        'recovered',
+      ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 10 * 60 * 1000);
+      final provider = _provider(
+        id: 'cooldown-expired',
+        keys: [key],
+        keyManagement: const KeyManagementConfig(
+          failureRecoveryTimeMinutes: 5,
+          enableAutoRecovery: false,
+        ),
+      );
+
+      final result = ApiKeyManager().selectForProvider(provider);
+
+      expect(result.key?.key, 'recovered');
+      expect(result.reason, 'strategy_roundRobin');
+    });
+
+    test(
+      'error key inside its cooldown is skipped when auto recovery is off',
+      () {
+        final now = DateTime.now().millisecondsSinceEpoch;
+        final key = _key(
+          'key_a',
+          'cooling',
+        ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 60 * 1000);
+        final provider = _provider(
+          id: 'cooldown-active',
+          keys: [key],
+          keyManagement: const KeyManagementConfig(
+            failureRecoveryTimeMinutes: 5,
+            enableAutoRecovery: false,
+          ),
+        );
+
+        final result = ApiKeyManager().selectForProvider(provider);
+
+        expect(result.key, isNull);
+        expect(result.reason, 'no_available_keys');
+      },
+    );
+
+    test('all-error pool escalates to the key with the earliest failure', () {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      // Both inside the 5-minute cooldown; oldest failure is last in the
+      // list to prove escalation is ordered by recency, not list order.
+      final provider = _provider(
+        id: 'escalation-oldest',
+        keys: [
+          _key(
+            'key_b',
+            'fresh-fail',
+          ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 60 * 1000),
+          _key('key_a', 'old-fail').copyWith(
+            status: ApiKeyStatus.error,
+            updatedAt: now - 4 * 60 * 1000,
+          ),
+        ],
+      );
+
+      final result = ApiKeyManager().selectForProvider(provider);
+
+      expect(result.key?.key, 'old-fail');
+      expect(result.reason, 'escalation_all_error');
+    });
+
+    test('escalation is disabled by enableAutoRecovery=false', () {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final provider = _provider(
+        id: 'escalation-disabled',
+        keys: [
+          _key('key_a', 'failing').copyWith(
+            status: ApiKeyStatus.error,
+            updatedAt: now - 3 * 60 * 1000,
+          ),
+        ],
+        keyManagement: const KeyManagementConfig(
+          failureRecoveryTimeMinutes: 5,
+          enableAutoRecovery: false,
+        ),
+      );
+
+      final result = ApiKeyManager().selectForProvider(provider);
+
+      expect(result.key, isNull);
+      expect(result.reason, 'no_available_keys');
+    });
+
+    test('active keys take precedence over escalation candidates', () {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final provider = _provider(
+        id: 'escalation-not-triggered',
+        keys: [
+          _key(
+            'key_a',
+            'cooling',
+          ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 60 * 1000),
+          _key('key_b', 'healthy'),
+        ],
+      );
+
+      final result = ApiKeyManager().selectForProvider(provider);
+
+      expect(result.key?.key, 'healthy');
+      expect(result.reason, 'strategy_roundRobin');
     });
   });
 }

--- a/test/core/services/search/search_tool_service_search_test.dart
+++ b/test/core/services/search/search_tool_service_search_test.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/api_keys.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/search/search_service.dart';
+import 'package:Cuplivo/core/services/search/search_tool_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  var businessPrefs = BusinessPreferences.memoryForTests();
+  setUp(() {
+    businessPrefs = BusinessPreferences.memoryForTests({});
+  });
+
+  test(
+    'all-error pool escalates to the key with the earliest failure and recovers',
+    () async {
+      final settings = SettingsProvider(preferences: businessPrefs);
+      await pumpEventQueue();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      await settings.setSearchServices([
+        TavilyOptions(
+          id: 'probe-recovery',
+          apiKeys: [
+            ApiKeyConfig.create(
+              'dead-new',
+            ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 60 * 1000),
+            ApiKeyConfig.create('dead-old').copyWith(
+              status: ApiKeyStatus.error,
+              updatedAt: now - 4 * 60 * 1000,
+            ),
+          ],
+          keyManagement: const KeyManagementConfig(
+            failureRecoveryTimeMinutes: 5,
+            maxFailuresBeforeDisable: 1,
+          ),
+        ),
+      ]);
+      final usedKeys = <String>[];
+      final client = MockClient((request) async {
+        usedKeys.add(request.headers['Authorization'] ?? '');
+        return http.Response(
+          jsonEncode({
+            'results': [
+              {
+                'title': 'Example',
+                'url': 'https://example.com/a',
+                'content': 'hello world',
+              },
+            ],
+          }),
+          200,
+        );
+      });
+
+      final result =
+          jsonDecode(
+                await SearchToolService.executeSearch(
+                  'cuplivo',
+                  settings,
+                  searchClient: client,
+                ),
+              )
+              as Map<String, dynamic>;
+
+      expect(usedKeys, ['Bearer dead-old']);
+      expect((result['items'] as List).length, 1);
+
+      final old = settings.searchServices.single.apiKeys.firstWhere(
+        (k) => k.key == 'dead-old',
+      );
+      expect(old.status, ApiKeyStatus.active);
+      expect(old.lastError, isNull);
+      expect(old.usage.successfulRequests, 1);
+    },
+  );
+
+  test('all keys drained reports the underlying provider error', () async {
+    final settings = SettingsProvider(preferences: businessPrefs);
+    await pumpEventQueue();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await settings.setSearchServices([
+      TavilyOptions(
+        id: 'probe-all-fail',
+        apiKeys: [
+          ApiKeyConfig.create('dead-b').copyWith(
+            status: ApiKeyStatus.error,
+            updatedAt: now - 2 * 60 * 1000,
+          ),
+          ApiKeyConfig.create(
+            'dead-a',
+          ).copyWith(status: ApiKeyStatus.error, updatedAt: now - 60 * 1000),
+        ],
+        keyManagement: const KeyManagementConfig(
+          failureRecoveryTimeMinutes: 5,
+          maxFailuresBeforeDisable: 1,
+        ),
+      ),
+    ]);
+    var requests = 0;
+    final client = MockClient((_) async {
+      requests++;
+      return http.Response('boom', 503);
+    });
+
+    final result =
+        jsonDecode(
+              await SearchToolService.executeSearch(
+                'cuplivo',
+                settings,
+                searchClient: client,
+              ),
+            )
+            as Map<String, dynamic>;
+
+    expect(requests, 2);
+    expect(result['error'], contains('All search keys failed'));
+    expect(result['error'], contains('Tavily search failed'));
+    expect(result['error'], contains('503'));
+  });
+
+  test('cooldown-expired error key is retried and healed on success', () async {
+    final settings = SettingsProvider(preferences: businessPrefs);
+    await pumpEventQueue();
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await settings.setSearchServices([
+      TavilyOptions(
+        id: 'cooldown-heal',
+        apiKeys: [
+          ApiKeyConfig.create('expired-key').copyWith(
+            status: ApiKeyStatus.error,
+            lastError: 'previous failure',
+            updatedAt: now - 10 * 60 * 1000,
+          ),
+        ],
+        keyManagement: const KeyManagementConfig(
+          failureRecoveryTimeMinutes: 5,
+          enableAutoRecovery: false,
+        ),
+      ),
+    ]);
+    var requests = 0;
+    final client = MockClient((_) async {
+      requests++;
+      return http.Response(
+        jsonEncode({
+          'results': [
+            {
+              'title': 'Example',
+              'url': 'https://example.com/a',
+              'content': 'hello world',
+            },
+          ],
+        }),
+        200,
+      );
+    });
+
+    final result =
+        jsonDecode(
+              await SearchToolService.executeSearch(
+                'cuplivo',
+                settings,
+                searchClient: client,
+              ),
+            )
+            as Map<String, dynamic>;
+
+    expect(requests, 1);
+    expect((result['items'] as List).length, 1);
+
+    final key = settings.searchServices.single.apiKeys.single;
+    expect(key.status, ApiKeyStatus.active);
+    expect(key.lastError, isNull);
+  });
+}


### PR DESCRIPTION
## Problem

Multi-key round robin could permanently strand a key in `error` status:

- `ApiKeyManager.selectFromKeys` checked a cooldown for error keys, but the filter fell through to a `status == active` guard, so the cooldown branch was dead code — an error key was never re-admitted, regardless of `failureRecoveryTimeMinutes`.
- Nothing in the codebase flipped `error` back to `active` (only a successful `updateKeyStatusFromConfig`, which a stranded key never receives), so the state persisted across restarts.
- When search failed, the user-visible result was a bare `All search keys failed` with no underlying cause, unlike `web_fetch` which appends the provider error.

## What changed

**`lib/core/services/api_key_manager.dart`**
- Error keys are selectable again once their cooldown has elapsed. A probe failure re-marks the key `error` with a fresh `updatedAt` (new cooldown); success heals it back to `active`.
- When every enabled key is inside its cooldown, escalate to the key with the **earliest failure** (oldest `updatedAt`) as a single probe (gated by `KeyManagementConfig.enableAutoRecovery`, which was previously unused). Callers that persist the updated key rotate through the pool one probe per window instead of hammering a single key.
- Selection strategy (`roundRobin` / `priority` / `leastUsed` / `random`) is untouched: it only governs keys that are actually available.

**`lib/core/services/search/search_tool_service.dart`**
- `_trySearch` now reports the underlying provider error via an `onError` callback; the all-failed result becomes `All search keys failed: <last provider error>` (mirrors the `web_fetch` path).
- `executeSearch` accepts an optional `searchClient` for tests, mirroring `executeFetch(fetchClient:)`; `SearchService.getService` and the provider services now accept an injectable client accordingly.

## Behavior notes

- The escalation applies to the shared `selectFromKeys`, so chat/provider paths (`chat_api_service.dart`, `model_provider.dart`, `provider_balance_service.dart`) can also probe an all-error pool instead of silently falling back to `cfg.apiKey`. This is intentional (a probe may succeed), but worth knowing.
- With all keys in cooldown, each tool call probes the pool once per key — this is the intended "probe until one works" tradeoff; a single-key pool retries at user invocation rate, which is what enables recovery.

## Tests

- `test/api_key_manager_test.dart`: +5 cases (cooldown expiry re-admission, within-cooldown skip, earliest-failure escalation, escalation off, active keys take precedence).
- `test/core/services/search/search_tool_service_search_test.dart` (new): end-to-end escalation+recovery with persistence, all-failed error detail, cooldown-expiry heal.

Verified:

```bash
flutter test test/core/services/search test/api_key_manager_test.dart   # 93 passed
dart analyze --fatal-infos lib test                                       # no issues
dart format <changed paths>
```
