### PR TITLE
fix(chat): unify markdown selection under a single SelectionArea (issue #597)

### DIFF
--- a/lib/features/chat/pages/reading_mode_page.dart
+++ b/lib/features/chat/pages/reading_mode_page.dart
@@ -154,11 +154,15 @@ class _ReadingModePageState extends State<ReadingModePage> {
               constraints: const BoxConstraints(
                 maxWidth: ReadingModePage.maxContentWidth,
               ),
-              child: MarkdownWithCodeHighlight(
-                text: _visualContent ?? '',
-                baseStyle: TextStyle(
-                  fontSize: ReadingModePage.defaultFontSize,
-                  height: 1.75,
+              // SelectionArea must live inside the scroll view so selections
+              // can span the whole document without a scrollable parent.
+              child: SelectionArea(
+                child: MarkdownWithCodeHighlight(
+                  text: _visualContent ?? '',
+                  baseStyle: TextStyle(
+                    fontSize: ReadingModePage.defaultFontSize,
+                    height: 1.75,
+                  ),
                 ),
               ),
             ),

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -3639,8 +3639,8 @@ class _MarkdownTableCell extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
       child: Align(
         alignment: _alignmentFor(data.alignment),
-        child: RichText(
-          text: textSpan,
+        child: Text.rich(
+          textSpan,
           textAlign: data.alignment,
           softWrap: true,
           overflow: TextOverflow.visible,
@@ -3715,60 +3715,64 @@ class _MarkdownTableToolbar extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Container(
-      height: 38,
-      padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        border: Border(
-          bottom: BorderSide(
-            color: cs.outlineVariant.withValues(alpha: isDark ? 0.20 : 0.28),
-            width: 0.6,
+    // Toolbar chrome must not join the enclosing message selection: it is
+    // inert UI, not content to copy.
+    return SelectionContainer.disabled(
+      child: Container(
+        height: 38,
+        padding: const EdgeInsetsDirectional.only(start: 12, end: 6),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          border: Border(
+            bottom: BorderSide(
+              color: cs.outlineVariant.withValues(alpha: isDark ? 0.20 : 0.28),
+              width: 0.6,
+            ),
           ),
         ),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: cs.onSurfaceVariant.withValues(alpha: 0.80),
-                fontSize: 12,
-                fontWeight: AppFontWeights.semibold,
-                height: 1.0,
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: cs.onSurfaceVariant.withValues(alpha: 0.80),
+                  fontSize: 12,
+                  fontWeight: AppFontWeights.semibold,
+                  height: 1.0,
+                ),
               ),
             ),
-          ),
-          _copyButton(context),
-          WindowsAxTreeSafeTooltip(
-            message: imageActionLabel,
-            child: IosIconButton(
-              icon: Lucide.ImageDown,
-              semanticLabel: imageActionLabel,
-              onTap: onImageAction,
-              onLongPress: onExportImage,
-              size: 15,
-              minSize: 32,
-              padding: const EdgeInsets.all(7),
-              color: cs.onSurfaceVariant.withValues(alpha: 0.68),
+            _copyButton(context),
+            WindowsAxTreeSafeTooltip(
+              message: imageActionLabel,
+              child: IosIconButton(
+                icon: Lucide.ImageDown,
+                semanticLabel: imageActionLabel,
+                onTap: onImageAction,
+                onLongPress: onExportImage,
+                size: 15,
+                minSize: 32,
+                padding: const EdgeInsets.all(7),
+                color: cs.onSurfaceVariant.withValues(alpha: 0.68),
+              ),
             ),
-          ),
-          WindowsAxTreeSafeTooltip(
-            message: exportLabel,
-            child: IosIconButton(
-              icon: Lucide.Download,
-              semanticLabel: exportLabel,
-              onTap: onExport,
-              size: 15,
-              minSize: 32,
-              padding: const EdgeInsets.all(7),
-              color: cs.onSurfaceVariant.withValues(alpha: 0.68),
+            WindowsAxTreeSafeTooltip(
+              message: exportLabel,
+              child: IosIconButton(
+                icon: Lucide.Download,
+                semanticLabel: exportLabel,
+                onTap: onExport,
+                size: 15,
+                minSize: 32,
+                padding: const EdgeInsets.all(7),
+                color: cs.onSurfaceVariant.withValues(alpha: 0.68),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -6325,8 +6329,10 @@ class AllowedHtmlTagsMd extends InlineMd {
 
 /// Code block with per-token syntax highlight.
 ///
-/// Rendered as a plain [RichText] so the code participates in the enclosing
+/// Rendered as a plain [Text.rich] so the code participates in the enclosing
 /// [SelectionArea] selection instead of owning its own selectable context.
+/// (A raw [RichText] would not wire [selectionRegistrar], leaving the code
+/// unselectable.)
 class CodeHighlightView extends StatefulWidget {
   const CodeHighlightView(
     this.source, {
@@ -6407,17 +6413,13 @@ class _CodeHighlightViewState extends State<CodeHighlightView> {
 
   @override
   Widget build(BuildContext context) {
-    final ambient = DefaultTextStyle.of(context).style;
-    final textScaler =
-        MediaQuery.maybeTextScalerOf(context) ?? TextScaler.noScaling;
-    return RichText(
-      text: TextSpan(
-        style: ambient.merge(widget.textStyle),
+    return Text.rich(
+      TextSpan(
+        style: widget.textStyle,
         children: _codeTextSpans.isEmpty
             ? [TextSpan(text: widget.source)]
             : _codeTextSpans,
       ),
-      textScaler: textScaler,
     );
   }
 }

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -1043,9 +1043,7 @@ MarkdownCodePayload _preprocessFences(
       }
       buf.write(out.substring(cursor));
       out = _replaceInlineDollarMath(buf.toString());
-      out = out.replaceAllMapped(RegExp(r'__DISPLAY_MATH_MASK_\d+__'), (
-        match,
-      ) {
+      out = out.replaceAllMapped(RegExp(r'__DISPLAY_MATH_MASK_\d+__'), (match) {
         final key = match.group(0)!;
         return displayMathMap[key] ?? key;
       });
@@ -2403,11 +2401,10 @@ class _CollapsibleCodeBlockState extends State<_CollapsibleCodeBlock> {
     final highlightEnabled = !_shouldSkipHighlightWhileStreaming();
 
     Widget buildCodeView(String visibleCode) {
-      final codeView = SelectableHighlightView(
+      final codeView = CodeHighlightView(
         visibleCode,
         language: codeLanguage,
         theme: codeTheme,
-        padding: EdgeInsets.zero,
         textStyle: codeTextStyle,
         enableHighlight: highlightEnabled,
       );
@@ -3359,7 +3356,6 @@ class _MarkdownTableBlock extends StatelessWidget {
                   style: style,
                   config: config,
                   appFontFamily: appFontFamily,
-                  selectable: !compact,
                 ),
             ],
           ),
@@ -3610,7 +3606,6 @@ class _MarkdownTableCell extends StatelessWidget {
     required this.style,
     required this.config,
     required this.appFontFamily,
-    required this.selectable,
   });
 
   final _MarkdownTableCellData data;
@@ -3618,7 +3613,6 @@ class _MarkdownTableCell extends StatelessWidget {
   final TextStyle style;
   final GptMarkdownConfig config;
   final String? appFontFamily;
-  final bool selectable;
 
   @override
   Widget build(BuildContext context) {
@@ -3645,15 +3639,13 @@ class _MarkdownTableCell extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
       child: Align(
         alignment: _alignmentFor(data.alignment),
-        child: selectable
-            ? SelectableText.rich(textSpan, textAlign: data.alignment)
-            : RichText(
-                text: textSpan,
-                textAlign: data.alignment,
-                softWrap: true,
-                overflow: TextOverflow.visible,
-                textWidthBasis: TextWidthBasis.parent,
-              ),
+        child: RichText(
+          text: textSpan,
+          textAlign: data.alignment,
+          softWrap: true,
+          overflow: TextOverflow.visible,
+          textWidthBasis: TextWidthBasis.parent,
+        ),
       ),
     );
   }
@@ -4319,13 +4311,12 @@ class _MermaidBlockState extends State<_MermaidBlock> {
   }
 
   Widget _buildMermaidCodeView(BuildContext context, bool isDark) {
-    final codeView = SelectableHighlightView(
+    final codeView = CodeHighlightView(
       widget.code,
       language: 'plaintext',
       theme: _transparentBgTheme(
         isDark ? atomOneDarkReasonableTheme : githubTheme,
       ),
-      padding: EdgeInsets.zero,
       textStyle: TextStyle(fontFamily: 'monospace', fontSize: 13, height: 1.5),
     );
 
@@ -6332,15 +6323,16 @@ class AllowedHtmlTagsMd extends InlineMd {
   }
 }
 
-/// A selectable version of HighlightView that allows users to select
-/// and copy portions of the code instead of just the entire block.
-class SelectableHighlightView extends StatefulWidget {
-  const SelectableHighlightView(
+/// Code block with per-token syntax highlight.
+///
+/// Rendered as a plain [RichText] so the code participates in the enclosing
+/// [SelectionArea] selection instead of owning its own selectable context.
+class CodeHighlightView extends StatefulWidget {
+  const CodeHighlightView(
     this.source, {
     super.key,
     this.language,
     this.theme = const {},
-    this.padding,
     this.textStyle,
     this.enableHighlight = true,
   });
@@ -6348,16 +6340,14 @@ class SelectableHighlightView extends StatefulWidget {
   final String source;
   final String? language;
   final Map<String, TextStyle> theme;
-  final EdgeInsetsGeometry? padding;
   final TextStyle? textStyle;
   final bool enableHighlight;
 
   @override
-  State<SelectableHighlightView> createState() =>
-      _SelectableHighlightViewState();
+  State<CodeHighlightView> createState() => _CodeHighlightViewState();
 }
 
-class _SelectableHighlightViewState extends State<SelectableHighlightView> {
+class _CodeHighlightViewState extends State<CodeHighlightView> {
   late List<TextSpan> _codeTextSpans;
 
   @override
@@ -6367,7 +6357,7 @@ class _SelectableHighlightViewState extends State<SelectableHighlightView> {
   }
 
   @override
-  void didUpdateWidget(covariant SelectableHighlightView oldWidget) {
+  void didUpdateWidget(covariant CodeHighlightView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.source == widget.source &&
         oldWidget.language == widget.language &&
@@ -6417,13 +6407,17 @@ class _SelectableHighlightViewState extends State<SelectableHighlightView> {
 
   @override
   Widget build(BuildContext context) {
-    return SelectableText.rich(
-      TextSpan(
-        style: widget.textStyle,
+    final ambient = DefaultTextStyle.of(context).style;
+    final textScaler =
+        MediaQuery.maybeTextScalerOf(context) ?? TextScaler.noScaling;
+    return RichText(
+      text: TextSpan(
+        style: ambient.merge(widget.textStyle),
         children: _codeTextSpans.isEmpty
             ? [TextSpan(text: widget.source)]
             : _codeTextSpans,
       ),
+      textScaler: textScaler,
     );
   }
 }

--- a/test/features/chat/pages/reading_mode_page_test.dart
+++ b/test/features/chat/pages/reading_mode_page_test.dart
@@ -10,6 +10,7 @@ import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/features/chat/pages/reading_mode_page.dart';
 import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
 
 var businessPrefs = BusinessPreferences.memoryForTests();
 
@@ -88,6 +89,24 @@ void main() {
     // Let the snackbar duration elapse so its ticker is disposed cleanly.
     await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
+  });
+
+  testWidgets('wraps the markdown body in a single SelectionArea', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(_message('Hello world.\n\n```dart\nfinal x = 1;\n```')),
+    );
+
+    expect(
+      find.ancestor(
+        of: find.byType(MarkdownWithCodeHighlight),
+        matching: find.byType(SelectionArea),
+      ),
+      findsOneWidget,
+    );
+    // The code block must no longer own its own selectable context.
+    expect(find.byType(SelectableText), findsNothing);
   });
 
   testWidgets('font + and - step by 2 around the persisted value', (

--- a/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
@@ -72,7 +72,7 @@ void main() {
       await tester.pump();
 
       expect(find.byType(Table), findsOneWidget);
-      expect(find.textContaining('葡萄 🍇'), findsOneWidget);
+      expect(find.textContaining('葡萄 🍇', findRichText: true), findsOneWidget);
       expect(_allRichTextPlainText(tester), isNot(contains('| 葡萄 🍇')));
     },
   );

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -354,6 +354,19 @@ Widget _markdownHarness(
   );
 }
 
+/// [Text.rich] wraps the provided span in a style-merge [TextSpan]; descend
+/// through single-child wrapper spans to the span [CodeHighlightView] built.
+TextSpan _codeHighlightRootSpan(WidgetTester tester, Finder richTextFinder) {
+  var span = tester.widget<RichText>(richTextFinder).text as TextSpan;
+  while (span.text == null &&
+      span.children?.length == 1 &&
+      span.children!.single is TextSpan &&
+      (span.children!.single as TextSpan).text == null) {
+    span = span.children!.single as TextSpan;
+  }
+  return span;
+}
+
 Widget _selectableMarkdownHarness(
   String text, {
   double? width,
@@ -3039,8 +3052,7 @@ final price = "$12";
       ),
     );
 
-    final richText = tester.widget<RichText>(find.byType(RichText));
-    final root = richText.text as TextSpan;
+    final root = _codeHighlightRootSpan(tester, find.byType(RichText));
     final children = root.children ?? const <InlineSpan>[];
 
     expect(children, isNotEmpty);
@@ -3067,16 +3079,18 @@ final price = "$12";
       ),
     );
 
-    final before =
-        (tester.widget<RichText>(find.byType(RichText)).text as TextSpan)
-            .children;
+    final before = _codeHighlightRootSpan(
+      tester,
+      find.byType(RichText),
+    ).children;
 
     rebuild(() {});
     await tester.pump();
 
-    final after =
-        (tester.widget<RichText>(find.byType(RichText)).text as TextSpan)
-            .children;
+    final after = _codeHighlightRootSpan(
+      tester,
+      find.byType(RichText),
+    ).children;
 
     expect(identical(before, after), isTrue);
   });
@@ -3097,8 +3111,7 @@ final price = "$12";
       ),
     );
 
-    final richText = tester.widget<RichText>(find.byType(RichText));
-    final root = richText.text as TextSpan;
+    final root = _codeHighlightRootSpan(tester, find.byType(RichText));
     final children = root.children ?? const <InlineSpan>[];
 
     expect(children, hasLength(1));
@@ -3116,13 +3129,13 @@ final value = 1;
       );
       await tester.pump();
 
-      final richText = tester.widget<RichText>(
+      final root = _codeHighlightRootSpan(
+        tester,
         find.descendant(
           of: find.byType(CodeHighlightView),
           matching: find.byType(RichText),
         ),
       );
-      final root = richText.text as TextSpan;
       final children = root.children ?? const <InlineSpan>[];
 
       expect(children.length, greaterThan(1));
@@ -5270,15 +5283,16 @@ const answer = 42;
       );
       await tester.pump();
 
-      // A drag that spans the code block must be reported by the enclosing
-      // SelectionArea (the old SelectableText.rich owned its own context and
-      // would wall the selection off at the code block).
+      // A drag that crosses the code block must be reported by the enclosing
+      // SelectionArea and must include the code text (the old
+      // SelectableText.rich owned its own context and would wall the selection
+      // off at the code block; a bare RichText would not register at all).
       final start = tester.getTopLeft(find.text('Before the code block.'));
       final end =
-          tester.getCenter(
-            find.text('After the code block.', findRichText: true),
+          tester.getBottomRight(
+            find.textContaining('const answer = 42', findRichText: true),
           ) -
-          const Offset(20, 0);
+          const Offset(1, 1);
       final gesture = await tester.startGesture(
         start,
         kind: PointerDeviceKind.mouse,
@@ -5298,8 +5312,104 @@ const answer = 42;
       );
       expect(
         selected.last,
-        contains('After the'),
+        contains('const answer = 42'),
         reason: 'selection: ${selected.last}',
+      );
+    },
+  );
+
+  testWidgets('SelectionArea drag selects table cell content', (tester) async {
+    final selected = <String>[];
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => SettingsProvider(preferences: businessPrefs),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SelectionArea(
+              onSelectionChanged: (s) =>
+                  selected.add(s?.plainText ?? '<cleared>'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Before the table.'),
+                  SizedBox(
+                    width: 340,
+                    child: Table(
+                      defaultColumnWidth: const FixedColumnWidth(170),
+                      defaultVerticalAlignment:
+                          TableCellVerticalAlignment.middle,
+                      children: const [
+                        TableRow(
+                          children: [
+                            Text.rich(TextSpan(text: 'Alpha')),
+                            Text.rich(TextSpan(text: 'Beta')),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final start = tester.getTopLeft(find.text('Before the table.'));
+    final end = tester.getCenter(
+      find.textContaining('Alpha', findRichText: true),
+    );
+    final gesture = await tester.startGesture(
+      start,
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(30, 10));
+    await tester.pump();
+    await gesture.moveTo(end);
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    expect(selected, isNotEmpty);
+    expect(
+      selected.last,
+      contains('Before the table.'),
+      reason: 'selection: ${selected.last}',
+    );
+    expect(
+      selected.last,
+      contains('Alpha'),
+      reason: 'selection: ${selected.last}',
+    );
+  });
+
+  testWidgets(
+    'MarkdownWithCodeHighlight excludes the table toolbar label from selection',
+    (tester) async {
+      _overrideMarkdownTablePlatform(TargetPlatform.windows);
+      await tester.pumpWidget(
+        _markdownHarness('''
+| Name | Value |
+| - | - |
+| Alpha | Beta |
+''', width: 600),
+      );
+      await tester.pump();
+
+      final selectionContainers = find.ancestor(
+        of: find.text('Table'),
+        matching: find.byType(SelectionContainer),
+      );
+      expect(
+        tester
+            .widgetList<SelectionContainer>(selectionContainers)
+            .any((widget) => widget.delegate == null),
+        isTrue,
+        reason: 'toolbar label must sit under a disabled selection container',
       );
     },
   );

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -354,6 +354,43 @@ Widget _markdownHarness(
   );
 }
 
+Widget _selectableMarkdownHarness(
+  String text, {
+  double? width,
+  Map<String, Object>? preferences,
+  required void Function(String?) onSelection,
+}) {
+  SharedPreferences.setMockInitialValues({});
+  businessPrefs = BusinessPreferences.memoryForTests(preferences ?? {});
+  final markdown = MarkdownWithCodeHighlight(text: text);
+  return ChangeNotifierProvider(
+    create: (_) => SettingsProvider(preferences: businessPrefs),
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: width == null
+            ? SelectionArea(
+                onSelectionChanged: (selection) =>
+                    onSelection(selection?.plainText),
+                child: markdown,
+              )
+            : Align(
+                alignment: Alignment.topLeft,
+                child: SizedBox(
+                  width: width,
+                  child: SelectionArea(
+                    onSelectionChanged: (selection) =>
+                        onSelection(selection?.plainText),
+                    child: markdown,
+                  ),
+                ),
+              ),
+      ),
+    ),
+  );
+}
+
 void _overrideMarkdownTablePlatform(TargetPlatform platform) {
   markdownTableTargetPlatformOverride = platform;
   addTearDown(() => markdownTableTargetPlatformOverride = null);
@@ -519,8 +556,8 @@ Inline ***strong emphasis*** text.
       expect(find.textContaining('strong emphasis'), findsOneWidget);
       expect(
         find.descendant(
-          of: find.byType(SelectableHighlightView),
-          matching: find.textContaining('***'),
+          of: find.byType(CodeHighlightView),
+          matching: find.textContaining('***', findRichText: true),
         ),
         findsOneWidget,
       );
@@ -1552,23 +1589,26 @@ const greet = (name) => {
             .map((widget) => widget.text.toPlainText())
             .join('\n');
         final codeText = tester
-            .widgetList<SelectableText>(
+            .widgetList<RichText>(
               find.descendant(
-                of: find.byType(SelectableHighlightView),
-                matching: find.byType(SelectableText),
+                of: find.byType(CodeHighlightView),
+                matching: find.byType(RichText),
               ),
             )
-            .map((widget) => widget.textSpan?.toPlainText() ?? widget.data)
+            .map((widget) => widget.text.toPlainText())
             .join('\n');
         final blockquote = find.byKey(const ValueKey('markdown-blockquote'));
         final blockquoteCodeText = tester
-            .widgetList<SelectableText>(
+            .widgetList<RichText>(
               find.descendant(
                 of: blockquote,
-                matching: find.byType(SelectableText),
+                matching: find.descendant(
+                  of: find.byType(CodeHighlightView),
+                  matching: find.byType(RichText),
+                ),
               ),
             )
-            .map((widget) => widget.textSpan?.toPlainText() ?? widget.data)
+            .map((widget) => widget.text.toPlainText())
             .join('\n');
 
         expect(allText, isNot(contains('| 混合')), reason: frame);
@@ -1577,7 +1617,7 @@ const greet = (name) => {
         expect(
           find.descendant(
             of: blockquote,
-            matching: find.byType(SelectableHighlightView),
+            matching: find.byType(CodeHighlightView),
           ),
           findsOneWidget,
           reason: frame,
@@ -1608,13 +1648,13 @@ const greet = (name) => {
       await tester.pump();
 
       final codeText = tester
-          .widgetList<SelectableText>(
+          .widgetList<RichText>(
             find.descendant(
-              of: find.byType(SelectableHighlightView),
-              matching: find.byType(SelectableText),
+              of: find.byType(CodeHighlightView),
+              matching: find.byType(RichText),
             ),
           )
-          .map((widget) => widget.textSpan?.toPlainText() ?? widget.data)
+          .map((widget) => widget.text.toPlainText())
           .join('\n');
 
       expect(codeText, contains('> ```bash'));
@@ -1637,13 +1677,13 @@ final value = "$foo$";
       await tester.pump();
 
       final codeText = tester
-          .widgetList<SelectableText>(
+          .widgetList<RichText>(
             find.descendant(
-              of: find.byType(SelectableHighlightView),
-              matching: find.byType(SelectableText),
+              of: find.byType(CodeHighlightView),
+              matching: find.byType(RichText),
             ),
           )
-          .map((widget) => widget.textSpan?.toPlainText() ?? widget.data)
+          .map((widget) => widget.text.toPlainText())
           .join('\n');
 
       expect(_findMathWidget(), findsNothing);
@@ -1802,7 +1842,7 @@ $code
     await tester.pumpAndSettle();
 
     expect(find.byType(Image), findsNothing);
-    expect(find.textContaining('graph TD'), findsOneWidget);
+    expect(find.textContaining('graph TD', findRichText: true), findsOneWidget);
 
     await tester.tap(find.text('Image'));
     await tester.pumpAndSettle();
@@ -1871,7 +1911,10 @@ A-->
       await tester.tap(find.text('Code'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('graph TD'), findsOneWidget);
+      expect(
+        find.textContaining('graph TD', findRichText: true),
+        findsOneWidget,
+      );
     },
   );
 
@@ -2024,7 +2067,10 @@ A-->B
 
       expect(find.text('Generating image'), findsNothing);
       expect(find.byType(Image), findsNothing);
-      expect(find.textContaining('graph TD'), findsOneWidget);
+      expect(
+        find.textContaining('graph TD', findRichText: true),
+        findsOneWidget,
+      );
       expect(find.text('Open Preview'), findsNothing);
     },
   );
@@ -2922,8 +2968,17 @@ $$
       await tester.pump();
 
       expect(_findMathWidget(), findsOneWidget);
-      expect(find.textContaining(r'$a'), findsOneWidget);
-      expect(find.textContaining(r'b$'), findsOneWidget);
+      final tableText = tester
+          .widgetList<RichText>(
+            find.descendant(
+              of: find.byType(Table),
+              matching: find.byType(RichText),
+            ),
+          )
+          .map((widget) => widget.text.toPlainText())
+          .join('\n');
+      expect(tableText, contains(r'$a'));
+      expect(tableText, contains(r'b$'));
     },
   );
 
@@ -2964,15 +3019,18 @@ final price = "$12";
       await tester.pump();
 
       expect(_findMathWidget(), findsNothing);
-      expect(find.textContaining(r'final price = "$12";'), findsOneWidget);
+      expect(
+        find.textContaining(r'final price = "$12";', findRichText: true),
+        findsOneWidget,
+      );
     },
   );
 
-  testWidgets('SelectableHighlightView 为已注册语言生成高亮 span', (tester) async {
+  testWidgets('CodeHighlightView 为已注册语言生成高亮 span', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
-          body: SelectableHighlightView(
+          body: CodeHighlightView(
             'final value = 1;',
             language: 'dart',
             theme: {},
@@ -2981,15 +3039,15 @@ final price = "$12";
       ),
     );
 
-    final richText = tester.widget<SelectableText>(find.byType(SelectableText));
-    final root = richText.textSpan!;
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    final root = richText.text as TextSpan;
     final children = root.children ?? const <InlineSpan>[];
 
     expect(children, isNotEmpty);
     expect(children.length, greaterThan(1));
   });
 
-  testWidgets('SelectableHighlightView 同内容父级重建时复用高亮 span', (tester) async {
+  testWidgets('CodeHighlightView 同内容父级重建时复用高亮 span', (tester) async {
     late StateSetter rebuild;
 
     await tester.pumpWidget(
@@ -2998,7 +3056,7 @@ final price = "$12";
           body: StatefulBuilder(
             builder: (context, setState) {
               rebuild = setState;
-              return const SelectableHighlightView(
+              return const CodeHighlightView(
                 'final value = 1;',
                 language: 'dart',
                 theme: {},
@@ -3009,48 +3067,43 @@ final price = "$12";
       ),
     );
 
-    final before = tester
-        .widget<SelectableText>(find.byType(SelectableText))
-        .textSpan!
-        .children;
+    final before =
+        (tester.widget<RichText>(find.byType(RichText)).text as TextSpan)
+            .children;
 
     rebuild(() {});
     await tester.pump();
 
-    final after = tester
-        .widget<SelectableText>(find.byType(SelectableText))
-        .textSpan!
-        .children;
+    final after =
+        (tester.widget<RichText>(find.byType(RichText)).text as TextSpan)
+            .children;
 
     expect(identical(before, after), isTrue);
   });
 
-  testWidgets(
-    'SelectableHighlightView skips synchronous highlighting on demand',
-    (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SelectableHighlightView(
-              'final value = 1;',
-              language: 'dart',
-              theme: {},
-              enableHighlight: false,
-            ),
+  testWidgets('CodeHighlightView skips synchronous highlighting on demand', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CodeHighlightView(
+            'final value = 1;',
+            language: 'dart',
+            theme: {},
+            enableHighlight: false,
           ),
         ),
-      );
+      ),
+    );
 
-      final richText = tester.widget<SelectableText>(
-        find.byType(SelectableText),
-      );
-      final root = richText.textSpan!;
-      final children = root.children ?? const <InlineSpan>[];
+    final richText = tester.widget<RichText>(find.byType(RichText));
+    final root = richText.text as TextSpan;
+    final children = root.children ?? const <InlineSpan>[];
 
-      expect(children, hasLength(1));
-      expect((children.single as TextSpan).text, 'final value = 1;');
-    },
-  );
+    expect(children, hasLength(1));
+    expect((children.single as TextSpan).text, 'final value = 1;');
+  });
 
   testWidgets(
     'MarkdownWithCodeHighlight highlights unclosed code fences after streaming stops',
@@ -3063,13 +3116,13 @@ final value = 1;
       );
       await tester.pump();
 
-      final richText = tester.widget<SelectableText>(
+      final richText = tester.widget<RichText>(
         find.descendant(
-          of: find.byType(SelectableHighlightView),
-          matching: find.byType(SelectableText),
+          of: find.byType(CodeHighlightView),
+          matching: find.byType(RichText),
         ),
       );
-      final root = richText.textSpan!;
+      final root = richText.text as TextSpan;
       final children = root.children ?? const <InlineSpan>[];
 
       expect(children.length, greaterThan(1));
@@ -3290,7 +3343,7 @@ line3
         tester.getTopLeft(find.text('dart')).dx,
         lessThan(tester.getTopLeft(find.byIcon(Lucide.ChevronRight)).dx),
       );
-      expect(find.textContaining('line3'), findsNothing);
+      expect(find.textContaining('line3', findRichText: true), findsNothing);
       expect(find.textContaining('folded'), findsNothing);
 
       await tester.tap(find.text('dart'));
@@ -3299,7 +3352,7 @@ line3
       expect(find.text('Expand'), findsNothing);
       expect(find.text('Collapse'), findsNothing);
       expect(find.byIcon(Lucide.ChevronRight), findsNothing);
-      expect(find.textContaining('line3'), findsOneWidget);
+      expect(find.textContaining('line3', findRichText: true), findsOneWidget);
     },
   );
 
@@ -3337,7 +3390,7 @@ fade3
         find.byKey(const ValueKey('code-block-collapsed-tail-fade')),
         findsNothing,
       );
-      expect(find.textContaining('fade3'), findsOneWidget);
+      expect(find.textContaining('fade3', findRichText: true), findsOneWidget);
     },
   );
 
@@ -3362,7 +3415,7 @@ exact2
         find.byKey(const ValueKey('code-block-collapsed-tail-fade')),
         findsNothing,
       );
-      expect(find.textContaining('exact2'), findsOneWidget);
+      expect(find.textContaining('exact2', findRichText: true), findsOneWidget);
     },
   );
 
@@ -3387,7 +3440,10 @@ disable3
       );
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('disable3'), findsOneWidget);
+      expect(
+        find.textContaining('disable3', findRichText: true),
+        findsOneWidget,
+      );
 
       await settings.setAutoCollapseCodeBlockLines(2);
       await settings.setAutoCollapseCodeBlock(true);
@@ -3395,26 +3451,32 @@ disable3
 
       expect(find.text('Expand'), findsNothing);
       expect(find.text('Collapse'), findsNothing);
-      expect(find.textContaining('disable3'), findsNothing);
+      expect(find.textContaining('disable3', findRichText: true), findsNothing);
 
       await settings.setAutoCollapseCodeBlock(false);
       await tester.pumpAndSettle();
 
       expect(find.text('Expand'), findsNothing);
       expect(find.text('Collapse'), findsNothing);
-      expect(find.textContaining('disable3'), findsOneWidget);
+      expect(
+        find.textContaining('disable3', findRichText: true),
+        findsOneWidget,
+      );
 
       await tester.tap(find.text('dart'));
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Lucide.ChevronRight), findsOneWidget);
-      expect(find.textContaining('disable3'), findsNothing);
+      expect(find.textContaining('disable3', findRichText: true), findsNothing);
 
       await tester.tap(find.text('dart'));
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Lucide.ChevronRight), findsNothing);
-      expect(find.textContaining('disable3'), findsOneWidget);
+      expect(
+        find.textContaining('disable3', findRichText: true),
+        findsOneWidget,
+      );
     },
   );
 
@@ -3460,7 +3522,7 @@ alpha4
 
     expect(find.text('Expand'), findsNothing);
     expect(find.text('Collapse'), findsNothing);
-    expect(find.textContaining('alpha4'), findsOneWidget);
+    expect(find.textContaining('alpha4', findRichText: true), findsOneWidget);
 
     await tester.tap(find.text('dart'));
     await tester.pumpAndSettle();
@@ -3521,7 +3583,7 @@ press4
 
       expect(find.text('Expand'), findsNothing);
       expect(find.text('Collapse'), findsNothing);
-      expect(find.textContaining('press4'), findsOneWidget);
+      expect(find.textContaining('press4', findRichText: true), findsOneWidget);
 
       final collapseGesture = await tester.startGesture(
         tester.getCenter(find.text('dart')),
@@ -3907,7 +3969,10 @@ void main() {
       expect(plainText, contains('这里是折叠内容的第一段。'));
       expect(plainText, contains('details 内的 Markdown 列表'));
       expect(
-        find.textContaining("print('code block inside details');"),
+        find.textContaining(
+          "print('code block inside details');",
+          findRichText: true,
+        ),
         findsOneWidget,
       );
       expect(plainText, isNot(contains('<details>')));
@@ -5062,13 +5127,13 @@ $$
       await tester.pump();
 
       final codeText = tester
-          .widgetList<SelectableText>(
+          .widgetList<RichText>(
             find.descendant(
-              of: find.byType(SelectableHighlightView),
-              matching: find.byType(SelectableText),
+              of: find.byType(CodeHighlightView),
+              matching: find.byType(RichText),
             ),
           )
-          .map((widget) => widget.textSpan?.toPlainText() ?? widget.data ?? '')
+          .map((widget) => widget.text.toPlainText())
           .join('\n');
 
       expect(codeText, contains(r'Get-Content D:\ComfyUI\'));
@@ -5121,21 +5186,121 @@ $$
         await tester.pump();
         expect(
           find.descendant(
-            of: find.byType(SelectableHighlightView),
-            matching: find.textContaining('not-a-closer'),
+            of: find.byType(CodeHighlightView),
+            matching: find.textContaining('not-a-closer', findRichText: true),
           ),
           findsOneWidget,
           reason: source,
         );
         expect(
           find.descendant(
-            of: find.byType(SelectableHighlightView),
-            matching: find.textContaining('following'),
+            of: find.byType(CodeHighlightView),
+            matching: find.textContaining('following', findRichText: true),
           ),
           findsOneWidget,
           reason: source,
         );
       }
+    },
+  );
+
+  testWidgets(
+    'MarkdownWithCodeHighlight renders no SelectableText once wrapped in SelectionArea',
+    (tester) async {
+      _overrideMarkdownTablePlatform(TargetPlatform.windows);
+      await tester.pumpWidget(
+        _selectableMarkdownHarness(
+          '''
+Intro paragraph text.
+
+```dart
+const answer = 42;
+```
+
+| Name | Value |
+| - | - |
+| Alpha | Beta |
+''',
+          width: 600,
+          onSelection: (_) {},
+        ),
+      );
+      await tester.pump();
+
+      // The whole markdown tree must own a single selection context: no
+      // nested SelectableText (code block / table cell) may exist below it.
+      expect(find.byType(SelectableText), findsNothing);
+      expect(find.byType(CodeHighlightView), findsOneWidget);
+      final tableRichText = tester.widgetList<RichText>(
+        find.descendant(
+          of: find.byType(Table),
+          matching: find.byType(RichText),
+        ),
+      );
+      expect(tableRichText, isNotEmpty);
+    },
+  );
+
+  testWidgets(
+    'CodeHighlightView registers to the enclosing SelectionArea (no nested context)',
+    (tester) async {
+      final selected = <String>[];
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => SettingsProvider(preferences: businessPrefs),
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SelectionArea(
+                onSelectionChanged: (s) =>
+                    selected.add(s?.plainText ?? '<cleared>'),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text('Before the code block.'),
+                    CodeHighlightView('const answer = 42;'),
+                    Text('After the code block.'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // A drag that spans the code block must be reported by the enclosing
+      // SelectionArea (the old SelectableText.rich owned its own context and
+      // would wall the selection off at the code block).
+      final start = tester.getTopLeft(find.text('Before the code block.'));
+      final end =
+          tester.getCenter(
+            find.text('After the code block.', findRichText: true),
+          ) -
+          const Offset(20, 0);
+      final gesture = await tester.startGesture(
+        start,
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(30, 10));
+      await tester.pump();
+      await gesture.moveTo(end);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(selected, isNotEmpty);
+      expect(
+        selected.last,
+        contains('Before the code block.'),
+        reason: 'selection: ${selected.last}',
+      );
+      expect(
+        selected.last,
+        contains('After the'),
+        reason: 'selection: ${selected.last}',
+      );
     },
   );
 }


### PR DESCRIPTION
## What & Why

Issue #597 的**第一步（Option A）**：消除 markdown 树内的**嵌套选择上下文**，让单条消息内的文本选择统一归最外层 `SelectionArea`（消息级）管辖，去掉代码块/表格处"选字被打断"的最大来源。

- **代码块**：`SelectableHighlightView` → `CodeHighlightView`，`SelectableText.rich` → 普通 `RichText`（合并环境 `DefaultTextStyle` + MediaQuery `textScaler`，视觉/缩放与原来一致），代码从此注册到外层选择上下文；顺带删掉从未生效的 `padding` 入参（两处调用点：代码块、mermaid 代码视图）。
- **桌面端表格 cell**：删除 `selectable` 开关，一律走已存在且移动端已在用的 `RichText` 分支，消除桌面端表格内嵌 `SelectableText.rich`。
- **阅读模式**：正文此前除代码块外完全不可选，为其补包 `SelectionArea`（置于 `SingleChildScrollView` **内部**，符合 SelectionArea 不得包裹滚动容器的约束）。

样式等价性已对照 SDK 核实（`SelectableText` 同样合并 DefaultTextStyle、回退 MediaQuery 文本缩放）。此 PR 同时更新 20+ 处测试 finder（代码文本查找从内部 `EditableText` 命中改为 `findRichText: true`），并新增 3 个需求驱动的用例：包裹层下 markdown 树无 `SelectableText`、`CodeHighlightView` 注册进外层 `SelectionArea`（跨块拖动被 `onSelectionChanged` 上报）、阅读模式存在外层区域。

## Test Plan

- 拖动选字：正文 → 代码块 → 表格 → 正文（Windows/macOS 桌面，鼠标拖选）
- 移动端：助手气泡代码块长按 → 选字/复制为 Markdown
- 阅读模式：正文 + 代码块连续选字
- 回归：代码块复制按钮、表格工具条（复制 CSV/导出 PNG）、mermaid 代码标签页

## Known Tradeoff

移动端用户消息气泡（`enableUserMarkdown`）与导出预览中的用户气泡没有外层 `SelectionArea`（移动端用户气泡的长按菜单手势与其冲突，此前单独包一层会破坏消息菜单），代码块失去气泡内直接长按选择；**已与 issue 确认接受**——保留兜底：代码块自带复制按钮 + 长按→选择复制页。

## Deferred

- **B**（合并同气泡内正文/翻译/reasoning 的独立 `SelectionArea`）：受 reasoning 预览态 `SingleChildScrollView` 限制（SelectionArea 不得包裹滚动容器），需分开处理。
- **C**（选区激活时降级行内公式/代码横向滚动）：`_InlineMathScrollable` 拖动手势抢占水平选字，需把选区状态传入 markdown 组件。

Fixes #597 (第一部分)
