### PR TITLE
feat(chat): support IME image paste on Android (Gboard / WeChat)

### DIFF
--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -1655,6 +1655,61 @@ class _ChatInputBarState extends State<ChatInputBar>
     return KeyEventResult.handled;
   }
 
+  /// Handles rich content pushed by an IME via the Android
+  /// `commitContent` path (Gboard / WeChat clipboard image paste, etc.).
+  /// The engine already resolved the content URI to bytes, so behave like
+  /// the normal clipboard flow: persist to the upload dir and attach.
+  Future<void> _handleInsertedContent(KeyboardInsertedContent content) async {
+    final format = switch (content.mimeType.toLowerCase()) {
+      'image/png' => 'png',
+      'image/jpeg' || 'image/jpg' => 'jpeg',
+      'image/gif' => 'gif',
+      'image/webp' => 'webp',
+      _ => null,
+    };
+    if (format == null) {
+      debugPrint(
+        '[ChatInputBar] Ignored IME content with unsupported type: '
+        '${content.mimeType}',
+      );
+      return;
+    }
+    final bytes = content.data;
+    if (bytes == null || bytes.isEmpty) {
+      debugPrint('[ChatInputBar] Ignored IME content with no data.');
+      return;
+    }
+    if (!mounted) return;
+    final savedPath = await _savePastedImageBytes(format, bytes);
+    if (savedPath == null || !mounted) return;
+    _addImages([savedPath]);
+  }
+
+  /// Persists pasted image bytes under the upload directory with a unique
+  /// `paste_<ts>.<ext>` name so the file outlives its temporary source.
+  Future<String?> _savePastedImageBytes(String format, Uint8List bytes) async {
+    try {
+      final dir = await AppDirectories.getUploadDirectory();
+      if (!await dir.exists()) {
+        await dir.create(recursive: true);
+      }
+      final ts = DateTime.now().millisecondsSinceEpoch;
+      final ext = format.toLowerCase();
+      final fileExt = ext == 'jpeg' ? 'jpg' : ext;
+      String name = 'paste_$ts.$fileExt';
+      String destPath = p.join(dir.path, name);
+      if (await File(destPath).exists()) {
+        name = 'paste_${ts}_${DateTime.now().microsecondsSinceEpoch}.$fileExt';
+        destPath = p.join(dir.path, name);
+      }
+      await File(destPath).writeAsBytes(bytes, flush: true);
+      return destPath;
+    } catch (e) {
+      debugPrint('[ChatInputBar] Failed to persist pasted image: $e');
+      return null;
+    }
+  }
+
   Future<void> _handlePasteFromClipboard() async {
     // 1) Prefer reading via super_clipboard for better Windows support
     try {
@@ -1687,30 +1742,6 @@ class _ChatInputBarState extends State<ChatInputBar>
               if (!completer.isCompleted) completer.complete(null);
             }
             return await completer.future;
-          } catch (_) {
-            return null;
-          }
-        }
-
-        // Helper: persist bytes as a file under upload directory
-        Future<String?> saveImageBytes(String format, Uint8List bytes) async {
-          try {
-            final dir = await AppDirectories.getUploadDirectory();
-            if (!await dir.exists()) {
-              await dir.create(recursive: true);
-            }
-            final ts = DateTime.now().millisecondsSinceEpoch;
-            final ext = format.toLowerCase();
-            final fileExt = ext == 'jpeg' ? 'jpg' : ext;
-            String name = 'paste_$ts.$fileExt';
-            String destPath = p.join(dir.path, name);
-            if (await File(destPath).exists()) {
-              name =
-                  'paste_${ts}_${DateTime.now().microsecondsSinceEpoch}.$fileExt';
-              destPath = p.join(dir.path, name);
-            }
-            await File(destPath).writeAsBytes(bytes, flush: true);
-            return destPath;
           } catch (_) {
             return null;
           }
@@ -1760,7 +1791,7 @@ class _ChatInputBarState extends State<ChatInputBar>
         }
 
         if (bytes != null && bytes.isNotEmpty && fmt != null) {
-          final savedPath = await saveImageBytes(fmt, bytes);
+          final savedPath = await _savePastedImageBytes(fmt, bytes);
           if (savedPath != null) {
             _addImages([savedPath]);
             return;
@@ -3211,6 +3242,21 @@ class _ChatInputBarState extends State<ChatInputBar>
                                             controller: _controller,
                                             focusNode: widget.focusNode,
                                             onChanged: _onTextChanged,
+                                            // Android only: accepts image content
+                                            // pushed by IMEs (Gboard / WeChat
+                                            // clipboard paste via commitContent).
+                                            contentInsertionConfiguration:
+                                                ContentInsertionConfiguration(
+                                                  onContentInserted:
+                                                      _handleInsertedContent,
+                                                  allowedMimeTypes: const [
+                                                    'image/png',
+                                                    'image/jpeg',
+                                                    'image/jpg',
+                                                    'image/gif',
+                                                    'image/webp',
+                                                  ],
+                                                ),
                                             readOnly: _composerLocked,
                                             minLines: 1,
                                             maxLines: _isExpanded ? 25 : 5,

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -1686,25 +1686,47 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   /// Persists pasted image bytes under the upload directory with a unique
-  /// `paste_<ts>.<ext>` name so the file outlives its temporary source.
+  /// `paste_<ts>[_n].<ext>` name so the file outlives its temporary source.
+  ///
+  /// Allocation is collision-safe under concurrent IME insertions: the name
+  /// is reserved atomically via exclusive create, and a numeric suffix is
+  /// retried on a name clash.
   Future<String?> _savePastedImageBytes(String format, Uint8List bytes) async {
+    File? reserved;
     try {
       final dir = await AppDirectories.getUploadDirectory();
       if (!await dir.exists()) {
         await dir.create(recursive: true);
       }
-      final ts = DateTime.now().millisecondsSinceEpoch;
       final ext = format.toLowerCase();
       final fileExt = ext == 'jpeg' ? 'jpg' : ext;
-      String name = 'paste_$ts.$fileExt';
-      String destPath = p.join(dir.path, name);
-      if (await File(destPath).exists()) {
-        name = 'paste_${ts}_${DateTime.now().microsecondsSinceEpoch}.$fileExt';
-        destPath = p.join(dir.path, name);
+      final baseName = 'paste_${DateTime.now().millisecondsSinceEpoch}';
+      var counter = 0;
+      while (true) {
+        final suffix = counter == 0 ? '' : '_$counter';
+        final file = File(p.join(dir.path, '$baseName$suffix.$fileExt'));
+        try {
+          await file.create(exclusive: true);
+          reserved = file;
+          break;
+        } on FileSystemException {
+          if (!await file.exists()) rethrow;
+          counter++;
+        }
       }
-      await File(destPath).writeAsBytes(bytes, flush: true);
-      return destPath;
+      await reserved.writeAsBytes(bytes, flush: true);
+      return reserved.path;
     } catch (e) {
+      if (reserved != null) {
+        try {
+          await reserved.delete();
+        } catch (cleanupError) {
+          debugPrint(
+            '[ChatInputBar] Failed to delete reserved upload '
+            '${reserved.path}: $cleanupError',
+          );
+        }
+      }
       debugPrint('[ChatInputBar] Failed to persist pasted image: $e');
       return null;
     }

--- a/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
+++ b/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -306,6 +307,71 @@ void main() {
     final paths = mediaController.snapshotInput('').imagePaths;
     expect(paths, hasLength(2));
     expect(paths.toSet(), hasLength(2));
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('concurrent IME inserts never overwrite each other', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+    // Second payload is the same png plus extra bytes: the non-atomic
+    // filename race would make both paths point at one file, and exactly
+    // one byte set would remain.
+    final bytesA = pngBytes;
+    final bytesB = Uint8List.fromList([...pngBytes, 0x01, 0x02, 0x03]);
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    await tester.runAsync(() async {
+      final editable = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+      // Fire both insertions back-to-back without waiting for the first
+      // save to settle, so their file allocation can interleave.
+      editable.insertContent(
+        KeyboardInsertedContent(
+          mimeType: 'image/png',
+          uri: contentUri('a.png'),
+          data: bytesA,
+        ),
+      );
+      editable.insertContent(
+        KeyboardInsertedContent(
+          mimeType: 'image/png',
+          uri: contentUri('b.png'),
+          data: bytesB,
+        ),
+      );
+      final deadline = DateTime.now().add(const Duration(seconds: 5));
+      while (mediaController.snapshotInput('').imagePaths.length < 2 &&
+          DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+    });
+    await tester.pump();
+
+    final paths = mediaController.snapshotInput('').imagePaths;
+    expect(paths, hasLength(2));
+    expect(paths.toSet(), hasLength(2));
+    final expected = <List<int>>[bytesA, bytesB];
+    for (final path in paths) {
+      expect(path, endsWith('.png'));
+      final data = await tester.runAsync(() => File(path).readAsBytes());
+      expect(
+        expected.where((candidate) => listEquals(candidate, data)),
+        hasLength(1),
+      );
+    }
 
     controller.dispose();
     focusNode.dispose();

--- a/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
+++ b/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
@@ -149,6 +149,7 @@ void main() {
     required String mimeType,
     required String uri,
     Uint8List? data,
+    required bool Function()? settled,
   }) async {
     await tester.runAsync(() async {
       tester
@@ -156,8 +157,18 @@ void main() {
           .insertContent(
             KeyboardInsertedContent(mimeType: mimeType, uri: uri, data: data),
           );
-      // Let the async save/attach flow in _handleInsertedContent settle.
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      if (settled == null) {
+        // Negative scenarios cannot assert "nothing happened" by polling;
+        // give the handler a fixed window to prove its no-op behavior.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return;
+      }
+      // Poll instead of a fixed delay: the async save/attach flow in
+      // _handleInsertedContent is real IO whose latency varies by runner.
+      final deadline = DateTime.now().add(const Duration(seconds: 5));
+      while (!settled() && DateTime.now().isBefore(deadline)) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
     });
     await tester.pump();
   }
@@ -213,6 +224,7 @@ void main() {
       mimeType: 'image/png',
       uri: contentUri('paste.png'),
       data: pngBytes,
+      settled: () => mediaController.snapshotInput('').imagePaths.length == 1,
     );
 
     final paths = mediaController.snapshotInput('').imagePaths;
@@ -250,6 +262,7 @@ void main() {
       mimeType: 'image/jpg',
       uri: contentUri('paste.jpg'),
       data: Uint8List.fromList(const [0xFF, 0xD8, 0xFF, 0xE0]),
+      settled: () => mediaController.snapshotInput('').imagePaths.length == 1,
     );
 
     final paths = mediaController.snapshotInput('').imagePaths;
@@ -280,12 +293,14 @@ void main() {
       mimeType: 'image/png',
       uri: contentUri('one.png'),
       data: pngBytes,
+      settled: () => mediaController.snapshotInput('').imagePaths.length == 1,
     );
     await insertContent(
       tester,
       mimeType: 'image/webp',
       uri: contentUri('two.webp'),
       data: Uint8List.fromList(const [0x52, 0x49, 0x46, 0x46]),
+      settled: () => mediaController.snapshotInput('').imagePaths.length == 2,
     );
 
     final paths = mediaController.snapshotInput('').imagePaths;
@@ -354,6 +369,7 @@ void main() {
       tester,
       mimeType: 'image/png',
       uri: contentUri('hollow.png'),
+      settled: null,
     );
 
     expect(mediaController.snapshotInput('').imagePaths, isEmpty);

--- a/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
+++ b/test/features/home/widgets/chat_input_bar_content_insertion_test.dart
@@ -1,0 +1,365 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/chat_input_data.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/input_status_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/features/group_chat/models/chat_input_mode.dart';
+import 'package:Cuplivo/features/home/services/input_draft_persistence.dart';
+import 'package:Cuplivo/features/home/widgets/chat_input_bar.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:path/path.dart' as p;
+
+/// Simulates an Android IME pushing image content into the text field
+/// (Gboard / WeChat clipboard paste via `commitContent`). The bytes flow
+/// through the same `ContentInsertionConfiguration` callback the Android
+/// embedding invokes, so these tests cover the platform entry point.
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
+}
+
+const String _tempPrefix = 'chat_input_ime_paste_test';
+
+void main() {
+  late BusinessPreferences businessPrefs;
+  late InputDraftPersistence? draftPersistence;
+  late SharedPreferences prefs;
+  late Directory tempDir;
+  late PathProviderPlatform originalPathProvider;
+
+  String contentUri(String name) =>
+      Uri.parse('content://com.example.ime/clipboard/$name').toString();
+
+  // Same valid 1x1 PNG used by the draft tests.
+  final pngBytes = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  );
+
+  void sweepPreviousTempDirs() {
+    final leftovers = Directory.systemTemp
+        .listSync()
+        .whereType<Directory>()
+        .where((d) => p.basename(d.path).startsWith(_tempPrefix));
+    for (final dir in leftovers) {
+      try {
+        dir.deleteSync(recursive: true);
+      } catch (e) {
+        debugPrint(
+          '[Test teardown] could not sweep leftover temp dir '
+          '${dir.path}: $e',
+        );
+      }
+    }
+  }
+
+  Future<void> deleteTempWithRetries(Directory dir) async {
+    for (var attempt = 0; attempt < 20; attempt++) {
+      try {
+        dir.deleteSync(recursive: true);
+        return;
+      } on PathAccessException {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+    }
+    debugPrint(
+      '[Test teardown] temp dir ${dir.path} still pinned by flutter_tester; '
+      'it will be swept by the next test run.',
+    );
+  }
+
+  setUp(() async {
+    // Windows-only quirk: flutter_tester's image decoder can keep a
+    // previewed image file pinned until the process exits, so this process
+    // may find orphan temp dirs that a fresh instance can delete.
+    sweepPreviousTempDirs();
+    businessPrefs = BusinessPreferences.memoryForTests();
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    draftPersistence = null;
+    tempDir = Directory.systemTemp.createTempSync(_tempPrefix);
+    originalPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+  });
+
+  tearDown(() async {
+    PathProviderPlatform.instance = originalPathProvider;
+    draftPersistence?.disposeInternal();
+    draftPersistence = null;
+    await deleteTempWithRetries(tempDir);
+  });
+
+  InputDraftPersistence buildDraftPersistence() {
+    draftPersistence = InputDraftPersistence(prefs);
+    return draftPersistence!;
+  }
+
+  Widget buildHarness({
+    required TextEditingController controller,
+    required FocusNode focusNode,
+    required ChatInputBarController mediaController,
+  }) {
+    return MultiProvider(
+      providers: [
+        Provider<BusinessPreferences>.value(value: businessPrefs),
+        Provider<InputDraftPersistence>.value(value: buildDraftPersistence()),
+        ChangeNotifierProvider.value(
+          value: SettingsProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider.value(
+          value: AssistantProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider.value(value: InputStatusProvider()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ChatInputBar(
+            controller: controller,
+            focusNode: focusNode,
+            mediaController: mediaController,
+            onSend: (_) async => ChatInputSubmissionResult.rejected,
+            mode: ChatInputMode.normal,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> insertContent(
+    WidgetTester tester, {
+    required String mimeType,
+    required String uri,
+    Uint8List? data,
+  }) async {
+    await tester.runAsync(() async {
+      tester
+          .state<EditableTextState>(find.byType(EditableText))
+          .insertContent(
+            KeyboardInsertedContent(mimeType: mimeType, uri: uri, data: data),
+          );
+      // Let the async save/attach flow in _handleInsertedContent settle.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+  }
+
+  Directory uploadDir() => Directory('${tempDir.path}/upload');
+
+  List<String> uploadFiles() => uploadDir().existsSync()
+      ? uploadDir().listSync().map((e) => e.path).toList()
+      : [];
+
+  testWidgets('declares image mime types for IME content insertion', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: ChatInputBarController(),
+      ),
+    );
+
+    final config = tester
+        .widget<TextField>(find.byType(TextField))
+        .contentInsertionConfiguration;
+    expect(config, isNotNull);
+    expect(config!.allowedMimeTypes, containsAll(['image/png', 'image/gif']));
+    expect(config.onContentInserted, isNotNull);
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('IME paste (png) attaches the image and persists its bytes', (
+    tester,
+  ) async {
+    final controller = TextEditingController(text: 'show me this');
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    await insertContent(
+      tester,
+      mimeType: 'image/png',
+      uri: contentUri('paste.png'),
+      data: pngBytes,
+    );
+
+    final paths = mediaController.snapshotInput('').imagePaths;
+    expect(paths, hasLength(1));
+    expect(paths.single, endsWith('.png'));
+    final saved = File(paths.single);
+    expect(saved.existsSync(), isTrue);
+    expect(
+      await tester.runAsync(() => saved.readAsBytes()),
+      orderedEquals(pngBytes),
+    );
+    expect(controller.text, 'show me this');
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('IME paste with jpg alias saves with a .jpg extension', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    await insertContent(
+      tester,
+      mimeType: 'image/jpg',
+      uri: contentUri('paste.jpg'),
+      data: Uint8List.fromList(const [0xFF, 0xD8, 0xFF, 0xE0]),
+    );
+
+    final paths = mediaController.snapshotInput('').imagePaths;
+    expect(paths, hasLength(1));
+    expect(paths.single, endsWith('.jpg'));
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('consecutive IME image inserts attach both images', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    await insertContent(
+      tester,
+      mimeType: 'image/png',
+      uri: contentUri('one.png'),
+      data: pngBytes,
+    );
+    await insertContent(
+      tester,
+      mimeType: 'image/webp',
+      uri: contentUri('two.webp'),
+      data: Uint8List.fromList(const [0x52, 0x49, 0x46, 0x46]),
+    );
+
+    final paths = mediaController.snapshotInput('').imagePaths;
+    expect(paths, hasLength(2));
+    expect(paths.toSet(), hasLength(2));
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('unsupported IME mime type is ignored without side effects', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    // The framework guard rejects undeclared mimes before insertContent, so
+    // invoke the handler directly to exercise the defensive ignore branch.
+    await tester.runAsync(() async {
+      tester
+          .widget<TextField>(find.byType(TextField))
+          .contentInsertionConfiguration!
+          .onContentInserted(
+            KeyboardInsertedContent(
+              mimeType: 'video/mp4',
+              uri: contentUri('clip.mp4'),
+              data: Uint8List.fromList(const [0x00, 0x00, 0x00]),
+            ),
+          );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+
+    expect(mediaController.snapshotInput('').imagePaths, isEmpty);
+    expect(uploadFiles(), isEmpty);
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+
+  testWidgets('IME content without data is ignored without side effects', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final mediaController = ChatInputBarController();
+
+    await tester.pumpWidget(
+      buildHarness(
+        controller: controller,
+        focusNode: focusNode,
+        mediaController: mediaController,
+      ),
+    );
+
+    await insertContent(
+      tester,
+      mimeType: 'image/png',
+      uri: contentUri('hollow.png'),
+    );
+
+    expect(mediaController.snapshotInput('').imagePaths, isEmpty);
+    expect(uploadFiles(), isEmpty);
+
+    controller.dispose();
+    focusNode.dispose();
+  });
+}


### PR DESCRIPTION
## Summary

Fixes Android IME clipboard image paste for **Google IME (Gboard)** (#605) and **WeChat IME** (#608). Both IMEs do not write clipboard images into the Android system clipboard; they push them into the focused text field via `InputConnection.commitContent()`. Flutter only accepts such content when the field declares `contentInsertionConfiguration`, which Cuplivo's chat input lacked — images were silently dropped.

## What Changed

- **`lib/features/home/widgets/chat_input_bar.dart`**
  - `TextField` now wires `contentInsertionConfiguration` with `allowedMimeTypes` (`image/png`, `image/jpeg`, `image/jpg`, `image/gif`, `image/webp`) and `onContentInserted`. The Android embedding automatically mirrors these to `EditorInfo.contentMimeTypes` — no Kotlin/platform-file changes required.
  - New `_handleInsertedContent(KeyboardInsertedContent)`: maps the mime, persists bytes under the upload directory (`paste_<ts>.<ext>`), and attaches them as draft images via the normal flow. Unsupported mime types / empty payloads are logged with `debugPrint` (never silently swallowed), so unexpected IME formats can be diagnosed and the mime list extended easily.
  - The inline save closure inside `_handlePasteFromClipboard` was extracted into `_savePastedImageBytes()` and is now shared by both paste paths (behavior identical; failures now logged).

- **`test/features/home/widgets/chat_input_bar_content_insertion_test.dart`** (new)
  Six scenarios covering the framework entry point the Android embedding invokes (`EditableTextState.insertContent`):
  - declared mime types include png/gif and the callback is wired
  - `image/png` insert attaches the image, `.png` saved with exact byte round-trip, text untouched
  - `image/jpg` alias saves with `.jpg` extension
  - consecutive inserts attach both images (distinct paths)
  - unsupported mime (`video/mp4`) is ignored without side effects (callback invoked directly, since the framework guard rejects undeclared mimes before `insertContent`)
  - content without data is ignored without side effects

## Verification

- `dart format lib/features/home/widgets/chat_input_bar.dart test/features/home/widgets/chat_input_bar_content_insertion_test.dart` ✔
- `dart analyze --fatal-infos lib test` ✔ (no issues)
- `flutter test test/features/home/widgets/chat_input_bar_content_insertion_test.dart` — 6/6 ✔
- Related existing tests: `chat_input_bar_draft_test`, `chat_input_bar_queue_test`, `chat_input_bar_buttons_test`, `chat_input_bar_asr_test`, `chat_input_overlay_layout_test` — 53/53 ✔

## Manual Test Plan (Android device)

- Happy path: copy an image in Gboard clipboard → paste into chat input → thumbnail appears → send → message includes the image.
- Happy path: repeat with WeChat IME image paste.
- Edge cases: text paste unaffected; unsupported mime (e.g. `image/bmp`) — no crash (logged); two consecutive pastes attach two images; pasted image survives draft restore.

## Notes

- No user-visible strings added (logs only) — no l10n changes.
- Platform behavior is provided by the Flutter embedding; no `android/` changes.
- Windows dev-machine test quirk (not product bug): `flutter_tester` can keep a just-previewed image file pinned until process exit, so the new test's teardown retries deletion and sweeps leftovers on the next run; CI (Linux) is unaffected.
