### PR TITLE
fix(tts): exclude markdown code from text selection (issue #648)

### DIFF
--- a/lib/core/providers/tts_provider.dart
+++ b/lib/core/providers/tts_provider.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:Cuplivo/core/database/business_preferences.dart';
 
+import '../../utils/markdown_code_scanner.dart';
 import '../../utils/utf16_safe_cut.dart';
 import '../services/network/logging_http_client.dart';
 import '../services/tts/network_tts.dart';
@@ -1032,9 +1033,7 @@ class TtsProvider extends ChangeNotifier {
   }
 
   static String _stripMarkdown(String input) {
-    var s = input;
-    s = s.replaceAll(RegExp(r'```[\s\S]*?```', multiLine: true), ' ');
-    s = s.replaceAll(RegExp(r'`[^`]*`'), ' ');
+    var s = markdownRemoveCode(input);
     s = s.replaceAllMapped(
       RegExp(r'\[([^\]]+)\]\([^\)]+\)'),
       (m) => m.group(1) ?? '',

--- a/lib/core/services/tts/tts_text_selection.dart
+++ b/lib/core/services/tts/tts_text_selection.dart
@@ -1,3 +1,5 @@
+import '../../../utils/markdown_code_scanner.dart';
+
 enum TtsTextSelectionMode {
   fullText,
   quotedOnly,
@@ -27,17 +29,21 @@ class TtsTextSelection {
   }) {
     final original = input.trim();
     if (original.isEmpty) return '';
+    final source = mode == TtsTextSelectionMode.fullText
+        ? original
+        : markdownRemoveCode(original).trim();
+    if (source.isEmpty) return '';
 
     final selected = switch (mode) {
-      TtsTextSelectionMode.fullText => original,
-      TtsTextSelectionMode.quotedOnly => _quotedText(original),
-      TtsTextSelectionMode.outsideParentheses => _outsideParentheses(original),
-      TtsTextSelectionMode.italicOnly => _italicText(original),
-      TtsTextSelectionMode.nonItalic => _nonItalicText(original),
+      TtsTextSelectionMode.fullText => source,
+      TtsTextSelectionMode.quotedOnly => _quotedText(source),
+      TtsTextSelectionMode.outsideParentheses => _outsideParentheses(source),
+      TtsTextSelectionMode.italicOnly => _italicText(source),
+      TtsTextSelectionMode.nonItalic => _nonItalicText(source),
     };
     final normalized = _normalizeSelectedText(selected);
     if (normalized.isNotEmpty || !fallbackToOriginal) return normalized;
-    return original;
+    return source;
   }
 
   static String _quotedText(String input) {

--- a/lib/utils/markdown_code_scanner.dart
+++ b/lib/utils/markdown_code_scanner.dart
@@ -7,6 +7,8 @@
 /// - the display-math scanner in `widgets/markdown_line_lexer.dart` (
 ///   keep their own state machines; only the rules are shared)
 /// - the chat API image extractor in `services/api/chat_api_service.dart`
+/// - the TTS code removal in `services/tts/tts_text_selection.dart` and
+///   `providers/tts_provider.dart` ([markdownRemoveCode])
 ///
 /// Core rules (CommonMark except where noted):
 /// - A fence opens on a complete line holding a run of >= 3 backticks or
@@ -502,6 +504,28 @@ MarkdownCodeScanResult markdownCodeScan(String text) {
   }
 
   return MarkdownCodeScanResult(segments);
+}
+
+/// Returns [text] with every code region replaced by a single space,
+/// preserving the surrounding line structure.
+///
+/// Fence segments span opener-line start to closer-line end, so the line
+/// breaks before the opener and after the closer stay intact and adjacent
+/// lines are never joined. Inline spans are paired per line, so unmatched
+/// backtick runs never swallow prose.
+String markdownRemoveCode(String text) {
+  final segments = markdownCodeScan(text).segments;
+  if (segments.isEmpty) return text;
+  final buffer = StringBuffer();
+  var cursor = 0;
+  for (final segment in segments) {
+    buffer
+      ..write(text.substring(cursor, segment.start))
+      ..write(' ');
+    cursor = segment.end;
+  }
+  buffer.write(text.substring(cursor));
+  return buffer.toString();
 }
 
 String _interiorLine(String line, MarkdownCodeFenceContext context) {

--- a/test/core/providers/tts_provider_test.dart
+++ b/test/core/providers/tts_provider_test.dart
@@ -160,6 +160,30 @@ void main() {
     },
   );
 
+  test('system TTS strips supported Markdown code ranges', () async {
+    final provider = TtsProvider(preferences: businessPrefs);
+    addTearDown(provider.dispose);
+
+    await _waitUntil(() => provider.isAvailable);
+
+    unawaited(
+      provider.speakSystem(
+        '保留\n'
+        '``print("行内代码")``\n'
+        '~~~dart\n'
+        'print("波浪线围栏");\n'
+        '~~~\n'
+        '```dart\n'
+        'print("未闭合围栏");',
+      ),
+    );
+    await _waitUntil(
+      () => provider.playbackState.status == TtsPlaybackStatus.playing,
+    );
+
+    expect(spokenTexts.last, '保留');
+  });
+
   test(
     'int-stored rate/pitch from migrated backups are read as double',
     () async {

--- a/test/core/services/tts/tts_text_selection_test.dart
+++ b/test/core/services/tts/tts_text_selection_test.dart
@@ -36,6 +36,56 @@ void main() {
       },
     );
 
+    test('ignores quoted text inside fenced and inline code', () {
+      expect(
+        TtsTextSelection.apply(
+          '旁白 “保留”\n'
+          '```dart\n'
+          'print("代码块");\n'
+          '```\n'
+          '以及 `print("行内代码")`。',
+          mode: TtsTextSelectionMode.quotedOnly,
+        ),
+        '保留',
+      );
+    });
+
+    test('ignores quoted text inside all supported fence forms', () {
+      for (final source in const [
+        '旁白 “保留”\n~~~dart\nprint("波浪线");\n~~~',
+        '旁白 “保留”\n````markdown\n```\nprint("变长围栏");\n````',
+        '旁白 “保留”\n```dart\n``` not-a-closer\nprint("伪关闭");\n```',
+        '旁白 “保留”\n> ```dart\n> print("引用围栏");\n> ```',
+        '旁白 “保留”\n```dart\nprint("未闭合");',
+      ]) {
+        expect(
+          TtsTextSelection.apply(source, mode: TtsTextSelectionMode.quotedOnly),
+          '保留',
+          reason: source,
+        );
+      }
+    });
+
+    test('ignores quoted text inside multi-backtick inline code', () {
+      expect(
+        TtsTextSelection.apply(
+          '旁白 “保留”以及 ``print("行内代码")``。',
+          mode: TtsTextSelectionMode.quotedOnly,
+        ),
+        '保留',
+      );
+    });
+
+    test('does not pair unmatched backticks across lines', () {
+      expect(
+        TtsTextSelection.apply(
+          '`第一行\n旁白 “应朗读”\n第三行`',
+          mode: TtsTextSelectionMode.quotedOnly,
+        ),
+        '应朗读',
+      );
+    });
+
     test('does not close an unmatched quote with an apostrophe in a word', () {
       expect(
         TtsTextSelection.apply(
@@ -76,6 +126,20 @@ void main() {
       );
     });
 
+    test('ignores italic text inside fenced and inline code', () {
+      expect(
+        TtsTextSelection.apply(
+          '旁白 *保留*\n'
+          '```dart\n'
+          'final value = "*代码块*";\n'
+          '```\n'
+          '以及 `_行内代码_`。',
+          mode: TtsTextSelectionMode.italicOnly,
+        ),
+        '保留',
+      );
+    });
+
     test('falls back to original text when selected content is empty', () {
       expect(
         TtsTextSelection.apply(
@@ -83,6 +147,19 @@ void main() {
           mode: TtsTextSelectionMode.quotedOnly,
         ),
         '没有引号的内容',
+      );
+    });
+
+    test('fallback excludes code when no selected content remains', () {
+      expect(
+        TtsTextSelection.apply(
+          '普通旁白\n'
+          '```dart\n'
+          'print("不应朗读");\n'
+          '```',
+          mode: TtsTextSelectionMode.quotedOnly,
+        ),
+        '普通旁白',
       );
     });
   });

--- a/test/utils/markdown_code_scanner_test.dart
+++ b/test/utils/markdown_code_scanner_test.dart
@@ -253,4 +253,35 @@ void main() {
       }
     });
   });
+
+  group('markdownRemoveCode', () {
+    test('returns text unchanged when no code is present', () {
+      final input = '旁白 “保留” 以及普通段落。';
+      expect(markdownRemoveCode(input), input);
+    });
+
+    test('replaces inline code with a space', () {
+      expect(markdownRemoveCode('旁白 `print("hi")` 结尾'), '旁白   结尾');
+    });
+
+    test('preserves the line structure around a fenced block', () {
+      expect(
+        markdownRemoveCode('保留\n```dart\nprint(x);\n```\n结束'),
+        '保留\n \n结束',
+      );
+    });
+
+    test('removes fences in blockquotes and unclosed fences', () {
+      expect(markdownRemoveCode('> ```\n> code\n> ```\nafter'), ' \nafter');
+      expect(markdownRemoveCode('x\n```dart\nprint(1);'), 'x\n ');
+    });
+
+    test('removes spans and fences in source order', () {
+      expect(markdownRemoveCode('`a`\n```b\nc\n```\n`d`'), ' \n \n ');
+    });
+
+    test('unmatched backtick runs across lines keep the prose', () {
+      expect(markdownRemoveCode('`第一行\n旁白\n第三行`'), '`第一行\n旁白\n第三行`');
+    });
+  });
 }


### PR DESCRIPTION
Fixes #648

## Problem

TTS text selection ran filters directly on raw Markdown, so quotes/italic markers inside code were picked up; the empty-result fallback returned the full raw text; and `TtsProvider._stripMarkdown` used two naive regexes (triple-backtick fences, single-backtick spans) that missed tilde fences, multi-backtick fences, unclosed fences, container-prefixed fences, and multi-backtick inline code.

## Solution

Rebuild the removal on the existing single source of truth — `lib/utils/markdown_code_scanner.dart` — instead of porting upstream's hand-rolled line lexer loop, so TTS always removes exactly what the renderer shows as code:

- **`markdownRemoveCode()`** (`lib/utils/markdown_code_scanner.dart`): slices out every `markdownCodeScan` segment (inline spans + fenced blocks, incl. tilde/`````` /blockquote/list/`}`-closer/unclosed forms) and replaces it with a single space, preserving surrounding line breaks so adjacent lines never merge.
- **`TtsTextSelection.apply`**: non-`fullText` modes strip code before filtering; empty-result fallback returns the code-stripped text, never raw Markdown; code-only inputs return `''`.
- **`TtsProvider._stripMarkdown`**: the two code regexes are replaced by `markdownRemoveCode`, unifying final cleanup with selection-time rules.

`fullText` selection semantics are unchanged; the final cleanup still removes code for TTS.

## Tests

- Ported upstream [Kelivo a64400e](https://github.com/Chevey339/kelivo/commit/a64400ecf5f006ce7b61c01bcc9c32275e31a027) regression tests into `test/core/services/tts/tts_text_selection_test.dart` (fenced/inline quoted, all fence forms, multi-backtick inline, unmatched cross-line backticks, italic in code, fallback)
- New system-TTS strip test in `test/core/providers/tts_provider_test.dart`
- New `markdownRemoveCode` group in `test/utils/markdown_code_scanner_test.dart`

## Verification

- `flutter test test/utils/markdown_code_scanner_test.dart test/core/services/tts/tts_text_selection_test.dart test/core/providers/tts_provider_test.dart` — all pass (56)
- `flutter test test/shared/widgets/markdown_line_lexer_test.dart` — 66 pass (guard, lexer untouched)
- `dart analyze --fatal-infos lib test` — no issues

## Not covered

- Full `flutter test` run locally (CI validates the complete suite); no mobile/desktop platform-specific verification needed (logic-only change, no platform files touched)
