### PR TITLE
fix(markdown): enforce CommonMark underscore flanking in code fences

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -7,7 +7,7 @@ import 'package:gpt_markdown/custom_widgets/markdown_config.dart'
 import 'package:flutter_highlight/themes/github.dart';
 import 'package:flutter_highlight/themes/atom-one-dark-reasonable.dart';
 import 'package:flutter/rendering.dart';
-import 'package:highlight/highlight.dart' show Node, highlight;
+import 'package:highlight/highlight.dart' show Mode, Node, highlight;
 import '../../icons/lucide_adapter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:async';
@@ -6327,6 +6327,152 @@ class AllowedHtmlTagsMd extends InlineMd {
   }
 }
 
+/// Word characters for the CommonMark flanking checks in
+/// [_commonMarkMarkdownLanguage]. highlight grammar regexes are compiled
+/// without the Unicode flag, so `\p{L}` is unavailable; the explicit ranges
+/// cover CJK ideographs, kana, hangul and full-width alphanumerics so a CJK
+/// letter flanking a `_` counts as a word character (CommonMark classes CJK
+/// as letters: intraword underscores are not emphasis). Full-width `（）`
+/// and `・` are deliberately absent — they are punctuation, so `（_好_）`
+/// stays valid emphasis like `(_好_)`.
+const String _mdFenceWordClass =
+    'A-Za-z0-9_'
+    '\\u3400-\\u4DBF' // CJK Extension A
+    '\\u4E00-\\u9FFF' // CJK Unified Ideographs
+    '\\uF900-\\uFAFF' // CJK Compatibility Ideographs
+    '\\u3041-\\u309F' // Hiragana
+    // Katakana minus the U+30A0 hyphen and the U+30FB middle dot (punctuation).
+    '\\u30A1-\\u30FA\\u30FC-\\u30FF'
+    '\\u1100-\\u11FF\\u3130-\\u318F\\uAC00-\\uD7A3' // Hangul
+    '\\uFF10-\\uFF19\\uFF21-\\uFF3A\\uFF41-\\uFF5A'; // Full-width digits & Latin
+
+/// CommonMark §6.2 delimiter flanking for a single `_` emphasis pair: the
+/// opener must not be preceded by a word character (intraword `_` can never
+/// open), must not be followed by whitespace or another `_`; the closer must
+/// not be preceded by whitespace or another `_` and not be followed by a
+/// word character. `a _b_ c` matches; `a_b_c` stays literal.
+final String _mdFenceEmphasisUnderscore =
+    '(?<![$_mdFenceWordClass])'
+    '_(?![\\s_])'
+    '.+?'
+    '(?<=[^\\s_])_'
+    '(?![$_mdFenceWordClass])';
+
+/// Same flanking for a `__` strong pair: `a __b__ c` matches, `a__b__c`
+/// stays literal. (`*`/`**` are intentionally left intraword-valid: CommonMark
+/// permits asterisk emphasis inside words, e.g. `a*b*c`.)
+final String _mdFenceStrongUnderscore =
+    '(?<![$_mdFenceWordClass])'
+    '__(?![\\s_])'
+    '.+?'
+    '(?<=[^\\s_])__'
+    '(?![$_mdFenceWordClass])';
+
+/// The `markdown` highlight grammar rebuilt to honor CommonMark instead of
+/// the bundled naive rules (issue #662).
+///
+/// The bundled grammar's `_.+?_` / `[*_]{2}.+?[*_]{2}` rules match between
+/// any two underscores, including intraword ones (`a_b_c`), and the code
+/// themes style `emphasis`/`strong` as italic/bold — so a `markdown`-fenced
+/// code block rendered identifiers like `{model_name}` in italic (this
+/// issue). CommonMark never treats an intraword `_` as an emphasis delimiter
+/// and requires a space (or end of line) after ATX `#` (§4.2): `#hashtag`
+/// is a literal line, `# Heading` a heading.
+final Mode _commonMarkMarkdownLanguage = Mode(
+  refs: {},
+  aliases: const ['md', 'mkdown', 'mkd'],
+  contains: [
+    Mode(
+      className: 'section',
+      variants: [
+        Mode(begin: '^#{1,6}(?= |\$)', end: '\$'),
+        Mode(begin: '^.+?\\n[=-]{2,}\$'),
+      ],
+    ),
+    Mode(begin: '<', end: '>', subLanguage: const ['xml'], relevance: 0),
+    Mode(className: 'bullet', begin: '^\\s*([*+-]|(\\d+\\.))\\s+'),
+    Mode(
+      className: 'strong',
+      variants: [
+        Mode(begin: r'\*\*.+?\*\*'),
+        Mode(begin: _mdFenceStrongUnderscore, relevance: 0),
+      ],
+    ),
+    Mode(
+      className: 'emphasis',
+      variants: [
+        Mode(begin: r'\*.+?\*'),
+        Mode(begin: _mdFenceEmphasisUnderscore, relevance: 0),
+      ],
+    ),
+    Mode(className: 'quote', begin: '^>\\s+', end: '\$'),
+    Mode(
+      className: 'code',
+      variants: [
+        Mode(begin: '^```\\w*\\s*\$', end: '^```[ ]*\$'),
+        Mode(begin: r'`.+?`'),
+        Mode(begin: '^( {4}|\\t)', end: '\$', relevance: 0),
+      ],
+    ),
+    Mode(begin: '^[-\\*]{3,}', end: '\$'),
+    Mode(
+      begin: '\\[.+?\\][\\(\\[].*?[\\)\\]]',
+      returnBegin: true,
+      contains: [
+        Mode(
+          className: 'string',
+          begin: '\\[',
+          end: '\\]',
+          excludeBegin: true,
+          returnEnd: true,
+          relevance: 0,
+        ),
+        Mode(
+          className: 'link',
+          begin: '\\]\\(',
+          end: '\\)',
+          excludeBegin: true,
+          excludeEnd: true,
+        ),
+        Mode(
+          className: 'symbol',
+          begin: '\\]\\[',
+          end: '\\]',
+          excludeBegin: true,
+          excludeEnd: true,
+        ),
+      ],
+      relevance: 10,
+    ),
+    Mode(
+      begin: '^\\[[^\\n]+\\]:',
+      returnBegin: true,
+      contains: [
+        Mode(
+          className: 'symbol',
+          begin: '\\[',
+          end: '\\]',
+          excludeBegin: true,
+          excludeEnd: true,
+        ),
+        Mode(className: 'link', begin: ':\\s*', end: '\$', excludeBegin: true),
+      ],
+    ),
+  ],
+);
+
+bool _commonMarkMarkdownRegistered = false;
+
+/// Replaces the bundled `markdown` grammar with [_commonMarkMarkdownLanguage].
+/// Must run before the first markdown parse; the highlight singleton is
+/// process-wide and this file is its only consumer, so registration is safe
+/// and idempotent.
+void _ensureCommonMarkMarkdownGrammar() {
+  if (_commonMarkMarkdownRegistered) return;
+  _commonMarkMarkdownRegistered = true;
+  highlight.registerLanguage('markdown', _commonMarkMarkdownLanguage);
+}
+
 /// Code block with per-token syntax highlight.
 ///
 /// Rendered as a plain [Text.rich] so the code participates in the enclosing
@@ -6380,6 +6526,7 @@ class _CodeHighlightViewState extends State<CodeHighlightView> {
       return <TextSpan>[TextSpan(text: widget.source)];
     }
     try {
+      _ensureCommonMarkMarkdownGrammar();
       final result = highlight.parse(widget.source, language: widget.language);
       return _convertNodes(result.nodes ?? const []);
     } catch (_) {

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -6327,47 +6327,6 @@ class AllowedHtmlTagsMd extends InlineMd {
   }
 }
 
-/// Word characters for the CommonMark flanking checks in
-/// [_commonMarkMarkdownLanguage]. highlight grammar regexes are compiled
-/// without the Unicode flag, so `\p{L}` is unavailable; the explicit ranges
-/// cover CJK ideographs, kana, hangul and full-width alphanumerics so a CJK
-/// letter flanking a `_` counts as a word character (CommonMark classes CJK
-/// as letters: intraword underscores are not emphasis). Full-width `（）`
-/// and `・` are deliberately absent — they are punctuation, so `（_好_）`
-/// stays valid emphasis like `(_好_)`.
-const String _mdFenceWordClass =
-    'A-Za-z0-9_'
-    '\\u3400-\\u4DBF' // CJK Extension A
-    '\\u4E00-\\u9FFF' // CJK Unified Ideographs
-    '\\uF900-\\uFAFF' // CJK Compatibility Ideographs
-    '\\u3041-\\u309F' // Hiragana
-    // Katakana minus the U+30A0 hyphen and the U+30FB middle dot (punctuation).
-    '\\u30A1-\\u30FA\\u30FC-\\u30FF'
-    '\\u1100-\\u11FF\\u3130-\\u318F\\uAC00-\\uD7A3' // Hangul
-    '\\uFF10-\\uFF19\\uFF21-\\uFF3A\\uFF41-\\uFF5A'; // Full-width digits & Latin
-
-/// CommonMark §6.2 delimiter flanking for a single `_` emphasis pair: the
-/// opener must not be preceded by a word character (intraword `_` can never
-/// open), must not be followed by whitespace or another `_`; the closer must
-/// not be preceded by whitespace or another `_` and not be followed by a
-/// word character. `a _b_ c` matches; `a_b_c` stays literal.
-final String _mdFenceEmphasisUnderscore =
-    '(?<![$_mdFenceWordClass])'
-    '_(?![\\s_])'
-    '.+?'
-    '(?<=[^\\s_])_'
-    '(?![$_mdFenceWordClass])';
-
-/// Same flanking for a `__` strong pair: `a __b__ c` matches, `a__b__c`
-/// stays literal. (`*`/`**` are intentionally left intraword-valid: CommonMark
-/// permits asterisk emphasis inside words, e.g. `a*b*c`.)
-final String _mdFenceStrongUnderscore =
-    '(?<![$_mdFenceWordClass])'
-    '__(?![\\s_])'
-    '.+?'
-    '(?<=[^\\s_])__'
-    '(?![$_mdFenceWordClass])';
-
 /// The `markdown` highlight grammar rebuilt to honor CommonMark instead of
 /// the bundled naive rules (issue #662).
 ///
@@ -6376,8 +6335,15 @@ final String _mdFenceStrongUnderscore =
 /// themes style `emphasis`/`strong` as italic/bold — so a `markdown`-fenced
 /// code block rendered identifiers like `{model_name}` in italic (this
 /// issue). CommonMark never treats an intraword `_` as an emphasis delimiter
-/// and requires a space (or end of line) after ATX `#` (§4.2): `#hashtag`
-/// is a literal line, `# Heading` a heading.
+/// and requires a space or tab (or end of line) after ATX `#` (§4.2):
+/// `#hashtag` is a literal line, `# Heading` a heading.
+///
+/// The underscore variants below intentionally only do structural matching
+/// (whitespace/underscore guards, no character classification): grammar
+/// regexes in the `highlight` engine are compiled without the Unicode flag,
+/// so delimiter flanking cannot be expressed there with `\p{...}` classes.
+/// [_underscoreFlankingInvalidNodes] applies the real CommonMark §6.2 rules
+/// with proper Unicode classification right after parsing.
 final Mode _commonMarkMarkdownLanguage = Mode(
   refs: {},
   aliases: const ['md', 'mkdown', 'mkd'],
@@ -6385,7 +6351,7 @@ final Mode _commonMarkMarkdownLanguage = Mode(
     Mode(
       className: 'section',
       variants: [
-        Mode(begin: '^#{1,6}(?= |\$)', end: '\$'),
+        Mode(begin: '^#{1,6}(?=[\\t ]|\$)', end: '\$'),
         Mode(begin: '^.+?\\n[=-]{2,}\$'),
       ],
     ),
@@ -6395,14 +6361,14 @@ final Mode _commonMarkMarkdownLanguage = Mode(
       className: 'strong',
       variants: [
         Mode(begin: r'\*\*.+?\*\*'),
-        Mode(begin: _mdFenceStrongUnderscore, relevance: 0),
+        Mode(begin: '__(?![\\s_]).+?(?<=[^\\s_])__', relevance: 0),
       ],
     ),
     Mode(
       className: 'emphasis',
       variants: [
         Mode(begin: r'\*.+?\*'),
-        Mode(begin: _mdFenceEmphasisUnderscore, relevance: 0),
+        Mode(begin: '_(?![\\s_]).+?(?<=[^\\s_])_', relevance: 0),
       ],
     ),
     Mode(className: 'quote', begin: '^>\\s+', end: '\$'),
@@ -6473,6 +6439,119 @@ void _ensureCommonMarkMarkdownGrammar() {
   highlight.registerLanguage('markdown', _commonMarkMarkdownLanguage);
 }
 
+/// CommonMark §6.2 flanking classifications: "Unicode whitespace" is the `Z`
+/// categories plus tab/line terminators; "punctuation" is the Unicode `P`
+/// (punctuation) or `S` (symbol) general categories. These run with the
+/// Unicode flag, unlike the grammar regexes the engine compiles.
+final RegExp _unicodePunct = RegExp(r'[\p{P}\p{S}]', unicode: true);
+final RegExp _unicodeWhitespace = RegExp(r'[\p{Z}\t\n\v\f\r]', unicode: true);
+
+bool _isPunct(String char) => _unicodePunct.hasMatch(char);
+
+bool _isSpace(String char) => _unicodeWhitespace.hasMatch(char);
+
+/// Whether an underscore delimiter run can open emphasis per §6.2:
+/// left-flanking and either not right-flanking or preceded by punctuation.
+/// [prev]/[next] are the code points immediately outside the run; null
+/// means a text boundary, which CommonMark treats like whitespace.
+bool _underscoreCanOpen(String? prev, String? next) {
+  final prevWs = prev == null || _isSpace(prev);
+  final prevPunct = prev != null && _isPunct(prev);
+  final nextWs = next == null || _isSpace(next);
+  final nextPunct = next != null && _isPunct(next);
+  final leftFlanking = !nextWs && (!nextPunct || prevWs || prevPunct);
+  final rightFlanking = !prevWs && (!prevPunct || nextWs || nextPunct);
+  return leftFlanking && (!rightFlanking || prevPunct);
+}
+
+/// Whether an underscore delimiter run can close emphasis per §6.2:
+/// right-flanking and either not left-flanking or followed by punctuation.
+bool _underscoreCanClose(String? prev, String? next) {
+  final prevWs = prev == null || _isSpace(prev);
+  final prevPunct = prev != null && _isPunct(prev);
+  final nextWs = next == null || _isSpace(next);
+  final nextPunct = next != null && _isPunct(next);
+  final leftFlanking = !nextWs && (!nextPunct || prevWs || prevPunct);
+  final rightFlanking = !prevWs && (!prevPunct || nextWs || nextPunct);
+  return rightFlanking && (!leftFlanking || nextPunct);
+}
+
+/// The code point immediately before code-unit offset [index] in [text],
+/// or null at the start.
+String? _codePointBefore(String text, int index) {
+  if (index <= 0) return null;
+  return String.fromCharCode(text.substring(0, index).runes.last);
+}
+
+/// The code point immediately after code-unit offset [index] in [text],
+/// or null at the end.
+String? _codePointAfter(String text, int index) {
+  if (index >= text.length) return null;
+  return String.fromCharCode(text.substring(index).runes.first);
+}
+
+/// Walks the parsed node tree in document order and returns every
+/// `emphasis`/`strong` node whose `_` delimiters violate CommonMark flanking
+/// (§6.2). The grammar only matches _candidate_ delimiter pairs (its regexes
+/// cannot classify characters without the Unicode flag), so invalid pairs —
+/// e.g. `foo_bar_baz`, `α_β_γ`, `a__b__c` — are detected here by validating
+/// each candidate's surrounding code points, and rendered as plain text.
+///
+/// The engine puts a classed node's text in a child leaf (the container
+/// carries only the className), so runs are grouped by their nearest
+/// emphasis/strong ancestor before validation.
+Set<Node> _underscoreFlankingInvalidNodes(List<Node> nodes) {
+  final text = StringBuffer();
+  final extents = <Node, ({int start, int end})>{};
+  void walk(List<Node> list, Node? classed) {
+    for (final node in list) {
+      final value = node.value;
+      if (value != null && value.isNotEmpty) {
+        if (classed != null) {
+          final prior = extents[classed];
+          extents[classed] = (
+            start: prior?.start ?? text.length,
+            end: text.length + value.length,
+          );
+        }
+        text.write(value);
+      }
+      final children = node.children;
+      if (children != null) {
+        final nextClassed =
+            node.className == 'emphasis' || node.className == 'strong'
+            ? node
+            : classed;
+        walk(children, nextClassed);
+      }
+    }
+  }
+
+  walk(nodes, null);
+  final source = text.toString();
+  final invalid = <Node>{};
+  for (final entry in extents.entries) {
+    final node = entry.key;
+    final start = entry.value.start;
+    final end = entry.value.end;
+    final value = source.substring(start, end);
+    if (!value.startsWith('_') || !value.endsWith('_')) continue;
+    // The opener and closer delimiter runs flank with their own neighbors:
+    // opener uses the char before the run start and the first content char;
+    // closer uses the last content char and the char after the run end.
+    final runLength = value.startsWith('__') ? 2 : 1;
+    final openPrev = _codePointBefore(source, start);
+    final openNext = _codePointAfter(source, start + runLength);
+    final closePrev = _codePointBefore(source, end - runLength);
+    final closeNext = _codePointAfter(source, end);
+    if (!_underscoreCanOpen(openPrev, openNext) ||
+        !_underscoreCanClose(closePrev, closeNext)) {
+      invalid.add(node);
+    }
+  }
+  return invalid;
+}
+
 /// Code block with per-token syntax highlight.
 ///
 /// Rendered as a plain [Text.rich] so the code participates in the enclosing
@@ -6528,28 +6607,35 @@ class _CodeHighlightViewState extends State<CodeHighlightView> {
     try {
       _ensureCommonMarkMarkdownGrammar();
       final result = highlight.parse(widget.source, language: widget.language);
-      return _convertNodes(result.nodes ?? const []);
+      final nodes = result.nodes ?? const [];
+      return _convertNodes(nodes, _underscoreFlankingInvalidNodes(nodes));
     } catch (_) {
       return const [];
     }
   }
 
-  /// Converts a highlight Node tree to a TextSpan tree with appropriate styling
-  List<TextSpan> _convertNodes(List<Node> nodes) {
+  /// Converts a highlight Node tree to a TextSpan tree with appropriate styling.
+  /// Nodes in [flankingInvalid] render plain (underscore emphasis that
+  /// CommonMark deems literal).
+  List<TextSpan> _convertNodes(List<Node> nodes, [Set<Node>? flankingInvalid]) {
     final List<TextSpan> spans = [];
 
     for (final node in nodes) {
+      final unclassed = flankingInvalid?.contains(node) ?? false;
       if (node.value != null) {
         // Leaf node with text content
         spans.add(
-          TextSpan(text: node.value, style: widget.theme[node.className]),
+          TextSpan(
+            text: node.value,
+            style: unclassed ? null : widget.theme[node.className],
+          ),
         );
       } else if (node.children != null) {
         // Node with children - recurse
         spans.add(
           TextSpan(
-            children: _convertNodes(node.children!),
-            style: widget.theme[node.className],
+            children: _convertNodes(node.children!, flankingInvalid),
+            style: unclassed ? null : widget.theme[node.className],
           ),
         );
       }

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3160,6 +3160,193 @@ void main() {}
   });
 
   testWidgets(
+    'CodeHighlightView keeps intraword underscores literal in markdown fences (issue #662)',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'identity is {assistant_name} based on {model_name}',
+              language: 'markdown',
+              theme: {
+                'emphasis': TextStyle(fontStyle: FontStyle.italic),
+                'strong': TextStyle(fontWeight: FontWeight.bold),
+              },
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+
+      expect(
+        spans.where((span) => span.style.fontStyle == FontStyle.italic),
+        isEmpty,
+      );
+      expect(
+        spans.map((span) => span.text).join(),
+        contains('{assistant_name} based on {model_name}'),
+      );
+    },
+  );
+
+  testWidgets(
+    'CodeHighlightView keeps flanking-valid underscore emphasis italic',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'a _b_ c and a_b_c\n（_好_） and 爱_好_吗 and 文件_name_文件',
+              language: 'markdown',
+              theme: {'emphasis': TextStyle(fontStyle: FontStyle.italic)},
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+      final italicTexts = spans
+          .where((span) => span.style.fontStyle == FontStyle.italic)
+          .map((span) => span.text)
+          .toList();
+
+      // Flanking-valid: spaced word and CJK punctuation (（）) still italic.
+      expect(italicTexts, contains('_b_'));
+      // Exactly one italic pair of underscores across both lines: the valid
+      // （_好_）, never an extra one from intraword CJK (爱_好_吗).
+      expect(italicTexts.where((t) => t == '_好_'), hasLength(1));
+      // Below must render literal: no italic span containing these fragments.
+      expect(italicTexts.where((t) => t.contains('name')), isEmpty);
+      expect(spans.map((span) => span.text).join(), contains('爱_好_吗'));
+      expect(spans.map((span) => span.text).join(), contains('文件_name_文件'));
+    },
+  );
+
+  testWidgets(
+    'CodeHighlightView keeps flanking-valid strong bold and literal __',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'a **b** c a __b__ c\na__b__c',
+              language: 'markdown',
+              theme: {'strong': TextStyle(fontWeight: FontWeight.bold)},
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+      final boldTexts = spans
+          .where(
+            (span) =>
+                (span.style.fontWeight ?? FontWeight.normal) == FontWeight.bold,
+          )
+          .map((span) => span.text)
+          .toList();
+
+      expect(boldTexts, contains('**b**'));
+      expect(boldTexts, contains('__b__'));
+      // Intraword __ is literal: no bold span asserting a__b__c content.
+      expect(boldTexts.where((t) => t.contains('__b__')), hasLength(1));
+    },
+  );
+
+  testWidgets('CodeHighlightView requires a space after ATX heading hashes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CodeHighlightView(
+            '# Heading\n#hashtag',
+            language: 'markdown',
+            theme: {
+              'section': TextStyle(
+                color: Color(0xff990000),
+                fontWeight: FontWeight.bold,
+              ),
+            },
+          ),
+        ),
+      ),
+    );
+
+    final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+    final spans = _collectResolvedTextSpans(root);
+    final boldTexts = spans
+        .where(
+          (span) =>
+              (span.style.fontWeight ?? FontWeight.normal) == FontWeight.bold,
+        )
+        .map((span) => span.text)
+        .toList();
+
+    expect(boldTexts, contains('# Heading'));
+    expect(boldTexts, isNot(contains('#hashtag')));
+  });
+
+  testWidgets(
+    'CodeHighlightView md alias uses the CommonMark markdown grammar',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'a_b_c',
+              language: 'md',
+              theme: {
+                'emphasis': TextStyle(fontStyle: FontStyle.italic),
+                'section': TextStyle(fontWeight: FontWeight.bold),
+              },
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+
+      expect(
+        spans.where((span) => span.style.fontStyle == FontStyle.italic),
+        isEmpty,
+      );
+    },
+  );
+
+  testWidgets(
+    'CodeHighlightView keeps dart comment italics after grammar registration',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              '// note\nfinal value = 1;',
+              language: 'dart',
+              theme: {'comment': TextStyle(fontStyle: FontStyle.italic)},
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+      final italicTexts = spans
+          .where((span) => span.style.fontStyle == FontStyle.italic)
+          .map((span) => span.text)
+          .toList();
+
+      expect(italicTexts, isNotEmpty);
+      expect(italicTexts.any((t) => t.contains('note')), isTrue);
+    },
+  );
+
+  testWidgets(
     'MarkdownWithCodeHighlight keeps details tags literal in html code blocks',
     (tester) async {
       await tester.pumpWidget(

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3198,7 +3198,11 @@ void main() {}
         const MaterialApp(
           home: Scaffold(
             body: CodeHighlightView(
-              'a _b_ c and a_b_c\n（_好_） and 爱_好_吗 and 文件_name_文件',
+              'a _b_ c and a_b_c\n'
+              '（_好_） and 爱_好_吗 and 文件_name_文件\n'
+              'α _β_ γ and α_β_γ\n'
+              'привет_мир_тест\n'
+              '\u0301_x_\u0302 and \u0301 _y_ \u0302',
               language: 'markdown',
               theme: {'emphasis': TextStyle(fontStyle: FontStyle.italic)},
             ),
@@ -3213,15 +3217,28 @@ void main() {}
           .map((span) => span.text)
           .toList();
 
-      // Flanking-valid: spaced word and CJK punctuation (（）) still italic.
+      // Flanking-valid: spaced word, CJK punctuation (（）), Greek word and
+      // spacing-adjacent combining marks still italic.
       expect(italicTexts, contains('_b_'));
-      // Exactly one italic pair of underscores across both lines: the valid
-      // （_好_）, never an extra one from intraword CJK (爱_好_吗).
+      expect(italicTexts, contains('_β_'));
+      expect(italicTexts, contains('_y_'));
+      // Exactly one italic pair `_好_`: the valid （_好_）, never an extra one
+      // from intraword CJK (爱_好_吗).
       expect(italicTexts.where((t) => t == '_好_'), hasLength(1));
       // Below must render literal: no italic span containing these fragments.
       expect(italicTexts.where((t) => t.contains('name')), isEmpty);
+      expect(italicTexts.where((t) => t.contains('_α_')), isEmpty);
       expect(spans.map((span) => span.text).join(), contains('爱_好_吗'));
       expect(spans.map((span) => span.text).join(), contains('文件_name_文件'));
+      expect(spans.map((span) => span.text).join(), contains('α_β_γ'));
+      expect(
+        spans.map((span) => span.text).join(),
+        contains('привет_мир_тест'),
+      );
+      expect(
+        spans.map((span) => span.text).join(),
+        contains('\u0301_x_\u0302'),
+      );
     },
   );
 
@@ -3232,7 +3249,8 @@ void main() {}
         const MaterialApp(
           home: Scaffold(
             body: CodeHighlightView(
-              'a **b** c a __b__ c\na__b__c',
+              'a **b** c a __b__ c\n'
+              'a__b__c and α__β__γ and α __β__ γ',
               language: 'markdown',
               theme: {'strong': TextStyle(fontWeight: FontWeight.bold)},
             ),
@@ -3252,19 +3270,23 @@ void main() {}
 
       expect(boldTexts, contains('**b**'));
       expect(boldTexts, contains('__b__'));
+      expect(boldTexts, contains('__β__'));
       // Intraword __ is literal: no bold span asserting a__b__c content.
-      expect(boldTexts.where((t) => t.contains('__b__')), hasLength(1));
+      expect(boldTexts.where((t) => t == '__b__'), hasLength(1));
+      expect(boldTexts.where((t) => t == '__β__'), hasLength(1));
+      expect(spans.map((span) => span.text).join(), contains('a__b__c'));
+      expect(spans.map((span) => span.text).join(), contains('α__β__γ'));
     },
   );
 
-  testWidgets('CodeHighlightView requires a space after ATX heading hashes', (
+  testWidgets('CodeHighlightView requires a space or tab after ATX hashes', (
     tester,
   ) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
           body: CodeHighlightView(
-            '# Heading\n#hashtag',
+            '# Heading\n#hashtag\n#\tTabHeading',
             language: 'markdown',
             theme: {
               'section': TextStyle(
@@ -3288,6 +3310,7 @@ void main() {}
         .toList();
 
     expect(boldTexts, contains('# Heading'));
+    expect(boldTexts, contains('#\tTabHeading'));
     expect(boldTexts, isNot(contains('#hashtag')));
   });
 


### PR DESCRIPTION
## Summary

Fixes #662 — inside `markdown`-fenced code blocks, intraword underscores (e.g. `{assistant_name}`, `{model_name}`) were tokenized as emphasis by the bundled highlight.js markdown grammar (`_.+?_`) and rendered italic by the code theme.

## Root cause

The app highlights ```` ```markdown ```` fences with the `highlight` package's markdown grammar, which is a syntax-coloring mode, not a CommonMark parser. Its `_.+?_` emphasis rule matches between any two underscores, including intraword ones, and both bundled code themes style `emphasis` as italic. In prose `_` never italicizes (the app's italic components only accept `*`), which is why this only appeared inside code blocks.

## Change

Rebuilt the `markdown` grammar (`_commonMarkMarkdownLanguage`) with CommonMark §6.2 delimiter-flanking rules and registered it once at the single `highlight.parse` choke point (`CodeHighlightView._highlightSource`):

- `_` emphasis: intraword delimiters can never open/close — `a _b_ c` and `（_好_）` stay italic, `a_b_c` / `{assistant_name}…{model_name}` render literal.
- `__` strong: split from `**`, same flanking rules — `a__b__c` stays literal; `**`/`*` remain intraword-valid (CommonMark allows asterisk emphasis inside words).
- ATX headings require a space or EOL after `#` (§4.2) — `#hashtag` no longer rendered as a bold section (light theme).
- Word-class ranges include CJK ideographs/kana/Hangul/full-width alphanumerics, since grammar regexes compile without the Unicode flag. Full-width `（）`/`・` stay punctuation, so `（_好_）` remains valid emphasis.

Everything else is untouched: other ~185 languages, all theme token styling (comment italics, colors), prose rendering, mermaid/plaintext paths.

## Tests

Added 6 widget tests covering: the #662 sample renders literal, flanking-valid (`a _b_ c`, `（_好_）`) stays italic, intraword ASCII/CJK stays literal, `__` strong split, ATX space rule, `md` alias, and a dart-comment-italic control proving registration doesn't disturb other languages. Verified the regression test fails against the old grammar.

Verification: `dart analyze --fatal-infos lib test` (0 issues) · `flutter test` on the 5 markdown test files (171 + 127 passed) · grammar-type manual check in-app.

Closes #662
