### PR TITLE
fix(desktop): restore persisted sidebar widths on restart

### DIFF
--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -805,22 +805,32 @@ class HomePageController extends ChangeNotifier {
     return null;
   }
 
-  void initDesktopUi() {
-    if (PlatformUtils.isDesktopTarget && !_desktopUiInited) {
-      _desktopUiInited = true;
-      try {
-        final sp = _context.read<SettingsProvider>();
-        _embeddedSidebarWidth = sp.desktopSidebarWidth.clamp(
-          _sidebarMinWidth,
-          _sidebarMaxWidth,
-        );
-        _tabletSidebarOpen = sp.desktopSidebarOpen;
-        _rightSidebarOpen = sp.desktopRightSidebarOpen;
-        _rightSidebarWidth = sp.desktopRightSidebarWidth.clamp(
-          _sidebarMinWidth,
-          _sidebarMaxWidth,
-        );
-      } catch (_) {}
+  Future<void> initDesktopUi() async {
+    if (!PlatformUtils.isDesktopTarget || _desktopUiInited) return;
+    _desktopUiInited = true;
+    try {
+      // SettingsProvider._load() completes asynchronously (it performs real
+      // SQLite/logging I/O before the desktop-width assignments); the first
+      // frame builds HomePage before that, so reading widths here without
+      // awaiting would consume the constructor defaults and a later rebuild
+      // would never re-apply them (_desktopUiInited is one-shot).
+      final sp = _context.read<SettingsProvider>();
+      await sp.loaded;
+      if (_disposed || !_context.mounted) return;
+      _embeddedSidebarWidth = sp.desktopSidebarWidth.clamp(
+        _sidebarMinWidth,
+        _sidebarMaxWidth,
+      );
+      _tabletSidebarOpen = sp.desktopSidebarOpen;
+      _rightSidebarOpen = sp.desktopRightSidebarOpen;
+      _rightSidebarWidth = sp.desktopRightSidebarWidth.clamp(
+        _sidebarMinWidth,
+        _sidebarMaxWidth,
+      );
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('[HomePageController] initDesktopUi failed: $e');
+      debugPrint('$st');
     }
   }
 

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1012,7 +1012,7 @@ class _HomePageState extends State<HomePage>
     required String? modelDisplay,
     required ColorScheme cs,
   }) {
-    _controller.initDesktopUi();
+    unawaited(_controller.initDesktopUi());
 
     final collapsed = _controller.collapseVersions(_controller.messages);
     final selectable = collapsed

--- a/test/settings_provider_desktop_width_persistence_test.dart
+++ b/test/settings_provider_desktop_width_persistence_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:Cuplivo/core/database/business_preferences.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsProvider desktop width persistence', () {
+    test('loads persisted sidebar widths and open states', () async {
+      final businessPrefs = BusinessPreferences.memoryForTests({
+        'desktop_sidebar_width_v1': 352.0,
+        'desktop_sidebar_open_v1': false,
+        'desktop_right_sidebar_width_v1': 342.0,
+        'desktop_right_sidebar_open_v1': true,
+      });
+      final settings = SettingsProvider(preferences: businessPrefs);
+
+      await settings.loaded;
+
+      expect(settings.desktopSidebarWidth, 352.0);
+      expect(settings.desktopSidebarOpen, isFalse);
+      expect(settings.desktopRightSidebarWidth, 342.0);
+      expect(settings.desktopRightSidebarOpen, isTrue);
+    });
+
+    test('persists widths across a simulated restart', () async {
+      final businessPrefs = BusinessPreferences.memoryForTests({
+        'desktop_sidebar_width_v1': 300.0,
+        'desktop_right_sidebar_width_v1': 300.0,
+      });
+      final first = SettingsProvider(preferences: businessPrefs);
+      await first.loaded;
+
+      await first.setDesktopSidebarWidth(352);
+      await first.setDesktopRightSidebarWidth(330);
+
+      final second = SettingsProvider(preferences: businessPrefs);
+      await second.loaded;
+
+      expect(second.desktopSidebarWidth, 352.0);
+      expect(second.desktopRightSidebarWidth, 330.0);
+    });
+
+    test('persists sidebar open state across a simulated restart', () async {
+      final businessPrefs = BusinessPreferences.memoryForTests();
+      final first = SettingsProvider(preferences: businessPrefs);
+      await first.loaded;
+
+      await first.setDesktopRightSidebarOpen(false);
+      await first.setDesktopSidebarOpen(false);
+
+      final second = SettingsProvider(preferences: businessPrefs);
+      await second.loaded;
+
+      expect(second.desktopRightSidebarOpen, isFalse);
+      expect(second.desktopSidebarOpen, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Background

Since v3.1, resizing the assistant/group-chat pane widths on desktop (left and right sidebars) would not survive a restart: every relaunch fell back to the default widths (300/300, open) even though the values were persisted.

## Root cause

`HomePageController.initDesktopUi()` ran during the first frame of `HomePage`, before `SettingsProvider._load()` finished its asynchronous work (real SQLite/logging I/O precedes the desktop-width assignments). It therefore read constructor defaults (240/300, open=true), set the one-shot `_desktopUiInited` flag, and never re-applied the persisted values — `desktop_sidebar_width_v1` / `desktop_right_sidebar_width_v1` were saved correctly by the drag handle but never restored.

Upstream Kelivo's `_load()` happens to stay on the microtask chain up to the width reads, so the same first-frame timing never hit it there.

## Changes

- `HomePageController.initDesktopUi()` now awaits `SettingsProvider.loaded` before applying widths/open states, guards against disposed/unmounted contexts, and notifies listeners so the layout picks up the restored values. `_desktopUiInited` stays a one-shot entry guard.
- Call site updated to `unawaited(...)`.
- New test `settings_provider_desktop_width_persistence_test.dart`: persisted widths/open states load correctly and survive a simulated restart.

## Test plan

- `dart analyze --fatal-infos lib test` — clean.
- New test: 3/3 passed.
- Manual Windows verification: resized left/right pane widths → relaunch → widths and open states restored.

## No further changes since manual verification

Manual verification was performed on Windows after the review follow-ups (one-shot entry guard, error logging).
