### PR TITLE
fix(chat): invalidate stale tool card extents during streaming

### DIFF
--- a/lib/core/services/streaming_content_notifier.dart
+++ b/lib/core/services/streaming_content_notifier.dart
@@ -1,4 +1,21 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+
+import 'logging/flutter_logger.dart';
+
+/// Lightweight tool-height signal for [MessageListView] extent invalidation.
+///
+/// The list must not compare [oldWidget.toolParts] — that map is mutated in
+/// place. This event is the streaming path; a stored signature snapshot covers
+/// non-streaming rebuilds.
+@immutable
+class ToolHeightEvent {
+  const ToolHeightEvent({required this.messageId, required this.version});
+
+  final String messageId;
+  final int version;
+}
 
 /// Lightweight notifier for streaming message content updates.
 ///
@@ -16,6 +33,15 @@ class StreamingContentNotifier {
   /// Each streaming message has its own `ValueNotifier<String>`.
   final Map<String, ValueNotifier<StreamingContentData>> _notifiers =
       <String, ValueNotifier<StreamingContentData>>{};
+
+  /// Coalesced tool-height events. Listeners must not rebuild the page.
+  final ValueNotifier<ToolHeightEvent?> toolHeightEvents =
+      ValueNotifier<ToolHeightEvent?>(null);
+
+  int _toolHeightVersion = 0;
+  final Set<String> _pendingHeightIds = <String>{};
+  bool _heightFlushScheduled = false;
+  bool _disposed = false;
 
   /// Get or create a notifier for a message.
   ValueNotifier<StreamingContentData> getNotifier(String messageId) {
@@ -47,7 +73,7 @@ class StreamingContentNotifier {
     final notifier = _notifiers[messageId];
     if (notifier != null) {
       final current = notifier.value;
-      notifier.value = StreamingContentData(
+      final next = StreamingContentData(
         content: content,
         totalTokens: totalTokens,
         reasoningText: current.reasoningText,
@@ -65,8 +91,29 @@ class StreamingContentNotifier {
         durationMs: durationMs ?? current.durationMs,
         translation: current.translation,
       );
+      notifier.value = next;
+      if (_structureSignatureChanged(current, next)) {
+        notifyToolHeightChanged(messageId);
+      }
     }
   }
+
+  /// Whether the timeline block structure changed between two streaming
+  /// snapshots. Pure text growth keeps the split counter stable — the built
+  /// row re-measures itself — but a new thinking or tool block adds rows the
+  /// list must be told about, or its extent stays stale.
+  static bool _structureSignatureChanged(
+    StreamingContentData a,
+    StreamingContentData b,
+  ) {
+    return _splitCount(a.contentSplitOffsets) !=
+            _splitCount(b.contentSplitOffsets) ||
+        _splitCount(a.reasoningCountAtSplit) !=
+            _splitCount(b.reasoningCountAtSplit) ||
+        _splitCount(a.toolCountAtSplit) != _splitCount(b.toolCountAtSplit);
+  }
+
+  static int _splitCount(List<int>? offsets) => offsets?.length ?? 0;
 
   /// Update only the live translation for a message. This keeps translation
   /// streaming local to the message row instead of rebuilding HomePage.
@@ -106,7 +153,7 @@ class StreamingContentNotifier {
     final notifier = _notifiers[messageId];
     if (notifier != null) {
       final current = notifier.value;
-      notifier.value = StreamingContentData(
+      final next = StreamingContentData(
         content: current.content,
         totalTokens: current.totalTokens,
         reasoningText: reasoningText ?? current.reasoningText,
@@ -124,6 +171,10 @@ class StreamingContentNotifier {
         durationMs: current.durationMs,
         translation: current.translation,
       );
+      notifier.value = next;
+      if (_structureSignatureChanged(current, next)) {
+        notifyToolHeightChanged(messageId);
+      }
     }
   }
 
@@ -155,6 +206,35 @@ class StreamingContentNotifier {
         cachedTokens: current.cachedTokens,
         durationMs: current.durationMs,
         translation: current.translation,
+      );
+    }
+    notifyToolHeightChanged(messageId);
+  }
+
+  /// Emit a coalesced tool-height event. Safe to call without a content notifier.
+  void notifyToolHeightChanged(String messageId) {
+    if (_disposed || !_pendingHeightIds.add(messageId)) return;
+    if (_heightFlushScheduled) return;
+    _heightFlushScheduled = true;
+    scheduleMicrotask(_flushToolHeightEvents);
+  }
+
+  void _flushToolHeightEvents() {
+    _heightFlushScheduled = false;
+    if (_disposed) return;
+    final ids = List<String>.of(_pendingHeightIds);
+    _pendingHeightIds.clear();
+    for (final id in ids) {
+      _toolHeightVersion += 1;
+      toolHeightEvents.value = ToolHeightEvent(
+        messageId: id,
+        version: _toolHeightVersion,
+      );
+    }
+    if (FlutterLogger.enabled) {
+      FlutterLogger.log(
+        'tool height events flushed: ids=$ids',
+        tag: 'TimelineExtent',
       );
     }
   }
@@ -198,7 +278,10 @@ class StreamingContentNotifier {
 
   /// Dispose all resources.
   void dispose() {
+    _disposed = true;
+    _pendingHeightIds.clear();
     clear();
+    toolHeightEvents.dispose();
   }
 }
 

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1218,6 +1218,7 @@ class HomePageController extends ChangeNotifier {
       parts.add(answeredPart);
     }
     _streamController.setToolParts(message.id, parts);
+    streamingContentNotifier.notifyToolHeightChanged(message.id);
     notifyListeners();
 
     await _viewModel.continueAssistantMessageAfterToolAnswer(

--- a/lib/features/home/controllers/tool_extent_invalidation_port.dart
+++ b/lib/features/home/controllers/tool_extent_invalidation_port.dart
@@ -1,0 +1,20 @@
+/// Narrow view over the list controller that the tool-extent coordinator
+/// drives.
+///
+/// The coordinator must inspect whether the controller is attached or layout
+/// locked when a height event arrives, and invalidate a slot once it can.
+/// A production port wraps the real `ListController`; tests inject a
+/// controllable view through [MessageListView.toolExtentPort] so the
+/// detached/lock windows — which the framework never exposes between frames —
+/// can be driven deterministically. The seam itself is marked
+/// `@visibleForTesting` on the widget parameter; this type is consumed by
+/// production code (the default wrapper) and therefore stays public.
+abstract class ToolExtentInvalidationPort {
+  bool get isAttached;
+
+  bool get isLocked;
+
+  (int, int)? get visibleRange;
+
+  void invalidateExtent(int index);
+}

--- a/lib/features/home/controllers/tool_extent_invalidation_queue.dart
+++ b/lib/features/home/controllers/tool_extent_invalidation_queue.dart
@@ -1,0 +1,44 @@
+/// Coalesced queue for pending tool-extent invalidations.
+///
+/// A tree-height change lands while the list controller is detached (cold
+/// window load still in flight, or a controller swap during rebuild) or
+/// locked by the layout pass. The queue holds the message ids until the
+/// controller is attached and unlocked, so a dropped event never leaves a
+/// stale extent behind.
+///
+/// The state machine is deliberately small and owns no timers: the
+/// [MessageListView] schedules the retries, this class answers whether a
+/// flush can drain now.
+final class ToolExtentInvalidationQueue {
+  final Set<String> _pending = <String>{};
+
+  /// Whether any invalidation is queued.
+  bool get hasPending => _pending.isNotEmpty;
+
+  /// A snapshot of the queued ids, newest-first order preserved as queued.
+  List<String> get pendingIds => List<String>.unmodifiable(_pending);
+
+  /// Queues [messageId]; returns false when it was already queued, so the
+  /// caller can skip a redundant flush.
+  bool enqueue(String messageId) => _pending.add(messageId);
+
+  /// Drains the queue when [isAttached] is true and [isLocked] is false.
+  ///
+  /// Returns the ids to invalidate and whether the caller must poll again:
+  /// [reschedule] is true while the controller stays detached or locked and
+  /// work is still pending. The caller owns the polling cadence.
+  ({List<String> ids, bool reschedule}) takeForFlush({
+    required bool isAttached,
+    required bool isLocked,
+  }) {
+    if (isAttached && !isLocked) {
+      final ids = _pending.toList();
+      _pending.clear();
+      return (ids: ids, reschedule: false);
+    }
+    return (ids: const <String>[], reschedule: _pending.isNotEmpty);
+  }
+
+  /// Drops everything queued (widget teardown).
+  void clear() => _pending.clear();
+}

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -27,6 +27,7 @@ import '../../chat/widgets/message_more_sheet.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
 import '../controllers/message_render_model.dart';
 import '../controllers/scroll_controller.dart' as scroll_ctrl;
+import '../controllers/tool_extent_invalidation_queue.dart';
 import '../services/ask_user_interaction_service.dart';
 import '../utils/chat_layout_constants.dart';
 import 'model_icon.dart';
@@ -318,7 +319,8 @@ class _MessageListViewState extends State<MessageListView> {
   late Map<String, int> _slotIndexById;
   late Map<String, int> _messageIndexById;
   final Map<String, int> _lastToolSignatures = <String, int>{};
-  final Set<String> _pendingToolExtentIds = <String>{};
+  final ToolExtentInvalidationQueue _toolExtentQueue =
+      ToolExtentInvalidationQueue();
   bool _toolExtentFlushScheduled = false;
   bool _awaitingAttachFlush = false;
   bool _attachFlushScheduled = false;
@@ -377,7 +379,7 @@ class _MessageListViewState extends State<MessageListView> {
       );
     }
     if (!identical(oldWidget.listController, widget.listController)) {
-      _awaitingAttachFlush = _pendingToolExtentIds.isNotEmpty;
+      _awaitingAttachFlush = _toolExtentQueue.hasPending;
       _scheduleAttachAwareFlush();
     }
     final oldRenderModels = _effectiveRenderModels;
@@ -459,7 +461,7 @@ class _MessageListViewState extends State<MessageListView> {
     _extentEstimateCache.remove(messageId);
     final controller = widget.listController;
     if (!controller.isAttached) {
-      _pendingToolExtentIds.add(messageId);
+      _toolExtentQueue.enqueue(messageId);
       _awaitingAttachFlush = true;
       _scheduleAttachAwareFlush();
       return;
@@ -468,14 +470,14 @@ class _MessageListViewState extends State<MessageListView> {
       _applyToolExtentInvalidation(messageId);
       return;
     }
-    if (_pendingToolExtentIds.add(messageId)) {
+    if (_toolExtentQueue.enqueue(messageId)) {
       _scheduleToolExtentFlush();
     }
   }
 
   void _scheduleAttachAwareFlush() {
     if (_attachFlushScheduled) return;
-    if (!_awaitingAttachFlush && _pendingToolExtentIds.isEmpty) return;
+    if (!_awaitingAttachFlush && !_toolExtentQueue.hasPending) return;
     _attachFlushScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _attachFlushScheduled = false;
@@ -483,13 +485,13 @@ class _MessageListViewState extends State<MessageListView> {
       if (!widget.listController.isAttached) {
         // Cold window load still in flight: the controller attaches in a later
         // frame. Retry while work is pending instead of stranding the queue.
-        if (_pendingToolExtentIds.isNotEmpty) {
+        if (_toolExtentQueue.hasPending) {
           _scheduleAttachAwareFlush();
         }
         return;
       }
       _awaitingAttachFlush = false;
-      if (_pendingToolExtentIds.isEmpty) return;
+      if (!_toolExtentQueue.hasPending) return;
       _flushToolExtentIds();
     });
   }
@@ -506,16 +508,20 @@ class _MessageListViewState extends State<MessageListView> {
 
   void _flushToolExtentIds() {
     final controller = widget.listController;
-    if (!controller.isAttached || controller.isLocked) {
-      if (_pendingToolExtentIds.isNotEmpty) {
-        _scheduleToolExtentFlush();
-      }
-      return;
-    }
-    final ids = _pendingToolExtentIds.toList();
-    _pendingToolExtentIds.clear();
-    for (final id in ids) {
+    final result = _toolExtentQueue.takeForFlush(
+      isAttached: controller.isAttached,
+      isLocked: controller.isLocked,
+    );
+    for (final id in result.ids) {
       _applyToolExtentInvalidation(id);
+    }
+    if (result.reschedule) {
+      _scheduleToolExtentFlush();
+    } else if (_toolExtentQueue.hasPending) {
+      // A new invalidation raced in while draining; hand it to the
+      // attach-aware path in case the controller detached again.
+      _awaitingAttachFlush = true;
+      _scheduleAttachAwareFlush();
     }
   }
 

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -13,6 +13,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
+import '../../../core/services/logging/flutter_logger.dart';
 import '../../../core/services/storage/message_locate_bus.dart';
 import '../../../core/services/streaming_content_notifier.dart';
 import '../../../icons/lucide_adapter.dart';
@@ -315,6 +316,12 @@ class _MessageListViewState extends State<MessageListView> {
   bool _pointerScrollActivityCheckScheduled = false;
   late List<MessageRenderModel> _effectiveRenderModels;
   late Map<String, int> _slotIndexById;
+  late Map<String, int> _messageIndexById;
+  final Map<String, int> _lastToolSignatures = <String, int>{};
+  final Set<String> _pendingToolExtentIds = <String>{};
+  bool _toolExtentFlushScheduled = false;
+  bool _awaitingAttachFlush = false;
+  bool _attachFlushScheduled = false;
   final FocusNode _keyboardFocusNode = FocusNode(
     debugLabel: 'timeline-keyboard-scroll-region',
   );
@@ -352,14 +359,31 @@ class _MessageListViewState extends State<MessageListView> {
   void initState() {
     super.initState();
     _refreshRenderModels();
+    _snapshotToolSignatures();
+    widget.streamingContentNotifier?.toolHeightEvents.addListener(
+      _handleToolHeightEvent,
+    );
   }
 
   @override
   void didUpdateWidget(covariant MessageListView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.streamingContentNotifier != widget.streamingContentNotifier) {
+      oldWidget.streamingContentNotifier?.toolHeightEvents.removeListener(
+        _handleToolHeightEvent,
+      );
+      widget.streamingContentNotifier?.toolHeightEvents.addListener(
+        _handleToolHeightEvent,
+      );
+    }
+    if (!identical(oldWidget.listController, widget.listController)) {
+      _awaitingAttachFlush = _pendingToolExtentIds.isNotEmpty;
+      _scheduleAttachAwareFlush();
+    }
     final oldRenderModels = _effectiveRenderModels;
     _refreshRenderModels();
     _synchronizeExtentCache(oldWidget, oldRenderModels);
+    _snapshotToolSignatures();
   }
 
   void _refreshRenderModels() {
@@ -375,6 +399,152 @@ class _MessageListViewState extends State<MessageListView> {
       for (var index = 0; index < _effectiveRenderModels.length; index++)
         _effectiveRenderModels[index].slotId: index + _headerOffset,
     };
+    _messageIndexById = <String, int>{
+      for (var index = 0; index < _effectiveRenderModels.length; index++)
+        _effectiveRenderModels[index].message.id: index + _headerOffset,
+    };
+  }
+
+  /// Number of timeline-visible tools, mirroring the renderer's builtin_search
+  /// exclusion.
+  ///
+  /// The estimate depends only on this count, so the signature that keys the
+  /// memo must be the count too: stream updates replace each [ToolUIPart] with
+  /// a new instance on every chunk, so object identity would churn the memo
+  /// and invalidate every tool-bearing message on every rebuild.
+  int _visibleToolCount(List<ToolUIPart>? parts) {
+    if (parts == null || parts.isEmpty) return 0;
+    var count = 0;
+    for (final part in parts) {
+      if (part.toolName == 'builtin_search') continue;
+      count++;
+    }
+    return count;
+  }
+
+  /// Stores per-message visible tool counts. Ids whose count changed since the
+  /// last rebuild carried an in-place mutation the list could not otherwise
+  /// see, so their extents are invalidated here (streaming emits the dedicated
+  /// event; this covers non-streaming rebuilds).
+  void _snapshotToolSignatures() {
+    final next = <String, int>{};
+    final changed = <String>[];
+    for (final model in _effectiveRenderModels) {
+      final id = model.message.id;
+      final count = _visibleToolCount(widget.toolParts[id]);
+      final previous = _lastToolSignatures[id];
+      next[id] = count;
+      if (previous != null && previous != count) changed.add(id);
+    }
+    _lastToolSignatures
+      ..clear()
+      ..addAll(next);
+    for (final id in changed) {
+      _invalidateToolExtentForMessage(id);
+    }
+  }
+
+  void _handleToolHeightEvent() {
+    final event = widget.streamingContentNotifier?.toolHeightEvents.value;
+    if (event == null) return;
+    _invalidateToolExtentForMessage(event.messageId);
+  }
+
+  /// Drops the estimate for [messageId] and schedules an extent invalidation
+  /// against the list controller. When the controller is not attached (cold
+  /// window load still in flight) or locked by layout, the invalidation is
+  /// queued and flushed when it becomes available — a dropped event would
+  /// leave the stale extent in place until the user scrolls.
+  void _invalidateToolExtentForMessage(String messageId) {
+    _extentEstimateCache.remove(messageId);
+    final controller = widget.listController;
+    if (!controller.isAttached) {
+      _pendingToolExtentIds.add(messageId);
+      _awaitingAttachFlush = true;
+      _scheduleAttachAwareFlush();
+      return;
+    }
+    if (!controller.isLocked) {
+      _applyToolExtentInvalidation(messageId);
+      return;
+    }
+    if (_pendingToolExtentIds.add(messageId)) {
+      _scheduleToolExtentFlush();
+    }
+  }
+
+  void _scheduleAttachAwareFlush() {
+    if (_attachFlushScheduled) return;
+    if (!_awaitingAttachFlush && _pendingToolExtentIds.isEmpty) return;
+    _attachFlushScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _attachFlushScheduled = false;
+      if (!mounted) return;
+      if (!widget.listController.isAttached) {
+        // Cold window load still in flight: the controller attaches in a later
+        // frame. Retry while work is pending instead of stranding the queue.
+        if (_pendingToolExtentIds.isNotEmpty) {
+          _scheduleAttachAwareFlush();
+        }
+        return;
+      }
+      _awaitingAttachFlush = false;
+      if (_pendingToolExtentIds.isEmpty) return;
+      _flushToolExtentIds();
+    });
+  }
+
+  void _scheduleToolExtentFlush() {
+    if (_toolExtentFlushScheduled) return;
+    _toolExtentFlushScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _toolExtentFlushScheduled = false;
+      if (!mounted) return;
+      _flushToolExtentIds();
+    });
+  }
+
+  void _flushToolExtentIds() {
+    final controller = widget.listController;
+    if (!controller.isAttached || controller.isLocked) {
+      if (_pendingToolExtentIds.isNotEmpty) {
+        _scheduleToolExtentFlush();
+      }
+      return;
+    }
+    final ids = _pendingToolExtentIds.toList();
+    _pendingToolExtentIds.clear();
+    for (final id in ids) {
+      _applyToolExtentInvalidation(id);
+    }
+  }
+
+  void _applyToolExtentInvalidation(String messageId) {
+    final controller = widget.listController;
+    if (!controller.isAttached || controller.isLocked) return;
+    final index = _messageIndexById[messageId];
+    if (index == null) return;
+    final visible = controller.visibleRange;
+    final scrollController = widget.scrollController;
+    if (visible != null &&
+        index < visible.$1 &&
+        scrollController is scroll_ctrl.ChatAutoFollowScrollController) {
+      final request = scrollController
+          .requestPreserveDistanceFromEndDuringLayout();
+      if (request != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          scrollController.finishPreserveDistanceFromEndDuringLayout(request);
+        });
+      }
+    }
+    if (FlutterLogger.enabled) {
+      FlutterLogger.log(
+        'tool extent invalidated: message=$messageId index=$index '
+        'positionRequestActive=${scrollController is scroll_ctrl.ChatAutoFollowScrollController ? scrollController.hasActiveLayoutPositioningRequest : false}',
+        tag: 'TimelineExtent',
+      );
+    }
+    controller.invalidateExtent(index);
   }
 
   /// Header row + action bar + vertical margins around a bubble.
@@ -464,7 +634,11 @@ class _MessageListViewState extends State<MessageListView> {
     final hasReasoning =
         (reasoning?.text.isNotEmpty ?? false) ||
         (reasoningSegments?.isNotEmpty ?? false);
-    if (text.isEmpty && !hasReasoning) return _estimateChrome;
+    final toolParts = message.role == 'assistant'
+        ? widget.toolParts[message.id]
+        : null;
+    final hasTools = toolParts != null && toolParts.isNotEmpty;
+    if (text.isEmpty && !hasReasoning && !hasTools) return _estimateChrome;
 
     // Layout asks for the same item repeatedly (every resize, every window
     // change), and the scan below is linear in the message length, so a memo
@@ -477,13 +651,15 @@ class _MessageListViewState extends State<MessageListView> {
       reasoning,
       reasoningSegments,
     );
+    final toolSignature = _visibleToolCount(toolParts);
     final cached = _extentEstimateCache[message.id];
     if (cached != null &&
         identical(cached.content, text) &&
         cached.crossAxisExtent == crossAxisExtent &&
         cached.fontScale == fontScale &&
         cached.settings == settings &&
-        cached.reasoningSignature == reasoningSignature) {
+        cached.reasoningSignature == reasoningSignature &&
+        cached.toolSignature == toolSignature) {
       return cached.extent;
     }
 
@@ -516,17 +692,19 @@ class _MessageListViewState extends State<MessageListView> {
     // column and stacks at a different row height than the body text.
     final codeFontSize = _estimateCodeFontSize * fontScale;
     final codeCharsPerLine = math.max(1.0, textWidth / (codeFontSize * 0.6));
+    // An empty body still reports one wrapped line; skip it so a tools-only
+    // assistant turn is chrome + cards, not chrome + a phantom text row.
+    final bodyLines = body.isEmpty
+        ? 0.0
+        : _wrappedLineCount(
+            body,
+            charsPerLine: charsPerLine,
+            codeCharsPerLine: settings.wrapCodeBlocks ? codeCharsPerLine : null,
+            codeLineRatio: codeFontSize / fontSize,
+            collapsedCodeLines: settings.collapsedCodeLines,
+          );
     final extent =
-        _wrappedLineCount(
-              body,
-              charsPerLine: charsPerLine,
-              codeCharsPerLine: settings.wrapCodeBlocks
-                  ? codeCharsPerLine
-                  : null,
-              codeLineRatio: codeFontSize / fontSize,
-              collapsedCodeLines: settings.collapsedCodeLines,
-            ) *
-            lineHeight +
+        bodyLines * lineHeight +
         _estimateChrome +
         collapsedCards * _estimateCollapsedCard +
         _estimateReasoningExtent(
@@ -534,7 +712,8 @@ class _MessageListViewState extends State<MessageListView> {
           reasoningSegments,
           textWidth: textWidth,
           fontScale: fontScale,
-        );
+        ) +
+        _estimateToolExtent(toolParts);
 
     if (_extentEstimateCache.length > _extentEstimateCacheLimit) {
       _extentEstimateCache.clear();
@@ -545,9 +724,20 @@ class _MessageListViewState extends State<MessageListView> {
       fontScale: fontScale,
       settings: settings,
       reasoningSignature: reasoningSignature,
+      toolSignature: toolSignature,
       extent: extent,
     );
     return extent;
+  }
+
+  /// Estimated height of the tool cards rendered in the timeline.
+  ///
+  /// Tool parts live outside [ChatMessage.content], so a content-only estimate
+  /// used to treat a tools-only assistant turn as [_estimateChrome]. Every
+  /// visible tool is one collapsed step — a header row — which is the same
+  /// height constant as a collapsed thinking card.
+  double _estimateToolExtent(List<ToolUIPart>? parts) {
+    return _visibleToolCount(parts) * _estimateCollapsedCard;
   }
 
   /// Estimated height of the reasoning card(s) rendered above the answer.
@@ -1118,6 +1308,9 @@ class _MessageListViewState extends State<MessageListView> {
     _scrollIdleTimer?.cancel();
     _deferStreamingMessageUpdates.dispose();
     _keyboardFocusNode.dispose();
+    widget.streamingContentNotifier?.toolHeightEvents.removeListener(
+      _handleToolHeightEvent,
+    );
     super.dispose();
   }
 
@@ -2025,6 +2218,7 @@ final class _ExtentEstimate {
     required this.fontScale,
     required this.settings,
     required this.reasoningSignature,
+    required this.toolSignature,
     required this.extent,
   });
 
@@ -2033,6 +2227,7 @@ final class _ExtentEstimate {
   final double fontScale;
   final _EstimateSettings settings;
   final int reasoningSignature;
+  final int toolSignature;
   final double extent;
 }
 

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -27,6 +27,7 @@ import '../../chat/widgets/message_more_sheet.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
 import '../controllers/message_render_model.dart';
 import '../controllers/scroll_controller.dart' as scroll_ctrl;
+import '../controllers/tool_extent_invalidation_port.dart';
 import '../controllers/tool_extent_invalidation_queue.dart';
 import '../services/ask_user_interaction_service.dart';
 import '../utils/chat_layout_constants.dart';
@@ -134,6 +135,7 @@ class MessageListView extends StatefulWidget {
     this.isPinnedIndicatorActive = false,
     required this.isProcessingFiles,
     this.streamingContentNotifier,
+    @visibleForTesting this.toolExtentPort,
     this.spotlightMessageId,
     this.spotlightToken = 0,
     this.removingSlotIds = const <String>{},
@@ -215,6 +217,12 @@ class MessageListView extends StatefulWidget {
   /// When provided, streaming messages will use ValueListenableBuilder
   /// to avoid full page rebuilds.
   final StreamingContentNotifier? streamingContentNotifier;
+
+  /// Tests inject a controllable view over the list controller so the
+  /// detached/lock windows of the extent coordinator can be driven
+  /// deterministically. Production builds the default wrapper.
+  @visibleForTesting
+  final ToolExtentInvalidationPort? toolExtentPort;
 
   /// When set, the message with this ID will receive a spotlight pulse animation.
   final String? spotlightMessageId;
@@ -321,6 +329,7 @@ class _MessageListViewState extends State<MessageListView> {
   final Map<String, int> _lastToolSignatures = <String, int>{};
   final ToolExtentInvalidationQueue _toolExtentQueue =
       ToolExtentInvalidationQueue();
+  late ToolExtentInvalidationPort _extentPort;
   bool _toolExtentFlushScheduled = false;
   bool _awaitingAttachFlush = false;
   bool _attachFlushScheduled = false;
@@ -360,6 +369,9 @@ class _MessageListViewState extends State<MessageListView> {
   @override
   void initState() {
     super.initState();
+    _extentPort =
+        widget.toolExtentPort ??
+        _ListControllerExtentPort(widget.listController);
     _refreshRenderModels();
     _snapshotToolSignatures();
     widget.streamingContentNotifier?.toolHeightEvents.addListener(
@@ -370,6 +382,12 @@ class _MessageListViewState extends State<MessageListView> {
   @override
   void didUpdateWidget(covariant MessageListView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.toolExtentPort, widget.toolExtentPort) ||
+        !identical(oldWidget.listController, widget.listController)) {
+      _extentPort =
+          widget.toolExtentPort ??
+          _ListControllerExtentPort(widget.listController);
+    }
     if (oldWidget.streamingContentNotifier != widget.streamingContentNotifier) {
       oldWidget.streamingContentNotifier?.toolHeightEvents.removeListener(
         _handleToolHeightEvent,
@@ -459,14 +477,14 @@ class _MessageListViewState extends State<MessageListView> {
   /// leave the stale extent in place until the user scrolls.
   void _invalidateToolExtentForMessage(String messageId) {
     _extentEstimateCache.remove(messageId);
-    final controller = widget.listController;
-    if (!controller.isAttached) {
+    final port = _extentPort;
+    if (!port.isAttached) {
       _toolExtentQueue.enqueue(messageId);
       _awaitingAttachFlush = true;
       _scheduleAttachAwareFlush();
       return;
     }
-    if (!controller.isLocked) {
+    if (!port.isLocked) {
       _applyToolExtentInvalidation(messageId);
       return;
     }
@@ -482,7 +500,7 @@ class _MessageListViewState extends State<MessageListView> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _attachFlushScheduled = false;
       if (!mounted) return;
-      if (!widget.listController.isAttached) {
+      if (!_extentPort.isAttached) {
         // Cold window load still in flight: the controller attaches in a later
         // frame. Retry while work is pending instead of stranding the queue.
         if (_toolExtentQueue.hasPending) {
@@ -494,6 +512,10 @@ class _MessageListViewState extends State<MessageListView> {
       if (!_toolExtentQueue.hasPending) return;
       _flushToolExtentIds();
     });
+    // The chained post-frame callback only runs when a frame is scheduled;
+    // drive frames itself so a pending invalidation cannot stall silently while
+    // the controller is still detached or locked.
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   void _scheduleToolExtentFlush() {
@@ -504,13 +526,13 @@ class _MessageListViewState extends State<MessageListView> {
       if (!mounted) return;
       _flushToolExtentIds();
     });
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   void _flushToolExtentIds() {
-    final controller = widget.listController;
     final result = _toolExtentQueue.takeForFlush(
-      isAttached: controller.isAttached,
-      isLocked: controller.isLocked,
+      isAttached: _extentPort.isAttached,
+      isLocked: _extentPort.isLocked,
     );
     for (final id in result.ids) {
       _applyToolExtentInvalidation(id);
@@ -526,11 +548,11 @@ class _MessageListViewState extends State<MessageListView> {
   }
 
   void _applyToolExtentInvalidation(String messageId) {
-    final controller = widget.listController;
-    if (!controller.isAttached || controller.isLocked) return;
+    final port = _extentPort;
+    if (!port.isAttached || port.isLocked) return;
     final index = _messageIndexById[messageId];
     if (index == null) return;
-    final visible = controller.visibleRange;
+    final visible = port.visibleRange;
     final scrollController = widget.scrollController;
     if (visible != null &&
         index < visible.$1 &&
@@ -550,7 +572,7 @@ class _MessageListViewState extends State<MessageListView> {
         tag: 'TimelineExtent',
       );
     }
-    controller.invalidateExtent(index);
+    port.invalidateExtent(index);
   }
 
   /// Header row + action bar + vertical margins around a bubble.
@@ -2185,6 +2207,25 @@ class _MessageListViewState extends State<MessageListView> {
       ),
     );
   }
+}
+
+/// Production view of the list controller behind [ToolExtentInvalidationPort].
+class _ListControllerExtentPort implements ToolExtentInvalidationPort {
+  _ListControllerExtentPort(this._controller);
+
+  final ListController _controller;
+
+  @override
+  bool get isAttached => _controller.isAttached;
+
+  @override
+  bool get isLocked => _controller.isLocked;
+
+  @override
+  (int, int)? get visibleRange => _controller.visibleRange;
+
+  @override
+  void invalidateExtent(int index) => _controller.invalidateExtent(index);
 }
 
 /// Display settings that change how tall a message renders.

--- a/test/features/home/controllers/tool_extent_invalidation_queue_test.dart
+++ b/test/features/home/controllers/tool_extent_invalidation_queue_test.dart
@@ -1,0 +1,72 @@
+import 'package:Cuplivo/features/home/controllers/tool_extent_invalidation_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('enqueue keeps work pending while detached', () {
+    final queue = ToolExtentInvalidationQueue();
+
+    expect(queue.enqueue('m1'), isTrue);
+    expect(queue.hasPending, isTrue);
+    expect(queue.pendingIds, ['m1']);
+
+    // The controller is still detached: the queue must keep the id and tell
+    // the caller to poll again instead of losing it.
+    final result = queue.takeForFlush(isAttached: false, isLocked: false);
+    expect(result.ids, isEmpty);
+    expect(result.reschedule, isTrue);
+    expect(queue.hasPending, isTrue);
+  });
+
+  test('locked layout keeps work pending until unlocked', () {
+    final queue = ToolExtentInvalidationQueue();
+    queue.enqueue('m1');
+    queue.enqueue('m2');
+
+    final locked = queue.takeForFlush(isAttached: true, isLocked: true);
+    expect(locked.ids, isEmpty);
+    expect(locked.reschedule, isTrue);
+    expect(queue.hasPending, isTrue);
+
+    var unlocked = queue.takeForFlush(isAttached: true, isLocked: false);
+    expect(unlocked.reschedule, isFalse);
+    expect(unlocked.ids, ['m1', 'm2']);
+    expect(queue.hasPending, isFalse);
+
+    // Nothing left: an idle poll must not ask for another round.
+    final idle = queue.takeForFlush(isAttached: true, isLocked: false);
+    expect(idle.ids, isEmpty);
+    expect(idle.reschedule, isFalse);
+  });
+
+  test('duplicate enqueue coalesces and drops the redundant flush', () {
+    final queue = ToolExtentInvalidationQueue();
+
+    expect(queue.enqueue('m1'), isTrue);
+    expect(queue.enqueue('m1'), isFalse);
+    expect(queue.pendingIds, ['m1']);
+
+    final drained = queue.takeForFlush(isAttached: true, isLocked: false);
+    expect(drained.ids, ['m1']);
+  });
+
+  test('drain order follows enqueue order', () {
+    final queue = ToolExtentInvalidationQueue();
+    queue.enqueue('a');
+    queue.enqueue('b');
+    queue.enqueue('c');
+
+    final result = queue.takeForFlush(isAttached: true, isLocked: false);
+    expect(result.ids, ['a', 'b', 'c']);
+  });
+
+  test('clear drops everything without error', () {
+    final queue = ToolExtentInvalidationQueue();
+    queue.enqueue('m1');
+    queue.clear();
+
+    expect(queue.hasPending, isFalse);
+    final result = queue.takeForFlush(isAttached: true, isLocked: false);
+    expect(result.ids, isEmpty);
+    expect(result.reschedule, isFalse);
+  });
+}

--- a/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
+++ b/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
@@ -142,6 +142,197 @@ void main() {
     expect(after, isNot(96));
   });
 
+  testWidgets(
+    'streaming height change invalidates an already measured extent',
+    (tester) async {
+      final notifier = StreamingContentNotifier();
+      addTearDown(notifier.dispose);
+      notifier.getNotifier('tool-1');
+
+      final key = GlobalKey<_HarnessState>();
+      final messages = <ChatMessage>[
+        ChatMessage(
+          id: 'tool-1',
+          role: 'assistant',
+          content: '',
+          conversationId: 'conversation-1',
+          isStreaming: true,
+        ),
+        ChatMessage(
+          id: 'text-1',
+          role: 'assistant',
+          content: 'A' * 1800,
+          conversationId: 'conversation-1',
+        ),
+        ChatMessage(
+          id: 'text-2',
+          role: 'assistant',
+          content: 'B' * 1800,
+          conversationId: 'conversation-1',
+        ),
+        ChatMessage(
+          id: 'text-3',
+          role: 'assistant',
+          content: 'C' * 1800,
+          conversationId: 'conversation-1',
+        ),
+      ];
+      final toolParts = <String, List<ToolUIPart>>{
+        'tool-1': const [
+          ToolUIPart(
+            id: 'ask',
+            toolName: 'ask_user_input_v0',
+            arguments: {},
+            loading: true,
+          ),
+        ],
+      };
+
+      await tester.pumpWidget(
+        _Harness(
+          key: key,
+          notifier: notifier,
+          messages: messages,
+          toolParts: toolParts,
+        ),
+      );
+      await tester.pump();
+
+      // Row 0 is laid out at the top: the controller holds its measured extent.
+      final listController = tester
+          .widget<SuperListView>(find.byType(SuperListView))
+          .listController!;
+      expect(listController.extentForIndex(0).$2, isFalse);
+
+      // Scroll the tail into view: row 0 leaves the cache area and is no longer
+      // built, but its measured extent stays stored in the controller.
+      key.currentState!.jumpToBottom();
+      await tester.pump();
+      final visible = listController.visibleRange;
+      expect(visible, isNotNull);
+      expect(visible!.$1, greaterThanOrEqualTo(1));
+      expect(listController.extentForIndex(0).$2, isFalse);
+
+      // Streaming answer arrives: the visible tool count stays 1, only the
+      // rendered height of the card changes. No rebuild reaches row 0, so the
+      // height event is the only signal that its stored extent is stale.
+      toolParts['tool-1'] = [
+        ToolUIPart(
+          id: 'ask',
+          toolName: 'ask_user_input_v0',
+          arguments: const {},
+          content: '{"answers":{}}',
+        ),
+      ];
+      notifier.notifyToolPartsUpdated('tool-1');
+      await tester.pump();
+      await tester.pump();
+
+      // The stale measured extent must have been replaced by a fresh estimate.
+      // Without the event subscription and the invalidateExtent call this
+      // assertion stays false — the stored extent survives untouched.
+      final updated = listController.extentForIndex(0);
+      expect(
+        updated.$2,
+        isTrue,
+        reason: 'stale measured extent was not dropped',
+      );
+
+      // Functional consequence: bottom rendering still lands on the tail.
+      key.currentState!.jumpToBottom();
+      await tester.pump();
+      final tail = listController.visibleRange!;
+      expect(tail.$2, greaterThanOrEqualTo(messages.length - 1));
+    },
+  );
+
+  testWidgets('events queued across a controller swap flush after re-attach', (
+    tester,
+  ) async {
+    final notifier = StreamingContentNotifier();
+    addTearDown(notifier.dispose);
+    notifier.getNotifier('tool-1');
+
+    final key = GlobalKey<_HarnessState>();
+    final messages = <ChatMessage>[
+      ChatMessage(
+        id: 'tool-1',
+        role: 'assistant',
+        content: '',
+        conversationId: 'conversation-1',
+        isStreaming: true,
+      ),
+      ChatMessage(
+        id: 'text-1',
+        role: 'assistant',
+        content: 'A' * 1800,
+        conversationId: 'conversation-1',
+      ),
+      ChatMessage(
+        id: 'text-2',
+        role: 'assistant',
+        content: 'B' * 1800,
+        conversationId: 'conversation-1',
+      ),
+      ChatMessage(
+        id: 'text-3',
+        role: 'assistant',
+        content: 'C' * 1800,
+        conversationId: 'conversation-1',
+      ),
+    ];
+    final toolParts = <String, List<ToolUIPart>>{
+      'tool-1': const [
+        ToolUIPart(
+          id: 'ask',
+          toolName: 'ask_user_input_v0',
+          arguments: {},
+          loading: true,
+        ),
+      ],
+    };
+
+    await tester.pumpWidget(
+      _Harness(
+        key: key,
+        notifier: notifier,
+        messages: messages,
+        toolParts: toolParts,
+      ),
+    );
+    await tester.pump();
+
+    // Swap to a fresh controller; the height event fires in the same window,
+    // before the new controller attaches. It must queue and flush post-attach
+    // instead of being dropped or spinning the retry loop forever.
+    final fresh = ListController();
+    key.currentState!.replaceListController(fresh);
+    toolParts['tool-1'] = [
+      ToolUIPart(
+        id: 'ask',
+        toolName: 'ask_user_input_v0',
+        arguments: const {},
+        content: '{"answers":{}}',
+      ),
+    ];
+    notifier.notifyToolPartsUpdated('tool-1');
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    final attached = tester
+        .widget<SuperListView>(find.byType(SuperListView))
+        .listController!;
+    expect(identical(attached, fresh), isTrue);
+
+    // The queue drained and the list stays fully functional: jumping to the
+    // bottom still renders the tail through the last row.
+    key.currentState!.jumpToBottom();
+    await tester.pump();
+    final tail = fresh.visibleRange!;
+    expect(tail.$2, greaterThanOrEqualTo(messages.length - 1));
+  });
+
   testWidgets('recovered tool signature change invalidates extent on rebuild', (
     tester,
   ) async {
@@ -250,7 +441,7 @@ class _Harness extends StatefulWidget {
 
 class _HarnessState extends State<_Harness> {
   late final ScrollController scrollController;
-  late final ListController listController;
+  late ListController listController;
   late final ValueNotifier<bool> isProcessingFiles;
   late Map<String, List<ToolUIPart>> toolParts;
 
@@ -267,6 +458,15 @@ class _HarnessState extends State<_Harness> {
 
   void replaceTools(Map<String, List<ToolUIPart>> next) {
     setState(() => toolParts = next);
+  }
+
+  void replaceListController(ListController next) {
+    setState(() => listController = next);
+  }
+
+  void jumpToBottom() {
+    if (!scrollController.hasClients) return;
+    scrollController.jumpTo(scrollController.position.maxScrollExtent);
   }
 
   @override

--- a/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
+++ b/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
@@ -246,7 +246,7 @@ void main() {
     },
   );
 
-  testWidgets('events queued across a controller swap flush after re-attach', (
+  testWidgets('controller swap mid-stream drains the queue and stays usable', (
     tester,
   ) async {
     final notifier = StreamingContentNotifier();
@@ -302,9 +302,10 @@ void main() {
     );
     await tester.pump();
 
-    // Swap to a fresh controller; the height event fires in the same window,
-    // before the new controller attaches. It must queue and flush post-attach
-    // instead of being dropped or spinning the retry loop forever.
+    // A fresh controller replaces the current one while a tool height change
+    // is in flight. The swap runs through MessageListView.didUpdateWidget and
+    // the attach-aware scheduler; a regression that strands the queue or spins
+    // the retry loop would deadlock the post-frame callbacks here.
     final fresh = ListController();
     key.currentState!.replaceListController(fresh);
     toolParts['tool-1'] = [
@@ -325,8 +326,11 @@ void main() {
         .listController!;
     expect(identical(attached, fresh), isTrue);
 
-    // The queue drained and the list stays fully functional: jumping to the
-    // bottom still renders the tail through the last row.
+    // Queue semantics themselves (detached/locked hold, drain on attach) are
+    // unit-covered in test/features/home/controllers/
+    // tool_extent_invalidation_queue_test.dart; this guard only verifies the
+    // widget-level integration remains functional: jumping to the bottom still
+    // renders the tail through the last row.
     key.currentState!.jumpToBottom();
     await tester.pump();
     final tail = fresh.visibleRange!;

--- a/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
+++ b/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
@@ -1,0 +1,326 @@
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/tts_provider.dart';
+import 'package:Cuplivo/core/providers/user_provider.dart';
+import 'package:Cuplivo/core/services/streaming_content_notifier.dart';
+import 'package:Cuplivo/features/chat/models/tool_ui_part.dart';
+import 'package:Cuplivo/features/home/controllers/stream_controller.dart'
+    as stream_ctrl;
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+import 'package:Cuplivo/features/home/widgets/message_list_view.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:super_sliver_list/super_sliver_list.dart';
+
+var businessPrefs = BusinessPreferences.memoryForTests();
+
+void main() {
+  setUp(() {
+    businessPrefs = BusinessPreferences.memoryForTests();
+    businessPrefs = BusinessPreferences.memoryForTests({});
+  });
+
+  test('tool height events coalesce by messageId and bump version', () async {
+    final notifier = StreamingContentNotifier();
+    addTearDown(notifier.dispose);
+
+    final seen = <ToolHeightEvent>[];
+    notifier.toolHeightEvents.addListener(() {
+      final event = notifier.toolHeightEvents.value;
+      if (event != null) seen.add(event);
+    });
+
+    notifier.notifyToolHeightChanged('m1');
+    notifier.notifyToolHeightChanged('m1');
+    notifier.notifyToolHeightChanged('m2');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(seen, hasLength(2));
+    expect(seen.map((e) => e.messageId), ['m1', 'm2']);
+    expect(seen[1].version, greaterThan(seen[0].version));
+  });
+
+  test('height events stop silently after dispose', () async {
+    final notifier = StreamingContentNotifier();
+    var events = 0;
+    notifier.toolHeightEvents.addListener(() => events++);
+
+    notifier.notifyToolHeightChanged('m0');
+    await Future<void>.delayed(Duration.zero);
+    expect(events, 1);
+
+    notifier.dispose();
+    notifier.notifyToolHeightChanged('m1');
+    notifier.notifyToolPartsUpdated('m1');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, 1);
+  });
+
+  test(
+    'structure split growth emits a height event, stable text does not',
+    () async {
+      final notifier = StreamingContentNotifier();
+      addTearDown(notifier.dispose);
+      notifier.getNotifier('m1');
+
+      final seen = <String>[];
+      notifier.toolHeightEvents.addListener(() {
+        final event = notifier.toolHeightEvents.value;
+        if (event != null) seen.add(event.messageId);
+      });
+
+      // Pure text growth: no new block starts.
+      notifier.updateContent('m1', 'some content', 10);
+      await Future<void>.delayed(Duration.zero);
+      expect(seen, isEmpty);
+
+      // A new thinking block start changes the structure.
+      notifier.updateContent(
+        'm1',
+        'some content<thinking>x</thinking>',
+        12,
+        contentSplitOffsets: const <int>[18],
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(seen, ['m1']);
+    },
+  );
+
+  testWidgets('streaming tool event invalidates the cached extent', (
+    tester,
+  ) async {
+    final notifier = StreamingContentNotifier();
+    addTearDown(notifier.dispose);
+    notifier.getNotifier('stream-1');
+
+    final message = ChatMessage(
+      id: 'stream-1',
+      role: 'assistant',
+      content: '',
+      conversationId: 'conversation-1',
+      isStreaming: true,
+    );
+    final toolParts = <String, List<ToolUIPart>>{
+      'stream-1': const <ToolUIPart>[],
+    };
+
+    await tester.pumpWidget(
+      _Harness(notifier: notifier, messages: [message], toolParts: toolParts),
+    );
+    await tester.pump();
+
+    // _estimateChrome: a tools-only turn must not collapse to the chrome
+    // floor — the timeline has to budget for the cards that will stack here.
+    final list = tester.widget<SuperListView>(find.byType(SuperListView));
+    expect(list.extentEstimation!(0, 400), 96);
+
+    // The map is replaced in place, exactly like the streaming path does;
+    // MessageListView never sees didUpdateWidget, so the height event is the
+    // only signal that the height of this slot changed.
+    toolParts['stream-1'] = [
+      for (var i = 0; i < 8; i++)
+        ToolUIPart(
+          id: 't$i',
+          toolName: 'read_file',
+          arguments: {'path': '$i.dart'},
+          content: 'ok',
+        ),
+    ];
+    notifier.notifyToolPartsUpdated('stream-1');
+    await tester.pump();
+
+    final after = tester
+        .widget<SuperListView>(find.byType(SuperListView))
+        .extentEstimation!(0, 400);
+    expect(after, closeTo(96 + 8 * 44.0, 0.1));
+    expect(after, isNot(96));
+  });
+
+  testWidgets('recovered tool signature change invalidates extent on rebuild', (
+    tester,
+  ) async {
+    final key = GlobalKey<_HarnessState>();
+    final message = ChatMessage(
+      id: 'hist-1',
+      role: 'assistant',
+      content: '',
+      conversationId: 'conversation-1',
+    );
+
+    await tester.pumpWidget(
+      _Harness(
+        key: key,
+        messages: [message],
+        toolParts: {
+          'hist-1': const [
+            ToolUIPart(id: 'ask', toolName: 'ask_user_input_v0', arguments: {}),
+          ],
+        },
+      ),
+    );
+    await tester.pump();
+
+    final list = tester.widget<SuperListView>(find.byType(SuperListView));
+    final before = list.extentEstimation!(0, 400);
+
+    // The recovered answer replaces the tool list with new instances while
+    // also adding a second tool; only the signature snapshot can detect this.
+    key.currentState!.replaceTools({
+      'hist-1': [
+        ToolUIPart(
+          id: 'ask',
+          toolName: 'ask_user_input_v0',
+          arguments: const {},
+          content: '{"answers":{}}',
+        ),
+        const ToolUIPart(
+          id: 't1',
+          toolName: 'read_file',
+          arguments: {'path': 'a.txt'},
+          content: 'data',
+        ),
+      ],
+    });
+    await tester.pump();
+
+    final after = tester
+        .widget<SuperListView>(find.byType(SuperListView))
+        .extentEstimation!(0, 400);
+    expect(after, isNot(before));
+  });
+
+  testWidgets('tool estimate counts only timeline-visible tools', (
+    tester,
+  ) async {
+    final message = ChatMessage(
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      conversationId: 'conversation-1',
+    );
+
+    await tester.pumpWidget(
+      _Harness(
+        messages: [message],
+        toolParts: {
+          'm1': const [
+            ToolUIPart(
+              id: 'search',
+              toolName: 'builtin_search',
+              arguments: {'query': 'x'},
+            ),
+            ToolUIPart(
+              id: 'read',
+              toolName: 'read_file',
+              arguments: {'path': 'a.txt'},
+            ),
+          ],
+        },
+      ),
+    );
+    await tester.pump();
+
+    // builtin_search is hidden from the timeline; only read_file contributes.
+    final list = tester.widget<SuperListView>(find.byType(SuperListView));
+    expect(list.extentEstimation!(0, 400), closeTo(96 + 44.0, 0.1));
+  });
+}
+
+class _Harness extends StatefulWidget {
+  const _Harness({
+    super.key,
+    required this.messages,
+    required this.toolParts,
+    this.notifier,
+  });
+
+  final List<ChatMessage> messages;
+  final Map<String, List<ToolUIPart>> toolParts;
+  final StreamingContentNotifier? notifier;
+
+  @override
+  State<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends State<_Harness> {
+  late final ScrollController scrollController;
+  late final ListController listController;
+  late final ValueNotifier<bool> isProcessingFiles;
+  late Map<String, List<ToolUIPart>> toolParts;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollController = ScrollController();
+    listController = ListController();
+    isProcessingFiles = ValueNotifier<bool>(false);
+    // Share the same mutable map as production: stream updates replace the
+    // list in place instead of rebuilding MessageListView.
+    toolParts = widget.toolParts;
+  }
+
+  void replaceTools(Map<String, List<ToolUIPart>> next) {
+    setState(() => toolParts = next);
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    listController.dispose();
+    isProcessingFiles.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        Provider<BusinessPreferences>.value(value: businessPrefs),
+        ChangeNotifierProvider(
+          create: (_) => SettingsProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => AssistantProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => UserProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => TtsProvider(preferences: businessPrefs),
+        ),
+        ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+        ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: MessageListView(
+            scrollController: scrollController,
+            listController: listController,
+            messages: widget.messages,
+            byGroup: const {},
+            versionSelections: const {},
+            reasoning: const <String, stream_ctrl.ReasoningData>{},
+            reasoningSegments:
+                const <String, List<stream_ctrl.ReasoningSegmentData>>{},
+            contentSplits: const <String, stream_ctrl.ContentSplitData>{},
+            toolParts: toolParts,
+            translations: const {},
+            selecting: false,
+            selectedItems: const {},
+            dividerPadding: EdgeInsets.zero,
+            isProcessingFiles: isProcessingFiles,
+            streamingContentNotifier: widget.notifier,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
+++ b/test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart
@@ -8,6 +8,7 @@ import 'package:Cuplivo/core/services/streaming_content_notifier.dart';
 import 'package:Cuplivo/features/chat/models/tool_ui_part.dart';
 import 'package:Cuplivo/features/home/controllers/stream_controller.dart'
     as stream_ctrl;
+import 'package:Cuplivo/features/home/controllers/tool_extent_invalidation_port.dart';
 import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
 import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
 import 'package:Cuplivo/features/home/widgets/message_list_view.dart';
@@ -246,7 +247,7 @@ void main() {
     },
   );
 
-  testWidgets('controller swap mid-stream drains the queue and stays usable', (
+  testWidgets('detached-window event queues and drains after re-attach', (
     tester,
   ) async {
     final notifier = StreamingContentNotifier();
@@ -292,22 +293,33 @@ void main() {
       ],
     };
 
+    // The seam: the test controls the detached/locked view the coordinator
+    // reads, while invalidations are forwarded to the real controller so the
+    // extent effect is observable.
+    final controller = ListController();
+    final port = _RecordingExtentPort(controller);
     await tester.pumpWidget(
       _Harness(
         key: key,
         notifier: notifier,
         messages: messages,
         toolParts: toolParts,
+        toolExtentPort: port,
+        listController: controller,
       ),
     );
     await tester.pump();
 
-    // A fresh controller replaces the current one while a tool height change
-    // is in flight. The swap runs through MessageListView.didUpdateWidget and
-    // the attach-aware scheduler; a regression that strands the queue or spins
-    // the retry loop would deadlock the post-frame callbacks here.
-    final fresh = ListController();
-    key.currentState!.replaceListController(fresh);
+    // Row 0 is laid out and its extent is measured; scroll it out of the
+    // cache area so it stays unbuilt but keeps its stored measured extent.
+    expect(controller.extentForIndex(0).$2, isFalse);
+    key.currentState!.jumpToBottom();
+    await tester.pump();
+    expect(controller.extentForIndex(0).$2, isFalse);
+
+    // Force the detached window (unreachable through real frame timing) and
+    // stream an answer that keeps the visible tool count but changes height.
+    port.forceAttached = false;
     toolParts['tool-1'] = [
       ToolUIPart(
         id: 'ask',
@@ -318,23 +330,80 @@ void main() {
     ];
     notifier.notifyToolPartsUpdated('tool-1');
     await tester.pump();
+    expect(port.invalidations, isEmpty, reason: 'must hold while detached');
+
+    // Re-attach: the queued invalidation must drain through the coordinator.
+    port.forceAttached = null;
     await tester.pump();
     await tester.pump();
 
-    final attached = tester
-        .widget<SuperListView>(find.byType(SuperListView))
-        .listController!;
-    expect(identical(attached, fresh), isTrue);
+    expect(port.invalidations, contains(0));
+    expect(
+      controller.extentForIndex(0).$2,
+      isTrue,
+      reason: 'stale measured extent must be dropped after re-attach',
+    );
+  });
 
-    // Queue semantics themselves (detached/locked hold, drain on attach) are
-    // unit-covered in test/features/home/controllers/
-    // tool_extent_invalidation_queue_test.dart; this guard only verifies the
-    // widget-level integration remains functional: jumping to the bottom still
-    // renders the tail through the last row.
-    key.currentState!.jumpToBottom();
+  testWidgets('locked-window event queues and drains after unlock', (
+    tester,
+  ) async {
+    final notifier = StreamingContentNotifier();
+    addTearDown(notifier.dispose);
+    notifier.getNotifier('tool-1');
+
+    final key = GlobalKey<_HarnessState>();
+    final lockedController = ListController();
+    final port = _RecordingExtentPort(lockedController);
+    final toolParts = <String, List<ToolUIPart>>{
+      'tool-1': const [
+        ToolUIPart(
+          id: 'ask',
+          toolName: 'ask_user_input_v0',
+          arguments: {},
+          loading: true,
+        ),
+      ],
+    };
+
+    await tester.pumpWidget(
+      _Harness(
+        key: key,
+        notifier: notifier,
+        messages: [
+          ChatMessage(
+            id: 'tool-1',
+            role: 'assistant',
+            content: '',
+            conversationId: 'conversation-1',
+            isStreaming: true,
+          ),
+        ],
+        toolParts: toolParts,
+        toolExtentPort: port,
+        listController: lockedController,
+      ),
+    );
     await tester.pump();
-    final tail = fresh.visibleRange!;
-    expect(tail.$2, greaterThanOrEqualTo(messages.length - 1));
+
+    port.forceLocked = true;
+    toolParts['tool-1'] = [
+      ToolUIPart(
+        id: 'ask',
+        toolName: 'ask_user_input_v0',
+        arguments: const {},
+        content: '{"answers":{}}',
+      ),
+    ];
+    notifier.notifyToolPartsUpdated('tool-1');
+    await tester.pump();
+    expect(port.invalidations, isEmpty, reason: 'must hold while locked');
+
+    port.forceLocked = null;
+    await tester.pump();
+    await tester.pump();
+
+    expect(port.invalidations, isNotEmpty);
   });
 
   testWidgets('recovered tool signature change invalidates extent on rebuild', (
@@ -433,11 +502,15 @@ class _Harness extends StatefulWidget {
     required this.messages,
     required this.toolParts,
     this.notifier,
+    this.toolExtentPort,
+    this.listController,
   });
 
   final List<ChatMessage> messages;
   final Map<String, List<ToolUIPart>> toolParts;
   final StreamingContentNotifier? notifier;
+  final ToolExtentInvalidationPort? toolExtentPort;
+  final ListController? listController;
 
   @override
   State<_Harness> createState() => _HarnessState();
@@ -445,7 +518,7 @@ class _Harness extends StatefulWidget {
 
 class _HarnessState extends State<_Harness> {
   late final ScrollController scrollController;
-  late ListController listController;
+  late final ListController listController;
   late final ValueNotifier<bool> isProcessingFiles;
   late Map<String, List<ToolUIPart>> toolParts;
 
@@ -453,7 +526,7 @@ class _HarnessState extends State<_Harness> {
   void initState() {
     super.initState();
     scrollController = ScrollController();
-    listController = ListController();
+    listController = widget.listController ?? ListController();
     isProcessingFiles = ValueNotifier<bool>(false);
     // Share the same mutable map as production: stream updates replace the
     // list in place instead of rebuilding MessageListView.
@@ -464,10 +537,6 @@ class _HarnessState extends State<_Harness> {
     setState(() => toolParts = next);
   }
 
-  void replaceListController(ListController next) {
-    setState(() => listController = next);
-  }
-
   void jumpToBottom() {
     if (!scrollController.hasClients) return;
     scrollController.jumpTo(scrollController.position.maxScrollExtent);
@@ -476,7 +545,7 @@ class _HarnessState extends State<_Harness> {
   @override
   void dispose() {
     scrollController.dispose();
-    listController.dispose();
+    if (widget.listController == null) listController.dispose();
     isProcessingFiles.dispose();
     super.dispose();
   }
@@ -522,9 +591,44 @@ class _HarnessState extends State<_Harness> {
             dividerPadding: EdgeInsets.zero,
             isProcessingFiles: isProcessingFiles,
             streamingContentNotifier: widget.notifier,
+            toolExtentPort: widget.toolExtentPort,
           ),
         ),
       ),
     );
+  }
+}
+
+/// Test port: the test owns the detached/locked view while invalidations are
+/// forwarded to the real [ListController] so the extent effect stays real.
+class _RecordingExtentPort implements ToolExtentInvalidationPort {
+  _RecordingExtentPort(this._controller);
+
+  final ListController _controller;
+
+  /// When set, the coordinator sees this value instead of the controller's
+  /// real attach state.
+  bool? forceAttached;
+
+  /// When set, the coordinator sees this value instead of the controller's
+  /// real lock state.
+  bool? forceLocked;
+
+  /// Indices whose invalidation reached the coordinator.
+  final List<int> invalidations = <int>[];
+
+  @override
+  bool get isAttached => forceAttached ?? _controller.isAttached;
+
+  @override
+  bool get isLocked => forceLocked ?? _controller.isLocked;
+
+  @override
+  (int, int)? get visibleRange => _controller.visibleRange;
+
+  @override
+  void invalidateExtent(int index) {
+    invalidations.add(index);
+    _controller.invalidateExtent(index);
   }
 }


### PR DESCRIPTION
## Summary

Fixes random conversation rendering-range corruption (timeline squeezed into a thin strip with blank space, or extending past the screen with the bottom never rendered) that users reported after v3.1.0 shipped PR #530 (SuperSliverList adoption). The WebView episode in the report was coincidental; the regression is the ported SuperSliverList timeline in `message_list_view.dart`.

This also ports the essence of upstream Kelivo `90c9f4cc` ("invalidate and align tool extent estimates", committed one day after the original port and never synchronized here) adapted to the Cuplivo timeline.

## Root cause

- Tool parts mutate in place during streaming, so `didUpdateWidget` diffs can never see them; no invalidation event existed. During tool calls SuperSliverList kept extents measured for the previous card heap — whether the corruption triggers depends on scroll position (matches "randomly triggers, sometimes not").
- The extent estimator ignored tool cards entirely: a tools-only turn collapsed to the 96px chrome floor while the renderer stacks hundreds of pixels of tool cards (under-estimate → "beyond-screen/bottom never renders"); mis-signed estimates also produced the reverse "blank strip" symptom.
- Switching conversations recreates the keyed subtree + `ListController`, which is why it recovered.

## Changes

- `StreamingContentNotifier`: coalesced `ToolHeightEvent` channel (microtask flush, dispose guard). Emitted from tool-part updates, the tool-answer settle path, and when a streamed thinking/tool block starts (split-count structure signature — covers article-streaming).
- `MessageListView`:
  - Subscribes to `toolHeightEvents`, drops the estimate memo entry and calls `invalidateExtent`, queueing while the controller is not attached (cold window load) or layout-locked; above-viewport changes pin the bottom so the tail doesn't slide.
  - Per-message visible-tool-count snapshot covers non-streaming rebuilds (in-place mutations invisible to `didUpdateWidget`).
  - Estimator budgets one collapsed step per visible tool (44px, mirroring the renderer's `builtin_search` exclusion) and no longer counts a phantom text row for empty bodies. The memo key is the visible tool count, so streaming identity churn does not defeat it.
- `home_page_controller.dart`: emits after `setToolParts` on tool-answer recovery.
- Tests: `test/features/home/widgets/message_list_view_tool_extent_invalidation_test.dart` (6 cases: coalescing, dispose guard, split-structure event, streaming invalidation, rebuild-time count change, estimate floor/visibility).

## Verification

- `dart format` on changed paths.
- `dart analyze --fatal-infos lib test` — no issues.
- New test file: 6/6 pass; `test/features/home/widgets/` subset: all pass.
- `test/core/services/` backup LAN-sync file tests fail on clean `master` too (pre-existing environment/timing flakiness, unrelated); full suite not run locally.

## Residual risk

- Original symptom not reproducible locally (developer device / CI both). Diagnostics available via the existing flutter log toggle: `TimelineExtent`-tagged invalidation events land in `flutter_logs.txt` — worth asking the reporter to confirm on the next build.
- Pure text growth (no split change) for off-screen streaming rows is still estimate-lagged until measured; the upstream `partStructureTokens` approach requires the `MessagePart` model and is tracked separately.
- `showToolResultSummary` / `collapseThinkingSteps` estimate alignment (upstream 69b62fad) and the frosted contract rework (58888af3) are intentionally out of scope.
