### PR TITLE
fix(chat): context management submenu dead when folded into row + overflow

### DIFF
--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -2275,10 +2275,10 @@ class _ChatInputBarState extends State<ChatInputBar>
         }
 
         if (widget.onClearContext != null) {
-          void showContextMenu() {
+          void showContextMenu(GlobalKey anchorKey) {
             showDesktopAnchoredMenu(
               context,
-              anchorKey: _contextMgmtAnchorKey,
+              anchorKey: anchorKey,
               items: [
                 if (widget.onCompressContext != null)
                   DesktopContextMenuItem(
@@ -2303,13 +2303,19 @@ class _ChatInputBarState extends State<ChatInputBar>
               child: _CompactIconButton(
                 tooltip: l10n.contextManagement,
                 icon: Lucide.Eraser,
-                onTap: _composerLocked ? null : showContextMenu,
+                onTap: _composerLocked
+                    ? null
+                    : () => showContextMenu(_contextMgmtAnchorKey),
               ),
             ),
             menu: DesktopContextMenuItem(
               icon: Lucide.Eraser,
               label: l10n.contextManagement,
-              onTap: _composerLocked ? null : showContextMenu,
+              // Overflowed into the row "+" menu: the per-button anchor is not
+              // mounted there, so anchor the second-level menu at the "+" itself.
+              onTap: _composerLocked
+                  ? null
+                  : () => showContextMenu(_leftOverflowAnchorKey),
             ),
           );
         }


### PR DESCRIPTION
## 问题

桌面/平板输入栏按钮行宽度不足时,放不下的按钮会折叠进行尾 "+" 溢出菜单。

从 "+" 菜单点击「上下文管理」点击无弹窗(其他按钮如世界书/技能/搜索均正常)。

## 根因

- 溢出菜单只渲染每个动作的 `DesktopContextMenuItem`(menu 数据),真实按钮 widget 的 `builder()` 不会被调用。
- 「上下文管理」menu 项点击后触发 `showContextMenu()` → `showDesktopAnchoredMenu(anchorKey: _contextMgmtAnchorKey)`,而该 GlobalKey 绑定的按钮 Container 在折叠态下不在树中,`anchorKey.currentContext?.findRenderObject()` 为 null,`showDesktopAnchoredMenu` 静默 return → 无弹窗、无报错。
- 其余按钮的弹窗均锚定 `_inputBarKey`(整个输入栏,始终挂载),所以不受影响。手机端溢出走右 "+" 底部工具页(`BottomToolsSheet`),也不受影响。

## 修复

`showContextMenu(GlobalKey anchorKey)` 参数化锚点:

- 直接显示时,锚按钮自身 `_contextMgmtAnchorKey`(保持不变)。
- 折叠进 "+" 菜单时,锚始终挂载的 "+" 按钮 `_leftOverflowAnchorKey`,点击后仍弹出「压缩上下文 / 清空上下文」二级菜单,保留原有二级选择 UX。

## 验证

- `dart format lib/features/home/widgets/chat_input_bar.dart`
- `dart analyze --fatal-infos lib test` 通过
- 建议手动:桌面端拉窄窗口(或自定义按钮布局把上下文管理往后拖)使其折入 "+",点击「上下文管理」应弹出二级菜单。

行为变更路径仅桌面 "+" 菜单一项(由无响应变为弹出二级菜单),属预期修复。
