### PR TITLE
build: bump Flutter to 3.44.9 (issue #649)

### DIFF
--- a/.github/workflows/build-stable-44.yml
+++ b/.github/workflows/build-stable-44.yml
@@ -1,7 +1,7 @@
 name: Flutter Multi-Platform Build Stable 3.44
 
 env:
-  FLUTTER_VERSION: '3.44.1'  # 当前 stable 3.44.1 / Dart 3.12.1
+  FLUTTER_VERSION: '3.44.9'  # 当前 stable 3.44.9 / Dart 3.12.x
 
 on:
   # 手动触发

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 env:
-  FLUTTER_VERSION: '3.44.1'
+  FLUTTER_VERSION: '3.44.9'
 
 on:
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### 1.1 Overall
 
-- This is a Flutter app repository. Root `pubspec.yaml` declares `sdk: ^3.12.1` and `flutter: >=3.44.1` with `flutter.generate: true`.
+- This is a Flutter app repository. Root `pubspec.yaml` declares `sdk: ^3.12.1` and `flutter: >=3.44.9` with `flutter.generate: true`.
 - Main code lives in `lib/`, tests in `test/`. Local path dependencies exist:
   - `dependencies/mcp_client`
   - `dependencies/tray_manager/packages/tray_manager`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ version: 3.1.1+37
 
 environment:
   sdk: ^3.12.1
-  flutter: ">=3.44.1"
+  flutter: ">=3.44.9"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## What

Unify the Flutter toolchain to `3.44.9` across CI, build workflows, and the minimum constraint — mirroring upstream Kelivo (f789ef299544a0cf976fc6b9e603abab97e4e884).

- `.github/workflows/pr-check.yml`: `FLUTTER_VERSION` `3.44.1` → `3.44.9`
- `.github/workflows/build-stable-44.yml`: `FLUTTER_VERSION` `3.44.1` → `3.44.9`
- `pubspec.yaml`: minimum Flutter `>=3.44.1` → `>=3.44.9`
- `AGENTS.md`: sync repository-fact statement

Skipped `web-ci.yml` — it is website-only (pnpm/Node), no Flutter. `sdk: ^3.12.1` unchanged: it covers both CI's Dart 3.12.x and newer local SDKs.

## Verification

- `flutter pub get` — clean (local Flutter 3.47.0 satisfies the new constraint)
- `dart analyze --fatal-infos lib test` — no issues
- No Dart code changes, so no related test subset applies; full `flutter test` and the 5-platform builds are validated by CI (`pr-check.yml` + `build-stable-44.yml`)

Closes #649
