### PR TITLE
feat(android): request high refresh rate on supported devices (issue #647)

### DIFF
--- a/android/app/src/main/kotlin/com/cup11/cuplivo/HighRefreshRateSelector.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/HighRefreshRateSelector.kt
@@ -1,0 +1,24 @@
+package com.cup11.cuplivo
+
+/** Resolution-qualified display mode snapshot used by [HighRefreshRateSelector]. */
+data class SupportedDisplayMode(
+  val physicalWidth: Int,
+  val physicalHeight: Int,
+  val refreshRate: Float,
+)
+
+/**
+ * Picks the highest refresh rate among supported modes that share the active
+ * mode's physical resolution. Returns null when no mode matches. Pure logic:
+ * no Android framework types, so it is JVM-unit-testable.
+ */
+object HighRefreshRateSelector {
+  fun select(
+    activeWidth: Int,
+    activeHeight: Int,
+    modes: List<SupportedDisplayMode>,
+  ): Float? = modes
+    .asSequence()
+    .filter { it.physicalWidth == activeWidth && it.physicalHeight == activeHeight }
+    .maxOfOrNull { it.refreshRate }
+}

--- a/android/app/src/main/kotlin/com/cup11/cuplivo/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/MainActivity.kt
@@ -4,8 +4,13 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.net.Uri
 import android.content.Intent
+import android.os.Build
+import android.util.Log
 import android.view.KeyEvent
+import android.view.Surface
+import android.view.SurfaceHolder
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterSurfaceView
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
@@ -14,18 +19,45 @@ import java.io.FileInputStream
 class MainActivity : FlutterActivity() {
     private companion object {
         const val CREATE_DOCUMENT_REQUEST_CODE = 4107
+        const val TAG = "MainActivity"
     }
 
     private val processTextChannelName = "app.process_text"
     private val fileSaveChannelName = "app.file_save"
+    private val displayModeChannelName = "app.display_mode"
     private var processTextChannel: MethodChannel? = null
     private var fileSaveChannel: MethodChannel? = null
+    private var displayModeChannel: MethodChannel? = null
+    private var flutterSurfaceView: FlutterSurfaceView? = null
     private var pendingProcessText: String? = null
     private var pendingSaveResult: MethodChannel.Result? = null
     private var pendingSaveSourcePath: String? = null
     var volumeCtrlPlugin: LinuxSandboxPlugin? = null
     private var deviceLocalToolsHandler: DeviceLocalToolsHandler? = null
     private var webChatPdfHandler: AndroidWebChatPdfHandler? = null
+
+    override fun onFlutterSurfaceViewCreated(flutterSurfaceView: FlutterSurfaceView) {
+        super.onFlutterSurfaceViewCreated(flutterSurfaceView)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            this.flutterSurfaceView = flutterSurfaceView
+            flutterSurfaceView.holder.addCallback(object : SurfaceHolder.Callback {
+                override fun surfaceCreated(holder: SurfaceHolder) {
+                    requestNativeHighRefreshRate()
+                }
+
+                override fun surfaceChanged(
+                    holder: SurfaceHolder,
+                    format: Int,
+                    width: Int,
+                    height: Int,
+                ) {
+                    requestNativeHighRefreshRate()
+                }
+
+                override fun surfaceDestroyed(holder: SurfaceHolder) = Unit
+            })
+        }
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -59,7 +91,54 @@ class MainActivity : FlutterActivity() {
                 else -> result.notImplemented()
             }
         }
+        displayModeChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, displayModeChannelName)
+        displayModeChannel?.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "requestHighRefreshRate" -> result.success(requestNativeHighRefreshRate())
+                else -> result.notImplemented()
+            }
+        }
         pendingProcessText = extractProcessText(intent)
+    }
+
+    /**
+     * Requests the highest refresh rate available at the current resolution by
+     * hinting the Flutter rendering surface. Mode selection, adaptive refresh,
+     * and system power limits stay with Android; only seamless switches are
+     * requested. Returns false when the native path is unavailable (SDK < 35)
+     * so the Dart side falls back to the legacy display-mode plugin.
+     */
+    private fun requestNativeHighRefreshRate(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) return false
+
+        try {
+            val surface = flutterSurfaceView?.holder?.surface
+            if (surface?.isValid == true) {
+                val currentDisplay = display ?: return true
+                val activeMode = currentDisplay.mode
+                val targetRefreshRate = HighRefreshRateSelector.select(
+                    activeMode.physicalWidth,
+                    activeMode.physicalHeight,
+                    currentDisplay.supportedModes.map { mode ->
+                        SupportedDisplayMode(
+                            mode.physicalWidth,
+                            mode.physicalHeight,
+                            mode.refreshRate,
+                        )
+                    },
+                )
+                if (targetRefreshRate != null) {
+                    surface.setFrameRate(
+                        targetRefreshRate,
+                        Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+                        Surface.CHANGE_FRAME_RATE_ONLY_IF_SEAMLESS,
+                    )
+                }
+            }
+        } catch (error: RuntimeException) {
+            Log.w(TAG, "Unable to request a high refresh rate", error)
+        }
+        return true
     }
 
     override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {

--- a/android/app/src/test/kotlin/com/cup11/cuplivo/HighRefreshRateSelectorTest.kt
+++ b/android/app/src/test/kotlin/com/cup11/cuplivo/HighRefreshRateSelectorTest.kt
@@ -1,0 +1,50 @@
+package com.cup11.cuplivo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HighRefreshRateSelectorTest {
+
+  @Test
+  fun picksHighestRefreshRateAtActiveResolution() {
+    val rate = HighRefreshRateSelector.select(
+      1080,
+      2340,
+      listOf(
+        SupportedDisplayMode(1440, 3120, 120f),
+        SupportedDisplayMode(1080, 2340, 60f),
+        SupportedDisplayMode(1080, 2340, 90f),
+      ),
+    )
+    assertEquals(90f, rate!!)
+  }
+
+  @Test
+  fun ignoresModesWithDifferentResolution() {
+    val rate = HighRefreshRateSelector.select(
+      1080,
+      2340,
+      listOf(
+        SupportedDisplayMode(1440, 3120, 120f),
+        SupportedDisplayMode(720, 1600, 90f),
+      ),
+    )
+    assertNull(rate)
+  }
+
+  @Test
+  fun emptySupportedModesYieldsNull() {
+    assertNull(HighRefreshRateSelector.select(1080, 2340, emptyList()))
+  }
+
+  @Test
+  fun singleMatchingModeWins() {
+    val rate = HighRefreshRateSelector.select(
+      1440,
+      3120,
+      listOf(SupportedDisplayMode(1440, 3120, 120f)),
+    )
+    assertEquals(120f, rate!!)
+  }
+}

--- a/lib/core/services/android_display_mode.dart
+++ b/lib/core/services/android_display_mode.dart
@@ -1,0 +1,61 @@
+import 'dart:async' show unawaited;
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show AppLifecycleListener;
+import 'package:flutter_displaymode/flutter_displaymode.dart';
+
+/// Requests the highest available refresh rate on Android.
+///
+/// Android 15+ (SDK >= 35): the native side hints the Flutter rendering
+/// surface via `Surface.setFrameRate` and reports `true`. Older versions
+/// fall back to the [FlutterDisplayMode] plugin. Every failure path is
+/// recoverable: logged, never thrown, never blocking startup or resume.
+class AndroidDisplayModeService {
+  AndroidDisplayModeService._();
+
+  static final AndroidDisplayModeService instance =
+      AndroidDisplayModeService._();
+
+  static const MethodChannel _channel = MethodChannel('app.display_mode');
+
+  bool debugForceAndroidForTest = false;
+  AppLifecycleListener? _lifecycleListener;
+
+  bool get _isAndroid => debugForceAndroidForTest || Platform.isAndroid;
+
+  /// Registers the resume re-request hook and fires one initial request.
+  /// Idempotent; no-op on non-Android platforms.
+  void install() {
+    if (!_isAndroid || _lifecycleListener != null) return;
+
+    // Some Android variants clear refresh-rate requests in background.
+    _lifecycleListener = AppLifecycleListener(
+      onResume: () => unawaited(requestHighRefreshRate()),
+    );
+    unawaited(requestHighRefreshRate());
+  }
+
+  /// Asks the native side for a high refresh rate. `false` means the native
+  /// path is unavailable (SDK < 35), so the legacy plugin takes over.
+  Future<void> requestHighRefreshRate() async {
+    if (!_isAndroid) return;
+    try {
+      final handledNatively =
+          await _channel.invokeMethod<bool>('requestHighRefreshRate') ?? false;
+      if (!handledNatively) {
+        await FlutterDisplayMode.setHighRefreshRate();
+      }
+    } catch (error) {
+      debugPrint('[DisplayMode] High refresh rate request failed: $error');
+    }
+  }
+
+  @visibleForTesting
+  void debugResetForTest() {
+    _lifecycleListener?.dispose();
+    _lifecycleListener = null;
+    debugForceAndroidForTest = false;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,7 @@ import 'package:system_fonts/system_fonts.dart';
 import 'dart:io'
     show Platform; // kept for global override usage inside provider
 import 'core/services/android_background.dart';
+import 'core/services/android_display_mode.dart';
 import 'core/services/notification_service.dart';
 import 'core/services/proactive_care_alarm_service.dart';
 import 'core/services/proactive_care_message_flow.dart';
@@ -113,6 +114,9 @@ Future<void> main() async {
       WindowsPasteFix.instance.inject();
 
       FlutterLogger.installGlobalHandlers();
+      // Android: request the highest refresh rate now and again on every
+      // resume (fire-and-forget; failures never block startup).
+      AndroidDisplayModeService.instance.install();
       try {
         final prefs = await SharedPreferences.getInstance();
         final enabled = prefs.getBool('flutter_log_enabled_v1') ?? false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
     sdk: flutter
   provider: ^6.0.5
   dynamic_color: ^1.8.1
+  flutter_displaymode: ^0.7.0
   material_color_utilities: ^0.13.0
   lucide_icons_flutter: ^3.1.13
   shared_preferences: ^2.2.3

--- a/test/core/services/android_display_mode_test.dart
+++ b/test/core/services/android_display_mode_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/services/android_display_mode.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const displayModeChannel = MethodChannel('app.display_mode');
+  // flutter_displaymode 0.7.0 internal channel (verified against plugin
+  // source): setHighRefreshRate() = getSupportedModes -> getActiveMode ->
+  // setPreferredMode.
+  const pluginChannel = MethodChannel('flutter_display_mode');
+
+  final nativeCalls = <MethodCall>[];
+  final pluginCalls = <MethodCall>[];
+  late bool nativeHandled;
+  Object? nativeError;
+
+  AndroidDisplayModeService service() => AndroidDisplayModeService.instance
+    ..debugResetForTest()
+    ..debugForceAndroidForTest = true;
+
+  setUp(() {
+    nativeCalls.clear();
+    pluginCalls.clear();
+    nativeHandled = true;
+    nativeError = null;
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(displayModeChannel, (call) async {
+      if (nativeError != null) throw nativeError!;
+      nativeCalls.add(call);
+      return nativeHandled;
+    });
+    messenger.setMockMethodCallHandler(pluginChannel, (call) async {
+      pluginCalls.add(call);
+      switch (call.method) {
+        case 'getSupportedModes':
+          return <Map<dynamic, dynamic>>[
+            {'id': 1, 'width': 1080, 'height': 2340, 'refreshRate': 60.0},
+            {'id': 2, 'width': 1080, 'height': 2340, 'refreshRate': 90.0},
+            {'id': 3, 'width': 1440, 'height': 3120, 'refreshRate': 120.0},
+          ];
+        case 'getActiveMode':
+          return {'id': 1, 'width': 1080, 'height': 2340, 'refreshRate': 60.0};
+        case 'setPreferredMode':
+          return null;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(displayModeChannel, null);
+    messenger.setMockMethodCallHandler(pluginChannel, null);
+    AndroidDisplayModeService.instance.debugResetForTest();
+  });
+
+  test('native handling suppresses the plugin fallback', () async {
+    await service().requestHighRefreshRate();
+
+    expect(nativeCalls.map((c) => c.method), ['requestHighRefreshRate']);
+    expect(pluginCalls, isEmpty);
+  });
+
+  test('native false (SDK < 35) falls back to flutter_displaymode', () async {
+    nativeHandled = false;
+
+    await service().requestHighRefreshRate();
+
+    // setHighRefreshRate(): pick max refresh at active resolution -> mode 2.
+    expect(pluginCalls.map((c) => c.method), [
+      'getSupportedModes',
+      'getActiveMode',
+      'setPreferredMode',
+    ]);
+    expect(pluginCalls.last.arguments, {'mode': 2});
+  });
+
+  test('native channel failure never throws and skips fallback', () async {
+    nativeError = PlatformException(code: 'boom');
+
+    await service().requestHighRefreshRate();
+
+    expect(nativeCalls, isEmpty);
+    expect(pluginCalls, isEmpty);
+  });
+
+  test('does nothing on non-Android platforms', () async {
+    AndroidDisplayModeService.instance.debugResetForTest();
+
+    await AndroidDisplayModeService.instance.requestHighRefreshRate();
+    AndroidDisplayModeService.instance.install();
+
+    if (!Platform.isAndroid) {
+      expect(nativeCalls, isEmpty);
+      expect(pluginCalls, isEmpty);
+    }
+  });
+  test('install is idempotent and fires exactly one initial request',
+      () async {
+    service()
+      ..install()
+      ..install();
+
+    await Future<void>.delayed(Duration.zero);
+
+    expect(nativeCalls, hasLength(1));
+  });
+}


### PR DESCRIPTION
## 摘要 / Summary

Closes #647

Cuplivo 现在会在支持的 Android 设备上请求高刷新率：

- **Android 15+ (SDK >= 35)**: `MainActivity` 在 `FlutterSurfaceView` 创建后注册 `SurfaceHolder.Callback`，在 surface 创建/变更时对渲染 Surface 调用 `Surface.setFrameRate`，目标为当前分辨率下最高的刷新率（`FRAME_RATE_COMPATIBILITY_DEFAULT` + `CHANGE_FRAME_RATE_ONLY_IF_SEAMLESS`，只请求无缝切换，模式选择/自适应刷新/省电降级交由系统决定）；同时暴露 `app.display_mode` MethodChannel（`requestHighRefreshRate`），恢复前台时由 Dart 侧重新请求；失败仅 `Log.w`，不影响启动或恢复。
- **较旧 Android (< 35)**: Dart 侧收到 `false` 后回退到 `flutter_displaymode` 插件（`FlutterDisplayMode.setHighRefreshRate()`），经新增 `AndroidDisplayModeService`（镜像 `IosBackgroundGenerationService` 模式）：幂等 `install()`、`Platform.isAndroid` 门控、`AppLifecycleListener` onResume 重新请求、所有失败 `debugPrint` 而非抛出。

上游参考: Kelivo commit `c21ee50a`（原生 Surface 请求 + 旧版本插件回退）。

## 改动文件 / Files

| 文件 | 说明 |
| --- | --- |
| `android/.../MainActivity.kt` | surface 回调 + `app.display_mode` channel + 原生请求逻辑 |
| `android/.../HighRefreshRateSelector.kt` (新) | 纯选择逻辑（当前分辨率最高刷新率），JVM 可测 |
| `android/app/src/test/.../HighRefreshRateSelectorTest.kt` (新) | 4 个 JUnit4 测试 |
| `lib/core/services/android_display_mode.dart` (新) | `AndroidDisplayModeService` |
| `lib/main.dart` | 启动时 `AndroidDisplayModeService.instance.install()` |
| `test/core/services/android_display_mode_test.dart` (新) | 5 个 Dart 测试（原生处理/回退/异常不抛/非 Android 屏蔽/幂等） |
| `pubspec.yaml` | `flutter_displaymode: ^0.7.0` |

## 验证 / Verification

已运行:

- `flutter pub get`
- `dart format <changed paths>`
- `dart analyze --fatal-infos lib test` → **No issues found!**
- `flutter test test/core/services/android_display_mode_test.dart` → **5/5 pass**
- `flutter build apk --debug` → **APK built successfully**
- `.\gradlew.bat :app:testDebugUnitTest --tests "com.cup11.cuplivo.HighRefreshRateSelectorTest"` → **4/4 pass**

## 说明 / Notes

- `:app:testDebugUnitTest` 全套中 `RootfsExtractorTest` 有 2 个既有失败（symlink 用例，与本改动无关、文件未改动），疑似 Windows 宿主环境（CI 为 Linux）所致。
- Kotlin 的 SDK<35 分支（原生返回 `false`）无法在无 Robolectric 的 JVM 单测中直接覆盖，已由 Dart 回退测试 + 选择器单测承担。
- `flutter build apk` 日志中的 Kotlin daemon "different roots" 噪音为 worktree（D:）与 Pub 缓存（C:）根路径差异导致的无害增量缓存告警，构建最终成功。

## 手动测试计划 / Manual Test Plan

1. **正常路径**: Android 15 高刷真机启动 → `adb shell dumpsys SurfaceFlinger` 观察 >60 Hz；后台→前台循环再次确认请求生效。
2. **边界**: 60 Hz 设备与 Android <15 设备启动无崩溃、无启动回归；省电模式允许系统降级。
3. **失败路径**: 无有效 Surface / `setFrameRate` 异常时仅 `Log.w`，应用启动与恢复前台不受影响。
