### PR TITLE
fix(workspace): don't read providers in dispose on detail page

### DIFF
--- a/lib/features/workspace/pages/workspace_detail_page.dart
+++ b/lib/features/workspace/pages/workspace_detail_page.dart
@@ -43,11 +43,13 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   bool _depProbeFailed = false;
   bool _hasRuntime = true;
   int _depStatusRefreshGeneration = 0;
+  DependencyInstallController? _installController;
 
   @override
   void initState() {
     super.initState();
-    context.read<DependencyInstallController>().addListener(_onInstallChanged);
+    _installController = context.read<DependencyInstallController>()
+      ..addListener(_onInstallChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) unawaited(_refreshDepStatus());
     });
@@ -72,15 +74,13 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   @override
   void dispose() {
     routeObserver.unsubscribe(this);
-    context.read<DependencyInstallController>().removeListener(
-      _onInstallChanged,
-    );
+    _installController?.removeListener(_onInstallChanged);
     super.dispose();
   }
 
   void _onInstallChanged() {
     if (!mounted) return;
-    final controller = context.read<DependencyInstallController>();
+    final controller = _installController!;
     final wp = context.read<WorkspaceProvider>();
     final ws = wp.getById(widget.workspaceId);
     if (ws == null) return;


### PR DESCRIPTION
## Problem

User logs from v3.1.0 show a crash during route teardown of the workspace detail page:

```
Null check operator used on a null value
#0  Element.widget (framework.dart:3653)
#1  Provider._inheritedElementOf (provider.dart:377)
#3  ReadContext.read (provider.dart:683)
#4  _WorkspaceDetailPageState.dispose (workspace_detail_page.dart:75)
#5  StatefulElement.unmount (framework.dart:6030)
```

## Root cause

Flutter's `StatefulElement.unmount` state is removed (`_widget = null`) **before** `State.dispose()` runs, so `context.read` → `Provider.of` → `Element.widget` hits a null check (`!`). In debug builds Flutter's defunct-element assert gives a friendly message; in release builds only the bare null-check exception remains, so this only shows up in release logs.

`context.read` in `dispose()` also has another failure mode: when an ancestor provider element is deactivated before this State's `dispose` (app teardown, hot restart), it throws "Looking up a deactivated widget's ancestor is unsafe".

## Fix

Cache the app-scoped controller in a field during `initState` (instance never changes for the route's lifetime — created once in the root `MultiProvider`, `main.dart`), then use the field in `dispose()` and `_onInstallChanged()` instead of touching `context`.

Also fixes the fallout: because `removeListener` never ran, the listener leaked and `mounted` stayed stale (`_state._element` was cleared after the throwing line), re-throwing the same error on every subsequent install notification until app restart.

## Verification

- `dart analyze --fatal-infos lib test` — no issues
- Scanned every `dispose()` body in `lib/` with a brace-paired parser — no other page has the same `context.read`-in-dispose pattern
