### PR TITLE
feat(storage): expose per-subcategory cache file lists (issue #320)

### DIFF
--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -881,6 +881,145 @@ abstract final class StorageUsageService {
     return deleted;
   }
 
+  /// Lists every file [clearCache]/[clearOtherCache]/[clearSystemCache]/
+  /// [clearTmpCache] would delete for the given cache [subcategoryId], so the
+  /// storage page can show exactly which files are judged as cache before
+  /// clearing. Mirrors the clear methods' boundaries:
+  /// - 'avatar_cache': everything under `appData/cache/avatars`
+  /// - 'other_cache':  everything under `appData/cache` except avatars
+  /// - 'system_cache': platform application cache directory
+  /// - 'tmp_cache':    real iOS tmp dir (empty on other platforms)
+  ///
+  /// Sorted by size descending (largest first). Unknown ids return an empty
+  /// list. Unreadable entries or dirs are skipped, never thrown.
+  static Future<List<StorageFileEntry>> listCacheEntries({
+    required String subcategoryId,
+  }) async {
+    final out = <StorageFileEntry>[];
+
+    final cacheDir = await AppDirectories.getCacheDirectory();
+    final avatarCacheDir = await AppDirectories.getAvatarCacheDirectory();
+    final systemCacheDir = await AppDirectories.getSystemCacheDirectory();
+
+    Directory root;
+    String? excludedRoot;
+    switch (subcategoryId) {
+      case 'avatar_cache':
+        root = Directory(avatarCacheDir.path);
+        break;
+      case 'other_cache':
+        root = Directory(cacheDir.path);
+        excludedRoot = p.normalize(
+          Directory(avatarCacheDir.path).absolute.path,
+        );
+        break;
+      case 'system_cache':
+        root = Directory(systemCacheDir.path);
+        break;
+      case 'tmp_cache':
+        final iosTmpPath = await IosTmpDirectory.getPath();
+        if (iosTmpPath == null) return out;
+        root = Directory(iosTmpPath);
+        break;
+      default:
+        return out;
+    }
+
+    if (!await root.exists()) return out;
+
+    try {
+      await for (final ent in root.list(recursive: true, followLinks: false)) {
+        if (ent is! File) continue;
+        final abs = p.normalize(ent.absolute.path);
+        if (excludedRoot != null && p.isWithin(excludedRoot, abs)) continue;
+        int bytes = 0;
+        DateTime modifiedAt = DateTime.fromMillisecondsSinceEpoch(0);
+        try {
+          final stat = await ent.stat();
+          bytes = stat.size;
+          modifiedAt = stat.modified;
+        } catch (_) {
+          try {
+            bytes = await ent.length();
+          } catch (_) {}
+        }
+        out.add(
+          StorageFileEntry(
+            path: ent.path,
+            name: p.basename(ent.path),
+            bytes: bytes,
+            modifiedAt: modifiedAt,
+          ),
+        );
+      }
+    } catch (_) {
+      // Unreadable directory: return partial results instead of failing.
+    }
+
+    out.sort((a, b) {
+      final r = a.bytes.compareTo(b.bytes);
+      if (r != 0) return -r;
+      return a.modifiedAt.compareTo(b.modifiedAt);
+    });
+    return out;
+  }
+
+  /// Deletes the given files from one cache subcategory, validating every
+  /// path against the same roots [listCacheEntries] reports. Paths outside
+  /// the allowed root, or inside the excluded 'avatars' root for
+  /// 'other_cache', are skipped. Returns the number of files actually
+  /// deleted.
+  static Future<int> deleteCacheFiles(
+    Iterable<String> paths, {
+    required String subcategoryId,
+  }) async {
+    final cacheDir = await AppDirectories.getCacheDirectory();
+    final avatarCacheDir = await AppDirectories.getAvatarCacheDirectory();
+    final systemCacheDir = await AppDirectories.getSystemCacheDirectory();
+
+    final roots = <String>[];
+    String? excludedRoot;
+    switch (subcategoryId) {
+      case 'avatar_cache':
+        roots.add(p.normalize(Directory(avatarCacheDir.path).absolute.path));
+        break;
+      case 'other_cache':
+        roots.add(p.normalize(Directory(cacheDir.path).absolute.path));
+        excludedRoot = p.normalize(
+          Directory(avatarCacheDir.path).absolute.path,
+        );
+        break;
+      case 'system_cache':
+        roots.add(p.normalize(Directory(systemCacheDir.path).absolute.path));
+        break;
+      case 'tmp_cache':
+        final iosTmpPath = await IosTmpDirectory.getPath();
+        if (iosTmpPath == null) return 0;
+        roots.add(p.normalize(Directory(iosTmpPath).absolute.path));
+        break;
+      default:
+        return 0;
+    }
+
+    int deleted = 0;
+    for (final raw in paths) {
+      try {
+        final abs = p.normalize(File(raw).absolute.path);
+        final allowed = roots.any(
+          (root) => p.isWithin(root, abs) || abs == root,
+        );
+        if (!allowed) continue;
+        if (excludedRoot != null && p.isWithin(excludedRoot, abs)) continue;
+        final f = File(abs);
+        if (await f.exists()) {
+          await f.delete();
+          deleted += 1;
+        }
+      } catch (_) {}
+    }
+    return deleted;
+  }
+
   static Future<void> _deleteDirectoryContents(Directory dir) async {
     if (!await dir.exists()) return;
     try {

--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -653,6 +653,36 @@ abstract final class StorageUsageService {
     progress.onEmit(progress.files, progress.bytes);
   }
 
+  /// Walks [dir] recursively, invoking [onFile] once per file.
+  ///
+  /// A single `list(recursive: true)` stream would abort at the first
+  /// unreadable subdirectory and silently drop every file traversed after
+  /// it — the same failure mode [listCacheEntries] used to have and the one
+  /// that produced the zero-usage incident documented on
+  /// [_scanFilesConcurrently]. Each subdirectory is therefore recursed
+  /// individually: a failing directory is logged and skipped while its
+  /// siblings keep being traversed. A failure to list the walked root itself
+  /// is not caught here — the caller logs it and returns partial results.
+  static Future<void> _listFilesTolerantly(
+    Directory dir, {
+    required Future<void> Function(File file) onFile,
+  }) async {
+    await for (final ent in dir.list(followLinks: false)) {
+      if (ent is Directory) {
+        try {
+          await _listFilesTolerantly(ent, onFile: onFile);
+        } catch (e) {
+          debugPrint(
+            'StorageUsageService: skipping unreadable directory '
+            '${ent.path}: $e',
+          );
+        }
+      } else if (ent is File) {
+        await onFile(ent);
+      }
+    }
+  }
+
   /// Categorizes a workspace tree entry: per-workspace Linux sandboxes
   /// (.sandbox: rootfs, tmp, staged dependency archives) are counted
   /// separately so they can be cleared; everything else under a workspace
@@ -813,34 +843,38 @@ abstract final class StorageUsageService {
     }) async {
       if (!await d.exists()) return;
       try {
-        await for (final ent in d.list(recursive: true, followLinks: false)) {
-          if (ent is! File) continue;
-          final name = p.basename(ent.path);
-          final isImg = _isImageExt(name);
-          if (isImg && !includeImages) continue;
-          if (!isImg && !includeNonImages) continue;
-          int bytes = 0;
-          DateTime modifiedAt = DateTime.fromMillisecondsSinceEpoch(0);
-          try {
-            final stat = await ent.stat();
-            bytes = stat.size;
-            modifiedAt = stat.modified;
-          } catch (_) {
+        await _listFilesTolerantly(
+          d,
+          onFile: (file) async {
+            final name = p.basename(file.path);
+            final isImg = _isImageExt(name);
+            if (isImg && !includeImages) return;
+            if (!isImg && !includeNonImages) return;
+            int bytes = 0;
+            DateTime modifiedAt = DateTime.fromMillisecondsSinceEpoch(0);
             try {
-              bytes = await ent.length();
-            } catch (_) {}
-          }
-          out.add(
-            StorageFileEntry(
-              path: ent.path,
-              name: name,
-              bytes: bytes,
-              modifiedAt: modifiedAt,
-            ),
-          );
-        }
-      } catch (_) {
-        // Ignore listing errors and return partial results.
+              final stat = await file.stat();
+              bytes = stat.size;
+              modifiedAt = stat.modified;
+            } catch (_) {
+              try {
+                bytes = await file.length();
+              } catch (_) {}
+            }
+            out.add(
+              StorageFileEntry(
+                path: file.path,
+                name: name,
+                bytes: bytes,
+                modifiedAt: modifiedAt,
+              ),
+            );
+          },
+        );
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService: failed to list upload dir ${d.path}: $e',
+        );
       }
     }
 
@@ -876,7 +910,11 @@ abstract final class StorageUsageService {
           await f.delete();
           deleted += 1;
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService.deleteUploadFiles: failed to delete $raw: $e',
+        );
+      }
     }
     return deleted;
   }
@@ -891,7 +929,10 @@ abstract final class StorageUsageService {
   /// - 'tmp_cache':    real iOS tmp dir (empty on other platforms)
   ///
   /// Sorted by size descending (largest first). Unknown ids return an empty
-  /// list. Unreadable entries or dirs are skipped, never thrown.
+  /// list. Unreadable subdirectories are logged and skipped while their
+  /// siblings keep being traversed (see [_listFilesTolerantly]); a failure
+  /// to list the root itself is logged and the partial results are returned,
+  /// never thrown.
   static Future<List<StorageFileEntry>> listCacheEntries({
     required String subcategoryId,
   }) async {
@@ -928,32 +969,36 @@ abstract final class StorageUsageService {
     if (!await root.exists()) return out;
 
     try {
-      await for (final ent in root.list(recursive: true, followLinks: false)) {
-        if (ent is! File) continue;
-        final abs = p.normalize(ent.absolute.path);
-        if (excludedRoot != null && p.isWithin(excludedRoot, abs)) continue;
-        int bytes = 0;
-        DateTime modifiedAt = DateTime.fromMillisecondsSinceEpoch(0);
-        try {
-          final stat = await ent.stat();
-          bytes = stat.size;
-          modifiedAt = stat.modified;
-        } catch (_) {
+      await _listFilesTolerantly(
+        root,
+        onFile: (file) async {
+          final abs = p.normalize(file.absolute.path);
+          if (excludedRoot != null && p.isWithin(excludedRoot, abs)) return;
+          int bytes = 0;
+          DateTime modifiedAt = DateTime.fromMillisecondsSinceEpoch(0);
           try {
-            bytes = await ent.length();
-          } catch (_) {}
-        }
-        out.add(
-          StorageFileEntry(
-            path: ent.path,
-            name: p.basename(ent.path),
-            bytes: bytes,
-            modifiedAt: modifiedAt,
-          ),
-        );
-      }
-    } catch (_) {
-      // Unreadable directory: return partial results instead of failing.
+            final stat = await file.stat();
+            bytes = stat.size;
+            modifiedAt = stat.modified;
+          } catch (_) {
+            try {
+              bytes = await file.length();
+            } catch (_) {}
+          }
+          out.add(
+            StorageFileEntry(
+              path: file.path,
+              name: p.basename(file.path),
+              bytes: bytes,
+              modifiedAt: modifiedAt,
+            ),
+          );
+        },
+      );
+    } catch (e) {
+      debugPrint(
+        'StorageUsageService: failed to list cache dir ${root.path}: $e',
+      );
     }
 
     out.sort((a, b) {
@@ -1015,7 +1060,11 @@ abstract final class StorageUsageService {
           await f.delete();
           deleted += 1;
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint(
+          'StorageUsageService.deleteCacheFiles: failed to delete $raw: $e',
+        );
+      }
     }
     return deleted;
   }

--- a/lib/features/settings/pages/storage_space_page.dart
+++ b/lib/features/settings/pages/storage_space_page.dart
@@ -1469,6 +1469,19 @@ class _CategoryDetail extends StatelessWidget {
   final Future<void> Function() refreshReport;
   final Future<DbCompactResult> Function()? onCompactDb;
 
+  void _openCacheFiles(BuildContext context, StorageUsageSubcategory s) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => _CacheFilesPage(
+          title: subTitleFor(s.id),
+          subcategoryId: s.id,
+          dirPath: s.path!,
+          refreshReport: refreshReport,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -1639,7 +1652,6 @@ class _CategoryDetail extends StatelessWidget {
                   for (final s in category.subcategories)
                     Container(
                       margin: const EdgeInsets.only(bottom: 8),
-                      padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
                       decoration: BoxDecoration(
                         color: cs.onSurface.withValues(alpha: 0.03),
                         borderRadius: BorderRadius.circular(10),
@@ -1647,87 +1659,115 @@ class _CategoryDetail extends StatelessWidget {
                           color: cs.onSurface.withValues(alpha: 0.08),
                         ),
                       ),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  subTitleFor(s.id),
-                                  style: TextStyle(
-                                    fontSize: 13,
-                                    fontWeight: AppFontWeights.semibold,
+                      clipBehavior: Clip.antiAlias,
+                      child: IosCardPress(
+                        onTap:
+                            category.key == StorageUsageCategoryKey.cache &&
+                                s.stats.fileCount > 0 &&
+                                s.path != null &&
+                                s.path!.isNotEmpty
+                            ? () => _openCacheFiles(context, s)
+                            : null,
+                        haptics: false,
+                        pressedScale: 1.0,
+                        borderRadius: BorderRadius.circular(10),
+                        baseColor: Colors.transparent,
+                        padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    subTitleFor(s.id),
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: AppFontWeights.semibold,
+                                    ),
                                   ),
-                                ),
-                                if (subDescFor(s.id) case final desc?
-                                    when desc.isNotEmpty) ...[
+                                  if (subDescFor(s.id) case final desc?
+                                      when desc.isNotEmpty) ...[
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      desc,
+                                      style: TextStyle(
+                                        fontSize: 12,
+                                        color: cs.onSurface.withValues(
+                                          alpha: 0.6,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
                                   const SizedBox(height: 2),
                                   Text(
-                                    desc,
+                                    '${fmtBytes(s.stats.bytes)} · ${l10n.storageSpaceFilesCount(s.stats.fileCount)}',
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: cs.onSurface.withValues(
-                                        alpha: 0.6,
+                                        alpha: 0.65,
                                       ),
                                     ),
                                   ),
-                                ],
-                                const SizedBox(height: 2),
-                                Text(
-                                  '${fmtBytes(s.stats.bytes)} · ${l10n.storageSpaceFilesCount(s.stats.fileCount)}',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: cs.onSurface.withValues(alpha: 0.65),
-                                  ),
-                                ),
-                                if (s.path != null && s.path!.isNotEmpty) ...[
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    s.path!,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: TextStyle(
-                                      fontSize: 11.5,
-                                      color: cs.onSurface.withValues(
-                                        alpha: 0.55,
+                                  if (s.path != null && s.path!.isNotEmpty) ...[
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      s.path!,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: TextStyle(
+                                        fontSize: 11.5,
+                                        color: cs.onSurface.withValues(
+                                          alpha: 0.55,
+                                        ),
                                       ),
                                     ),
-                                  ),
+                                  ],
                                 ],
-                              ],
+                              ),
                             ),
-                          ),
-                          if (category.key == StorageUsageCategoryKey.cache &&
-                              s.id == 'avatar_cache')
-                            _MiniActionButton(
-                              label: l10n.storageSpaceClearButton,
-                              enabled: !clearing,
-                              onTap: () =>
-                                  onClearCache?.call(avatarsOnly: true),
-                            ),
-                          if (category.key == StorageUsageCategoryKey.cache &&
-                              s.id == 'other_cache')
-                            _MiniActionButton(
-                              label: l10n.storageSpaceClearButton,
-                              enabled: !clearing,
-                              onTap: () => onClearOtherCache?.call(),
-                            ),
-                          if (category.key == StorageUsageCategoryKey.cache &&
-                              s.id == 'system_cache')
-                            _MiniActionButton(
-                              label: l10n.storageSpaceClearButton,
-                              enabled: !clearing,
-                              onTap: () => onClearSystemCache?.call(),
-                            ),
-                          if (category.key == StorageUsageCategoryKey.cache &&
-                              s.id == 'tmp_cache')
-                            _MiniActionButton(
-                              label: l10n.storageSpaceClearButton,
-                              enabled: !clearing,
-                              onTap: () => onClearTmpCache?.call(),
-                            ),
-                        ],
+                            if (category.key == StorageUsageCategoryKey.cache &&
+                                s.id == 'avatar_cache')
+                              _MiniActionButton(
+                                label: l10n.storageSpaceClearButton,
+                                enabled: !clearing,
+                                onTap: () =>
+                                    onClearCache?.call(avatarsOnly: true),
+                              ),
+                            if (category.key == StorageUsageCategoryKey.cache &&
+                                s.id == 'other_cache')
+                              _MiniActionButton(
+                                label: l10n.storageSpaceClearButton,
+                                enabled: !clearing,
+                                onTap: () => onClearOtherCache?.call(),
+                              ),
+                            if (category.key == StorageUsageCategoryKey.cache &&
+                                s.id == 'system_cache')
+                              _MiniActionButton(
+                                label: l10n.storageSpaceClearButton,
+                                enabled: !clearing,
+                                onTap: () => onClearSystemCache?.call(),
+                              ),
+                            if (category.key == StorageUsageCategoryKey.cache &&
+                                s.id == 'tmp_cache')
+                              _MiniActionButton(
+                                label: l10n.storageSpaceClearButton,
+                                enabled: !clearing,
+                                onTap: () => onClearTmpCache?.call(),
+                              ),
+                            if (category.key == StorageUsageCategoryKey.cache &&
+                                s.stats.fileCount > 0 &&
+                                s.path != null &&
+                                s.path!.isNotEmpty) ...[
+                              const SizedBox(width: 6),
+                              Icon(
+                                Lucide.ChevronRight,
+                                size: 16,
+                                color: cs.onSurface.withValues(alpha: 0.75),
+                              ),
+                            ],
+                          ],
+                        ),
                       ),
                     ),
                 ],
@@ -2087,53 +2127,6 @@ class _UploadManagerState extends State<_UploadManager> {
     );
   }
 
-  Widget _buildSortSegment(ColorScheme cs) {
-    final border = cs.onSurface.withValues(alpha: 0.12);
-    final l10n = AppLocalizations.of(context)!;
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: border),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _sortCell(
-            label: _bySize
-                ? '${_descending ? '↓' : '↑'} ${l10n.storageSpaceSortBySize}'
-                : l10n.storageSpaceSortBySize,
-            active: _bySize,
-            cs: cs,
-            onTap: () => setState(() {
-              if (_bySize) {
-                _descending = !_descending;
-              } else {
-                _bySize = true;
-                _descending = true;
-              }
-            }),
-          ),
-          Container(width: 1, height: 20, color: border),
-          _sortCell(
-            label: !_bySize
-                ? '${_descending ? '↓' : '↑'} ${l10n.storageSpaceSortByTime}'
-                : l10n.storageSpaceSortByTime,
-            active: !_bySize,
-            cs: cs,
-            onTap: () => setState(() {
-              if (!_bySize) {
-                _descending = !_descending;
-              } else {
-                _bySize = false;
-                _descending = true;
-              }
-            }),
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget _togglePill(
     ColorScheme cs,
     String label,
@@ -2179,7 +2172,26 @@ class _UploadManagerState extends State<_UploadManager> {
       runSpacing: 10,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        _buildSortSegment(cs),
+        _SortControl(
+          bySize: _bySize,
+          descending: _descending,
+          onSortSize: () => setState(() {
+            if (_bySize) {
+              _descending = !_descending;
+            } else {
+              _bySize = true;
+              _descending = true;
+            }
+          }),
+          onSortTime: () => setState(() {
+            if (!_bySize) {
+              _descending = !_descending;
+            } else {
+              _bySize = false;
+              _descending = true;
+            }
+          }),
+        ),
         if (_refs != null && _orphanCount > 0)
           _togglePill(
             cs,
@@ -2367,6 +2379,288 @@ class _UploadManagerState extends State<_UploadManager> {
   }
 }
 
+/// Per-subcategory cache file list (issue #320): users can see exactly which
+/// files are judged as cache and delete selected ones before/without clearing
+/// the whole subcategory. Mirrors the upload list interactions (sort, select,
+/// delete) but for one cache directory.
+class _CacheFilesPage extends StatefulWidget {
+  const _CacheFilesPage({
+    required this.title,
+    required this.subcategoryId,
+    required this.dirPath,
+    required this.refreshReport,
+  });
+
+  final String title;
+  final String subcategoryId;
+  final String dirPath;
+  final Future<void> Function() refreshReport;
+
+  @override
+  State<_CacheFilesPage> createState() => _CacheFilesPageState();
+}
+
+class _CacheFilesPageState extends State<_CacheFilesPage> {
+  bool _loading = false;
+  List<StorageFileEntry> _entries = const <StorageFileEntry>[];
+  final Set<String> _selected = <String>{};
+  bool _bySize = true;
+  bool _descending = true;
+
+  bool get _selectMode => _selected.isNotEmpty;
+
+  List<StorageFileEntry> get _displayEntries {
+    final list = _entries.toList();
+    final cmp = _bySize
+        ? ((a, b) => a.bytes.compareTo(b.bytes))
+        : ((a, b) => a.modifiedAt.compareTo(b.modifiedAt));
+    list.sort((a, b) {
+      final r = cmp(a, b);
+      if (r != 0) return _descending ? -r : r;
+      return a.name.compareTo(b.name); // tie-break
+    });
+    return list;
+  }
+
+  /// Parent directory of [entry] relative to the subcategory root, so nested
+  /// cache content (e.g. request-log-analysis/*.json) is distinguishable.
+  /// Empty for files directly in the root.
+  String _relativePathFor(StorageFileEntry entry) {
+    final root = p.normalize(p.absolute(widget.dirPath));
+    final parent = p.normalize(p.absolute(p.dirname(entry.path)));
+    if (p.equals(root, parent)) return '';
+    return p.relative(parent, from: root);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    if (_loading) return;
+    setState(() => _loading = true);
+    try {
+      final list = await StorageUsageService.listCacheEntries(
+        subcategoryId: widget.subcategoryId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _entries = list;
+        final paths = _entries.map((e) => e.path).toSet();
+        _selected.removeWhere((p) => !paths.contains(p));
+      });
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  void _toggleSelect(String path) {
+    setState(() {
+      if (_selected.contains(path)) {
+        _selected.remove(path);
+      } else {
+        _selected.add(path);
+      }
+    });
+  }
+
+  void _selectAll() {
+    setState(() {
+      _selected
+        ..clear()
+        ..addAll(_displayEntries.map((e) => e.path));
+    });
+  }
+
+  void _clearSelection() {
+    setState(() => _selected.clear());
+  }
+
+  Future<void> _deleteSelected() async {
+    if (_selected.isEmpty) return;
+    final l10n = AppLocalizations.of(context)!;
+    final count = _selected.length;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) {
+        return AlertDialog(
+          title: Text(l10n.storageSpaceDeleteConfirmTitle),
+          content: Text(l10n.storageSpaceDeleteSimpleConfirm(count)),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text(l10n.homePageCancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: Text(l10n.homePageDelete),
+            ),
+          ],
+        );
+      },
+    );
+    if (ok != true) return;
+
+    final deleted = await StorageUsageService.deleteCacheFiles(
+      _selected,
+      subcategoryId: widget.subcategoryId,
+    );
+    if (!mounted) return;
+
+    _clearSelection();
+    showAppSnackBar(
+      context,
+      message: l10n.storageSpaceDeletedCacheFilesDone(deleted),
+      type: NotificationType.success,
+    );
+    await _load();
+    await widget.refreshReport();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final display = _displayEntries;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: Tooltip(
+          message: l10n.settingsPageBackButton,
+          child: _TactileIconButton(
+            icon: Lucide.ArrowLeft,
+            color: cs.onSurface,
+            size: 22,
+            onTap: () => Navigator.of(context).maybePop(),
+          ),
+        ),
+        title: Text(widget.title),
+        actions: [
+          IosIconButton(
+            icon: Lucide.RefreshCw,
+            size: 20,
+            minSize: 44,
+            enabled: !_loading,
+            onTap: _loading ? null : _load,
+            semanticLabel: l10n.storageSpaceRefreshTooltip,
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.dirPath,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 12,
+                color: cs.onSurface.withValues(alpha: 0.55),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _SortControl(
+                  bySize: _bySize,
+                  descending: _descending,
+                  onSortSize: () => setState(() {
+                    if (_bySize) {
+                      _descending = !_descending;
+                    } else {
+                      _bySize = true;
+                      _descending = true;
+                    }
+                  }),
+                  onSortTime: () => setState(() {
+                    if (!_bySize) {
+                      _descending = !_descending;
+                    } else {
+                      _bySize = false;
+                      _descending = true;
+                    }
+                  }),
+                ),
+                IosTileButton(
+                  label: _selectMode
+                      ? l10n.storageSpaceClearSelection
+                      : l10n.storageSpaceSelectAll,
+                  icon: _selectMode ? Lucide.XCircle : Lucide.CheckSquare,
+                  backgroundColor: cs.primary,
+                  onTap: _selectMode ? _clearSelection : _selectAll,
+                ),
+                IosTileButton(
+                  label: l10n.homePageDelete,
+                  icon: Lucide.Trash2,
+                  backgroundColor: cs.error,
+                  enabled: _selected.isNotEmpty,
+                  onTap: _deleteSelected,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              _selectMode
+                  ? l10n.storageSpaceSelectedCount(_selected.length)
+                  : l10n.storageSpaceFilesCount(display.length),
+              style: TextStyle(
+                fontSize: 12.5,
+                color: cs.onSurface.withValues(alpha: 0.65),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: _loading && _entries.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : _entries.isEmpty
+                  ? Center(
+                      child: Text(
+                        l10n.storageSpaceNoCacheFiles,
+                        style: TextStyle(
+                          color: cs.onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    )
+                  : ListView.builder(
+                      padding: EdgeInsets.zero,
+                      itemCount: display.length,
+                      itemBuilder: (context, index) {
+                        final e = display[index];
+                        final selected = _selected.contains(e.path);
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: _FileRow(
+                            entry: e,
+                            selected: selected,
+                            icon: Lucide.FileText,
+                            relativePath: _relativePathFor(e),
+                            fmtBytes: formatBytes,
+                            onTap: () {
+                              if (_selectMode) {
+                                _toggleSelect(e.path);
+                              }
+                            },
+                            onLongPress: () => _toggleSelect(e.path),
+                            onToggle: () => _toggleSelect(e.path),
+                          ),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 Widget _sortCell({
   required String label,
   required bool active,
@@ -2388,6 +2682,55 @@ Widget _sortCell({
       ),
     ),
   );
+}
+
+class _SortControl extends StatelessWidget {
+  const _SortControl({
+    required this.bySize,
+    required this.descending,
+    required this.onSortSize,
+    required this.onSortTime,
+  });
+
+  final bool bySize;
+  final bool descending;
+  final VoidCallback onSortSize;
+  final VoidCallback onSortTime;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final border = cs.onSurface.withValues(alpha: 0.12);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _sortCell(
+            label: bySize
+                ? '${descending ? '↓' : '↑'} ${l10n.storageSpaceSortBySize}'
+                : l10n.storageSpaceSortBySize,
+            active: bySize,
+            cs: cs,
+            onTap: onSortSize,
+          ),
+          Container(width: 1, height: 20, color: border),
+          _sortCell(
+            label: !bySize
+                ? '${descending ? '↓' : '↑'} ${l10n.storageSpaceSortByTime}'
+                : l10n.storageSpaceSortByTime,
+            active: !bySize,
+            cs: cs,
+            onTap: onSortTime,
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _ImageTile extends StatelessWidget {
@@ -2565,6 +2908,8 @@ class _FileRow extends StatelessWidget {
     required this.fmtBytes,
     this.refCount,
     this.isAiGenerated = false,
+    this.icon,
+    this.relativePath,
     required this.onTap,
     required this.onLongPress,
     required this.onToggle,
@@ -2576,6 +2921,8 @@ class _FileRow extends StatelessWidget {
   final String Function(int) fmtBytes;
   final int? refCount;
   final bool isAiGenerated;
+  final IconData? icon;
+  final String? relativePath;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
   final VoidCallback onToggle;
@@ -2615,7 +2962,7 @@ class _FileRow extends StatelessWidget {
             ),
             const SizedBox(width: 10),
             Icon(
-              Lucide.Paperclip,
+              icon ?? Lucide.Paperclip,
               size: 18,
               color: cs.onSurface.withValues(alpha: 0.82),
             ),
@@ -2634,6 +2981,18 @@ class _FileRow extends StatelessWidget {
                       color: cs.onSurface.withValues(alpha: 0.88),
                     ),
                   ),
+                  if (relativePath != null && relativePath!.isNotEmpty) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      relativePath!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 11.5,
+                        color: cs.onSurface.withValues(alpha: 0.55),
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 2),
                   Text(
                     '${fmtBytes(entry.bytes)} · ${_fmtTime(entry.modifiedAt)}',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -189,6 +189,8 @@
   },
   "storageSpaceSortBySize": "By size",
   "storageSpaceSortByTime": "By date",
+  "storageSpaceNoCacheFiles": "No cache files",
+  "storageSpaceDeletedCacheFilesDone": "Deleted {count} cache files",
   "storageWorkspaceEntryTitle": "Workspace",
   "storageMountsTitle": "Filesystem Mounts",
   "storageMountsAddButton": "Add mount",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -723,6 +723,18 @@ abstract class AppLocalizations {
   /// **'By date'**
   String get storageSpaceSortByTime;
 
+  /// No description provided for @storageSpaceNoCacheFiles.
+  ///
+  /// In en, this message translates to:
+  /// **'No cache files'**
+  String get storageSpaceNoCacheFiles;
+
+  /// No description provided for @storageSpaceDeletedCacheFilesDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Deleted {count} cache files'**
+  String storageSpaceDeletedCacheFilesDone(Object count);
+
   /// No description provided for @storageWorkspaceEntryTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -366,6 +366,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get storageSpaceSortByTime => 'By date';
 
   @override
+  String get storageSpaceNoCacheFiles => 'No cache files';
+
+  @override
+  String storageSpaceDeletedCacheFilesDone(Object count) {
+    return 'Deleted $count cache files';
+  }
+
+  @override
   String get storageWorkspaceEntryTitle => 'Workspace';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -355,6 +355,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get storageSpaceSortByTime => '按时间';
 
   @override
+  String get storageSpaceNoCacheFiles => '暂无缓存文件';
+
+  @override
+  String storageSpaceDeletedCacheFilesDone(Object count) {
+    return '已删除 $count 个缓存文件';
+  }
+
+  @override
   String get storageWorkspaceEntryTitle => '工作区';
 
   @override
@@ -9524,6 +9532,14 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get storageSpaceSortByTime => '按时间';
+
+  @override
+  String get storageSpaceNoCacheFiles => '暂无缓存文件';
+
+  @override
+  String storageSpaceDeletedCacheFilesDone(Object count) {
+    return '已删除 $count 个缓存文件';
+  }
 
   @override
   String get storageWorkspaceEntryTitle => '工作区';
@@ -18696,6 +18712,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get storageSpaceSortByTime => '按時間';
+
+  @override
+  String get storageSpaceNoCacheFiles => '暫無快取檔案';
+
+  @override
+  String storageSpaceDeletedCacheFilesDone(Object count) {
+    return '已刪除 $count 個快取檔案';
+  }
 
   @override
   String get storageWorkspaceEntryTitle => '工作區';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -102,6 +102,8 @@
   "storageSpaceUploadsCount": "共 {count} 项",
   "storageSpaceSortBySize": "按大小",
   "storageSpaceSortByTime": "按时间",
+  "storageSpaceNoCacheFiles": "暂无缓存文件",
+  "storageSpaceDeletedCacheFilesDone": "已删除 {count} 个缓存文件",
   "storageWorkspaceEntryTitle": "工作区",
   "storageMountsTitle": "文件系统挂载",
   "storageMountsAddButton": "添加挂载",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -102,6 +102,8 @@
   "storageSpaceUploadsCount": "共 {count} 项",
   "storageSpaceSortBySize": "按大小",
   "storageSpaceSortByTime": "按时间",
+  "storageSpaceNoCacheFiles": "暂无缓存文件",
+  "storageSpaceDeletedCacheFilesDone": "已删除 {count} 个缓存文件",
   "storageWorkspaceEntryTitle": "工作区",
   "storageMountsTitle": "文件系统挂载",
   "storageMountsAddButton": "添加挂载",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -102,6 +102,8 @@
   "storageSpaceUploadsCount": "共 {count} 項",
   "storageSpaceSortBySize": "按大小",
   "storageSpaceSortByTime": "按時間",
+  "storageSpaceNoCacheFiles": "暫無快取檔案",
+  "storageSpaceDeletedCacheFilesDone": "已刪除 {count} 個快取檔案",
   "storageWorkspaceEntryTitle": "工作區",
   "storageMountsTitle": "檔案系統掛載",
   "storageMountsAddButton": "新增掛載",

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -509,6 +509,41 @@ void main() {
         : false,
   );
 
+  test(
+    'listCacheEntries keeps listing files after an unreadable subdirectory',
+    () async {
+      final cacheDir = Directory(p.join(appDataDir.path, 'cache'));
+      final blocked = Directory(p.join(cacheDir.path, 'a_blocked'));
+      await Directory(p.join(blocked.path, 'inner')).create(recursive: true);
+      await _writeSizedFile(
+        Directory(p.join(blocked.path, 'inner')),
+        'hidden.bin',
+        10,
+      );
+      final readable = Directory(p.join(cacheDir.path, 'z_readable'));
+      await readable.create(recursive: true);
+      await _writeSizedFile(readable, 'icon.png', 5);
+      final chmod = await Process.run('chmod', ['000', blocked.path]);
+      expect(chmod.exitCode, 0);
+      addTearDown(() async {
+        final restore = await Process.run('chmod', ['700', blocked.path]);
+        expect(restore.exitCode, 0);
+      });
+
+      final entries = await StorageUsageService.listCacheEntries(
+        subcategoryId: 'other_cache',
+      );
+
+      // Files inside the unreadable dir are inaccessible, but the readable
+      // sibling after it must still be returned instead of being dropped by
+      // a terminated recursive stream.
+      expect(entries.map((e) => e.name), ['icon.png']);
+    },
+    skip: Platform.isWindows
+        ? 'chmod cannot revoke permissions on Windows; covered on POSIX CI'
+        : false,
+  );
+
   test('listCacheEntries splits avatar and other cache boundaries', () async {
     final cacheDir = Directory(p.join(appDataDir.path, 'cache'));
     await Directory(p.join(cacheDir.path, 'avatars')).create(recursive: true);

--- a/test/core/services/storage/storage_usage_service_test.dart
+++ b/test/core/services/storage/storage_usage_service_test.dart
@@ -509,6 +509,138 @@ void main() {
         : false,
   );
 
+  test('listCacheEntries splits avatar and other cache boundaries', () async {
+    final cacheDir = Directory(p.join(appDataDir.path, 'cache'));
+    await Directory(p.join(cacheDir.path, 'avatars')).create(recursive: true);
+    await Directory(
+      p.join(cacheDir.path, 'request-log-analysis'),
+    ).create(recursive: true);
+    await _writeSizedFile(
+      Directory(p.join(cacheDir.path, 'avatars')),
+      'av_1.png',
+      10,
+    );
+    await _writeSizedFile(cacheDir, 'proactive_icon_1.png', 5);
+    await _writeSizedFile(
+      Directory(p.join(cacheDir.path, 'request-log-analysis')),
+      'draft.json',
+      7,
+    );
+
+    final avatars = await StorageUsageService.listCacheEntries(
+      subcategoryId: 'avatar_cache',
+    );
+    expect(avatars.map((e) => e.name), ['av_1.png']);
+    expect(avatars.single.bytes, 10);
+
+    final other = await StorageUsageService.listCacheEntries(
+      subcategoryId: 'other_cache',
+    );
+    expect(
+      other.map((e) => e.name),
+      containsAll(['proactive_icon_1.png', 'draft.json']),
+    );
+    expect(other.where((e) => e.name == 'av_1.png'), isEmpty);
+    expect(other.length, 2);
+  });
+
+  test(
+    'deleteCacheFiles validates paths against the subcategory root',
+    () async {
+      final cacheDir = Directory(p.join(appDataDir.path, 'cache'));
+      await Directory(p.join(cacheDir.path, 'avatars')).create(recursive: true);
+      await Directory(
+        p.join(cacheDir.path, 'request-log-analysis'),
+      ).create(recursive: true);
+      await _writeSizedFile(
+        Directory(p.join(cacheDir.path, 'avatars')),
+        'av_1.png',
+        10,
+      );
+      await _writeSizedFile(
+        Directory(p.join(cacheDir.path, 'request-log-analysis')),
+        'draft.json',
+        7,
+      );
+      await _writeSizedFile(appDataDir, 'notes.txt', 50);
+
+      final avatarPath = p.join(cacheDir.path, 'avatars', 'av_1.png');
+      final draftPath = p.join(
+        cacheDir.path,
+        'request-log-analysis',
+        'draft.json',
+      );
+      final notesPath = p.join(appDataDir.path, 'notes.txt');
+
+      // Avatar files must be refused by other_cache.
+      expect(
+        await StorageUsageService.deleteCacheFiles([
+          avatarPath,
+        ], subcategoryId: 'other_cache'),
+        0,
+      );
+      expect(File(avatarPath).existsSync(), isTrue);
+
+      // Paths outside the app cache roots must be refused.
+      expect(
+        await StorageUsageService.deleteCacheFiles([
+          notesPath,
+        ], subcategoryId: 'avatar_cache'),
+        0,
+      );
+      expect(File(notesPath).existsSync(), isTrue);
+
+      // In-root deletions return the count of actually deleted files.
+      expect(
+        await StorageUsageService.deleteCacheFiles([
+          draftPath,
+          notesPath,
+        ], subcategoryId: 'other_cache'),
+        1,
+      );
+      expect(File(draftPath).existsSync(), isFalse);
+      expect(File(notesPath).existsSync(), isTrue);
+    },
+  );
+
+  test('listCacheEntries lists the system cache directory', () async {
+    final sysCache = Directory(p.join(tempDir.path, 'cache'));
+    await sysCache.create(recursive: true);
+    await _writeSizedFile(sysCache, 'decoded.bin', 30);
+
+    final entries = await StorageUsageService.listCacheEntries(
+      subcategoryId: 'system_cache',
+    );
+
+    expect(entries.single.name, 'decoded.bin');
+    expect(entries.single.bytes, 30);
+  });
+
+  test('listCacheEntries and deleteCacheFiles are no-ops for unavailable '
+      'categories', () async {
+    // No iOS tmp channel (equivalent to non-iOS).
+    expect(
+      await StorageUsageService.listCacheEntries(subcategoryId: 'tmp_cache'),
+      isEmpty,
+    );
+    expect(
+      await StorageUsageService.deleteCacheFiles([
+        'x',
+      ], subcategoryId: 'tmp_cache'),
+      0,
+    );
+    expect(
+      await StorageUsageService.listCacheEntries(subcategoryId: 'unknown_id'),
+      isEmpty,
+    );
+    expect(
+      await StorageUsageService.deleteCacheFiles([
+        'x',
+      ], subcategoryId: 'unknown_id'),
+      0,
+    );
+  });
+
   test(
     'relocated workspaces root inside app data keeps its category split',
     () async {


### PR DESCRIPTION
## Summary

Closes #320 — 现在可以在存储页直接查看被判定为缓存的**具体文件**，并支持勾选删除。

**Storage → 缓存** 的每个子类（头像缓存 / 其他缓存 / 系统缓存 / 临时文件）明细行现在可点击（带 chevron），打开对应目录的文件列表页：显示每个文件（含嵌套相对路径）、大小、修改时间，支持按大小/时间排序、全选/多选删除，删除后自动刷新统计。原有的整类 "Clear" 按钮保持不动。

## What changed

- `StorageUsageService.listCacheEntries({subcategoryId})` — 枚举每个缓存子类实际会删除的文件（与 `clearCache`/`clearOtherCache`/`clearSystemCache`/`clearTmpCache` 的边界严格一致：`other_cache` 排除 `cache/avatars`），按大小降序，未读条目跳过不抛错。
- `StorageUsageService.deleteCacheFiles(paths, {subcategoryId})` — 逐路径校验根目录（拒绝越界路径；`other_cache` 拒绝 avatars 内的路径），返回实际删除数。
- `_CategoryDetail`：缓存子类行包上 `IosCardPress`，点击进 `_CacheFilesPage`；空目录行不可点。
- 新增 `_CacheFilesPage`：排序片段（抽成共享 `_SortControl`，Upload 列表复用）、全选/删除按钮、`_FileRow` 列表（扩展可选 `icon`/`relativePath` 参数）。
- l10n：`storageSpaceNoCacheFiles`、`storageSpaceDeletedCacheFilesDone(count)`（4 个 ARB + 生成文件）。

## Tests

`dart analyze --fatal-infos lib test` ✅ no issues
`flutter test test/core/services/storage/storage_usage_service_test.dart` ✅ 20 passed, 1 skipped (POSIX-only chmod case, pre-existing)

## Manual test plan

1. Windows/Linux/Android: 设置 → 存储空间 → 缓存 → 点击任一子类行 → 文件列表出现（排序片段、路径、大小/时间）。
2. 勾选若干文件删除 → 确认弹窗 → snackbar 显示删除计数 → 列表与统计刷新。
3. 其他缓存列表不得包含 `cache/avatars` 中的文件；头像缓存列表只含 `cache/avatars` 文件。
4. 临时文件子类仅 iOS 出现（非 iOS 由 `computeReport` 条件隐藏，列表入口随行消失）。

Manual app run was not performed locally (no device run); desktop/mobile UI verified through shared code paths + compile-time analysis. iOS tmp path behavior covered by existing channel-mocked service tests.
