### PR TITLE
fix(web-chat): serve Darwin shell from a loopback HTTP origin

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -938,6 +938,8 @@
 - **Render session (渲染会话)**: One ordered lifetime of a viewport bound to one conversation. Results and actions from an older render session are stale and must not affect the active conversation.
 - **Conversation-scoped fallback (会话级回退)**: A process-local choice that keeps one conversation on the Flutter viewport after a Web viewport failure or an unsupported MultiAI surface. It is not persisted.
 - **Rich content block (富内容块)**: An independently rendered unit inside a message, such as Markdown, code, math, Mermaid, SVG, HTML preview, an attachment, reasoning, or a tool card. Failure of one block does not invalidate the surrounding message.
+- **Web chat shell (Web 壳)**: The versioned bundled HTML/JS surface (`assets/web_chat/`, currently `web-chat-v17`) that a platform WebView renders inside the Web conversation viewport. It owns only DOM presentation, local interaction, and viewport scroll; it is a presentation layer, never a second chat client.
+- **Shell origin (壳加载源)**: The URL origin from which the Web chat shell is loaded by the platform WebView — Windows: WebView2 HTTPS virtual host (`cuplivo-web-chat.invalid`), Android: `appassets.androidplatform.net` (secure asset origin), Darwin (iOS/macOS): loopback HTTP served by the in-process `LocalWebChatShellServer` with asset keys mapped to `/assets/...` paths. It is never a `file://` origin (ADR-0043; Darwin path in ADR-0051).
 
 ## Fork Conversation (创建分支)
 

--- a/docs/adr/0051-darwin-shell-origin-loopback-server.md
+++ b/docs/adr/0051-darwin-shell-origin-loopback-server.md
@@ -1,0 +1,58 @@
+# ADR-0051: Darwin shell origin — in-process loopback server
+
+ADR-0043 states the Web chat shell never loads from a `file://` origin, but the
+Darwin (iOS/macOS) implementation loaded it with `webview_flutter`
+`loadFlutterAsset`, which resolves to `WKWebView.loadFileURL` — a `file://`
+document origin. On WebKit that origin is opaque, so the shell's ES-module
+graph (`app.mjs` importing `protocol.mjs`) is CORS-blocked and the shell never
+sends `ready`: the native side reports `shell_ready_timeout` with no JS-side
+diagnostics. JavaScript-side retries cannot recover either case — module
+evaluation never happens, and the `CuplivoChat` channel wrapper is injected
+once per document (`atDocumentStart`), so a missed injection is permanent and a
+partial registration can still drop `ready`.
+
+## Decision
+
+On Darwin the shell is loaded from a loopback HTTP origin served by the
+in-process `LocalWebChatShellServer`: `assets/web_chat/**` and
+`assets/mermaid.min.js` are mapped to `/assets/...` request paths, bound to
+`127.0.0.1:0` (ephemeral port), created lazily as a process-level singleton
+and never stopped. The server is GET/HEAD only, has a strict path allowlist
+(`Uri.path` is percent-encoded, so the path is decoded *before* segment
+validation — literal and encoded traversal are both rejected at the boundary,
+not by the asset lookup), replies with exact
+MIME types (`.mjs` → `text/javascript`; module scripts enforce strict MIME
+checking) and `Cache-Control: no-store` so a versioned shell never survives an
+app upgrade in the WebKit HTTP cache. The WebView registers `CuplivoChat` and
+waits for registration with `await` before `loadRequest`, so `window.CuplivoChat`
+exists when the shell's `ready` fires. A failed bind surfaces as
+`shell_server_failed` on the existing Flutter-hosted error surface.
+
+ADR-0043's "the chat shell never uses a `file://` origin" now holds on all
+supported platforms: Windows (WebView2 HTTPS virtual host), Android
+(`appassets.androidplatform.net`), Darwin (loopback HTTP).
+
+## Alternatives rejected
+
+- LoadFlutterAsset / `file://` (status quo): opaque document origin on WebKit
+  blocks module fetches; the observed iOS `shell_ready_timeout`.
+- JavaScript-side `ready` retry (PR #613): cannot help when the module never
+  evaluates, and cannot re-create the per-document channel wrapper.
+- Single-file classic-script bundle (drop ES modules): removes the module
+  constraint but keeps `file://`; mermaid still loads `../mermaid.min.js`
+  outside the read-access directory and the CSP `'self'` guarantee weakens.
+- Disk-extracted cache with version markers (Windows pattern): no Darwin
+  equivalent of WebView2's virtual-host mapping exists, so the extra temp-dir
+  lifecycle adds nothing once HTTP serving is chosen.
+
+## Consequences
+
+- The app now hosts one loopback HTTP server per process on Darwin; bound to
+  the IPv4 loopback interface only, serving a fixed allowlist of bundled
+  assets — no dynamic content, no directory listing, no LAN exposure.
+- Web console messages are forwarded via `setOnConsoleMessage` to
+  `debugPrint`, so future Darwin shell failures in the field can be read from
+  the device console.
+- WKWebView subresource failures remain invisible to `onWebResourceError`
+  (main-frame-only); a shell resource failure still surfaces as
+  `resource_*` for main-frame errors only.

--- a/lib/features/home/webview/local_web_chat_shell_server.dart
+++ b/lib/features/home/webview/local_web_chat_shell_server.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Serves the bundled Web chat shell from a loopback HTTP origin so Darwin
+/// (iOS/macOS) WKWebView never uses a `file://` document origin (ADR-0051).
+/// Windows uses a WebView2 HTTPS virtual host and Android uses
+/// `appassets.androidplatform.net`; this server closes the last gap.
+///
+/// Process-level lazy singleton: once acquired it serves for the lifetime of
+/// the process and is never stopped. The port is ephemeral and re-bound fresh
+/// on each launch, so no port is reused across runs.
+final class LocalWebChatShellServer {
+  LocalWebChatShellServer._(this._server);
+
+  static LocalWebChatShellServer? _instance;
+  static Future<LocalWebChatShellServer>? _startup;
+
+  final HttpServer _server;
+
+  /// A strict allowlist: the whole bundled shell tree plus mermaid, which the
+  /// shell loads as `../mermaid.min.js` from `assets/web_chat/app.mjs`.
+  static const String _shellTreePrefix = 'assets/web_chat/';
+  static const String _mermaidAssetKey = 'assets/mermaid.min.js';
+
+  int get port => _server.port;
+
+  Uri get shellUri => Uri(
+    scheme: 'http',
+    host: '127.0.0.1',
+    port: port,
+    path: '/assets/web_chat/index.html',
+  );
+
+  /// Idempotent: always returns the one process-wide server. A failed start
+  /// clears the pending future so a later retry can bind again.
+  static Future<LocalWebChatShellServer> acquire() {
+    final existing = _instance;
+    if (existing != null) return Future.value(existing);
+    final pending = _startup;
+    if (pending != null) return pending;
+    final future = _start();
+    _startup = future;
+    future.then(
+      (server) {
+        if (identical(_startup, future)) _instance = server;
+      },
+      onError: (Object error) {
+        if (identical(_startup, future)) _startup = null;
+        debugPrint(
+          'LocalWebChatShellServer: start failed (${error.runtimeType})',
+        );
+      },
+    );
+    return future;
+  }
+
+  static Future<LocalWebChatShellServer> _start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final instance = LocalWebChatShellServer._(server);
+    server.listen(
+      (request) => unawaited(instance._serve(request)),
+      onError: (Object error) {
+        debugPrint(
+          'LocalWebChatShellServer: connection error (${error.runtimeType})',
+        );
+      },
+    );
+    return instance;
+  }
+
+  /// Whether [uri] addresses this server with a whitelisted shell path. Used
+  /// by the WebView navigation delegate so the shell itself is allowed while
+  /// any other loopback URL falls through to the external browser. Only the
+  /// literal `127.0.0.1` host matches — the server binds IPv4 loopback only,
+  /// and on Darwin `localhost` may resolve to `::1` first.
+  bool isLocalShellUri(Uri uri) {
+    if (uri.scheme != 'http') return false;
+    if (uri.host != '127.0.0.1') return false;
+    if (uri.port != port) return false;
+    return assetKeyForPath(uri.path) != null;
+  }
+
+  /// Resolves a raw URL path to an asset key, or null when the path escapes
+  /// the allowlist. `Uri.path` is percent-encoded, so the path is decoded
+  /// *before* segment validation — literal and encoded `..`/dot segments are
+  /// both rejected at the boundary instead of falling through to the asset
+  /// lookup, and malformed escapes are rejected outright.
+  static String? assetKeyForPath(String rawPath) {
+    if (rawPath.contains('\u0000')) return null;
+    final String decoded;
+    try {
+      decoded = Uri.decodeFull(rawPath);
+    } on ArgumentError {
+      return null;
+    }
+    final normalized = decoded.replaceAll('\\', '/');
+    if (!normalized.startsWith('/')) return null;
+    final segments = normalized.split('/');
+    if (segments.any((segment) => segment == '..' || segment == '.')) {
+      return null;
+    }
+    final key = normalized.substring(1);
+    if (!key.startsWith(_shellTreePrefix) && key != _mermaidAssetKey) {
+      return null;
+    }
+    return key;
+  }
+
+  static String contentTypeForKey(String key) {
+    final extension = key.split('.').last.toLowerCase();
+    return switch (extension) {
+      'html' || 'htm' => 'text/html; charset=utf-8',
+      'css' => 'text/css; charset=utf-8',
+      'js' || 'mjs' => 'text/javascript; charset=utf-8',
+      'json' || 'map' => 'application/json; charset=utf-8',
+      'svg' => 'image/svg+xml',
+      'png' => 'image/png',
+      'jpg' || 'jpeg' => 'image/jpeg',
+      'gif' => 'image/gif',
+      'webp' => 'image/webp',
+      'woff' => 'font/woff',
+      'woff2' => 'font/woff2',
+      'ttf' => 'font/ttf',
+      'otf' => 'font/otf',
+      'ico' => 'image/x-icon',
+      'txt' => 'text/plain; charset=utf-8',
+      _ => 'application/octet-stream',
+    };
+  }
+
+  Future<void> _serve(HttpRequest request) async {
+    try {
+      if (request.method != 'GET' && request.method != 'HEAD') {
+        await _respond(
+          request,
+          HttpStatus.methodNotAllowed,
+          'method not allowed',
+        );
+        return;
+      }
+      final key = assetKeyForPath(request.uri.path);
+      if (key == null) {
+        await _respond(request, HttpStatus.notFound, 'not found');
+        return;
+      }
+      final data = await rootBundle.load(key);
+      final bytes = data.buffer.asUint8List(
+        data.offsetInBytes,
+        data.lengthInBytes,
+      );
+      final headers = request.response.headers;
+      headers.set(HttpHeaders.contentTypeHeader, contentTypeForKey(key));
+      headers.set(HttpHeaders.cacheControlHeader, 'no-store');
+      headers.set(HttpHeaders.contentLengthHeader, bytes.length);
+      request.response.statusCode = HttpStatus.ok;
+      if (request.method == 'HEAD') {
+        await request.response.close();
+      } else {
+        request.response.add(bytes);
+        await request.response.close();
+      }
+    } catch (error) {
+      debugPrint(
+        'LocalWebChatShellServer: request failed (${error.runtimeType})',
+      );
+      await _respond(request, HttpStatus.notFound, 'not found');
+    }
+  }
+
+  Future<void> _respond(HttpRequest request, int status, String body) async {
+    try {
+      final response = request.response;
+      response.statusCode = status;
+      response.headers.set(
+        HttpHeaders.contentTypeHeader,
+        'text/plain; charset=utf-8',
+      );
+      response.headers.set(HttpHeaders.cacheControlHeader, 'no-store');
+      response.write(body);
+      await response.close();
+    } catch (error) {
+      debugPrint(
+        'LocalWebChatShellServer: response failed (${error.runtimeType})',
+      );
+    }
+  }
+}

--- a/lib/features/home/webview/web_conversation_viewport.dart
+++ b/lib/features/home/webview/web_conversation_viewport.dart
@@ -19,6 +19,7 @@ import '../../../theme/app_semantic_colors.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../controllers/conversation_viewport_port.dart';
 import 'android_web_chat_view.dart';
+import 'local_web_chat_shell_server.dart';
 import 'web_chat_protocol.dart';
 import 'web_chat_remote_media.dart';
 import 'web_chat_snapshot.dart';
@@ -77,6 +78,7 @@ class _WebConversationViewportState extends State<WebConversationViewport> {
   ];
 
   WebViewController? _flutterController;
+  LocalWebChatShellServer? _shellServer;
   AndroidWebChatController? _androidController;
   winweb.WebviewController? _windowsController;
   StreamSubscription<dynamic>? _windowsMessageSubscription;
@@ -274,39 +276,62 @@ class _WebConversationViewportState extends State<WebConversationViewport> {
   }
 
   Future<void> _initializeFlutterWebView(int generation) async {
-    final controller =
-        WebViewController(
-            onPermissionRequest: (request) => unawaited(request.deny()),
-          )
-          ..setJavaScriptMode(JavaScriptMode.unrestricted)
-          ..setBackgroundColor(const Color(0x00000000))
-          ..setNavigationDelegate(
-            NavigationDelegate(
-              onNavigationRequest: (request) {
-                if (!request.isMainFrame || _isLocalShellUrl(request.url)) {
-                  return NavigationDecision.navigate;
-                }
-                unawaited(_openExternalUrl(request.url));
-                return NavigationDecision.prevent;
-              },
-              onWebResourceError: (error) {
-                if (error.isForMainFrame != true) return;
-                debugPrint(
-                  'WebConversationViewport: shell resource failed: '
-                  '${error.errorCode}',
-                );
-                _fail(generation, 'resource_${error.errorCode}');
-              },
-            ),
-          )
-          ..addJavaScriptChannel(
-            'CuplivoChat',
-            onMessageReceived: (message) =>
-                _handleBridgeMessage(message.message),
+    // The shell must load from a loopback HTTP origin (ADR-0051): a
+    // `file://` document origin is opaque on WebKit and blocks the shell's
+    // ES-module graph, so it can never signal `ready`.
+    LocalWebChatShellServer server;
+    try {
+      server = await LocalWebChatShellServer.acquire();
+    } catch (error) {
+      debugPrint(
+        'WebConversationViewport: shell server failed '
+        '(${error.runtimeType})',
+      );
+      _fail(generation, 'shell_server_failed');
+      return;
+    }
+    if (_isStale(generation)) return;
+    _shellServer = server;
+    final controller = WebViewController(
+      onPermissionRequest: (request) => unawaited(request.deny()),
+    );
+    // Ordering matters: every channel/setting registration must complete
+    // before the navigation is issued so `window.CuplivoChat` exists for the
+    // shell's first `ready`.
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.setBackgroundColor(const Color(0x00000000));
+    await controller.setNavigationDelegate(
+      NavigationDelegate(
+        onNavigationRequest: (request) {
+          if (!request.isMainFrame || _isLocalShellUrl(request.url)) {
+            return NavigationDecision.navigate;
+          }
+          unawaited(_openExternalUrl(request.url));
+          return NavigationDecision.prevent;
+        },
+        onWebResourceError: (error) {
+          if (error.isForMainFrame != true) return;
+          debugPrint(
+            'WebConversationViewport: shell resource failed: '
+            '${error.errorCode}',
           );
+          _fail(generation, 'resource_${error.errorCode}');
+        },
+      ),
+    );
+    await controller.addJavaScriptChannel(
+      'CuplivoChat',
+      onMessageReceived: (message) => _handleBridgeMessage(message.message),
+    );
+    await controller.setOnConsoleMessage((message) {
+      debugPrint(
+        'WebConversationViewport: web console ${message.level.name}: '
+        '${message.message}',
+      );
+    });
     if (_isStale(generation)) return;
     _flutterController = controller;
-    await controller.loadFlutterAsset('assets/web_chat/index.html');
+    await controller.loadRequest(server.shellUri);
   }
 
   Future<void> _handleAndroidViewCreated(int viewId, int generation) async {
@@ -349,12 +374,19 @@ class _WebConversationViewportState extends State<WebConversationViewport> {
     }
   }
 
-  bool _isLocalShellUrl(String url) =>
-      url.startsWith('file:') ||
-      url.startsWith('data:') ||
-      url.startsWith('about:') ||
-      url.startsWith('https://$_windowsVirtualHost/') ||
-      url.startsWith('https://appassets.androidplatform.net/');
+  bool _isLocalShellUrl(String url) {
+    if (url.startsWith('file:') ||
+        url.startsWith('data:') ||
+        url.startsWith('about:') ||
+        url.startsWith('https://$_windowsVirtualHost/') ||
+        url.startsWith('https://appassets.androidplatform.net/')) {
+      return true;
+    }
+    final server = _shellServer;
+    if (server == null) return false;
+    final uri = Uri.tryParse(url);
+    return uri != null && server.isLocalShellUri(uri);
+  }
 
   Future<File> _prepareWindowsShell() async {
     final temp = await getTemporaryDirectory();

--- a/test/features/home/web_chat_shell_server_test.dart
+++ b/test/features/home/web_chat_shell_server_test.dart
@@ -1,0 +1,208 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/home/webview/local_web_chat_shell_server.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('path allowlist', () {
+    test('maps the shell tree and mermaid markers to asset keys', () {
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/web_chat/index.html'),
+        'assets/web_chat/index.html',
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/web_chat/app.mjs'),
+        'assets/web_chat/app.mjs',
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/web_chat/vendor/fonts/katex.woff2',
+        ),
+        'assets/web_chat/vendor/fonts/katex.woff2',
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/mermaid.min.js'),
+        'assets/mermaid.min.js',
+      );
+    });
+
+    test('rejects traversal, separators, and out-of-scope paths', () {
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/../pubspec.yaml'),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/web_chat/../../pubspec.yaml',
+        ),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/web_chat/..\\pubspec.yaml',
+        ),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/%2e%2e%2fpubspec.yaml',
+        ),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/web_chat/%2e%2e%2f..%2fpubspec.yaml',
+        ),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath(
+          '/assets/web_chat/%5c..%5cpubspec.yaml',
+        ),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/%zz/pubspec.yaml'),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/web_chat'),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/assets/icons/kelivo.png'),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('/workspaces/foo'),
+        isNull,
+      );
+      expect(
+        LocalWebChatShellServer.assetKeyForPath('assets/web_chat/index.html'),
+        isNull,
+      );
+    });
+  });
+
+  group('content types', () {
+    test('module and shell assets resolve to strict browser MIME types', () {
+      expect(
+        LocalWebChatShellServer.contentTypeForKey('assets/web_chat/app.mjs'),
+        'text/javascript; charset=utf-8',
+      );
+      expect(
+        LocalWebChatShellServer.contentTypeForKey('assets/mermaid.min.js'),
+        'text/javascript; charset=utf-8',
+      );
+      expect(
+        LocalWebChatShellServer.contentTypeForKey('assets/web_chat/index.html'),
+        'text/html; charset=utf-8',
+      );
+      expect(
+        LocalWebChatShellServer.contentTypeForKey('assets/web_chat/styles.css'),
+        'text/css; charset=utf-8',
+      );
+      expect(
+        LocalWebChatShellServer.contentTypeForKey(
+          'assets/web_chat/vendor/fonts/katex.woff2',
+        ),
+        'font/woff2',
+      );
+    });
+  });
+
+  group('loopback server', () {
+    late LocalWebChatShellServer server;
+    late HttpOverrides? originalHttpOverrides;
+
+    setUpAll(() async {
+      // TestWidgetsFlutterBinding installs a global Http client mock that
+      // answers 400 to everything; the loopback tests need real sockets.
+      originalHttpOverrides = HttpOverrides.current;
+      HttpOverrides.global = null;
+      server = await LocalWebChatShellServer.acquire();
+    });
+
+    tearDownAll(() {
+      HttpOverrides.global = originalHttpOverrides;
+    });
+
+    test('acquire is idempotent for the process lifetime', () async {
+      expect(
+        identical(await LocalWebChatShellServer.acquire(), server),
+        isTrue,
+      );
+    });
+
+    test('serves the shell origin with whitelisted assets', () async {
+      final client = HttpClient();
+      try {
+        final index = await (await client.getUrl(server.shellUri)).close();
+        expect(index.statusCode, HttpStatus.ok);
+        expect(index.headers.contentType?.mimeType, 'text/html');
+        await index.drain<void>();
+
+        final app = await (await client.getUrl(
+          server.shellUri.replace(path: '/assets/web_chat/app.mjs'),
+        )).close();
+        expect(app.statusCode, HttpStatus.ok);
+        expect(app.headers.contentType?.mimeType, 'text/javascript');
+        await app.drain<void>();
+
+        // The shell resolves mermaid as ../mermaid.min.js from app.mjs.
+        final mermaid = await (await client.getUrl(
+          server.shellUri.replace(path: '/assets/mermaid.min.js'),
+        )).close();
+        expect(mermaid.statusCode, HttpStatus.ok);
+        await mermaid.drain<void>();
+
+        expect(
+          server.isLocalShellUri(
+            server.shellUri.replace(path: '/assets/web_chat/app.mjs'),
+          ),
+          isTrue,
+        );
+      } finally {
+        client.close(force: true);
+      }
+    });
+
+    test('rejects out-of-scope paths and non-GET methods', () async {
+      final client = HttpClient();
+      try {
+        final outside = await (await client.getUrl(
+          server.shellUri.replace(path: '/pubspec.yaml'),
+        )).close();
+        expect(outside.statusCode, HttpStatus.notFound);
+        await outside.drain<void>();
+
+        final request = await client.postUrl(server.shellUri);
+        final response = await request.close();
+        expect(response.statusCode, HttpStatus.methodNotAllowed);
+        await response.drain<void>();
+
+        expect(
+          server.isLocalShellUri(
+            server.shellUri.replace(port: server.port + 1),
+          ),
+          isFalse,
+        );
+        expect(
+          server.isLocalShellUri(
+            server.shellUri.replace(path: '/assets/icons/kelivo.png'),
+          ),
+          isFalse,
+        );
+        expect(
+          server.isLocalShellUri(server.shellUri.replace(host: 'localhost')),
+          isFalse,
+        );
+      } finally {
+        client.close(force: true);
+      }
+    });
+  });
+}

--- a/test/features/home/web_conversation_viewport_contract_test.dart
+++ b/test/features/home/web_conversation_viewport_contract_test.dart
@@ -299,4 +299,27 @@ void main() {
       );
     },
   );
+
+  test(
+    'Darwin shell loads from a loopback server and awaits channel registration',
+    () {
+      final source = File(
+        'lib/features/home/webview/web_conversation_viewport.dart',
+      ).readAsStringSync();
+
+      expect(source, contains('LocalWebChatShellServer.acquire()'));
+      expect(source, contains('isLocalShellUri'));
+      final acquireAt = source.indexOf('LocalWebChatShellServer.acquire()');
+      final channelAt = source.indexOf('await controller.addJavaScriptChannel');
+      expect(acquireAt, greaterThan(0));
+      expect(channelAt, greaterThan(0));
+      final loadAt = source.indexOf(
+        'await controller.loadRequest(server.shellUri)',
+      );
+      expect(loadAt, greaterThan(0));
+      expect(channelAt, greaterThan(acquireAt));
+      expect(loadAt, greaterThan(channelAt));
+      expect(source.substring(acquireAt, loadAt), contains("'CuplivoChat'"));
+    },
+  );
 }


### PR DESCRIPTION
## 问题

iOS 开启实验性 Web 对话视口后始终报 `shell_ready_timeout`（诊断里 `renderRevision: null`、无 `lastWebDiagnosticCode` —— 说明 JS 壳一次都没跑起来）。

根因：Darwin（iOS/macOS）路径用 `webview_flutter.loadFlutterAsset` 加载壳，它在 WKWebView 上解析为 `loadFileURL` = **`file://` document origin**。WebKit 下该 origin 是 opaque 的，壳的 ES-module 图（`app.mjs` → `protocol.mjs`）以 CORS 模式加载被拦截 → `ready` 永远不会发。Windows（WebView2 https 虚拟主机）与 Android（`appassets.androidplatform.net` 安全资产源）都没有这个问题，唯独 Darwin 一直违反 ADR-0043 的 "never a file:// origin"。

## 修复

### 服务器（新增 `LocalWebChatShellServer`）

- 进程级懒加载单例，绑定 `127.0.0.1:0`（临时端口，随进程生命周期存活）
- 通过 `rootBundle` 直出 `assets/web_chat/**` 与 `assets/mermaid.min.js`（壳以 `../mermaid.min.js` 引用后者）
- 严格边界：GET/HEAD only、严格路径白名单（**先解码再分段校验**，字面与编码遍历均在路径层拒绝，不依赖 asset 查表兜底）、精确 MIME（`.mjs` → `text/javascript`，module 脚本强制校验 MIME）、`Cache-Control: no-store`（防止升级后 WebKit HTTP 缓存喂旧版壳）
- ATS 豁免 loopback，无需改 Info.plist；macOS entitlement 已含 `network.server`

### viewport（`web_conversation_viewport.dart`）

- `_initializeFlutterWebView`：先 `acquire()` 服务器 → **`await` `addJavaScriptChannel` 及全部 channel 注册** → `loadRequest(http://127.0.0.1:<port>/assets/web_chat/index.html)`（原来 cascade 丢弃了 `addJavaScriptChannel` 的 Future，注入存在竞态）
- `_isLocalShellUrl` 增加 loopback 白名单（`decidePolicyForNavigationAction` 会对初始主帧导航回调 `onNavigationRequest`，不加白名单壳会被 `prevent` 掉）
- 挂 `setOnConsoleMessage` → `debugPrint`：以后真机上的 WKWebView JS 报错（CORS 等）可直接从设备日志读
- bind 失败 → 现有错误面 + `shell_server_failed` 诊断码

### 文档

- `docs/adr/0051-darwin-shell-origin-loopback-server.md`：Darwin 壳加载源决策 + 被否方案（含 #613 的 JS 侧重试——模块根本不执行时重试无从谈起，且 `CuplivoChat` wrapper 是每文档一次性注入，错过即整文档缺失）
- `CONTEXT.md`：新增 **Web chat shell** / **Shell origin** 术语

## 与 #613 的关系

#613 是 JS 侧症状修补（bridge 返回投递状态 + 40×250ms 重发）。它覆盖不了本根因：① 模块被 file:// CORS 拦截时重试逻辑自身不会运行；② `window.CuplivoChat` 由 `atDocumentStart` WKUserScript 一次性注入，文档创建前错过注入则整份文档生命周期内不可用，重发 40 次全部落空；③ 40×250ms=10s 恰好贴齐 Dart 侧 10s timeout，且 `_fail()` 后迟到 `ready` 不会清 `_errorCode`。

两者不冲突（#613 合入对本次无害），但若仅合入 #613，预计 iOS 仍无法恢复可用。

## 验证

- `dart analyze --fatal-infos lib test`：无 issues
- `flutter test`（`web_chat_shell_server_test` + `web_conversation_viewport_contract_test` + `web_chat_platform_test`）：22/22 通过
- `dart format`：已执行

**未验证**（如实说明）：本机为 Windows，无法运行 Darwin 设备/模拟器；ATS 对 loopback 的豁免按 Apple 文档预期，若真机出现 `resource_-1022`，后备方案为两个 Info.plist 加 `NSAllowsLocalNetworking`（最小作用域）。

## 手动测试清单（iPhone + Mac 各一次）

- Happy path：开启实验开关 → 会话正常渲染（ready + renderCommitted）
- 边界：直接切换会话（复用同一端口）；会话内渲染 ` ```mermaid ` 图（`/assets/mermaid.min.js` 可达）；重启 app 后功能依旧（新进程重新 bind 随机端口）
- 失败路径：断网状态不受影响（纯本地 origin 无网络依赖）
