### PR TITLE
fix(chat): bind tool approval buttons to the pending tool call by id

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -55,6 +55,7 @@ import 'token_display_widget.dart';
 import '../../../theme/app_font_weights.dart';
 import '../../../theme/app_semantic_colors.dart';
 import '../models/tool_ui_part.dart';
+import 'tool_approval_binding.dart';
 
 export '../models/tool_ui_part.dart';
 
@@ -4150,30 +4151,6 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
   bool get _askUserAnswered =>
       widget.part.content?.trim().isNotEmpty == true && !widget.part.loading;
 
-  /// The approval request bound to this step, if any.
-  ///
-  /// Requests are keyed by the same stream tool-call id as the part;
-  /// matching only by id keeps resolved past steps non-interactive. When the
-  /// part has no id (no-id tool events are supported by the engine), fall
-  /// back to name binding so the current request stays renderable.
-  ToolApprovalRequest? _pendingApprovalRequest(
-    ToolApprovalService approvalService,
-    String partId,
-  ) {
-    if (!widget.part.loading) return null;
-    if (partId.isNotEmpty && approvalService.isPending(partId)) {
-      return approvalService.pendingRequests[partId];
-    }
-    if (partId.isEmpty) {
-      for (final request in approvalService.pendingRequests.values) {
-        if (request.toolName == widget.part.toolName) {
-          return request;
-        }
-      }
-    }
-    return null;
-  }
-
   @override
   void didUpdateWidget(covariant _ChainOfThoughtToolStep oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -4257,8 +4234,10 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
     final fg = _chatSurfaceForegroundPalette(context);
     final settings = context.watch<SettingsProvider>();
     final approvalService = context.watch<ToolApprovalService>();
-    final partId = widget.part.id.trim();
-    final approvalRequest = _pendingApprovalRequest(approvalService, partId);
+    final approvalRequest = pendingApprovalRequestFor(
+      approvalService,
+      widget.part,
+    );
     final isPendingApproval = approvalRequest != null;
 
     final icon = _isAskUser
@@ -4494,30 +4473,6 @@ class _ToolCallItemState extends State<_ToolCallItem> {
     return entries.join(', ') + suffix;
   }
 
-  /// The pending approval id bound to this part, if any.
-  ///
-  /// Requests are keyed by the same stream tool-call id as the part, so past
-  /// resolved tool calls never bind to a newer request. When the part has no
-  /// id (no-id tool events are supported by the engine), fall back to name
-  /// binding so the current request stays renderable.
-  String? _pendingToolCallIdFor(
-    ToolApprovalService approvalService,
-    String partId,
-  ) {
-    if (!widget.part.loading) return null;
-    if (partId.isNotEmpty && approvalService.isPending(partId)) {
-      return partId;
-    }
-    if (partId.isEmpty) {
-      for (final request in approvalService.pendingRequests.values) {
-        if (request.toolName == widget.part.toolName) {
-          return request.toolCallId;
-        }
-      }
-    }
-    return null;
-  }
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -4538,12 +4493,11 @@ class _ToolCallItemState extends State<_ToolCallItem> {
 
     // Check if this tool call is pending approval.
     final approvalService = context.watch<ToolApprovalService>();
-    final partId = widget.part.id.trim();
-    final String? pendingToolCallId = _pendingToolCallIdFor(
+    final approvalRequest = pendingApprovalRequestFor(
       approvalService,
-      partId,
+      widget.part,
     );
-    final isPendingApproval = pendingToolCallId != null;
+    final isPendingApproval = approvalRequest != null;
 
     return IosCardPress(
       borderRadius: BorderRadius.circular(16),
@@ -4690,7 +4644,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
               ),
             ],
             // Approval action buttons
-            if (isPendingApproval) ...[
+            if (approvalRequest != null) ...[
               const SizedBox(height: 10),
               Row(
                 children: [
@@ -4702,7 +4656,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       onTap: () => _showDenyDialog(
                         context,
                         approvalService,
-                        pendingToolCallId,
+                        approvalRequest.toolCallId,
                       ),
                     ),
                   ),
@@ -4712,7 +4666,8 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       label: l10n.toolApprovalApprove,
                       color: fg.accent,
                       filled: true,
-                      onTap: () => approvalService.approve(pendingToolCallId),
+                      onTap: () =>
+                          approvalService.approve(approvalRequest.toolCallId),
                     ),
                   ),
                 ],

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -4150,6 +4150,30 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
   bool get _askUserAnswered =>
       widget.part.content?.trim().isNotEmpty == true && !widget.part.loading;
 
+  /// The approval request bound to this step, if any.
+  ///
+  /// Requests are keyed by the same stream tool-call id as the part;
+  /// matching only by id keeps resolved past steps non-interactive. When the
+  /// part has no id (no-id tool events are supported by the engine), fall
+  /// back to name binding so the current request stays renderable.
+  ToolApprovalRequest? _pendingApprovalRequest(
+    ToolApprovalService approvalService,
+    String partId,
+  ) {
+    if (!widget.part.loading) return null;
+    if (partId.isNotEmpty && approvalService.isPending(partId)) {
+      return approvalService.pendingRequests[partId];
+    }
+    if (partId.isEmpty) {
+      for (final request in approvalService.pendingRequests.values) {
+        if (request.toolName == widget.part.toolName) {
+          return request;
+        }
+      }
+    }
+    return null;
+  }
+
   @override
   void didUpdateWidget(covariant _ChainOfThoughtToolStep oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -4233,20 +4257,9 @@ class _ChainOfThoughtToolStepState extends State<_ChainOfThoughtToolStep> {
     final fg = _chatSurfaceForegroundPalette(context);
     final settings = context.watch<SettingsProvider>();
     final approvalService = context.watch<ToolApprovalService>();
-    ToolApprovalRequest? pendingRequest;
-    if (widget.part.id.isNotEmpty &&
-        approvalService.isPending(widget.part.id)) {
-      pendingRequest = approvalService.pendingRequests[widget.part.id];
-    } else {
-      for (final request in approvalService.pendingRequests.values) {
-        if (request.toolName == widget.part.toolName) {
-          pendingRequest = request;
-          break;
-        }
-      }
-    }
-    final isPendingApproval = pendingRequest != null;
-    final approvalRequest = pendingRequest;
+    final partId = widget.part.id.trim();
+    final approvalRequest = _pendingApprovalRequest(approvalService, partId);
+    final isPendingApproval = approvalRequest != null;
 
     final icon = _isAskUser
         ? Icon(
@@ -4481,6 +4494,30 @@ class _ToolCallItemState extends State<_ToolCallItem> {
     return entries.join(', ') + suffix;
   }
 
+  /// The pending approval id bound to this part, if any.
+  ///
+  /// Requests are keyed by the same stream tool-call id as the part, so past
+  /// resolved tool calls never bind to a newer request. When the part has no
+  /// id (no-id tool events are supported by the engine), fall back to name
+  /// binding so the current request stays renderable.
+  String? _pendingToolCallIdFor(
+    ToolApprovalService approvalService,
+    String partId,
+  ) {
+    if (!widget.part.loading) return null;
+    if (partId.isNotEmpty && approvalService.isPending(partId)) {
+      return partId;
+    }
+    if (partId.isEmpty) {
+      for (final request in approvalService.pendingRequests.values) {
+        if (request.toolName == widget.part.toolName) {
+          return request.toolCallId;
+        }
+      }
+    }
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
@@ -4499,23 +4536,14 @@ class _ToolCallItemState extends State<_ToolCallItem> {
       );
     }
 
-    // Check if this tool call is pending approval
+    // Check if this tool call is pending approval.
     final approvalService = context.watch<ToolApprovalService>();
-    final isPendingApproval =
-        widget.part.loading &&
-        approvalService.pendingRequests.values.any(
-          (req) => req.toolName == widget.part.toolName,
-        );
-    // Find the matching approval request
-    String? pendingToolCallId;
-    if (isPendingApproval) {
-      try {
-        final req = approvalService.pendingRequests.values.firstWhere(
-          (req) => req.toolName == widget.part.toolName,
-        );
-        pendingToolCallId = req.toolCallId;
-      } catch (_) {}
-    }
+    final partId = widget.part.id.trim();
+    final String? pendingToolCallId = _pendingToolCallIdFor(
+      approvalService,
+      partId,
+    );
+    final isPendingApproval = pendingToolCallId != null;
 
     return IosCardPress(
       borderRadius: BorderRadius.circular(16),
@@ -4662,7 +4690,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
               ),
             ],
             // Approval action buttons
-            if (isPendingApproval && pendingToolCallId != null) ...[
+            if (isPendingApproval) ...[
               const SizedBox(height: 10),
               Row(
                 children: [
@@ -4674,7 +4702,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       onTap: () => _showDenyDialog(
                         context,
                         approvalService,
-                        pendingToolCallId!,
+                        pendingToolCallId,
                       ),
                     ),
                   ),
@@ -4684,7 +4712,7 @@ class _ToolCallItemState extends State<_ToolCallItem> {
                       label: l10n.toolApprovalApprove,
                       color: fg.accent,
                       filled: true,
-                      onTap: () => approvalService.approve(pendingToolCallId!),
+                      onTap: () => approvalService.approve(pendingToolCallId),
                     ),
                   ),
                 ],

--- a/lib/features/chat/widgets/tool_approval_binding.dart
+++ b/lib/features/chat/widgets/tool_approval_binding.dart
@@ -1,0 +1,23 @@
+import '../../home/services/tool_approval_service.dart';
+import '../models/tool_ui_part.dart';
+
+/// The approval request (if any) currently pending for [part], or null.
+///
+/// The pending request is keyed by the same stream tool-call id as the part:
+/// each provider passes its per-call id to both the emitted chunk (which
+/// becomes [ToolUIPart.id]) and the tool handler (which keys the approval
+/// request). Binding strictly by that id — never by tool name — keeps past
+/// and parallel same-name tool calls non-interactive.
+///
+/// A part without an id can never be pending: live parts always carry a
+/// non-empty id because every provider synthesizes one, approvals exist only
+/// during runtime, and restored messages are never pending.
+ToolApprovalRequest? pendingApprovalRequestFor(
+  ToolApprovalService approvalService,
+  ToolUIPart part,
+) {
+  if (!part.loading) return null;
+  final partId = part.id.trim();
+  if (partId.isEmpty) return null;
+  return approvalService.pendingRequests[partId];
+}

--- a/lib/features/home/services/tool_approval_service.dart
+++ b/lib/features/home/services/tool_approval_service.dart
@@ -65,6 +65,14 @@ class ToolApprovalService extends ChangeNotifier {
     required Map<String, dynamic> arguments,
     String? conversationId,
   }) {
+    // A provider retry can re-emit the same tool_call_id while the first
+    // request is still pending; silently overwriting would orphan the first
+    // completer and its awaiting handler could never resume. Complete it as
+    // replaced before inserting the new request.
+    final existing = _pending[toolCallId];
+    if (existing != null && !existing._completer.isCompleted) {
+      existing._completer.complete(ToolApprovalResult.denied('replaced'));
+    }
     final completer = Completer<ToolApprovalResult>();
     _pending[toolCallId] = ToolApprovalRequest(
       toolCallId: toolCallId,

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -700,8 +700,9 @@ class ToolHandlerService {
         if (hasMcpPrefix) {
           // Approval gate (using original unprefixed name)
           if (approvalService != null && mcp.toolNeedsApproval(resolvedName)) {
-            final callId =
-                '${resolvedName}_${DateTime.now().microsecondsSinceEpoch}';
+            final callId = (toolCallId?.trim().isNotEmpty == true)
+                ? toolCallId!.trim()
+                : '${resolvedName}_${DateTime.now().microsecondsSinceEpoch}';
             final result = await approvalService.requestApproval(
               toolCallId: callId,
               toolName: resolvedName,
@@ -851,7 +852,9 @@ class ToolHandlerService {
               boundWs?.isToolNeedsApproval(name) ??
               WorkspaceToolNames.defaultApprovalFor(name);
           if (approvalService != null && needsApproval) {
-            final callId = '${name}_${DateTime.now().microsecondsSinceEpoch}';
+            final callId = (toolCallId?.trim().isNotEmpty == true)
+                ? toolCallId!.trim()
+                : '${name}_${DateTime.now().microsecondsSinceEpoch}';
             final result = await approvalService.requestApproval(
               toolCallId: callId,
               toolName: name,
@@ -965,10 +968,11 @@ class ToolHandlerService {
 
         // Approval gate for MCP tools
         if (approvalService != null && mcp.toolNeedsApproval(name)) {
-          // Generate a unique id for this tool call approval request
-          final toolCallId = '${name}_${DateTime.now().microsecondsSinceEpoch}';
+          final approvalId = (toolCallId?.trim().isNotEmpty == true)
+              ? toolCallId!.trim()
+              : '${name}_${DateTime.now().microsecondsSinceEpoch}';
           final result = await approvalService.requestApproval(
-            toolCallId: toolCallId,
+            toolCallId: approvalId,
             toolName: name,
             arguments: args,
             conversationId: conversationId,

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -254,6 +254,22 @@ class ToolHandlerService {
     });
   }
 
+  /// Stable per-invocation id for a tool-call approval/interaction request.
+  ///
+  /// Streams normally provide a real tool-call id; the synthesized fallback
+  /// is a last resort for providers that hand none. It is logged, because
+  /// such a request key can never match a `ToolUIPart.id` — a future
+  /// provider regression must surface instead of silently unmatching.
+  static String _streamCallId(String? toolCallId, String fallbackName) {
+    final trimmed = toolCallId?.trim() ?? '';
+    if (trimmed.isNotEmpty) return trimmed;
+    debugPrint(
+      '[tool_handler] no stream tool-call id for "$fallbackName"; '
+      'synthesized request id',
+    );
+    return '${fallbackName}_${DateTime.now().microsecondsSinceEpoch}';
+  }
+
   // ============================================================================
   // Collision Detection & Prefix Validation
   // ============================================================================
@@ -700,9 +716,7 @@ class ToolHandlerService {
         if (hasMcpPrefix) {
           // Approval gate (using original unprefixed name)
           if (approvalService != null && mcp.toolNeedsApproval(resolvedName)) {
-            final callId = (toolCallId?.trim().isNotEmpty == true)
-                ? toolCallId!.trim()
-                : '${resolvedName}_${DateTime.now().microsecondsSinceEpoch}';
+            final callId = _streamCallId(toolCallId, resolvedName);
             final result = await approvalService.requestApproval(
               toolCallId: callId,
               toolName: resolvedName,
@@ -752,9 +766,7 @@ class ToolHandlerService {
             assistant != null &&
             assistant.localToolIds.contains(LocalToolNames.calendarCreate) &&
             approvalService != null) {
-          final approvalId = (toolCallId?.trim().isNotEmpty == true)
-              ? toolCallId!.trim()
-              : '${name}_${DateTime.now().microsecondsSinceEpoch}';
+          final approvalId = _streamCallId(toolCallId, name);
           final approval = await approvalService.requestApproval(
             toolCallId: approvalId,
             toolName: name,
@@ -852,9 +864,7 @@ class ToolHandlerService {
               boundWs?.isToolNeedsApproval(name) ??
               WorkspaceToolNames.defaultApprovalFor(name);
           if (approvalService != null && needsApproval) {
-            final callId = (toolCallId?.trim().isNotEmpty == true)
-                ? toolCallId!.trim()
-                : '${name}_${DateTime.now().microsecondsSinceEpoch}';
+            final callId = _streamCallId(toolCallId, name);
             final result = await approvalService.requestApproval(
               toolCallId: callId,
               toolName: name,
@@ -950,9 +960,7 @@ class ToolHandlerService {
           }
           try {
             final result = await askUserService.requestAnswer(
-              toolCallId: (toolCallId?.trim().isNotEmpty == true)
-                  ? toolCallId!.trim()
-                  : '${name}_${DateTime.now().microsecondsSinceEpoch}',
+              toolCallId: _streamCallId(toolCallId, name),
               arguments: args,
               conversationId: conversationId,
             );
@@ -968,9 +976,7 @@ class ToolHandlerService {
 
         // Approval gate for MCP tools
         if (approvalService != null && mcp.toolNeedsApproval(name)) {
-          final approvalId = (toolCallId?.trim().isNotEmpty == true)
-              ? toolCallId!.trim()
-              : '${name}_${DateTime.now().microsecondsSinceEpoch}';
+          final approvalId = _streamCallId(toolCallId, name);
           final result = await approvalService.requestApproval(
             toolCallId: approvalId,
             toolName: name,

--- a/test/features/chat/widgets/chat_message_widget_tool_approval_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_tool_approval_test.dart
@@ -94,6 +94,21 @@ const List<ToolUIPart> _resolvedNoIdAndPendingParts = [
   ),
 ];
 
+const List<ToolUIPart> _twoLoadingShellParts = [
+  ToolUIPart(
+    id: 'call-1',
+    toolName: 'shell',
+    arguments: {'command': 'echo one'},
+    loading: true,
+  ),
+  ToolUIPart(
+    id: 'call-2',
+    toolName: 'shell',
+    arguments: {'command': 'echo two'},
+    loading: true,
+  ),
+];
+
 ChatMessageWidget _toolMessage(List<ToolUIPart> parts) => ChatMessageWidget(
   message: ChatMessage(
     role: 'assistant',
@@ -167,8 +182,9 @@ void main() {
       expect(await approvalFuture, isNotNull);
     });
 
-    testWidgets('a no-id tool part binds the same-named pending request by '
-        'name', (tester) async {
+    testWidgets('a no-id tool part never shows approval buttons', (
+      tester,
+    ) async {
       Haptics.setEnabled(false);
       final settings = _createSettings();
       final approvalService = ToolApprovalService();
@@ -187,14 +203,11 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
-      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsOneWidget);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsNothing);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsNothing);
 
-      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check));
-      await tester.pump();
-
-      final result = await approvalFuture;
-      expect(result.approved, isTrue);
+      approvalService.approve('shell_1725000000000');
+      expect(await approvalFuture, isNotNull);
     });
 
     testWidgets('a whitespace-padded part id matches the trimmed request id', (
@@ -256,6 +269,65 @@ void main() {
 
       final result = await approvalFuture;
       expect(result.approved, isTrue);
+    });
+
+    testWidgets('concurrent same-name calls each target their own approval '
+        '(approve then deny)', (tester) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final firstFuture = approvalService.requestApproval(
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        arguments: const {'command': 'echo one'},
+      );
+      final secondFuture = approvalService.requestApproval(
+        toolCallId: 'call-2',
+        toolName: 'shell',
+        arguments: const {'command': 'echo two'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_twoLoadingShellParts),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        find.widgetWithIcon(IosIconButton, Lucide.Check),
+        findsNWidgets(2),
+      );
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsNWidgets(2));
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check).first);
+      await tester.pump();
+
+      final firstResult = await firstFuture;
+      expect(firstResult.approved, isTrue);
+      expect(approvalService.isPending('call-2'), isTrue);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.X));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      final dialogContext = tester.element(find.byType(AlertDialog));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text(
+            AppLocalizations.of(dialogContext)!.toolApprovalDeny,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final secondResult = await secondFuture;
+      expect(secondResult.approved, isFalse);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsNothing);
     });
   });
 }

--- a/test/features/chat/widgets/chat_message_widget_tool_approval_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_tool_approval_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/tts_provider.dart';
+import 'package:Cuplivo/core/services/haptics.dart';
+import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+import 'package:Cuplivo/icons/lucide_adapter.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_tactile.dart';
+
+var businessPrefs = BusinessPreferences.memoryForTests();
+
+SettingsProvider _createSettings() {
+  businessPrefs = BusinessPreferences.memoryForTests(const <String, Object>{});
+  return SettingsProvider(preferences: businessPrefs);
+}
+
+Widget _buildHarness({
+  required SettingsProvider settings,
+  required ToolApprovalService approvalService,
+  required Widget child,
+}) {
+  return MultiProvider(
+    providers: [
+      Provider<BusinessPreferences>.value(value: businessPrefs),
+      ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+      ChangeNotifierProvider(
+        create: (_) => TtsProvider(preferences: businessPrefs),
+      ),
+      ChangeNotifierProvider<ToolApprovalService>.value(value: approvalService),
+      ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+const List<ToolUIPart> _twoShellParts = [
+  ToolUIPart(
+    id: 'shell-1',
+    toolName: 'shell',
+    arguments: {'command': 'echo done'},
+    content: 'done',
+    loading: false,
+  ),
+  ToolUIPart(
+    id: 'shell-2',
+    toolName: 'shell',
+    arguments: {'command': 'echo pending'},
+    loading: true,
+  ),
+];
+
+const List<ToolUIPart> _blankIdShellPart = [
+  ToolUIPart(
+    id: '',
+    toolName: 'shell',
+    arguments: {'command': 'echo blank'},
+    loading: true,
+  ),
+];
+
+const List<ToolUIPart> _paddedShellPart = [
+  ToolUIPart(
+    id: ' shell-2 ',
+    toolName: 'shell',
+    arguments: {'command': 'echo padded'},
+    loading: true,
+  ),
+];
+
+const List<ToolUIPart> _resolvedNoIdAndPendingParts = [
+  ToolUIPart(
+    id: '',
+    toolName: 'shell',
+    arguments: {'command': 'echo done'},
+    content: 'done',
+    loading: false,
+  ),
+  ToolUIPart(
+    id: 'shell-2',
+    toolName: 'shell',
+    arguments: {'command': 'echo pending'},
+    loading: true,
+  ),
+];
+
+ChatMessageWidget _toolMessage(List<ToolUIPart> parts) => ChatMessageWidget(
+  message: ChatMessage(
+    role: 'assistant',
+    content: '',
+    conversationId: 'conv-approval',
+  ),
+  showModelIcon: false,
+  toolParts: parts,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('tool call approval buttons', () {
+    testWidgets('only the pending tool part shows approval buttons; '
+        'resolved past steps stay inactive', (tester) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final approvalFuture = approvalService.requestApproval(
+        toolCallId: 'shell-2',
+        toolName: 'shell',
+        arguments: const {'command': 'echo pending'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_twoShellParts),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check));
+      await tester.pump();
+
+      final result = await approvalFuture;
+      expect(result.approved, isTrue);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsNothing);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsNothing);
+    });
+
+    testWidgets('an approval request with a different id does not bind to a '
+        'same-named tool part', (tester) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final approvalFuture = approvalService.requestApproval(
+        toolCallId: 'shell-other',
+        toolName: 'shell',
+        arguments: const {'command': 'echo other'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_twoShellParts),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsNothing);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsNothing);
+
+      approvalService.approve('shell-other');
+      expect(await approvalFuture, isNotNull);
+    });
+
+    testWidgets('a no-id tool part binds the same-named pending request by '
+        'name', (tester) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final approvalFuture = approvalService.requestApproval(
+        toolCallId: 'shell_1725000000000',
+        toolName: 'shell',
+        arguments: const {'command': 'echo blank'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_blankIdShellPart),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check));
+      await tester.pump();
+
+      final result = await approvalFuture;
+      expect(result.approved, isTrue);
+    });
+
+    testWidgets('a whitespace-padded part id matches the trimmed request id', (
+      tester,
+    ) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final approvalFuture = approvalService.requestApproval(
+        toolCallId: 'shell-2',
+        toolName: 'shell',
+        arguments: const {'command': 'echo padded'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_paddedShellPart),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check));
+      await tester.pump();
+
+      final result = await approvalFuture;
+      expect(result.approved, isTrue);
+    });
+
+    testWidgets('a resolved no-id part stays inactive while a same-named '
+        'request pends', (tester) async {
+      Haptics.setEnabled(false);
+      final settings = _createSettings();
+      final approvalService = ToolApprovalService();
+      final approvalFuture = approvalService.requestApproval(
+        toolCallId: 'shell-2',
+        toolName: 'shell',
+        arguments: const {'command': 'echo pending'},
+      );
+
+      await tester.pumpWidget(
+        _buildHarness(
+          settings: settings,
+          approvalService: approvalService,
+          child: _toolMessage(_resolvedNoIdAndPendingParts),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.widgetWithIcon(IosIconButton, Lucide.Check), findsOneWidget);
+      expect(find.widgetWithIcon(IosIconButton, Lucide.X), findsOneWidget);
+
+      await tester.tap(find.widgetWithIcon(IosIconButton, Lucide.Check));
+      await tester.pump();
+
+      final result = await approvalFuture;
+      expect(result.approved, isTrue);
+    });
+  });
+}

--- a/test/features/chat/widgets/tool_approval_binding_test.dart
+++ b/test/features/chat/widgets/tool_approval_binding_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/chat/models/tool_ui_part.dart';
+import 'package:Cuplivo/features/chat/widgets/tool_approval_binding.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+
+void main() {
+  group('pendingApprovalRequestFor', () {
+    test('returns the matching request while it is still pending', () {
+      final service = ToolApprovalService();
+      final future = service.requestApproval(
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+      );
+
+      const part = ToolUIPart(
+        id: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+        loading: true,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNotNull);
+      expect(request!.toolCallId, 'call-1');
+      expect(request.toolName, 'shell');
+
+      service.approve('call-1');
+      return future;
+    });
+
+    test('returns null for a resolved part even when a request pends', () {
+      final service = ToolApprovalService();
+      service.requestApproval(
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+      );
+
+      const part = ToolUIPart(
+        id: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+        content: 'done',
+        loading: false,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNull);
+    });
+
+    test('returns null for an id-less part with a same-named request', () {
+      final service = ToolApprovalService();
+      service.requestApproval(
+        toolCallId: 'shell_1725000000000',
+        toolName: 'shell',
+        arguments: {'command': 'echo blank'},
+      );
+
+      const part = ToolUIPart(
+        id: '',
+        toolName: 'shell',
+        arguments: {'command': 'echo blank'},
+        loading: true,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNull);
+    });
+
+    test('matches a whitespace-padded part id against the trimmed key', () {
+      final service = ToolApprovalService();
+      service.requestApproval(
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo padded'},
+      );
+
+      const part = ToolUIPart(
+        id: ' call-1 ',
+        toolName: 'shell',
+        arguments: {'command': 'echo padded'},
+        loading: true,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNotNull);
+      expect(request!.toolCallId, 'call-1');
+    });
+
+    test('returns null for a non-matching id', () {
+      final service = ToolApprovalService();
+      service.requestApproval(
+        toolCallId: 'call-other',
+        toolName: 'shell',
+        arguments: {'command': 'echo other'},
+      );
+
+      const part = ToolUIPart(
+        id: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+        loading: true,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNull);
+    });
+
+    test('returns null once the request was resolved', () {
+      final service = ToolApprovalService();
+      service.requestApproval(
+        toolCallId: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+      );
+      service.deny('call-1', 'not now');
+
+      const part = ToolUIPart(
+        id: 'call-1',
+        toolName: 'shell',
+        arguments: {'command': 'echo one'},
+        loading: true,
+      );
+      final request = pendingApprovalRequestFor(service, part);
+
+      expect(request, isNull);
+    });
+  });
+}

--- a/test/tool_approval_service_test.dart
+++ b/test/tool_approval_service_test.dart
@@ -69,5 +69,30 @@ void main() {
 
       expect(service.pendingRequests.keys, ['call_1']);
     });
+
+    test('re-requesting an id completes the old request as replaced', () async {
+      final service = ToolApprovalService();
+      final firstFuture = service.requestApproval(
+        toolCallId: 'call_dup',
+        toolName: 'kelivo_delete',
+        arguments: const {'path': '/first/x'},
+      );
+      final secondFuture = service.requestApproval(
+        toolCallId: 'call_dup',
+        toolName: 'kelivo_delete',
+        arguments: const {'path': '/second/x'},
+      );
+
+      final firstResult = await firstFuture.timeout(const Duration(seconds: 1));
+      expect(firstResult.approved, isFalse);
+      expect(firstResult.denyReason, 'replaced');
+      expect(service.isPending('call_dup'), isTrue);
+
+      service.approve('call_dup');
+      final secondResult = await secondFuture.timeout(
+        const Duration(seconds: 1),
+      );
+      expect(secondResult.approved, isTrue);
+    });
   });
 }


### PR DESCRIPTION
## Summary

When the assistant requests shell/tool approval multiple times in one turn, approve/deny buttons appeared on **every past tool call block**, all wired to the same single current request (#665).

## Root cause

Two compounding defects:

1. **Handler minted fake approval ids** — `tool_handler_service.dart` keyed approval requests as `"<name>_<timestamp>"` instead of the real stream `tool_call_id` the closure already receives (3 approval gates: prefixed MCP, workspace/shell, unprefixed MCP).
2. **UI matched by tool *name*** — because the fake id never matched `ToolUIPart.id`, `_ChainOfThoughtToolStep` and `_ToolCallItem` fell back to binding *any* pending request with the same `toolName`. With repeated `shell` calls, every past step bound to the one pending request and showed interactive buttons.

## Changes

- `tool_handler_service.dart`: approval requests are keyed by the real `toolCallId` (timestamp fallback only when the provider hands none — same pattern as `calendar_create` / `ask_user`).
- `chat_message_widget.dart`: both tool states bind by exact (trimmed) `part.id`; name binding survives **only** for no-id tool events (supported by the engine's `_toolEventKey` machinery) and **only while the part is still loading**. Resolved past steps stay inactive.
- `tool_approval_service.dart`: re-requesting an already-pending id completes the old request as `denied('replaced')` instead of orphaning its completer (provider retries re-emitting the same `tool_call_id`).

## Tests

`test/features/chat/widgets/chat_message_widget_tool_approval_test.dart` (new, 5 tests — all verified red before, green after):

- only the pending part shows approval buttons; resolved past steps stay inactive
- a different-id same-named request binds to nothing
- no-id part binds the same-named pending request by name
- whitespace-padded part id matches the trimmed request id
- resolved no-id part stays inactive while a same-named request pends

`test/tool_approval_service_test.dart`: new duplicate-key replaced case.

Verification: `dart analyze --fatal-infos lib test` clean; related `flutter test` subset (chat_message_widget × 4, tool_approval_service, live_panel, handoff_tool_service) — 56 passed.

Fixes #665
