### PR TITLE
fix(chat): keep selected messages alive so scrolling does not drop the selection

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -825,11 +825,36 @@ class ChatMessageWidget extends StatefulWidget {
   State<ChatMessageWidget> createState() => _ChatMessageWidgetState();
 }
 
-class _ChatMessageWidgetState extends State<ChatMessageWidget> {
+class _ChatMessageWidgetState extends State<ChatMessageWidget>
+    with AutomaticKeepAliveClientMixin {
   final DateFormat _dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss');
   final ScrollController _reasoningScroll = ScrollController();
   bool _tickActive = false;
   String? _selectedPlainText;
+
+  // Per-region live-selection flags. When ANY text region of this message
+  // currently holds a non-empty selection, `wantKeepAlive` becomes true so
+  // the virtualized SuperListView never recycles this item while the user is
+  // still selecting / scrolling with a live highlight — recycling would drop
+  // the SelectionArea selection immediately.
+  static const String _selectionRegionAssistant = 'assistant';
+  static const String _selectionRegionUser = 'user';
+  final Map<String, bool> _selectionActive = <String, bool>{
+    _selectionRegionAssistant: false,
+    _selectionRegionUser: false,
+  };
+  bool _keepAliveFromSelection = false;
+
+  @override
+  bool get wantKeepAlive => _keepAliveFromSelection;
+
+  void _refreshSelectionKeepAlive() {
+    final anyActive = _selectionActive.values.any((a) => a);
+    if (_keepAliveFromSelection == anyActive) return;
+    setState(() {
+      _keepAliveFromSelection = anyActive;
+    });
+  }
 
   void _speakSelectedText(String text) {
     final settings = context.read<SettingsProvider>();
@@ -1694,6 +1719,15 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     return isDesktop
         ? SelectionArea(
             key: ValueKey('user_${widget.message.id}'),
+            onSelectionChanged: (selection) {
+              _selectedPlainText = selection?.plainText;
+              final active =
+                  selection != null && selection.plainText.isNotEmpty;
+              if (_selectionActive[_selectionRegionUser] != active) {
+                _selectionActive[_selectionRegionUser] = active;
+                _refreshSelectionKeepAlive();
+              }
+            },
             child: content,
           )
         : content;
@@ -1989,6 +2023,11 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
         key: ValueKey('assistant_${widget.message.id}'),
         onSelectionChanged: (selection) {
           _selectedPlainText = selection?.plainText;
+          final active = selection != null && selection.plainText.isNotEmpty;
+          if (_selectionActive[_selectionRegionAssistant] != active) {
+            _selectionActive[_selectionRegionAssistant] = active;
+            _refreshSelectionKeepAlive();
+          }
         },
         contextMenuBuilder: (context, selectableRegionState) {
           final defaultItems = selectableRegionState.contextMenuButtonItems
@@ -3220,6 +3259,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context); // required by AutomaticKeepAliveClientMixin
     if (widget.message.role == 'user') return _buildUserMessage();
     if (widget.message.role == 'tool') return _buildToolMessage();
     return _buildAssistantMessage();


### PR DESCRIPTION
## Problem

In the chat timeline, selecting a run of text and then scrolling up/down **drops the selection** — the highlight disappears. Selecting also feels unstable around virtualized items.

### Root cause

The timeline is rendered by a **virtualized** `SuperListView` (`super_sliver_list`). Its render object garbage-collects items that scroll out of the `cacheExtent` window ("remove those that are no longer in cache area"). Each message wraps its text in its own `SelectionArea` with **no keep-alive**, so once the message is recycled its `Selectable` nodes are torn down and the `SelectionArea` selection is destroyed immediately.

## Fix

Give `_ChatMessageWidgetState` an `AutomaticKeepAliveClientMixin` whose `wantKeepAlive` is driven by the live selection state:

- As soon as **any** text region of the message holds a non-empty selection (`onSelectionChanged` → `SelectionArea` on the assistant body, and the desktop user body), the item is kept alive.
- When the selection is cleared the item returns to normal virtualization.

So while you are selecting / scrolling with a live highlight the message is never recycled, and the highlight survives scrolling — with no cost to the timeline's memory behavior in the common (no-selection) case, because only the 1–2 messages that actually hold a selection are pinned.

### Scope

- `lib/features/chat/widgets/chat_message_widget.dart` (`_ChatMessageWidgetState`, +37/−4).
- Works for both streaming and non-streaming messages (both render `ChatMessageWidget`).
- No change to rendering, scroll positioning, auto-follow, or the `addRepaintBoundaries:false` perf setting.

## Verification

- `dart format` on the file: passes (syntax valid).
- Behavior follows the standard Flutter keep-alive protocol; `super_sliver_list` inherits the stock `SliverMultiBoxAdaptor` keep-alive handling (no special-casing in its source), so `AutomaticKeepAliveClientMixin` is honored.
- I could not run `flutter test` in this environment (no Flutter SDK; the Dart VM is unstable here), so please run the existing `lib/features/home` widget tests to confirm no regression.
- Note: the deeper “selection drags are swallowed by the outer vertical-scroll gesture and by markdown-internal horizontal scrollers” issue is a separate structural problem and is intentionally not addressed in this PR.