### PR TITLE
fix(markdown): scope underscore flanking post-pass to markdown fences (review follow-up)

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -6439,6 +6439,20 @@ void _ensureCommonMarkMarkdownGrammar() {
   highlight.registerLanguage('markdown', _commonMarkMarkdownLanguage);
 }
 
+/// Whether [language] resolves to the CommonMark markdown grammar.
+///
+/// [_ensureCommonMarkMarkdownGrammar] registers it as `markdown` with the
+/// aliases listed on [_commonMarkMarkdownLanguage]. Any other grammar must
+/// keep the [highlight.parse] node tree untouched: languages such as AsciiDoc
+/// legitimately style underscore emphasis with their own rules, which the
+/// CommonMark intraword flanking would otherwise strip.
+bool _isMarkdownLanguage(String? language) {
+  if (language == null) return false;
+  final l = language.trim().toLowerCase();
+  return l == 'markdown' ||
+      (_commonMarkMarkdownLanguage.aliases ?? const <String>[]).contains(l);
+}
+
 /// CommonMark §6.2 flanking classifications: "Unicode whitespace" is the `Z`
 /// categories plus tab/line terminators; "punctuation" is the Unicode `P`
 /// (punctuation) or `S` (symbol) general categories. These run with the
@@ -6496,6 +6510,9 @@ String? _codePointAfter(String text, int index) {
 /// cannot classify characters without the Unicode flag), so invalid pairs —
 /// e.g. `foo_bar_baz`, `α_β_γ`, `a__b__c` — are detected here by validating
 /// each candidate's surrounding code points, and rendered as plain text.
+///
+/// Markdown-only: callers must gate this behind [_isMarkdownLanguage]; other
+/// grammars style underscore emphasis with their own (non-CommonMark) rules.
 ///
 /// The engine puts a classed node's text in a child leaf (the container
 /// carries only the className), so runs are grouped by their nearest
@@ -6608,7 +6625,12 @@ class _CodeHighlightViewState extends State<CodeHighlightView> {
       _ensureCommonMarkMarkdownGrammar();
       final result = highlight.parse(widget.source, language: widget.language);
       final nodes = result.nodes ?? const [];
-      return _convertNodes(nodes, _underscoreFlankingInvalidNodes(nodes));
+      // The CommonMark flanking fix (#662) is markdown-specific; other
+      // grammars (e.g. AsciiDoc) keep their original parse output.
+      final flankingInvalid = _isMarkdownLanguage(widget.language)
+          ? _underscoreFlankingInvalidNodes(nodes)
+          : null;
+      return _convertNodes(nodes, flankingInvalid);
     } catch (_) {
       return const [];
     }

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -3370,6 +3370,63 @@ void main() {}
   );
 
   testWidgets(
+    'CodeHighlightView keeps asciidoc a__b__c underscore emphasis styled (regression control)',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'a__b__c',
+              language: 'asciidoc',
+              theme: {'emphasis': TextStyle(fontStyle: FontStyle.italic)},
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+      final italicTexts = spans
+          .where((span) => span.style.fontStyle == FontStyle.italic)
+          .map((span) => span.text)
+          .join();
+
+      expect(italicTexts, contains('_b_'));
+      expect(spans.map((span) => span.text).join(), contains('a__b__c'));
+    },
+  );
+
+  testWidgets(
+    'CodeHighlightView keeps asciidoc intraword underscore emphasis styled (no markdown flanking)',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: CodeHighlightView(
+              'snake_case_word',
+              language: 'asciidoc',
+              theme: {'emphasis': TextStyle(fontStyle: FontStyle.italic)},
+            ),
+          ),
+        ),
+      );
+
+      final root = _codeHighlightRootSpan(tester, find.byType(RichText));
+      final spans = _collectResolvedTextSpans(root);
+      final italicTexts = spans
+          .where((span) => span.style.fontStyle == FontStyle.italic)
+          .map((span) => span.text)
+          .join();
+
+      expect(italicTexts, contains('_case_'));
+      expect(
+        spans.map((span) => span.text).join(),
+        contains('snake_case_word'),
+      );
+    },
+  );
+
+  testWidgets(
     'MarkdownWithCodeHighlight keeps details tags literal in html code blocks',
     (tester) async {
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Follow-up to #674 ([review follow-up comment](https://github.com/cuplivo/cuplivo/pull/674#pullrequestreview-5101445704)): `_highlightSource` applied the CommonMark underscore flanking post-pass to **every** highlighted language, not only Markdown. Other bundled grammars legitimately emit `emphasis`/`strong` nodes with underscore delimiters under their own rules; applying Markdown's §6.2 intraword rule to them strips valid styling (observed: `snake_case_word` in an `asciidoc` fence renders literal instead of emphasized).

## Change

- Added `_isMarkdownLanguage()` derived from the registered grammar name (`markdown`) and its aliases on `_commonMarkMarkdownLanguage` (`md` / `mkdown` / `mkd`), so the gate stays in sync if aliases ever change.
- `_highlightSource` now runs `_underscoreFlankingInvalidNodes` only for markdown parses; all other languages keep the original `_convertNodes(nodes)` path (pre-#674 behavior).
- Documented the markdown-only scope on the post-pass.

Markdown fence rendering (#662 fix, incl. `md` alias, `__` strong, ATX space rule) is unchanged.

## Tests

Added two AsciiDoc regression tests (fails against the previous code):

- `a__b__c` — reviewer-requested control: remains emphasized.
- `snake_case_word` — fails pre-fix (emphasis was stripped), passes post-fix.

Verification: `flutter test test/shared/widgets/markdown_with_highlight_test.dart` (173 passed) · `dart analyze --fatal-infos lib test` (0 issues).

No localization, database, or persistence changes.
