### PR TITLE
fix(web-chat): avoid iOS shell ready timeout

### DIFF
--- a/assets/web_chat/app.mjs
+++ b/assets/web_chat/app.mjs
@@ -102,8 +102,19 @@ let rendererRefreshFrame = 0;
 const bridge = {
   post(message) {
     const encoded = JSON.stringify(message);
-    if (window.chrome?.webview) window.chrome.webview.postMessage(encoded);
-    else window.CuplivoChat?.postMessage(encoded);
+    try {
+      if (window.chrome?.webview) {
+        window.chrome.webview.postMessage(encoded);
+        return true;
+      }
+      if (window.CuplivoChat?.postMessage) {
+        window.CuplivoChat.postMessage(encoded);
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    return false;
   },
 };
 const renderCommitCoordinator = createRenderCommitCoordinator({
@@ -3171,4 +3182,34 @@ window.CuplivoWeb = {
   },
 };
 window.chrome?.webview?.addEventListener('message', (event) => window.CuplivoWeb.receive(event.data));
-bridge.post({ type: 'ready', protocolVersion: PROTOCOL_VERSION, assetVersion: ASSET_VERSION });
+let readyBootstrapTimer = 0;
+let readyBootstrapAttempts = 0;
+let readyBootstrapped = false;
+const readyBootstrapMaxAttempts = 40;
+const readyBootstrapIntervalMs = 250;
+
+function trySendReady() {
+  if (readyBootstrapped) return true;
+  const sent = bridge.post({
+    type: 'ready',
+    protocolVersion: PROTOCOL_VERSION,
+    assetVersion: ASSET_VERSION,
+  });
+  if (sent) readyBootstrapped = true;
+  return sent;
+}
+
+function scheduleReadyBootstrap() {
+  if (readyBootstrapped || readyBootstrapTimer !== 0) return;
+  const attempt = () => {
+    readyBootstrapTimer = 0;
+    if (trySendReady()) return;
+    readyBootstrapAttempts += 1;
+    if (readyBootstrapAttempts >= readyBootstrapMaxAttempts) return;
+    readyBootstrapTimer = window.setTimeout(attempt, readyBootstrapIntervalMs);
+  };
+  readyBootstrapTimer = window.setTimeout(attempt, 0);
+}
+
+window.addEventListener('load', scheduleReadyBootstrap, { once: true });
+scheduleReadyBootstrap();

--- a/assets/web_chat/test/protocol.test.mjs
+++ b/assets/web_chat/test/protocol.test.mjs
@@ -102,6 +102,14 @@ test('transfer chunks reassemble UTF-8 snapshots', () => {
   assert.deepEqual(result, payload);
 });
 
+test('bridge post reports delivery readiness', () => {
+  assert.match(appSource, /const bridge = \{/);
+  assert.match(appSource, /return true;/);
+  assert.match(appSource, /return false;/);
+  assert.match(appSource, /let readyBootstrapped = false;/);
+  assert.match(appSource, /if \(readyBootstrapped\) return true;/);
+});
+
 test('snapshot reducer rejects an older revision in the same session', () => {
   const current = { type: 'snapshot', protocolVersion: 4, assetVersion: 'web-chat-v17', renderSessionId: 's', renderRevision: 4, messages: [] };
   const older = { ...current, renderRevision: 3, messages: [{ id: 'old' }] };


### PR DESCRIPTION
## 问题

在 iOS/macOS 的 WKWebView 路径中，`app.mjs` 只在模块初始化时发送一次 `ready`。当 `CuplivoChat` JavaScript channel 尚未注入或暂时不可用时，原来的可选调用会静默丢弃消息，Dart 侧随后触发 `shell_ready_timeout`。

## 修复

- 让 bridge 明确返回消息是否已提交；
- `ready` 在初始化和 `load` 事件后通过定时器重试；
- 最多重试 40 次、间隔 250ms，并在首次成功后停止，避免重复初始化；
- 增加回归契约测试。

## 验证

- `node --test assets/web_chat/test/protocol.test.mjs`：69/69 通过；
- `git diff --check`：通过；
- 未在本环境运行 Flutter/iOS 真机测试。
