### PR TITLE
feat(chat): 同步助手多气泡与毛玻璃滚动修复

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -263,6 +263,8 @@ class SettingsProvider extends ChangeNotifier {
       'display_chat_message_background_style_v1';
   static const String _displayAssistantBubbleFitContentKey =
       'display_assistant_bubble_fit_content_v1';
+  static const String _displayAssistantBubbleSplitParagraphsKey =
+      'display_assistant_bubble_split_paragraphs_v1';
   static const String _chatBubbleStyleOverridesKey =
       'chat_bubble_style_overrides_v1';
   static const String _userChatBubbleStyleOverridesKey =
@@ -1487,6 +1489,8 @@ class SettingsProvider extends ChangeNotifier {
     }
     _assistantBubbleFitContent =
         prefs.getBool(_displayAssistantBubbleFitContentKey) ?? false;
+    _assistantBubbleSplitParagraphs =
+        prefs.getBool(_displayAssistantBubbleSplitParagraphsKey) ?? false;
     final bubbleOverridesRaw = prefs.getString(_chatBubbleStyleOverridesKey);
     if (bubbleOverridesRaw != null && bubbleOverridesRaw.isNotEmpty) {
       try {
@@ -3021,6 +3025,16 @@ class SettingsProvider extends ChangeNotifier {
     _assistantBubbleFitContent = v;
     notifyListeners();
     await _preferences.setBool(_displayAssistantBubbleFitContentKey, v);
+  }
+
+  // When on, blank lines split assistant text into one bubble per paragraph.
+  bool _assistantBubbleSplitParagraphs = false;
+  bool get assistantBubbleSplitParagraphs => _assistantBubbleSplitParagraphs;
+  Future<void> setAssistantBubbleSplitParagraphs(bool v) async {
+    if (_assistantBubbleSplitParagraphs == v) return;
+    _assistantBubbleSplitParagraphs = v;
+    notifyListeners();
+    await _preferences.setBool(_displayAssistantBubbleSplitParagraphsKey, v);
   }
 
   ChatBubbleStyleOverrides _chatBubbleStyleOverrides =
@@ -5575,6 +5589,7 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     copy._selectedCustomThemeId = _selectedCustomThemeId;
     copy._chatMessageBackgroundStyle = _chatMessageBackgroundStyle;
     copy._assistantBubbleFitContent = _assistantBubbleFitContent;
+    copy._assistantBubbleSplitParagraphs = _assistantBubbleSplitParagraphs;
     copy._chatBubbleStyleOverrides = _chatBubbleStyleOverrides;
     copy._userChatBubbleStyleOverrides = _userChatBubbleStyleOverrides;
     copy._mobileAssistantEditTabOrder = _mobileAssistantEditTabOrder;

--- a/lib/features/chat/utils/assistant_paragraph_splitter.dart
+++ b/lib/features/chat/utils/assistant_paragraph_splitter.dart
@@ -1,0 +1,88 @@
+import '../../../shared/widgets/markdown_line_lexer.dart';
+
+/// Splits assistant markdown into paragraph chunks, one per bubble.
+///
+/// A blank line starts a new chunk, except where that would break a Markdown
+/// construct. Structure state comes from [MarkdownLineLexer] and
+/// [markdownScanDisplayMath] — the same rules the renderer applies — so code
+/// fences, `<details>` blocks, and `$$`/`\[…\]` display math keep their blank
+/// lines, including while an unclosed one is still streaming. On top of that,
+/// indented continuations stay attached to the block above them, adjacent list
+/// blocks stay together (so ordered lists do not restart numbering in every
+/// bubble), and a lone heading is kept with the block it introduces.
+///
+/// Returns a single-element list holding [text] unchanged when there is
+/// nothing to split.
+List<String> splitAssistantParagraphs(String text) {
+  if (text.trim().isEmpty) return <String>[text];
+
+  final lines = text.split('\n');
+  final chunks = <String>[];
+  final current = <String>[];
+  final lexer = MarkdownLineLexer();
+  final math = markdownScanDisplayMath(text);
+  var offset = 0;
+
+  void flush() {
+    final chunk = current.join('\n').trim();
+    if (chunk.isNotEmpty) chunks.add(chunk);
+    current.clear();
+  }
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    final lineStart = offset;
+    offset += line.length + 1;
+    lexer.consumePhysicalLine(line);
+
+    final breaksParagraph =
+        line.trim().isEmpty &&
+        !lexer.protected &&
+        !math.covers(lineStart) &&
+        !_continuesBlock(lines, i + 1);
+    if (breaksParagraph) {
+      flush();
+      continue;
+    }
+    current.add(line);
+  }
+  flush();
+
+  if (chunks.length < 2) return <String>[text];
+  return _mergeRelatedChunks(chunks);
+}
+
+final RegExp _listItemPattern = RegExp(r'^\s*([-*+]\s|\d+[.)]\s)');
+final RegExp _headingPattern = RegExp(r'^#{1,6}\s');
+
+/// A blank line followed by an indented line is a continuation (indented code,
+/// lazy list continuation), not a paragraph break.
+bool _continuesBlock(List<String> lines, int from) {
+  for (var i = from; i < lines.length; i++) {
+    if (lines[i].trim().isEmpty) continue;
+    return lines[i].startsWith('    ') || lines[i].startsWith('\t');
+  }
+  return false;
+}
+
+List<String> _mergeRelatedChunks(List<String> chunks) {
+  final merged = <String>[];
+  for (final chunk in chunks) {
+    if (merged.isNotEmpty && _shouldMerge(merged.last, chunk)) {
+      merged[merged.length - 1] = '${merged.last}\n\n$chunk';
+      continue;
+    }
+    merged.add(chunk);
+  }
+  return merged;
+}
+
+bool _shouldMerge(String previous, String next) {
+  if (_isHeadingOnly(previous)) return true;
+  return _startsList(previous) && _startsList(next);
+}
+
+bool _isHeadingOnly(String chunk) =>
+    !chunk.contains('\n') && _headingPattern.hasMatch(chunk);
+
+bool _startsList(String chunk) => _listItemPattern.hasMatch(chunk);

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -48,6 +48,7 @@ import '../../home/services/ask_user_interaction_service.dart';
 import '../../home/services/local_tools_service.dart';
 import 'screen_time_tool_ui.dart';
 import '../../home/services/tool_approval_service.dart';
+import '../utils/assistant_paragraph_splitter.dart';
 import '../utils/thinking_tag_parser.dart';
 import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
@@ -56,6 +57,7 @@ import '../../../theme/app_font_weights.dart';
 import '../../../theme/app_semantic_colors.dart';
 import '../../../theme/chat_bubble_style.dart';
 import '../models/tool_ui_part.dart';
+import 'frosted/frosted_surface.dart';
 import 'tool_approval_binding.dart';
 
 export '../models/tool_ui_part.dart';
@@ -1949,8 +1951,9 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
   Widget _buildAssistantTextContent(
     BuildContext context,
     String visualContent,
-    SettingsProvider settings,
-  ) {
+    SettingsProvider settings, {
+    String contentKey = '',
+  }) {
     final bool isDesktop =
         defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows ||
@@ -1991,7 +1994,11 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
 
     return RepaintBoundary(
       child: SelectionArea(
-        key: ValueKey('assistant_${widget.message.id}'),
+        key: ValueKey(
+          contentKey.isEmpty
+              ? 'assistant_${widget.message.id}'
+              : 'assistant_${widget.message.id}_$contentKey',
+        ),
         onSelectionChanged: (selection) {
           _selectedPlainText = selection?.plainText;
         },
@@ -2116,15 +2123,41 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
   Widget _buildAssistantTextBlock(
     BuildContext context,
     String visualContent,
-    SettingsProvider settings,
-  ) {
+    SettingsProvider settings, {
+    String contentKey = '',
+  }) {
     return _assistantBlockWidth(
       context,
       child: _buildAssistantBubbleContainer(
         context: context,
-        child: _buildAssistantTextContent(context, visualContent, settings),
+        child: _buildAssistantTextContent(
+          context,
+          visualContent,
+          settings,
+          contentKey: contentKey,
+        ),
       ),
     );
+  }
+
+  List<Widget> _buildAssistantTextBubbles(
+    BuildContext context,
+    String visualContent,
+    SettingsProvider settings, {
+    required String blockKey,
+  }) {
+    final parts = settings.assistantBubbleSplitParagraphs
+        ? splitAssistantParagraphs(visualContent)
+        : <String>[visualContent];
+    return <Widget>[
+      for (var i = 0; i < parts.length; i++)
+        _buildAssistantTextBlock(
+          context,
+          parts[i],
+          settings,
+          contentKey: parts.length == 1 ? '' : '$blockKey.$i',
+        ),
+    ];
   }
 
   List<_TimelineStepData> _buildTimelineSteps(
@@ -2577,22 +2610,31 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
             }
 
             final widgets = <Widget>[];
+            void addVisible(Widget child) {
+              if (widgets.isNotEmpty) {
+                widgets.add(const SizedBox(height: 8));
+              }
+              widgets.add(child);
+            }
+
             for (int i = 0; i < renderBlocks.length; i++) {
               final block = renderBlocks[i];
               if (block.type == _RenderBlockType.text && block.text != null) {
-                widgets.add(
-                  _buildAssistantTextBlock(context, block.text!, settings),
-                );
+                for (final bubble in _buildAssistantTextBubbles(
+                  context,
+                  block.text!,
+                  settings,
+                  blockKey: 'text$i',
+                )) {
+                  addVisible(bubble);
+                }
               } else if (block.steps.isNotEmpty) {
-                widgets.add(
+                addVisible(
                   _ChainOfThoughtCard(
                     steps: block.steps,
                     onRecoveredAnswer: widget.onRecoveredAskUserAnswer,
                   ),
                 );
-              }
-              if (i != renderBlocks.length - 1) {
-                widgets.add(const SizedBox(height: 8));
               }
             }
 
@@ -3336,25 +3378,11 @@ Widget _buildSharedChatSurface(
   switch (style) {
     case ChatMessageBackgroundStyle.frosted:
       final radius = BorderRadius.circular(resolved.radius);
-      return ClipRRect(
+      return FrostedSurface(
+        style: resolved,
         borderRadius: radius,
-        child: BackdropFilter.grouped(
-          filter: ui.ImageFilter.blur(
-            sigmaX: resolved.blurSigma,
-            sigmaY: resolved.blurSigma,
-          ),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: resolved.background,
-              borderRadius: radius,
-              border: Border.all(
-                color: resolved.border,
-                width: resolved.borderWidth,
-              ),
-            ),
-            child: paddedChild,
-          ),
-        ),
+        isUser: isUser,
+        child: paddedChild,
       );
     case ChatMessageBackgroundStyle.solid:
       final radius = BorderRadius.circular(resolved.radius);

--- a/lib/features/chat/widgets/frosted/chat_frosted_backdrop.dart
+++ b/lib/features/chat/widgets/frosted/chat_frosted_backdrop.dart
@@ -1,0 +1,799 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/providers/assistant_provider.dart';
+import '../../../../core/providers/settings_provider.dart';
+import '../../../../utils/sandbox_path_resolver.dart';
+
+/// When true, [FrostedSurface] always uses a live [BackdropFilter].
+///
+/// Used by goldens to generate a reference image. Never flip this during
+/// a frame in production — the switch is one-way at runtime as well.
+bool debugFrostedForceLiveBackdropFilter = false;
+
+/// When true, [ChatFrostedBackdrop] treats snapshot capture as failed.
+///
+/// Distinct from [debugFrostedForceLiveBackdropFilter]: this exercises the
+/// real failure path (`snapshotUnsupported`) so wallpaper removal can still
+/// return to the solid-color fast path.
+bool debugFrostedForceSnapshotFailure = false;
+
+/// Down-sample factor for a pre-blur snapshot.
+///
+/// `Δ = σ/6` keeps the bilinear reconstruction error below one 8-bit LSB
+/// before the frosted tint attenuates it further. `σ <= 0` is a no-op.
+double frostedSampleScale({required double sigma, required double dpr}) {
+  if (sigma <= 0) return 0;
+  return (6.0 / sigma).clamp(0.05, dpr);
+}
+
+enum FrostedRenderMode { uniform, cached, liveBackdropFilter }
+
+/// Identity of the static chat backdrop a frosted snapshot was built from.
+class ChatBackdropSpec {
+  const ChatBackdropSpec({
+    required this.backgroundRaw,
+    required this.active,
+    required this.maskStrength,
+    required this.surface,
+    required this.shadow,
+    required this.brightness,
+    required this.logicalSize,
+    required this.dpr,
+    this.revision = 0,
+  });
+
+  final String backgroundRaw;
+  final bool active;
+  final double maskStrength;
+  final Color surface;
+  final Color shadow;
+  final Brightness brightness;
+  final Size logicalSize;
+  final double dpr;
+
+  /// Bumped by [ChatFrostedBackdrop] when identity fields change.
+  ///
+  /// Theme interpolation keeps this moving. Wallpaper paint does not.
+  final int revision;
+
+  ChatBackdropSpec withRevision(int revision) {
+    return ChatBackdropSpec(
+      backgroundRaw: backgroundRaw,
+      active: active,
+      maskStrength: maskStrength,
+      surface: surface,
+      shadow: shadow,
+      brightness: brightness,
+      logicalSize: logicalSize,
+      dpr: dpr,
+      revision: revision,
+    );
+  }
+
+  /// Whether a wallpaper (local file or network) is actually shown.
+  ///
+  /// Lifted from [HomePage]'s `_assistantBackgroundActive` so "has wallpaper"
+  /// is decided in one place.
+  static ChatBackdropSpec resolve(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final mq = MediaQuery.of(context);
+    final backgroundRaw = context.select<AssistantProvider, String>(
+      (p) => (p.currentAssistant?.background ?? '').trim(),
+    );
+    final maskStrength = context.select<SettingsProvider, double>(
+      (s) => s.chatBackgroundMaskStrength,
+    );
+    return ChatBackdropSpec(
+      backgroundRaw: backgroundRaw,
+      active: isBackgroundActive(backgroundRaw),
+      maskStrength: maskStrength,
+      surface: cs.surface,
+      shadow: cs.shadow,
+      brightness: theme.brightness,
+      logicalSize: mq.size,
+      dpr: mq.devicePixelRatio,
+    );
+  }
+
+  static bool isBackgroundActive(String backgroundRaw) {
+    final bgRaw = backgroundRaw.trim();
+    if (bgRaw.isEmpty) return false;
+    if (bgRaw.startsWith('http')) return true;
+    try {
+      return File(SandboxPathResolver.fix(bgRaw)).existsSync();
+    } catch (error, stackTrace) {
+      debugPrint(
+        'ChatBackdropSpec: failed to inspect assistant background: $error',
+      );
+      debugPrintStack(stackTrace: stackTrace);
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ChatBackdropSpec &&
+      other.backgroundRaw == backgroundRaw &&
+      other.active == active &&
+      other.maskStrength == maskStrength &&
+      other.surface == surface &&
+      other.shadow == shadow &&
+      other.brightness == brightness &&
+      other.logicalSize == logicalSize &&
+      other.dpr == dpr &&
+      other.revision == revision;
+
+  @override
+  int get hashCode => Object.hash(
+    backgroundRaw,
+    active,
+    maskStrength,
+    surface,
+    shadow,
+    brightness,
+    logicalSize,
+    dpr,
+    revision,
+  );
+}
+
+class FrostedBackdropSnapshot {
+  const FrostedBackdropSnapshot({
+    required this.image,
+    required this.logicalSize,
+    required this.sigma,
+    required this.generation,
+  });
+
+  final ui.Image image;
+  final Size logicalSize;
+  final double sigma;
+  final int generation;
+}
+
+class _SnapshotBucket {
+  _SnapshotBucket() : notifier = ValueNotifier<FrostedBackdropSnapshot?>(null);
+
+  final ValueNotifier<FrostedBackdropSnapshot?> notifier;
+  int refs = 0;
+}
+
+/// Owns the pinned backdrop [LayerLink] and per-sigma blur snapshots.
+///
+/// Desktop/tablet bubbles near the chat-panel edge no longer ingest sidebar
+/// pixels: the snapshot is taken from the artwork layer only, which is
+/// painted on a [ColoredBox] of [ColorScheme.surface]. The visual difference
+/// versus sampling the composited sidebar is negligible.
+class ChatFrostedBackdropController extends ChangeNotifier {
+  ChatFrostedBackdropController();
+
+  final LayerLink link = LayerLink();
+
+  FrostedRenderMode mode = FrostedRenderMode.uniform;
+
+  /// Capture is permanently disabled for cached mode only. Removing wallpaper
+  /// still returns to [FrostedRenderMode.uniform].
+  bool snapshotUnsupported = false;
+
+  /// Temporary grouped live glass while the backdrop is changing.
+  ///
+  /// Theme interpolation, wallpaper switches, and animated wallpapers use
+  /// this. Generation and scroll never set it.
+  bool liveTransition = false;
+
+  bool _wallpaperActive = false;
+
+  final Map<double, _SnapshotBucket> _buckets = <double, _SnapshotBucket>{};
+  final List<ui.Image> _pendingDispose = <ui.Image>[];
+  int _generation = 0;
+  int _pixelVersion = 0;
+  bool _disposed = false;
+  var _retireScheduled = false;
+  VoidCallback? onSnapshotRequested;
+
+  ValueNotifier<FrostedBackdropSnapshot?> acquireSnapshot(double sigma) {
+    final bucket = _buckets.putIfAbsent(sigma, _SnapshotBucket.new);
+    final wasZero = bucket.refs == 0;
+    bucket.refs += 1;
+    if (wasZero) {
+      onSnapshotRequested?.call();
+    }
+    return bucket.notifier;
+  }
+
+  void releaseSnapshot(double sigma) {
+    final bucket = _buckets[sigma];
+    if (bucket == null) return;
+    bucket.refs -= 1;
+    if (bucket.refs > 0) return;
+    // Delay one frame so a still-compositing RawImage is not handed a
+    // disposed ui.Image / notifier.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_disposed) return;
+      final current = _buckets[sigma];
+      if (current == null || current.refs > 0 || !identical(current, bucket)) {
+        return;
+      }
+      final snap = current.notifier.value;
+      current.notifier.value = null;
+      _buckets.remove(sigma);
+      current.notifier.dispose();
+      if (snap != null) {
+        _pendingDispose.add(snap.image);
+        _scheduleDisposeRetired();
+      }
+    });
+  }
+
+  Iterable<double> get acquiredSigmas => [
+    for (final entry in _buckets.entries)
+      if (entry.value.refs > 0) entry.key,
+  ];
+
+  bool hasCurrentSnapshot(double sigma) {
+    if (sigma <= 0) return true;
+    final bucket = _buckets[sigma];
+    final snap = bucket?.notifier.value;
+    return bucket != null &&
+        bucket.refs > 0 &&
+        snap != null &&
+        snap.generation == _generation;
+  }
+
+  bool get hasAllCurrentSnapshots {
+    var any = false;
+    for (final sigma in acquiredSigmas) {
+      any = true;
+      if (!hasCurrentSnapshot(sigma)) return false;
+    }
+    return any;
+  }
+
+  @visibleForTesting
+  int get debugBucketCount => _buckets.length;
+
+  @visibleForTesting
+  int get debugAcquiredSigmaCount => acquiredSigmas.length;
+
+  /// Successful [toImageSync] calls for tests (one per sigma per capture).
+  @visibleForTesting
+  int debugCaptureCount = 0;
+
+  void applyBackdropState({
+    required bool wallpaperActive,
+    bool enterLive = false,
+  }) {
+    final nextLive = _nextLiveTransition(
+      wallpaperActive: wallpaperActive,
+      enterLive: enterLive,
+    );
+    final next = _nextRenderMode(
+      wallpaperActive: wallpaperActive,
+      liveTransition: nextLive,
+    );
+    final changed =
+        _wallpaperActive != wallpaperActive ||
+        liveTransition != nextLive ||
+        mode != next;
+    _wallpaperActive = wallpaperActive;
+    liveTransition = nextLive;
+    mode = next;
+    if (changed) notifyListeners();
+  }
+
+  bool _nextLiveTransition({
+    required bool wallpaperActive,
+    required bool enterLive,
+  }) {
+    if (debugFrostedForceLiveBackdropFilter) return liveTransition;
+    if (!wallpaperActive || snapshotUnsupported) return false;
+    if (enterLive) return true;
+    return liveTransition;
+  }
+
+  FrostedRenderMode _nextRenderMode({
+    required bool wallpaperActive,
+    required bool liveTransition,
+  }) {
+    if (debugFrostedForceLiveBackdropFilter) {
+      return FrostedRenderMode.liveBackdropFilter;
+    }
+    if (!wallpaperActive) return FrostedRenderMode.uniform;
+    if (snapshotUnsupported || liveTransition) {
+      return FrostedRenderMode.liveBackdropFilter;
+    }
+    return FrostedRenderMode.cached;
+  }
+
+  void beginLiveTransition() {
+    applyBackdropState(wallpaperActive: _wallpaperActive, enterLive: true);
+  }
+
+  void endLiveTransition() {
+    if (!liveTransition) return;
+    liveTransition = false;
+    applyBackdropState(wallpaperActive: _wallpaperActive);
+  }
+
+  void markSnapshotUnsupported() {
+    snapshotUnsupported = true;
+    liveTransition = false;
+    final next = _nextRenderMode(
+      wallpaperActive: _wallpaperActive,
+      liveTransition: false,
+    );
+    if (mode == next) {
+      notifyListeners();
+      return;
+    }
+    mode = next;
+    notifyListeners();
+  }
+
+  /// Transfers [snapshot] ownership on success. Returns `false` if the caller
+  /// must dispose [snapshot.image].
+  bool publish(double sigma, FrostedBackdropSnapshot snapshot) {
+    if (_disposed) return false;
+    final bucket = _buckets[sigma];
+    if (bucket == null || bucket.refs <= 0) return false;
+    if (snapshot.generation != _generation) return false;
+    final previous = bucket.notifier.value;
+    bucket.notifier.value = snapshot;
+    if (previous != null) {
+      _pendingDispose.add(previous.image);
+    }
+    return true;
+  }
+
+  /// Bump generation and immediately hide every cached crop.
+  ///
+  /// Old images stay alive for one frame so [RawImage] can finish compositing.
+  int invalidateSnapshots() {
+    _generation += 1;
+    for (final bucket in _buckets.values) {
+      final previous = bucket.notifier.value;
+      bucket.notifier.value = null;
+      if (previous != null) {
+        _pendingDispose.add(previous.image);
+      }
+    }
+    _scheduleDisposeRetired();
+    return _generation;
+  }
+
+  void _scheduleDisposeRetired() {
+    if (_retireScheduled || _disposed) return;
+    _retireScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _retireScheduled = false;
+      if (!_disposed) {
+        disposeRetiredImages();
+      }
+    });
+  }
+
+  void disposeRetiredImages() {
+    for (final image in _pendingDispose) {
+      image.dispose();
+    }
+    _pendingDispose.clear();
+  }
+
+  int get generation => _generation;
+
+  /// Incremented when the captured backdrop pixels actually change.
+  int get pixelVersion => _pixelVersion;
+
+  /// A real backdrop paint (decode / theme / first frame), not a capture paint.
+  int noteBackdropPixelsChanged() {
+    _pixelVersion += 1;
+    return invalidateSnapshots();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    for (final bucket in _buckets.values) {
+      bucket.notifier.value?.image.dispose();
+      bucket.notifier.dispose();
+    }
+    _buckets.clear();
+    disposeRetiredImages();
+    super.dispose();
+  }
+
+  bool get isDisposed => _disposed;
+}
+
+class ChatFrostedBackdropScope extends InheritedWidget {
+  const ChatFrostedBackdropScope({
+    super.key,
+    required this.controller,
+    required super.child,
+  });
+
+  final ChatFrostedBackdropController controller;
+
+  static ChatFrostedBackdropScope? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<ChatFrostedBackdropScope>();
+  }
+
+  static ChatFrostedBackdropScope? maybeOfStatic(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<ChatFrostedBackdropScope>();
+  }
+
+  @override
+  bool updateShouldNotify(ChatFrostedBackdropScope oldWidget) =>
+      oldWidget.controller != controller;
+}
+
+/// Pins a static chat backdrop and publishes pre-blurred snapshots for
+/// [FrostedSurface] to crop via [CompositedTransformFollower].
+class ChatFrostedBackdrop extends StatefulWidget {
+  const ChatFrostedBackdrop({
+    super.key,
+    required this.backdrop,
+    required this.child,
+  });
+
+  final Widget backdrop;
+  final Widget child;
+
+  @override
+  State<ChatFrostedBackdrop> createState() => _ChatFrostedBackdropState();
+}
+
+class _ChatFrostedBackdropState extends State<ChatFrostedBackdrop> {
+  final ChatFrostedBackdropController _controller =
+      ChatFrostedBackdropController();
+  final GlobalKey _boundaryKey = GlobalKey();
+  final BackdropKey _backdropKey = BackdropKey();
+  ChatBackdropSpec? _lastSpec;
+  var _revision = 0;
+  var _capturePending = false;
+  var _pendingPixelInvalidate = false;
+  var _awaitingStableSpec = false;
+  var _deferEndLive = false;
+  var _specChangedThisBuild = false;
+  var _frame = 0;
+  final List<int> _dirtyFrames = <int>[];
+  var _paintBurstScheduled = false;
+  var _paintsSinceSettle = 0;
+  var _paintSettleScheduled = false;
+  VoidCallback? _onDirty;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  bool get _canCapture =>
+      _controller.mode == FrostedRenderMode.cached ||
+      _controller.liveTransition;
+
+  void _requestCapture({bool pixelsChanged = false}) {
+    if (!mounted || _controller.isDisposed) return;
+    if (!_canCapture) return;
+    // First paint / first build has no snapshot yet — capture only.
+    // A later real paint (decode, theme) invalidates then recaptures.
+    if (pixelsChanged && _controller.hasAllCurrentSnapshots) {
+      _pendingPixelInvalidate = true;
+    }
+    if (_capturePending) return;
+    if (!pixelsChanged &&
+        !_pendingPixelInvalidate &&
+        _controller.hasAllCurrentSnapshots) {
+      return;
+    }
+    _capturePending = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _capturePending = false;
+      if (!mounted || _controller.isDisposed) return;
+      if (!_canCapture) return;
+      if (_pendingPixelInvalidate) {
+        _pendingPixelInvalidate = false;
+        _controller.noteBackdropPixelsChanged();
+      }
+      _capture();
+      _controller._scheduleDisposeRetired();
+      if (_deferEndLive) {
+        _scheduleSettleFrameCheck();
+      }
+    });
+  }
+
+  void _capture() {
+    if (debugFrostedForceLiveBackdropFilter) {
+      _controller.applyBackdropState(
+        wallpaperActive: _lastSpec?.active ?? false,
+      );
+      return;
+    }
+    if (debugFrostedForceSnapshotFailure) {
+      _controller.markSnapshotUnsupported();
+      return;
+    }
+    if (!_canCapture) return;
+    if (_controller.hasAllCurrentSnapshots) {
+      return;
+    }
+    final boundary =
+        _boundaryKey.currentContext?.findRenderObject()
+            as _RenderBackdropCaptureBoundary?;
+    if (boundary == null || !boundary.hasSize || boundary.size.isEmpty) {
+      return;
+    }
+    final spec = _lastSpec;
+    if (spec == null) return;
+    try {
+      final generation = _controller.generation;
+      final sigmas = _controller.acquiredSigmas.toList(growable: false);
+      if (sigmas.isEmpty) return;
+      boundary.suppressPaintNotify = true;
+      try {
+        for (final sigma in sigmas) {
+          if (sigma <= 0) continue;
+          final sample = frostedSampleScale(sigma: sigma, dpr: spec.dpr);
+          if (sample <= 0) continue;
+          ui.Image? raw;
+          try {
+            raw = boundary.toImageSync(pixelRatio: sample);
+            _controller.debugCaptureCount += 1;
+            final blurred = _blurImage(raw, sigma * sample);
+            final published = _controller.publish(
+              sigma,
+              FrostedBackdropSnapshot(
+                image: blurred,
+                logicalSize: boundary.size,
+                sigma: sigma,
+                generation: generation,
+              ),
+            );
+            if (!published) {
+              blurred.dispose();
+            }
+          } finally {
+            raw?.dispose();
+          }
+        }
+      } finally {
+        // Capture-induced paints during toImageSync stay suppressed.
+        // The next independent paint (decode / theme) must recapture.
+        boundary.suppressPaintNotify = false;
+      }
+    } catch (error, stackTrace) {
+      debugPrint('ChatFrostedBackdrop: snapshot capture failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _controller.markSnapshotUnsupported();
+      return;
+    }
+    if (!_controller.hasAllCurrentSnapshots) {
+      return;
+    }
+    if (!_deferEndLive) {
+      _controller.endLiveTransition();
+      return;
+    }
+    // Spec-change captures stay live until a later settle frame. A later
+    // acquire/recapture on the same revision can return to cached now.
+    if (!_specChangedThisBuild) {
+      _deferEndLive = false;
+      _controller.endLiveTransition();
+    }
+  }
+
+  void _scheduleSettleFrameCheck() {
+    final revision = _revision;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _maybeEndLiveAfterSettle(revision);
+    });
+  }
+
+  void _maybeEndLiveAfterSettle(int revision) {
+    if (!mounted || _controller.isDisposed) return;
+    if (_revision != revision) return;
+    if (!_controller.hasAllCurrentSnapshots) {
+      if (_canCapture && _controller.debugAcquiredSigmaCount > 0) {
+        _requestCapture();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _maybeEndLiveAfterSettle(revision);
+        });
+      }
+      return;
+    }
+    _deferEndLive = false;
+    _controller.endLiveTransition();
+  }
+
+  void _schedulePaintSettleCapture() {
+    if (_paintSettleScheduled) return;
+    _paintSettleScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _paintSettleScheduled = false;
+      if (!mounted || _controller.isDisposed) return;
+      if (_paintsSinceSettle > 0) {
+        _paintsSinceSettle = 0;
+        _schedulePaintSettleCapture();
+        return;
+      }
+      _requestCapture(pixelsChanged: true);
+    });
+  }
+
+  void _schedulePaintBurstCheck() {
+    if (_paintBurstScheduled) return;
+    _paintBurstScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _paintBurstScheduled = false;
+      if (!mounted || _controller.isDisposed) return;
+      _dirtyFrames.removeWhere((frame) => _frame - frame > 3);
+      if (_dirtyFrames.length >= 3) {
+        _controller.beginLiveTransition();
+        _paintsSinceSettle++;
+        _schedulePaintSettleCapture();
+        return;
+      }
+      if (_controller.liveTransition) return;
+      if (_dirtyFrames.isNotEmpty) {
+        _requestCapture(pixelsChanged: true);
+      }
+    });
+  }
+
+  ui.Image _blurImage(ui.Image src, double sigmaPx) {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final rect =
+        Offset.zero & Size(src.width.toDouble(), src.height.toDouble());
+    canvas.saveLayer(
+      rect,
+      Paint()
+        ..imageFilter = ui.ImageFilter.blur(
+          sigmaX: sigmaPx,
+          sigmaY: sigmaPx,
+          tileMode: TileMode.clamp,
+        ),
+    );
+    canvas.drawImage(src, Offset.zero, Paint());
+    canvas.restore();
+    final picture = recorder.endRecording();
+    try {
+      return picture.toImageSync(src.width, src.height);
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _frame++;
+    final incoming = ChatBackdropSpec.resolve(context).withRevision(_revision);
+    final specChanged = _lastSpec != incoming;
+    if (specChanged) {
+      _revision += 1;
+    }
+    final spec = incoming.withRevision(_revision);
+    _lastSpec = spec;
+    _specChangedThisBuild = specChanged;
+
+    if (specChanged) {
+      _controller.invalidateSnapshots();
+      if (spec.active && !_controller.snapshotUnsupported) {
+        _controller.applyBackdropState(wallpaperActive: true, enterLive: true);
+        _awaitingStableSpec = true;
+        _deferEndLive = true;
+      } else {
+        _controller.applyBackdropState(wallpaperActive: spec.active);
+        _awaitingStableSpec = false;
+        _deferEndLive = false;
+      }
+    } else {
+      _controller.applyBackdropState(wallpaperActive: spec.active);
+      if (_deferEndLive && spec.active) {
+        _scheduleSettleFrameCheck();
+      }
+    }
+
+    if (_awaitingStableSpec && spec.active) {
+      _awaitingStableSpec = false;
+      _requestCapture();
+    } else if (!specChanged &&
+        spec.active &&
+        _controller.mode == FrostedRenderMode.cached &&
+        !_controller.hasAllCurrentSnapshots) {
+      _requestCapture();
+    }
+
+    _controller.onSnapshotRequested ??= () {
+      _requestCapture();
+    };
+    _onDirty ??= () {
+      if (_controller.snapshotUnsupported) return;
+      if (_controller.mode == FrostedRenderMode.uniform) return;
+      // Spec-driven live (theme / wallpaper identity) is settled by
+      // revision checks, not by backdrop paints.
+      if (_deferEndLive) return;
+      if (_controller.liveTransition) {
+        _paintsSinceSettle++;
+        _schedulePaintSettleCapture();
+        return;
+      }
+      if (_controller.mode != FrostedRenderMode.cached) return;
+      _dirtyFrames.add(_frame);
+      _dirtyFrames.removeWhere((frame) => _frame - frame > 3);
+      if (_dirtyFrames.length >= 3) {
+        _schedulePaintBurstCheck();
+        return;
+      }
+      _requestCapture(pixelsChanged: true);
+    };
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Positioned.fill(
+          child: _BackdropCaptureBoundary(
+            key: _boundaryKey,
+            onPainted: _onDirty!,
+            child: CompositedTransformTarget(
+              link: _controller.link,
+              child: ColoredBox(color: spec.surface, child: widget.backdrop),
+            ),
+          ),
+        ),
+        BackdropGroup(
+          backdropKey: _backdropKey,
+          child: ChatFrostedBackdropScope(
+            controller: _controller,
+            child: widget.child,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BackdropCaptureBoundary extends SingleChildRenderObjectWidget {
+  const _BackdropCaptureBoundary({
+    super.key,
+    required this.onPainted,
+    required super.child,
+  });
+
+  final VoidCallback onPainted;
+
+  @override
+  RenderRepaintBoundary createRenderObject(BuildContext context) {
+    return _RenderBackdropCaptureBoundary(onPainted: onPainted);
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderBackdropCaptureBoundary renderObject,
+  ) {
+    renderObject.onPainted = onPainted;
+  }
+}
+
+class _RenderBackdropCaptureBoundary extends RenderRepaintBoundary {
+  _RenderBackdropCaptureBoundary({required this.onPainted});
+
+  VoidCallback onPainted;
+  bool suppressPaintNotify = false;
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    super.paint(context, offset);
+    if (suppressPaintNotify) return;
+    onPainted();
+  }
+}

--- a/lib/features/chat/widgets/frosted/frosted_surface.dart
+++ b/lib/features/chat/widgets/frosted/frosted_surface.dart
@@ -1,0 +1,229 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../../../theme/chat_bubble_style.dart';
+import 'chat_frosted_backdrop.dart';
+
+/// Frosted chat bubble surface.
+///
+/// Tier 0 (uniform / no scope / `blurSigma <= 0`): a [DecoratedBox] tint.
+/// Tier 1 (cached snapshot): a pinned, pre-blurred crop plus the same tint.
+/// Live [BackdropFilter] is only a fallback if snapshot capture fails,
+/// or when [debugFrostedForceLiveBackdropFilter] is set.
+///
+/// A missing snapshot never flips to live glass — it shows the tint only.
+class FrostedSurface extends StatelessWidget {
+  const FrostedSurface({
+    super.key,
+    required this.style,
+    required this.borderRadius,
+    required this.child,
+    this.isUser = false,
+  });
+
+  final ResolvedBubbleStyle style;
+  final BorderRadius borderRadius;
+  final Widget child;
+  final bool isUser;
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = ChatFrostedBackdropScope.maybeOf(context);
+    final sigma = style.blurSigma;
+    final Widget painted;
+    if (debugFrostedForceLiveBackdropFilter && sigma > 0) {
+      painted = _liveBackdrop(child);
+    } else if (scope == null || sigma <= 0) {
+      painted = _tint(child);
+    } else {
+      painted = ListenableBuilder(
+        listenable: scope.controller,
+        builder: (context, _) {
+          final mode = scope.controller.mode;
+          if (mode == FrostedRenderMode.uniform) {
+            return _tint(child);
+          }
+          if (mode == FrostedRenderMode.liveBackdropFilter) {
+            return Stack(
+              fit: StackFit.passthrough,
+              children: [
+                _FrostedSnapshotLease(
+                  controller: scope.controller,
+                  sigma: sigma,
+                ),
+                _liveBackdrop(child),
+              ],
+            );
+          }
+          // passthrough: a loose Stack would shrink-wrap the tint while the
+          // Positioned.fill crop still spans the incoming (often tight-width)
+          // constraints, so the glass would overflow the bubble border.
+          return Stack(
+            fit: StackFit.passthrough,
+            children: [
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: _FrostedBackdropCrop(
+                    controller: scope.controller,
+                    sigma: sigma,
+                  ),
+                ),
+              ),
+              _tint(child),
+            ],
+          );
+        },
+      );
+    }
+    return ClipRRect(
+      borderRadius: borderRadius,
+      clipBehavior: Clip.antiAlias,
+      child: painted,
+    );
+  }
+
+  Widget _tint(Widget child) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: style.background,
+        borderRadius: borderRadius,
+        border: Border.all(color: style.border, width: style.borderWidth),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _liveBackdrop(Widget child) {
+    return BackdropFilter.grouped(
+      filter: ui.ImageFilter.blur(
+        sigmaX: style.blurSigma,
+        sigmaY: style.blurSigma,
+      ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: style.background,
+          borderRadius: borderRadius,
+          border: Border.all(color: style.border, width: style.borderWidth),
+        ),
+        child: child,
+      ),
+    );
+  }
+}
+
+/// Holds a snapshot bucket so capture can resume after live glass stops.
+/// Does not paint [RawImage].
+class _FrostedSnapshotLease extends StatefulWidget {
+  const _FrostedSnapshotLease({required this.controller, required this.sigma});
+
+  final ChatFrostedBackdropController controller;
+  final double sigma;
+
+  @override
+  State<_FrostedSnapshotLease> createState() => _FrostedSnapshotLeaseState();
+}
+
+class _FrostedSnapshotLeaseState extends State<_FrostedSnapshotLease> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.acquireSnapshot(widget.sigma);
+  }
+
+  @override
+  void didUpdateWidget(covariant _FrostedSnapshotLease oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller ||
+        oldWidget.sigma != widget.sigma) {
+      oldWidget.controller.releaseSnapshot(oldWidget.sigma);
+      widget.controller.acquireSnapshot(widget.sigma);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.releaseSnapshot(widget.sigma);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class _FrostedBackdropCrop extends StatefulWidget {
+  const _FrostedBackdropCrop({required this.controller, required this.sigma});
+
+  final ChatFrostedBackdropController controller;
+  final double sigma;
+
+  @override
+  State<_FrostedBackdropCrop> createState() => _FrostedBackdropCropState();
+}
+
+class _FrostedBackdropCropState extends State<_FrostedBackdropCrop> {
+  late ValueNotifier<FrostedBackdropSnapshot?> _listenable;
+
+  @override
+  void initState() {
+    super.initState();
+    _listenable = widget.controller.acquireSnapshot(widget.sigma);
+  }
+
+  @override
+  void didUpdateWidget(covariant _FrostedBackdropCrop oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller ||
+        oldWidget.sigma != widget.sigma) {
+      oldWidget.controller.releaseSnapshot(oldWidget.sigma);
+      _listenable = widget.controller.acquireSnapshot(widget.sigma);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.releaseSnapshot(widget.sigma);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<FrostedBackdropSnapshot?>(
+      valueListenable: _listenable,
+      builder: (context, snapshot, _) {
+        if (snapshot == null ||
+            snapshot.generation != widget.controller.generation) {
+          return const SizedBox.shrink();
+        }
+        assert(() {
+          // A follower with no leader hides its child. Capturing this
+          // subtree with toImage would produce a blank glass — export
+          // and screenshots must go through the no-scope Tier 0 path.
+          return true;
+        }());
+        return OverflowBox(
+          alignment: Alignment.topLeft,
+          minWidth: 0,
+          minHeight: 0,
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: CompositedTransformFollower(
+            link: widget.controller.link,
+            showWhenUnlinked: false,
+            targetAnchor: Alignment.topLeft,
+            followerAnchor: Alignment.topLeft,
+            child: SizedBox(
+              width: snapshot.logicalSize.width,
+              height: snapshot.logicalSize.height,
+              child: RawImage(
+                image: snapshot.image,
+                fit: BoxFit.fill,
+                filterQuality: FilterQuality.low,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/home/pages/home_desktop_layout.dart
+++ b/lib/features/home/pages/home_desktop_layout.dart
@@ -20,6 +20,7 @@ import '../../../utils/brand_assets.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../desktop/hotkeys/chat_action_bus.dart';
 import '../../../desktop/hotkeys/sidebar_tab_bus.dart';
+import '../../chat/widgets/frosted/chat_frosted_backdrop.dart';
 import '../widgets/assistant_avatar.dart';
 import '../widgets/assistant_entry_actions.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
@@ -118,53 +119,50 @@ class HomeDesktopScaffold extends StatelessWidget {
     final sp = context.watch<SettingsProvider>();
     final topicsOnRight = sp.desktopTopicPosition == DesktopTopicPosition.right;
 
-    return Stack(
-      children: [
-        Positioned.fill(child: buildAssistantBackground(context)),
-        SizedBox.expand(
-          child: Row(
-            children: [
-              // Left sidebar
-              _buildLeftSidebar(context, cs, topicsOnRight),
-              // Left sidebar resize handle / divider
-              if (_isDesktop)
-                SidebarResizeHandle(
-                  visible: tabletSidebarOpen,
-                  onDrag: onSidebarWidthChanged,
-                  onDragEnd: onSidebarWidthChangeEnd,
-                )
-              else
-                AnimatedContainer(
-                  duration: _sidebarAnimDuration,
-                  curve: _sidebarAnimCurve,
-                  width: tabletSidebarOpen ? 0.6 : 0,
-                  child: tabletSidebarOpen
-                      ? VerticalDivider(
-                          width: 0.6,
-                          thickness: 0.5,
-                          color: cs.outlineVariant.withValues(alpha: 0.20),
-                        )
-                      : const SizedBox.shrink(),
-                ),
-              // Main content
-              Expanded(
-                child: Scaffold(
-                  key: scaffoldKey,
-                  resizeToAvoidBottomInset: true,
-                  extendBodyBehindAppBar: true,
-                  backgroundColor: Colors.transparent,
-                  appBar:
-                      appBarOverride ??
-                      _buildAppBar(context, cs, topicsOnRight),
-                  body: body,
-                ),
+    return ChatFrostedBackdrop(
+      backdrop: buildAssistantBackground(context),
+      child: SizedBox.expand(
+        child: Row(
+          children: [
+            // Left sidebar
+            _buildLeftSidebar(context, cs, topicsOnRight),
+            // Left sidebar resize handle / divider
+            if (_isDesktop)
+              SidebarResizeHandle(
+                visible: tabletSidebarOpen,
+                onDrag: onSidebarWidthChanged,
+                onDragEnd: onSidebarWidthChangeEnd,
+              )
+            else
+              AnimatedContainer(
+                duration: _sidebarAnimDuration,
+                curve: _sidebarAnimCurve,
+                width: tabletSidebarOpen ? 0.6 : 0,
+                child: tabletSidebarOpen
+                    ? VerticalDivider(
+                        width: 0.6,
+                        thickness: 0.5,
+                        color: cs.outlineVariant.withValues(alpha: 0.20),
+                      )
+                    : const SizedBox.shrink(),
               ),
-              // Right sidebar (desktop only with topics on right)
-              _buildRightSidebar(context, cs, topicsOnRight),
-            ],
-          ),
+            // Main content
+            Expanded(
+              child: Scaffold(
+                key: scaffoldKey,
+                resizeToAvoidBottomInset: true,
+                extendBodyBehindAppBar: true,
+                backgroundColor: Colors.transparent,
+                appBar:
+                    appBarOverride ?? _buildAppBar(context, cs, topicsOnRight),
+                body: body,
+              ),
+            ),
+            // Right sidebar (desktop only with topics on right)
+            _buildRightSidebar(context, cs, topicsOnRight),
+          ],
         ),
-      ],
+      ),
     );
   }
 

--- a/lib/features/home/pages/home_mobile_layout.dart
+++ b/lib/features/home/pages/home_mobile_layout.dart
@@ -18,6 +18,7 @@ import '../../../core/services/haptics.dart';
 import '../../../shared/animations/widgets.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../utils/sandbox_path_resolver.dart';
+import '../../chat/widgets/frosted/chat_frosted_backdrop.dart';
 import '../widgets/assistant_avatar.dart';
 import '../widgets/assistant_entry_actions.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
@@ -116,22 +117,16 @@ class HomeMobileScaffold extends StatelessWidget {
           if (closeDrawer) drawerController.close();
         },
       ),
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          // Keep the chat artwork at the full window size while Scaffold
-          // resizes only its body around the keyboard. Transparent IMEs can
-          // then reveal the artwork instead of Scaffold's surface color.
-          const MobileBackgroundLayer(),
-          Scaffold(
-            key: scaffoldKey,
-            resizeToAvoidBottomInset: true,
-            extendBodyBehindAppBar: true,
-            backgroundColor: Colors.transparent,
-            appBar: appBarOverride ?? _buildAppBar(context, cs),
-            body: body,
-          ),
-        ],
+      child: ChatFrostedBackdrop(
+        backdrop: const MobileBackgroundLayer(),
+        child: Scaffold(
+          key: scaffoldKey,
+          resizeToAvoidBottomInset: true,
+          extendBodyBehindAppBar: true,
+          backgroundColor: Colors.transparent,
+          appBar: appBarOverride ?? _buildAppBar(context, cs),
+          body: body,
+        ),
       ),
     );
   }
@@ -348,7 +343,7 @@ class MobileBackgroundLayer extends StatelessWidget {
         .watch<SettingsProvider>()
         .chatBackgroundMaskStrength;
 
-    if (bg == null || bg.trim().isEmpty) return const SizedBox.shrink();
+    if (bg == null || bg.trim().isEmpty) return const SizedBox.expand();
 
     ImageProvider provider;
     if (bg.startsWith('http')) {
@@ -356,49 +351,44 @@ class MobileBackgroundLayer extends StatelessWidget {
     } else {
       final localPath = SandboxPathResolver.fix(bg);
       final file = File(localPath);
-      if (!file.existsSync()) return const SizedBox.shrink();
+      if (!file.existsSync()) return const SizedBox.expand();
       provider = FileImage(file);
     }
 
-    return Positioned.fill(
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                image: DecorationImage(
-                  image: provider,
-                  fit: BoxFit.cover,
-                  colorFilter: ColorFilter.mode(
-                    Colors.black.withValues(alpha: 0.04),
-                    BlendMode.srcATop,
-                  ),
-                ),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            image: DecorationImage(
+              image: provider,
+              fit: BoxFit.cover,
+              colorFilter: ColorFilter.mode(
+                cs.shadow.withValues(alpha: 0.04),
+                BlendMode.srcATop,
               ),
             ),
           ),
-          Positioned.fill(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      cs.surface.withValues(
-                        alpha: (0.20 * maskStrength).clamp(0.0, 1.0),
-                      ),
-                      cs.surface.withValues(
-                        alpha: (0.50 * maskStrength).clamp(0.0, 1.0),
-                      ),
-                    ],
+        ),
+        IgnorePointer(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  cs.surface.withValues(
+                    alpha: (0.20 * maskStrength).clamp(0.0, 1.0),
                   ),
-                ),
+                  cs.surface.withValues(
+                    alpha: (0.50 * maskStrength).clamp(0.0, 1.0),
+                  ),
+                ],
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -62,6 +62,7 @@ import '../../chat/pages/html_preview_page.dart';
 import '../../chat/models/tool_ui_part.dart';
 import '../../chat/utils/message_visual_content.dart';
 import '../../chat/widgets/citation_sources_sheet.dart';
+import '../../chat/widgets/frosted/chat_frosted_backdrop.dart';
 import '../../search/widgets/search_settings_sheet.dart';
 import '../../model/widgets/model_select_sheet.dart';
 import '../../mcp/pages/mcp_page.dart';
@@ -615,7 +616,6 @@ class _HomePageState extends State<HomePage>
       ImageGenerationOptionsController();
   scroll_ctrl.ChatAutoFollowScrollController _scrollController =
       scroll_ctrl.ChatAutoFollowScrollController();
-  final BackdropKey _messageListBackdropKey = BackdropKey();
   final GlobalKey _inputBarKey = GlobalKey();
   final GlobalKey _selectionMiniMapKey = GlobalKey();
   final GlobalKey _selectionActionBarKey = GlobalKey();
@@ -1319,17 +1319,7 @@ class _HomePageState extends State<HomePage>
   }
 
   bool _assistantBackgroundActive(BuildContext context) {
-    final bgRaw =
-        (context.watch<AssistantProvider>().currentAssistant?.background ?? '')
-            .trim();
-    if (bgRaw.isEmpty) return false;
-    if (bgRaw.startsWith('http')) return true;
-    try {
-      final fixed = SandboxPathResolver.fix(bgRaw);
-      return File(fixed).existsSync();
-    } catch (_) {
-      return false;
-    }
+    return ChatBackdropSpec.resolve(context).active;
   }
 
   double _chatTopOverlayInset(BuildContext context) {
@@ -1711,10 +1701,7 @@ class _HomePageState extends State<HomePage>
       },
     );
 
-    return BackdropGroup(
-      backdropKey: _messageListBackdropKey,
-      child: messageList,
-    );
+    return messageList;
   }
 
   bool _webViewportRequested(SettingsProvider settings, String conversationId) {

--- a/lib/features/settings/pages/message_style_settings_page.dart
+++ b/lib/features/settings/pages/message_style_settings_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_core/theme.dart';
@@ -19,6 +17,8 @@ import '../../../theme/chat_bubble_style.dart';
 import '../../../theme/custom_theme.dart';
 import '../../../theme/palettes.dart';
 import '../../../theme/theme_factory.dart';
+import '../../chat/widgets/frosted/chat_frosted_backdrop.dart';
+import '../../chat/widgets/frosted/frosted_surface.dart';
 import '../../home/pages/home_mobile_layout.dart';
 import '../widgets/custom_theme_widgets.dart';
 
@@ -181,6 +181,14 @@ class _MessageStyleSettingsBodyState extends State<MessageStyleSettingsBody> {
           subtitle: l10n.messageStyleSettingsPageAssistantFitContentSubtitle,
           value: settings.assistantBubbleFitContent,
           onChanged: settings.setAssistantBubbleFitContent,
+        ),
+        _iosDivider(context),
+        _SwitchRow(
+          label: l10n.messageStyleSettingsPageAssistantSplitParagraphs,
+          subtitle:
+              l10n.messageStyleSettingsPageAssistantSplitParagraphsSubtitle,
+          value: settings.assistantBubbleSplitParagraphs,
+          onChanged: settings.setAssistantBubbleSplitParagraphs,
         ),
       ],
     );
@@ -1144,119 +1152,114 @@ class _PreviewScene extends StatelessWidget {
       return Opacity(opacity: 0.45, child: child);
     }
 
-    return BackdropGroup(
-      child: Stack(
+    return ChatFrostedBackdrop(
+      backdrop: Stack(
         fit: StackFit.expand,
         children: [
           ColoredBox(color: cs.surface),
           const MobileBackgroundLayer(),
-          Stack(
-            fit: StackFit.expand,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 240),
-                        child: maybeDim(
-                          active: editingUser,
-                          child: _PreviewSurface(
-                            style: style,
-                            resolved: userResolved,
-                            defaultColor: brightness == Brightness.dark
-                                ? cs.primary.withValues(alpha: 0.15)
-                                : cs.primary.withValues(alpha: 0.08),
-                            padding: const EdgeInsets.all(11),
-                            child: Text(
-                              l10n.messageStyleSettingsPagePreviewUser,
-                              style: TextStyle(
-                                fontSize: 14,
-                                height: 1.35,
-                                color:
-                                    style ==
-                                        ChatMessageBackgroundStyle.defaultStyle
-                                    ? cs.onSurface
-                                    : userResolved.text,
-                              ),
-                            ),
+        ],
+      ),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 14, 12, 14),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 240),
+                    child: maybeDim(
+                      active: editingUser,
+                      child: _PreviewSurface(
+                        style: style,
+                        resolved: userResolved,
+                        defaultColor: brightness == Brightness.dark
+                            ? cs.primary.withValues(alpha: 0.15)
+                            : cs.primary.withValues(alpha: 0.08),
+                        padding: const EdgeInsets.all(11),
+                        child: Text(
+                          l10n.messageStyleSettingsPagePreviewUser,
+                          style: TextStyle(
+                            fontSize: 14,
+                            height: 1.35,
+                            color:
+                                style == ChatMessageBackgroundStyle.defaultStyle
+                                ? cs.onSurface
+                                : userResolved.text,
                           ),
                         ),
                       ),
                     ),
-                    maybeDim(
+                  ),
+                ),
+                maybeDim(
+                  active: !editingUser,
+                  child: _PreviewSurface(
+                    style: style,
+                    resolved: assistantResolved,
+                    defaultColor: cs.primaryContainer.withValues(
+                      alpha: brightness == Brightness.dark ? 0.25 : 0.30,
+                    ),
+                    padding: const EdgeInsets.fromLTRB(12, 9, 12, 9),
+                    child: Row(
+                      children: [
+                        ReasoningIcons.thinkingCardIcon(
+                          size: 16,
+                          color: _previewStrong(context, assistantResolved),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            l10n.messageStyleSettingsPagePreviewThinking,
+                            style: TextStyle(
+                              fontSize: 13,
+                              fontWeight: AppFontWeights.emphasis,
+                              color: _previewStrong(context, assistantResolved),
+                            ),
+                          ),
+                        ),
+                        Icon(
+                          Lucide.ChevronRight,
+                          size: 16,
+                          color: _previewStrong(context, assistantResolved),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 260),
+                    child: maybeDim(
                       active: !editingUser,
                       child: _PreviewSurface(
                         style: style,
                         resolved: assistantResolved,
-                        defaultColor: cs.primaryContainer.withValues(
-                          alpha: brightness == Brightness.dark ? 0.25 : 0.30,
-                        ),
-                        padding: const EdgeInsets.fromLTRB(12, 9, 12, 9),
-                        child: Row(
-                          children: [
-                            ReasoningIcons.thinkingCardIcon(
-                              size: 16,
-                              color: _previewStrong(context, assistantResolved),
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                l10n.messageStyleSettingsPagePreviewThinking,
-                                style: TextStyle(
-                                  fontSize: 13,
-                                  fontWeight: AppFontWeights.emphasis,
-                                  color: _previewStrong(
-                                    context,
-                                    assistantResolved,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Icon(
-                              Lucide.ChevronRight,
-                              size: 16,
-                              color: _previewStrong(context, assistantResolved),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    Align(
-                      alignment: Alignment.centerLeft,
-                      child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 260),
-                        child: maybeDim(
-                          active: !editingUser,
-                          child: _PreviewSurface(
-                            style: style,
-                            resolved: assistantResolved,
-                            bareOnDefault: true,
-                            padding: const EdgeInsets.all(11),
-                            child: Text(
-                              l10n.messageStyleSettingsPagePreviewAssistant,
-                              style: TextStyle(
-                                fontSize: 14,
-                                height: 1.45,
-                                color:
-                                    style ==
-                                        ChatMessageBackgroundStyle.defaultStyle
-                                    ? cs.onSurface
-                                    : assistantResolved.text,
-                              ),
-                            ),
+                        bareOnDefault: true,
+                        padding: const EdgeInsets.all(11),
+                        child: Text(
+                          l10n.messageStyleSettingsPagePreviewAssistant,
+                          style: TextStyle(
+                            fontSize: 14,
+                            height: 1.45,
+                            color:
+                                style == ChatMessageBackgroundStyle.defaultStyle
+                                ? cs.onSurface
+                                : assistantResolved.text,
                           ),
                         ),
                       ),
                     ),
-                  ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ],
       ),
@@ -1297,26 +1300,10 @@ class _PreviewSurface extends StatelessWidget {
     final padded = Padding(padding: padding, child: child);
     switch (style) {
       case ChatMessageBackgroundStyle.frosted:
-        final radius = BorderRadius.circular(resolved.radius);
-        return ClipRRect(
-          borderRadius: radius,
-          child: BackdropFilter.grouped(
-            filter: ui.ImageFilter.blur(
-              sigmaX: resolved.blurSigma,
-              sigmaY: resolved.blurSigma,
-            ),
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: resolved.background,
-                borderRadius: radius,
-                border: Border.all(
-                  color: resolved.border,
-                  width: resolved.borderWidth,
-                ),
-              ),
-              child: padded,
-            ),
-          ),
+        return FrostedSurface(
+          style: resolved,
+          borderRadius: BorderRadius.circular(resolved.radius),
+          child: padded,
         );
       case ChatMessageBackgroundStyle.solid:
         final radius = BorderRadius.circular(resolved.radius);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4186,6 +4186,8 @@
   "webConversationStylesNoDescription": "No description",
   "messageStyleSettingsPageAssistantFitContent": "Fit assistant bubble to content",
   "messageStyleSettingsPageAssistantFitContentSubtitle": "Assistant bubbles hug their text instead of filling the row",
+  "messageStyleSettingsPageAssistantSplitParagraphs": "Split paragraphs into bubbles",
+  "messageStyleSettingsPageAssistantSplitParagraphsSubtitle": "Blank lines break an assistant reply into one bubble per paragraph",
   "messageStyleSettingsPageBackgroundColor": "Background",
   "messageStyleSettingsPageBackgroundOpacity": "Background Opacity",
   "messageStyleSettingsPageBlur": "Blur",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17311,6 +17311,18 @@ abstract class AppLocalizations {
   /// **'Assistant bubbles hug their text instead of filling the row'**
   String get messageStyleSettingsPageAssistantFitContentSubtitle;
 
+  /// No description provided for @messageStyleSettingsPageAssistantSplitParagraphs.
+  ///
+  /// In en, this message translates to:
+  /// **'Split paragraphs into bubbles'**
+  String get messageStyleSettingsPageAssistantSplitParagraphs;
+
+  /// No description provided for @messageStyleSettingsPageAssistantSplitParagraphsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Blank lines break an assistant reply into one bubble per paragraph'**
+  String get messageStyleSettingsPageAssistantSplitParagraphsSubtitle;
+
   /// No description provided for @messageStyleSettingsPageBackgroundColor.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9677,6 +9677,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Assistant bubbles hug their text instead of filling the row';
 
   @override
+  String get messageStyleSettingsPageAssistantSplitParagraphs =>
+      'Split paragraphs into bubbles';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphsSubtitle =>
+      'Blank lines break an assistant reply into one bubble per paragraph';
+
+  @override
   String get messageStyleSettingsPageBackgroundColor => 'Background';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9222,6 +9222,13 @@ class AppLocalizationsZh extends AppLocalizations {
       '助手气泡按文字宽度收缩，不再占满整行';
 
   @override
+  String get messageStyleSettingsPageAssistantSplitParagraphs => '分段显示为多个气泡';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphsSubtitle =>
+      '助手回复遇到空行时拆分，每段单独一个气泡';
+
+  @override
   String get messageStyleSettingsPageBackgroundColor => '背景颜色';
 
   @override
@@ -18514,6 +18521,13 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   @override
   String get messageStyleSettingsPageAssistantFitContentSubtitle =>
       '助手气泡按文字宽度收缩，不再占满整行';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphs => '分段显示为多个气泡';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphsSubtitle =>
+      '助手回复遇到空行时拆分，每段单独一个气泡';
 
   @override
   String get messageStyleSettingsPageBackgroundColor => '背景颜色';
@@ -27810,6 +27824,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get messageStyleSettingsPageAssistantFitContentSubtitle =>
       '助手氣泡按文字寬度收縮，不再佔滿整行';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphs => '分段顯示為多個氣泡';
+
+  @override
+  String get messageStyleSettingsPageAssistantSplitParagraphsSubtitle =>
+      '助手回覆遇到空行時拆分，每段單獨一個氣泡';
 
   @override
   String get messageStyleSettingsPageBackgroundColor => '背景顏色';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3588,6 +3588,8 @@
   "webConversationStylesNoDescription": "无描述",
   "messageStyleSettingsPageAssistantFitContent": "助手气泡贴合内容",
   "messageStyleSettingsPageAssistantFitContentSubtitle": "助手气泡按文字宽度收缩，不再占满整行",
+  "messageStyleSettingsPageAssistantSplitParagraphs": "分段显示为多个气泡",
+  "messageStyleSettingsPageAssistantSplitParagraphsSubtitle": "助手回复遇到空行时拆分，每段单独一个气泡",
   "messageStyleSettingsPageBackgroundColor": "背景颜色",
   "messageStyleSettingsPageBackgroundOpacity": "背景不透明度",
   "messageStyleSettingsPageBlur": "模糊强度",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3589,6 +3589,8 @@
   "webConversationStylesNoDescription": "无描述",
   "messageStyleSettingsPageAssistantFitContent": "助手气泡贴合内容",
   "messageStyleSettingsPageAssistantFitContentSubtitle": "助手气泡按文字宽度收缩，不再占满整行",
+  "messageStyleSettingsPageAssistantSplitParagraphs": "分段显示为多个气泡",
+  "messageStyleSettingsPageAssistantSplitParagraphsSubtitle": "助手回复遇到空行时拆分，每段单独一个气泡",
   "messageStyleSettingsPageBackgroundColor": "背景颜色",
   "messageStyleSettingsPageBackgroundOpacity": "背景不透明度",
   "messageStyleSettingsPageBlur": "模糊强度",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3589,6 +3589,8 @@
   "webConversationStylesNoDescription": "無描述",
   "messageStyleSettingsPageAssistantFitContent": "助手氣泡貼合內容",
   "messageStyleSettingsPageAssistantFitContentSubtitle": "助手氣泡按文字寬度收縮，不再佔滿整行",
+  "messageStyleSettingsPageAssistantSplitParagraphs": "分段顯示為多個氣泡",
+  "messageStyleSettingsPageAssistantSplitParagraphsSubtitle": "助手回覆遇到空行時拆分，每段單獨一個氣泡",
   "messageStyleSettingsPageBackgroundColor": "背景顏色",
   "messageStyleSettingsPageBackgroundOpacity": "背景不透明度",
   "messageStyleSettingsPageBlur": "模糊強度",

--- a/test/features/chat/utils/assistant_paragraph_splitter_test.dart
+++ b/test/features/chat/utils/assistant_paragraph_splitter_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/chat/utils/assistant_paragraph_splitter.dart';
+
+void main() {
+  test('splits on blank lines', () {
+    expect(splitAssistantParagraphs('one\n\ntwo\n\nthree'), [
+      'one',
+      'two',
+      'three',
+    ]);
+  });
+
+  test('keeps single-newline text in one bubble', () {
+    expect(splitAssistantParagraphs('one\ntwo'), ['one\ntwo']);
+  });
+
+  test('returns text unchanged when there is nothing to split', () {
+    expect(splitAssistantParagraphs('  hi  '), ['  hi  ']);
+    expect(splitAssistantParagraphs(''), ['']);
+  });
+
+  test('keeps blank lines inside fenced code blocks', () {
+    const text = 'intro\n\n```dart\nvoid a() {}\n\nvoid b() {}\n```\n\nend';
+    expect(splitAssistantParagraphs(text), [
+      'intro',
+      '```dart\nvoid a() {}\n\nvoid b() {}\n```',
+      'end',
+    ]);
+  });
+
+  test('leaves an unterminated streaming fence intact', () {
+    const text = 'intro\n\n```dart\nvoid a() {}\n\nvoid b';
+    expect(splitAssistantParagraphs(text), [
+      'intro',
+      '```dart\nvoid a() {}\n\nvoid b',
+    ]);
+  });
+
+  test('keeps blank lines inside display math', () {
+    const text = 'before\n\n\$\$\na = b\n\nc = d\n\$\$\n\nafter';
+    expect(splitAssistantParagraphs(text), [
+      'before',
+      '\$\$\na = b\n\nc = d\n\$\$',
+      'after',
+    ]);
+  });
+
+  test('keeps a loose ordered list in one bubble', () {
+    const text = 'Steps:\n\n1. first\n\n2. second\n\n3. third';
+    expect(splitAssistantParagraphs(text), [
+      'Steps:',
+      '1. first\n\n2. second\n\n3. third',
+    ]);
+  });
+
+  test('keeps a heading with the paragraph it introduces', () {
+    expect(splitAssistantParagraphs('## Title\n\nbody\n\ntail'), [
+      '## Title\n\nbody',
+      'tail',
+    ]);
+  });
+
+  test('keeps indented continuations attached', () {
+    const text = 'code:\n\n    line a\n\n    line b\n\nend';
+    expect(splitAssistantParagraphs(text), [
+      'code:\n\n    line a\n\n    line b',
+      'end',
+    ]);
+  });
+
+  test('collapses runs of blank lines', () {
+    expect(splitAssistantParagraphs('a\n\n\n\nb'), ['a', 'b']);
+  });
+
+  test('keeps blank lines inside bracket display math', () {
+    const text = 'before\n\n\\[\na = b\n\nc = d\n\\]\n\nafter';
+    expect(splitAssistantParagraphs(text), [
+      'before',
+      '\\[\na = b\n\nc = d\n\\]',
+      'after',
+    ]);
+  });
+
+  test('keeps a details block whole', () {
+    const text =
+        'intro\n\n<details>\n<summary>more</summary>\n\nbody one\n\nbody two\n'
+        '</details>\n\nend';
+    expect(splitAssistantParagraphs(text), [
+      'intro',
+      '<details>\n<summary>more</summary>\n\nbody one\n\nbody two\n</details>',
+      'end',
+    ]);
+  });
+
+  test('does not treat an info-string line inside a fence as a closer', () {
+    const text = 'intro\n\n```\n```not-a-close\n\nstill code\n```\n\nend';
+    expect(splitAssistantParagraphs(text), [
+      'intro',
+      '```\n```not-a-close\n\nstill code\n```',
+      'end',
+    ]);
+  });
+
+  test('closes a fence only on a matching marker of at least equal length', () {
+    const text = 'intro\n\n````\n```\n\ninner\n````\n\nend';
+    expect(splitAssistantParagraphs(text), [
+      'intro',
+      '````\n```\n\ninner\n````',
+      'end',
+    ]);
+  });
+}

--- a/test/features/chat/widgets/assistant_bubble_split_paragraphs_test.dart
+++ b/test/features/chat/widgets/assistant_bubble_split_paragraphs_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/tts_provider.dart';
+import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+
+const String _content = 'first paragraph\n\nsecond paragraph';
+
+Future<int> _bubbleCount(WidgetTester tester, {required bool split}) async {
+  SharedPreferences.setMockInitialValues({});
+  final preferences = BusinessPreferences.memoryForTests({
+    'display_chat_message_background_style_v1': 'solid',
+    if (split) 'display_assistant_bubble_split_paragraphs_v1': true,
+  });
+  final settings = SettingsProvider(preferences: preferences);
+  await settings.loaded;
+  final message = ChatMessage(
+    role: 'assistant',
+    content: _content,
+    conversationId: 'conversation-split-paragraphs',
+  );
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        Provider<BusinessPreferences>.value(value: preferences),
+        ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+        ChangeNotifierProvider(
+          create: (_) => TtsProvider(preferences: preferences),
+        ),
+        ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+        ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ChatMessageWidget(message: message, showModelIcon: false),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return find.byType(SelectionArea).evaluate().length;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('option off keeps the whole reply in one bubble', (tester) async {
+    expect(await _bubbleCount(tester, split: false), 1);
+  });
+
+  testWidgets('option on renders one bubble per paragraph', (tester) async {
+    expect(await _bubbleCount(tester, split: true), 2);
+  });
+}

--- a/test/features/chat/widgets/chat_bubble_style_overrides_test.dart
+++ b/test/features/chat/widgets/chat_bubble_style_overrides_test.dart
@@ -10,6 +10,7 @@ import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/providers/tts_provider.dart';
 import 'package:Cuplivo/core/providers/user_provider.dart';
 import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/chat/widgets/frosted/frosted_surface.dart';
 import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
 import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
@@ -91,13 +92,14 @@ void main() {
       _clipAncestorOf('Plain override text'),
     );
     expect(clip.borderRadius, BorderRadius.circular(4));
-    expect(
+    final surface = tester.widget<FrostedSurface>(
       find.ancestor(
         of: find.text('Plain override text'),
-        matching: find.byType(BackdropFilter),
+        matching: find.byType(FrostedSurface),
       ),
-      findsOneWidget,
     );
+    expect(surface.style.blurSigma, 3);
+    expect(find.byType(BackdropFilter), findsNothing);
     expect(
       tester.widget<Text>(find.text('Plain override text')).style?.color,
       const Color(0xFF224466),

--- a/test/features/chat/widgets/chat_message_widget_background_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_background_test.dart
@@ -12,6 +12,7 @@ import 'package:Cuplivo/core/providers/tts_provider.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/core/services/generation_engine.dart';
 import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/chat/widgets/frosted/frosted_surface.dart';
 import 'package:Cuplivo/features/home/controllers/stream_controller.dart'
     as home_stream;
 import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
@@ -362,7 +363,8 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byType(BackdropFilter), findsOneWidget);
+      expect(find.byType(FrostedSurface), findsOneWidget);
+      expect(find.byType(BackdropFilter), findsNothing);
       expect(
         tester.widget<Text>(find.text('Deep Thinking')).style?.color,
         _expectedNeutralStrong(),
@@ -410,7 +412,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byType(BackdropFilter), findsNothing);
+      expect(find.byType(FrostedSurface), findsNothing);
       expect(
         tester.widget<Text>(find.text('Deep Thinking')).style?.color,
         _expectedNeutralStrong(),
@@ -443,7 +445,8 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byType(BackdropFilter), findsOneWidget);
+      expect(find.byType(FrostedSurface), findsOneWidget);
+      expect(find.byType(BackdropFilter), findsNothing);
       expect(
         tester.widget<Text>(find.text('Web Search: Kelivo')).style?.color,
         _expectedNeutralStrong(),
@@ -474,7 +477,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byType(BackdropFilter), findsNothing);
+      expect(find.byType(FrostedSurface), findsNothing);
       expect(
         tester.widget<Text>(find.text('Web Search: Kelivo')).style?.color,
         _expectedNeutralStrong(),
@@ -504,7 +507,8 @@ void main() {
         await tester.pump();
         await tester.pump(const Duration(milliseconds: 300));
 
-        expect(find.byType(BackdropFilter), findsNWidgets(2));
+        expect(find.byType(FrostedSurface), findsNWidgets(2));
+        expect(find.byType(BackdropFilter), findsNothing);
         expect(
           tester.widget<Text>(find.text('Translation')).style?.color,
           _expectedNeutralStrong(),
@@ -533,7 +537,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.byType(BackdropFilter), findsNothing);
+      expect(find.byType(FrostedSurface), findsNothing);
       expect(
         tester.widget<Text>(find.text('Translation')).style?.color,
         _expectedNeutralStrong(),

--- a/test/features/chat/widgets/frosted/frosted_surface_layer_test.dart
+++ b/test/features/chat/widgets/frosted/frosted_surface_layer_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/features/chat/widgets/frosted/chat_frosted_backdrop.dart';
+import 'package:Cuplivo/features/chat/widgets/frosted/frosted_surface.dart';
+import 'package:Cuplivo/theme/chat_bubble_style.dart';
+
+const _style = ResolvedBubbleStyle(
+  background: Color(0xA8FFFFFF),
+  border: Color(0x24FFFFFF),
+  text: Color(0xFF111111),
+  borderWidth: 0.8,
+  radius: 16,
+  blurSigma: 14,
+);
+
+class _FakeAssistantProvider extends AssistantProvider {
+  _FakeAssistantProvider(BusinessPreferences preferences, String background)
+    : _assistant = Assistant(
+        id: 'frosted-assistant',
+        name: 'Frosted',
+        background: background,
+      ),
+      super(preferences: preferences);
+
+  Assistant _assistant;
+
+  @override
+  Assistant get currentAssistant => _assistant;
+
+  void setBackground(String background) {
+    _assistant = _assistant.copyWith(background: background);
+    notifyListeners();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    debugFrostedForceLiveBackdropFilter = false;
+    debugFrostedForceSnapshotFailure = false;
+  });
+
+  testWidgets('cached frosted surfaces keep live filter layers out on scroll', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 2;
+    addTearDown(tester.view.reset);
+    final providers = await _providers(
+      background: 'https://example.com/wallpaper.png',
+    );
+
+    await tester.pumpWidget(
+      _app(
+        assistants: providers.$1,
+        settings: providers.$2,
+        child: ListView(
+          children: [
+            for (var i = 0; i < 8; i++)
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: FrostedSurface(
+                  style: _style,
+                  borderRadius: BorderRadius.all(Radius.circular(16)),
+                  child: SizedBox(height: 100, child: Text('card')),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(CompositedTransformFollower), findsWidgets);
+    expect(_countLayers<BackdropFilterLayer>(tester), 0);
+
+    tester.state<ScrollableState>(find.byType(Scrollable)).position.jumpTo(240);
+    await tester.pump();
+
+    expect(_countLayers<BackdropFilterLayer>(tester), 0);
+  });
+
+  testWidgets('no wallpaper uses tint-only frosted surface', (tester) async {
+    final providers = await _providers(background: '');
+
+    await tester.pumpWidget(
+      _app(
+        assistants: providers.$1,
+        settings: providers.$2,
+        child: const Center(
+          child: FrostedSurface(
+            style: _style,
+            borderRadius: BorderRadius.all(Radius.circular(16)),
+            child: SizedBox(width: 160, height: 64, child: Text('tint')),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(BackdropFilter), findsNothing);
+    expect(find.byType(CompositedTransformFollower), findsNothing);
+    final box = tester.widget<DecoratedBox>(
+      find
+          .descendant(
+            of: find.byType(FrostedSurface),
+            matching: find.byType(DecoratedBox),
+          )
+          .first,
+    );
+    expect((box.decoration as BoxDecoration).color, _style.background);
+  });
+
+  testWidgets('capture failure shares one group and wallpaper removal tints', (
+    tester,
+  ) async {
+    debugFrostedForceSnapshotFailure = true;
+    final providers = await _providers(
+      background: 'https://example.com/wallpaper.png',
+    );
+
+    await tester.pumpWidget(
+      _app(
+        assistants: providers.$1,
+        settings: providers.$2,
+        child: const Column(
+          children: [
+            FrostedSurface(
+              style: _style,
+              borderRadius: BorderRadius.all(Radius.circular(16)),
+              child: SizedBox(height: 40, child: Text('one')),
+            ),
+            FrostedSurface(
+              style: _style,
+              borderRadius: BorderRadius.all(Radius.circular(16)),
+              child: SizedBox(height: 40, child: Text('two')),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final filters = tester.renderObjectList<RenderBackdropFilter>(
+      find.byType(BackdropFilter),
+    );
+    expect(filters, hasLength(2));
+    expect(filters.first.backdropKey, isNotNull);
+    expect(filters.first.backdropKey, same(filters.last.backdropKey));
+    final controller = tester
+        .widget<ChatFrostedBackdropScope>(find.byType(ChatFrostedBackdropScope))
+        .controller;
+    expect(controller.snapshotUnsupported, isTrue);
+
+    providers.$1.setBackground('missing-local-wallpaper.png');
+    await tester.pump();
+    await tester.pump();
+
+    expect(controller.mode, FrostedRenderMode.uniform);
+    expect(find.byType(BackdropFilter), findsNothing);
+  });
+
+  testWidgets('changing sigma retires unused snapshot buckets', (tester) async {
+    final providers = await _providers(
+      background: 'https://example.com/wallpaper.png',
+    );
+
+    for (final sigma in <double>[8, 14, 22]) {
+      await tester.pumpWidget(
+        _app(
+          assistants: providers.$1,
+          settings: providers.$2,
+          child: FrostedSurface(
+            style: _styleWithSigma(sigma),
+            borderRadius: BorderRadius.circular(16),
+            child: const SizedBox(height: 40, child: Text('card')),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      final controller = tester
+          .widget<ChatFrostedBackdropScope>(
+            find.byType(ChatFrostedBackdropScope),
+          )
+          .controller;
+      expect(controller.debugAcquiredSigmaCount, 1);
+      expect(controller.debugBucketCount, lessThanOrEqualTo(2));
+    }
+
+    final controller = tester
+        .widget<ChatFrostedBackdropScope>(find.byType(ChatFrostedBackdropScope))
+        .controller;
+    await tester.pumpWidget(
+      _app(
+        assistants: providers.$1,
+        settings: providers.$2,
+        child: const SizedBox.shrink(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(controller.debugAcquiredSigmaCount, 0);
+    expect(controller.debugBucketCount, 0);
+  });
+}
+
+ResolvedBubbleStyle _styleWithSigma(double sigma) => ResolvedBubbleStyle(
+  background: _style.background,
+  border: _style.border,
+  text: _style.text,
+  borderWidth: _style.borderWidth,
+  radius: _style.radius,
+  blurSigma: sigma,
+);
+
+Future<(_FakeAssistantProvider, SettingsProvider)> _providers({
+  required String background,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final preferences = BusinessPreferences.memoryForTests();
+  final settings = SettingsProvider(preferences: preferences);
+  await settings.loaded;
+  return (_FakeAssistantProvider(preferences, background), settings);
+}
+
+Widget _app({
+  required _FakeAssistantProvider assistants,
+  required SettingsProvider settings,
+  required Widget child,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AssistantProvider>.value(value: assistants),
+      ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+    ],
+    child: MaterialApp(
+      home: ChatFrostedBackdrop(
+        backdrop: const ColoredBox(color: Color(0xFF4D5C92)),
+        child: child,
+      ),
+    ),
+  );
+}
+
+int _countLayers<T extends Layer>(WidgetTester tester) {
+  var count = 0;
+  void walk(Layer layer) {
+    if (layer is T) count++;
+    if (layer is ContainerLayer) {
+      var child = layer.firstChild;
+      while (child != null) {
+        walk(child);
+        child = child.nextSibling;
+      }
+    }
+  }
+
+  walk(tester.binding.renderViews.first.debugLayer!);
+  return count;
+}

--- a/test/features/settings/pages/message_style_settings_page_test.dart
+++ b/test/features/settings/pages/message_style_settings_page_test.dart
@@ -8,6 +8,7 @@ import 'package:Cuplivo/core/providers/assistant_provider.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/features/settings/pages/message_style_settings_page.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_switch.dart';
 
 var businessPrefs = BusinessPreferences.memoryForTests();
 
@@ -84,6 +85,27 @@ void main() {
     expect(find.text('Blur'), findsOneWidget);
     expect(find.text('Background'), findsOneWidget);
     expect(find.text('This is a user message'), findsWidgets);
+  });
+
+  testWidgets('paragraph split switch updates the setting', (tester) async {
+    final settings = await createSettings();
+
+    await pumpPage(tester, settings: settings);
+
+    final label = find.text('Split paragraphs into bubbles');
+    await tester.ensureVisible(label);
+    await tester.pump();
+    expect(label, findsOneWidget);
+    expect(settings.assistantBubbleSplitParagraphs, isFalse);
+
+    await tester.tap(find.byType(IosSwitch).at(1));
+    await tester.pump();
+
+    expect(settings.assistantBubbleSplitParagraphs, isTrue);
+    expect(
+      businessPrefs.getBool('display_assistant_bubble_split_paragraphs_v1'),
+      isTrue,
+    );
   });
 
   testWidgets('light and dark preview labels stay after switching', (

--- a/test/settings_provider_chat_bubble_style_test.dart
+++ b/test/settings_provider_chat_bubble_style_test.dart
@@ -37,6 +37,26 @@ void main() {
       settings.chatBubbleStyleOverridesFor(isUser: true),
       settings.chatBubbleStyleOverridesFor(isUser: false),
     );
+    expect(settings.assistantBubbleSplitParagraphs, isFalse);
+  });
+
+  test('assistant paragraph splitting persists, reloads, and copies', () async {
+    final prefs = BusinessPreferences.memoryForTests();
+    final settings = SettingsProvider(preferences: prefs);
+    await settings.loaded;
+
+    await settings.setAssistantBubbleSplitParagraphs(true);
+
+    expect(settings.assistantBubbleSplitParagraphs, isTrue);
+    expect(
+      prefs.getBool('display_assistant_bubble_split_paragraphs_v1'),
+      isTrue,
+    );
+    expect(settings.copyWith().assistantBubbleSplitParagraphs, isTrue);
+
+    final reloaded = SettingsProvider(preferences: prefs);
+    await reloaded.loaded;
+    expect(reloaded.assistantBubbleSplitParagraphs, isTrue);
   });
 
   test(
@@ -249,6 +269,10 @@ void main() {
       'display_assistant_bubble_fit_content_v1': BusinessKeyRegistry.classify(
         'display_assistant_bubble_fit_content_v1',
       ),
+      'display_assistant_bubble_split_paragraphs_v1':
+          BusinessKeyRegistry.classify(
+            'display_assistant_bubble_split_paragraphs_v1',
+          ),
     };
     for (final entry in dispositions.entries) {
       expect(

--- a/test/theme/chat_bubble_style_test.dart
+++ b/test/theme/chat_bubble_style_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/features/chat/widgets/frosted/chat_frosted_backdrop.dart';
 import 'package:Cuplivo/theme/chat_bubble_style.dart';
 
 void main() {
@@ -161,5 +162,13 @@ void main() {
     expect(dark.text, const Color(0xFF00FF00));
     expect(overrides.hasTextOverride(Brightness.light), isFalse);
     expect(overrides.hasTextOverride(Brightness.dark), isTrue);
+  });
+
+  test('frosted sample scale uses inverse sigma and clamps to dpr', () {
+    expect(frostedSampleScale(sigma: 0, dpr: 3), 0);
+    expect(frostedSampleScale(sigma: -1, dpr: 3), 0);
+    expect(frostedSampleScale(sigma: 14, dpr: 3), closeTo(6 / 14, 1e-9));
+    expect(frostedSampleScale(sigma: 1, dpr: 0.5), 0.5);
+    expect(frostedSampleScale(sigma: 200, dpr: 3), 0.05);
   });
 }


### PR DESCRIPTION
## 背景

补齐上游消息样式能力，允许助手回复按空行显示为多个独立气泡，并修复使用毛玻璃消息样式时，滚动消息列表会导致气泡透明度和模糊观感变化的问题。

Closes #141

## 主要改动

- 新增“分段显示为多个气泡”开关，默认关闭，并通过 BusinessPreferences 持久化
- 仅拆分助手正文中的空行段落；代码围栏、details、块级公式、连续列表、标题与其正文保持完整
- 每个拆分后的气泡继续应用内容贴合、角色颜色、圆角和其他消息样式设置
- 将聊天背景预模糊并缓存，各毛玻璃气泡裁剪同一背景快照，滚动时不再创建或重绘实时 BackdropFilterLayer
- 背景、主题、尺寸、DPR 或模糊强度变化时失效并重建快照；捕获失败时使用共享分组滤镜回退，无壁纸时使用稳定着色层
- 同步更新英文、简体中文和繁体中文本地化及设置页预览

## 兼容性

- 多气泡仅为显示层拆分，数据库中仍保存为一条 ChatMessage
- 不修改数据库结构、网络 API、备份/导出格式、编辑/重试/版本切换语义
- 未修改实验性 WebView 会话渲染链路
- 旧用户默认关闭新开关，现有显示行为不变

## 验证

- `flutter gen-l10n`
- `dart format`（全部改动 Dart 文件）
- `flutter test --no-pub test/features/chat/utils/assistant_paragraph_splitter_test.dart test/features/chat/widgets/assistant_bubble_split_paragraphs_test.dart test/settings_provider_chat_bubble_style_test.dart test/features/settings/pages/message_style_settings_page_test.dart`
- `flutter test --no-pub test/features/chat/widgets/frosted/frosted_surface_layer_test.dart test/features/chat/widgets/chat_bubble_style_overrides_test.dart test/features/chat/widgets/chat_message_widget_background_test.dart test/features/chat/widgets/assistant_bubble_fit_content_test.dart test/features/settings/pages/message_style_settings_dialog_test.dart test/theme/chat_bubble_style_test.dart`
- `dart analyze --fatal-infos lib test`

以上测试与静态分析均通过。滚动回归测试确认缓存模式在滚动前后均不产生 `BackdropFilterLayer`。

## 未执行与风险边界

- 按要求未在本机运行任何 `flutter build`，也未进行真机视觉走查
- 本机 Flutter 为 3.44.8，低于仓库要求的 3.44.9；本地依赖解析时仅临时放宽补丁版本且未提交，PR CI 将在仓库指定的 Flutter 3.44.9 上完成权威验证
- 实验性 WebView 渲染不在本次范围内