### PR TITLE
fix(chat): keep the chat background still when the keyboard opens (issue #297)

### DIFF
--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -946,9 +946,9 @@ class _HomePageState extends State<HomePage>
 
     return ChatInputOverlayLayout(
       topInset: _chatTopOverlayInset(context),
-      background: backgroundImageActive
-          ? _buildChatBackground(context, cs)
-          : null,
+      // The full-window artwork already sits behind the Scaffold
+      // (MobileBackgroundLayer); painting it again inside the body would only
+      // duplicate it in a box that shrinks with the keyboard.
       topBackground: backgroundImageActive
           ? _buildChatBackground(context, cs)
           : null,

--- a/lib/features/home/widgets/chat_input_overlay_layout.dart
+++ b/lib/features/home/widgets/chat_input_overlay_layout.dart
@@ -6,7 +6,6 @@ class ChatInputOverlayLayout extends StatelessWidget {
     required this.topInset,
     required this.content,
     required this.bottomOverlay,
-    this.background,
     this.topBackground,
     this.foreground,
     this.backgroundImageActive = false,
@@ -18,7 +17,6 @@ class ChatInputOverlayLayout extends StatelessWidget {
   final double topInset;
   final Widget content;
   final Widget bottomOverlay;
-  final Widget? background;
   final Widget? topBackground;
   final Widget? foreground;
   final bool backgroundImageActive;
@@ -27,7 +25,6 @@ class ChatInputOverlayLayout extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        if (background != null) Positioned.fill(child: background!),
         Positioned.fill(
           child: Stack(
             children: [
@@ -42,7 +39,7 @@ class ChatInputOverlayLayout extends StatelessWidget {
                       height: topInset + _topOverlayTailHeight,
                       child: IgnorePointer(
                         key: const Key('chat-input-overlay-top-background'),
-                        child: topBackground!,
+                        child: _KeyboardStableBackground(child: topBackground!),
                       ),
                     ),
                   ),
@@ -65,7 +62,7 @@ class ChatInputOverlayLayout extends StatelessWidget {
                       height: _bottomOverlayFadeHeight,
                       child: IgnorePointer(
                         key: const Key('chat-input-overlay-bottom-background'),
-                        child: topBackground!,
+                        child: _KeyboardStableBackground(child: topBackground!),
                       ),
                     ),
                   ),
@@ -91,6 +88,42 @@ class ChatInputOverlayLayout extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Lays the chat artwork out as if the keyboard were closed, letting the extra
+/// height overflow behind the IME instead of shrinking with the Scaffold body.
+/// A `BoxFit.cover` background re-crops whenever its box changes height, so
+/// without this the whole image visibly jumps upwards as the keyboard opens.
+///
+/// The inset has to come from the [View]: Scaffold strips the bottom view inset
+/// off the MediaQuery it hands to its body, so reading it from MediaQuery here
+/// would always yield zero. Reading it inside the [LayoutBuilder] also keeps it
+/// in sync, because the body's constraints change on the very same frame.
+class _KeyboardStableBackground extends StatelessWidget {
+  const _KeyboardStableBackground({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRect(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          if (!constraints.hasBoundedHeight) return child;
+          final view = View.of(context);
+          final bottomInset = view.viewInsets.bottom / view.devicePixelRatio;
+          if (bottomInset <= 0) return child;
+          final height = constraints.maxHeight + bottomInset;
+          return OverflowBox(
+            alignment: Alignment.topCenter,
+            minHeight: height,
+            maxHeight: height,
+            child: child,
+          );
+        },
+      ),
     );
   }
 }

--- a/test/features/home/widgets/chat_input_overlay_layout_test.dart
+++ b/test/features/home/widgets/chat_input_overlay_layout_test.dart
@@ -215,4 +215,51 @@ void main() {
     expect(bottomClip.top, 420);
     expect(bottomClip.height, 180);
   });
+
+  testWidgets('键盘弹出时背景仍按键盘收起时的高度布局', (tester) async {
+    const backgroundKey = Key('background');
+    const contentKey = Key('content');
+
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    Widget build() {
+      return const MaterialApp(
+        home: Scaffold(
+          resizeToAvoidBottomInset: true,
+          body: ChatInputOverlayLayout(
+            topInset: 100,
+            backgroundImageActive: true,
+            topBackground: ColoredBox(key: backgroundKey, color: Colors.green),
+            content: ColoredBox(key: contentKey, color: Colors.blue),
+            bottomOverlay: SizedBox(width: 200, height: 50),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build());
+    final closedContentHeight = tester.getSize(find.byKey(contentKey)).height;
+    final closedBackgroundHeight = tester
+        .getSize(find.byKey(backgroundKey).first)
+        .height;
+    expect(closedBackgroundHeight, closedContentHeight);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    await tester.pumpWidget(build());
+
+    // The body really did shrink around the keyboard...
+    expect(
+      tester.getSize(find.byKey(contentKey)).height,
+      closedContentHeight - 300,
+    );
+    // ...but the artwork keeps its original box, so BoxFit.cover does not
+    // re-crop and the background stays put.
+    expect(
+      tester.getSize(find.byKey(backgroundKey).first).height,
+      closedBackgroundHeight,
+    );
+    expect(tester.getTopLeft(find.byKey(backgroundKey).first).dy, 0);
+  });
 }


### PR DESCRIPTION
## 摘要

同步上游修复：**键盘弹出时聊天背景整体上移**（关联 issue #297）。

Cherry-pick of upstream commit `b8bb0bfa`（Kelivo fix(chat): keep the chat background still when the keyboard opens，包含于 v1.2.3/v1.2.4）。

## 修复原理

移动端背景此前被绘制两次：一次以全窗口大小垫在 Scaffold 之后（`MobileBackgroundLayer`），一次画在 body 内——而 body 会随输入法弹出收缩。内层拷贝的 `BoxFit.cover` 图片每到 inset 变化都会重新裁剪，因此键盘弹出时背景明显上移。

- 移除 `ChatInputOverlayLayout` 的 body 级重复 `background` 参数（`home_page.dart`）
- 新增 `_KeyboardStableBackground`：以"键盘收起"的高度对背景布局并追加底部 inset 高度溢出到 IME 之后（`ClipRect + LayoutBuilder + OverflowBox`）
- 关键细节：底部 inset 必须从 `View.of(context).viewInsets` 读取——Scaffold 会把传给 body 的 MediaQuery 底部 view inset 剥离，从 MediaQuery 读取恒为 0

## 变更清单

- `lib/features/home/pages/home_page.dart`
- `lib/features/home/widgets/chat_input_overlay_layout.dart`
- `test/features/home/widgets/chat_input_overlay_layout_test.dart`（新增回归用例：键盘弹出时背景按收起高度布局）

## 验证

- `dart format` 通过
- `dart analyze --fatal-infos lib test` → No issues found
- `flutter test test/features/home/widgets/chat_input_overlay_layout_test.dart` → 7/7 通过

Closes #297
