### PR TITLE
feat(桌面端): 在 Web 对话样式页添加 WebView 开关

### DIFF
--- a/lib/features/settings/pages/web_conversation_styles_page.dart
+++ b/lib/features/settings/pages/web_conversation_styles_page.dart
@@ -531,6 +531,30 @@ class _WebConversationStylesPageState extends State<WebConversationStylesPage> {
         ListView(
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
           children: [
+            if (widget.desktop) ...[
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 760),
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: IosSettingsSection(
+                    children: [
+                      IosSettingsSwitchRow(
+                        icon: Lucide.Globe,
+                        label: l10n
+                            .displaySettingsPageExperimentalWebViewRenderingTitle,
+                        subtitle: l10n
+                            .displaySettingsPageExperimentalWebViewRenderingSubtitle,
+                        value: settings.experimentalWebViewRendering,
+                        onChanged: context
+                            .read<SettingsProvider>()
+                            .setExperimentalWebViewRendering,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
             if (!settings.experimentalWebViewRendering)
               Container(
                 margin: const EdgeInsets.only(bottom: 12),

--- a/lib/shared/widgets/ios_settings_section.dart
+++ b/lib/shared/widgets/ios_settings_section.dart
@@ -119,18 +119,21 @@ class IosSettingsNavRow extends StatelessWidget {
   }
 }
 
-/// A settings row with a leading icon, label and an [IosSwitch].
+/// A settings row with a leading icon, label, optional subtitle and an
+/// [IosSwitch].
 class IosSettingsSwitchRow extends StatelessWidget {
   const IosSettingsSwitchRow({
     super.key,
     required this.icon,
     required this.label,
+    this.subtitle,
     required this.value,
     required this.onChanged,
   });
 
   final IconData icon;
   final String label;
+  final String? subtitle;
   final bool value;
   final ValueChanged<bool> onChanged;
 
@@ -152,7 +155,22 @@ class IosSettingsSwitchRow extends StatelessWidget {
               SizedBox(width: 36, child: Icon(icon, size: 20, color: c)),
               const SizedBox(width: 12),
               Expanded(
-                child: Text(label, style: TextStyle(fontSize: 15, color: c)),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(label, style: TextStyle(fontSize: 15, color: c)),
+                    if (subtitle != null && subtitle!.isNotEmpty) ...[
+                      const SizedBox(height: 3),
+                      Text(
+                        subtitle!,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: cs.onSurface.withValues(alpha: 0.62),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
               ),
               IosSwitch(value: value, onChanged: onChanged),
             ],

--- a/test/features/settings/pages/web_conversation_styles_page_test.dart
+++ b/test/features/settings/pages/web_conversation_styles_page_test.dart
@@ -97,6 +97,7 @@ void main() {
     await pumpPage(tester, const WebConversationStylesPage());
 
     expect(find.text('Experimental: WebView rendering'), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('desktop pane renders on forced Windows and macOS branches', (
@@ -140,6 +141,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(settings.experimentalWebViewRendering, isFalse);
     expect(inactiveNotice, findsOneWidget);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('imported style exposes activation, export and delete actions', (

--- a/test/features/settings/pages/web_conversation_styles_page_test.dart
+++ b/test/features/settings/pages/web_conversation_styles_page_test.dart
@@ -6,6 +6,7 @@ import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/features/settings/pages/display_settings_page.dart';
 import 'package:Cuplivo/features/settings/pages/web_conversation_styles_page.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_switch.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -89,6 +90,15 @@ void main() {
     },
   );
 
+  testWidgets('mobile styles page does not duplicate the WebView toggle', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    await pumpPage(tester, const WebConversationStylesPage());
+
+    expect(find.text('Experimental: WebView rendering'), findsNothing);
+  });
+
   testWidgets('desktop pane renders on forced Windows and macOS branches', (
     tester,
   ) async {
@@ -96,10 +106,40 @@ void main() {
       debugDefaultTargetPlatformOverride = platform;
       await pumpPage(tester, const WebConversationStylesPage(desktop: true));
       expect(find.text('Web conversation styles'), findsOneWidget);
+      expect(find.text('Experimental: WebView rendering'), findsOneWidget);
       expect(find.text('Default style'), findsOneWidget);
       expect(find.text('Import'), findsOneWidget);
     }
     debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('desktop WebView toggle controls the inactive-style notice', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final settings = await pumpPage(
+      tester,
+      const WebConversationStylesPage(desktop: true),
+    );
+
+    final title = find.text('Experimental: WebView rendering');
+    final inactiveNotice = find.textContaining('WebView rendering is off');
+    final toggle = find.byType(IosSwitch);
+    expect(toggle, findsOneWidget);
+    expect(
+      tester.getTopLeft(title).dy,
+      lessThan(tester.getTopLeft(inactiveNotice).dy),
+    );
+
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(settings.experimentalWebViewRendering, isTrue);
+    expect(inactiveNotice, findsNothing);
+
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+    expect(settings.experimentalWebViewRendering, isFalse);
+    expect(inactiveNotice, findsOneWidget);
   });
 
   testWidgets('imported style exposes activation, export and delete actions', (


### PR DESCRIPTION
## 改动
- 在桌面端“Web 对话样式”页标题下方增加实验性 WebView 渲染开关。
- 复用现有设备本地设置与文案；开关状态改变后，样式未生效提示会立即显示或隐藏。
- 保留“显示设置 → 渲染设置”中的原入口，移动端不新增重复开关。
- 为 iOS 风格设置开关行增加可选副标题，并补充 Windows、macOS 和开关交互的 widget 测试。

## 验证
- `dart format lib/shared/widgets/ios_settings_section.dart lib/features/settings/pages/web_conversation_styles_page.dart test/features/settings/pages/web_conversation_styles_page_test.dart`
- `git diff --check`
- 未运行 widget 测试和 `dart analyze --fatal-infos lib test`：当前环境 Flutter 3.44.8，低于项目要求的 >=3.44.9，导致 `flutter pub get` 版本求解失败。
- 按要求未执行任何本地 `flutter build`。