### PR TITLE
fix: strip thinking tags from all utility text generation (titles/summaries/suggestions)

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -13,6 +13,7 @@ import '../../models/token_usage.dart';
 import '../../../utils/sandbox_path_resolver.dart';
 import '../../../utils/app_directories.dart';
 import '../../utils/openai_model_compat.dart';
+import '../../utils/thinking_tag_parser.dart';
 import '../network/dio_http_client.dart';
 import 'google_service_account_auth.dart';
 import '../../services/api_key_manager.dart';
@@ -759,6 +760,27 @@ class ChatApiService {
 
   // Non-streaming text generation for utilities like title summarization
   static Future<String> generateText({
+    required ProviderConfig config,
+    required String modelId,
+    required String prompt,
+    Map<String, String>? extraHeaders,
+    Map<String, dynamic>? extraBody,
+    int? thinkingBudget,
+  }) async {
+    final raw = await _generateTextRaw(
+      config: config,
+      modelId: modelId,
+      prompt: prompt,
+      extraHeaders: extraHeaders,
+      extraBody: extraBody,
+      thinkingBudget: thinkingBudget,
+    );
+    // Strip <think>...</think> (and truncated CoT) so utility text like titles
+    // never exposes raw reasoning (issue #579).
+    return ThinkingTagParser.stripUtilityThinking(raw);
+  }
+
+  static Future<String> _generateTextRaw({
     required ProviderConfig config,
     required String modelId,
     required String prompt,

--- a/lib/core/utils/thinking_tag_parser.dart
+++ b/lib/core/utils/thinking_tag_parser.dart
@@ -56,4 +56,37 @@ class ThinkingTagParser {
       thinkingTexts: List.unmodifiable(thinkingTexts),
     );
   }
+
+  /// Utility-text variant of [parseLegacyInlineBlocks]: same visible content,
+  /// but an unclosed open tag (e.g. thinking truncated before `</think>`)
+  /// discards the remainder instead of exposing raw CoT. For titles, summaries
+  /// and suggestions.
+  static String stripUtilityThinking(String input) {
+    final visible = StringBuffer();
+    var cursor = 0;
+
+    while (cursor < input.length) {
+      final openMatch = _openTagRe.firstMatch(input.substring(cursor));
+      if (openMatch == null) {
+        visible.write(input.substring(cursor));
+        break;
+      }
+
+      final openStart = cursor + openMatch.start;
+      final openEnd = cursor + openMatch.end;
+      final tagName = (openMatch.group(1) ?? '').toLowerCase();
+      final closeTag = '</$tagName>';
+      final closeStart = input.toLowerCase().indexOf(closeTag, openEnd);
+
+      if (closeStart == -1) {
+        visible.write(input.substring(cursor, openStart));
+        break;
+      }
+
+      visible.write(input.substring(cursor, openStart));
+      cursor = closeStart + closeTag.length;
+    }
+
+    return visible.toString().trim();
+  }
 }

--- a/lib/features/chat/utils/message_visual_content.dart
+++ b/lib/features/chat/utils/message_visual_content.dart
@@ -9,7 +9,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../utils/assistant_regex.dart';
-import 'thinking_tag_parser.dart';
+import '../../../core/utils/thinking_tag_parser.dart';
 
 /// Minimum visual-content length (characters) for the reading-mode entry to
 /// appear in the message "More" menu.

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -48,7 +48,7 @@ import '../../home/services/ask_user_interaction_service.dart';
 import '../../home/services/local_tools_service.dart';
 import 'screen_time_tool_ui.dart';
 import '../../home/services/tool_approval_service.dart';
-import '../utils/thinking_tag_parser.dart';
+import '../../../core/utils/thinking_tag_parser.dart';
 import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
 import 'token_display_widget.dart';

--- a/lib/features/chat/widgets/message_export_sheet.dart
+++ b/lib/features/chat/widgets/message_export_sheet.dart
@@ -39,7 +39,7 @@ import '../../../theme/app_font_weights.dart';
 import '../../home/widgets/model_icon.dart';
 import '../../home/controllers/chat_controller.dart';
 import '../../home/webview/web_conversation_pdf_printer.dart';
-import '../utils/thinking_tag_parser.dart';
+import '../../../core/utils/thinking_tag_parser.dart';
 import '../models/tool_ui_part.dart';
 import 'chat_message_widget.dart' show ChatMessageWidget, ReasoningSegment;
 

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -21,7 +21,6 @@ import '../../../utils/utf16_safe_cut.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../chat/widgets/chat_message_widget.dart' show ToolUIPart;
-import '../../chat/utils/thinking_tag_parser.dart';
 import '../services/message_builder_service.dart';
 import '../services/message_generation_service.dart';
 import '../services/chat_suggestion_service.dart';
@@ -1620,16 +1619,12 @@ class HomeViewModel extends ChangeNotifier {
         .replaceAll('{content}', content);
 
     try {
-      final raw = (await ChatApiService.generateText(
+      final title = (await ChatApiService.generateText(
         config: cfg,
         modelId: mdlId,
         prompt: prompt,
         thinkingBudget: budget,
       )).trim();
-      // Strip <think>...</think> tags from models that include reasoning in output
-      final title = ThinkingTagParser.parseLegacyInlineBlocks(
-        raw,
-      ).visibleContent;
       if (title.isNotEmpty) {
         await _chatService.renameConversation(convo.id, title);
         if (currentConversation?.id == convo.id) {

--- a/lib/features/home/services/handoff_tool_service.dart
+++ b/lib/features/home/services/handoff_tool_service.dart
@@ -13,7 +13,6 @@ import '../../../core/services/api/chat_api_service.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../utils/utf16_safe_cut.dart';
-import '../../chat/utils/thinking_tag_parser.dart';
 import 'ask_user_interaction_service.dart';
 import 'local_tools_service.dart';
 import 'message_builder_service.dart';
@@ -371,15 +370,12 @@ class HandoffToolService {
           .replaceAll('{locale}', locale)
           .replaceAll('{content}', content);
 
-      final raw = (await ChatApiService.generateText(
+      final title = (await ChatApiService.generateText(
         config: cfg,
         modelId: mdlId,
         prompt: prompt,
         thinkingBudget: budget,
       )).trim();
-      final title = ThinkingTagParser.parseLegacyInlineBlocks(
-        raw,
-      ).visibleContent;
       if (title.isNotEmpty) {
         await chatService.renameConversation(conversationId, title);
         debugPrint('[HandoffTool] title generated for $conversationId: $title');

--- a/lib/features/home/webview/web_chat_snapshot.dart
+++ b/lib/features/home/webview/web_chat_snapshot.dart
@@ -12,7 +12,7 @@ import '../../../theme/app_semantic_colors.dart';
 import '../../../utils/brand_assets.dart';
 import '../../chat/models/tool_ui_part.dart';
 import '../../chat/utils/message_visual_content.dart';
-import '../../chat/utils/thinking_tag_parser.dart';
+import '../../../core/utils/thinking_tag_parser.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
 import 'web_chat_protocol.dart';
 

--- a/lib/features/home/widgets/message_list_view.dart
+++ b/lib/features/home/widgets/message_list_view.dart
@@ -21,7 +21,7 @@ import '../../../shared/widgets/ios_checkbox.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../chat/pages/reading_mode_page.dart';
 import '../../chat/widgets/chat_message_widget.dart';
-import '../../chat/utils/thinking_tag_parser.dart';
+import '../../../core/utils/thinking_tag_parser.dart';
 import '../../chat/widgets/message_more_sheet.dart';
 import '../controllers/stream_controller.dart' as stream_ctrl;
 import '../controllers/message_render_model.dart';

--- a/test/generate_text_utility_think_strip_test.dart
+++ b/test/generate_text_utility_think_strip_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+Future<String> _generateTextAgainst(String responseContent) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() async {
+    await server.close(force: true);
+  });
+
+  server.listen((request) async {
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType = ContentType.json;
+    request.response.write(
+      jsonEncode({
+        'id': 'chatcmpl-minimax',
+        'object': 'chat.completion',
+        'created': 0,
+        'model': 'MiniMax-M2.1',
+        'choices': [
+          {
+            'index': 0,
+            'message': {'role': 'assistant', 'content': responseContent},
+            'finish_reason': 'stop',
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 10,
+          'completion_tokens': 10,
+          'total_tokens': 20,
+        },
+      }),
+    );
+    await request.response.close();
+  });
+
+  final config = ProviderConfig(
+    id: 'MiniMax',
+    enabled: true,
+    name: 'MiniMax',
+    apiKey: 'sk-test',
+    baseUrl: 'http://${server.address.address}:${server.port}/v1',
+    providerType: ProviderKind.openai,
+  );
+  return ChatApiService.generateText(
+    config: config,
+    modelId: 'MiniMax-M2.1',
+    prompt: 'test prompt',
+  );
+}
+
+void main() {
+  group('generateText strips thinking tokens for utility text', () {
+    test(
+      'strips balanced inline <think> blocks from non-streaming content',
+      () async {
+        final result = await _generateTextAgainst(
+          '<think>用户想要一个标题</think>番茄炒蛋家常做法',
+        );
+        expect(result, '番茄炒蛋家常做法');
+      },
+    );
+
+    test('drops truncated unclosed <think> block', () async {
+      final result = await _generateTextAgainst('<think>用户想要一个标题');
+      expect(result, '');
+    });
+
+    test('keeps plain content unchanged', () async {
+      final result = await _generateTextAgainst('温泉之旅');
+      expect(result, '温泉之旅');
+    });
+  });
+}

--- a/test/thinking_tag_interleaved_test.dart
+++ b/test/thinking_tag_interleaved_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:Cuplivo/features/chat/utils/thinking_tag_parser.dart';
+import 'package:Cuplivo/core/utils/thinking_tag_parser.dart';
 
 void main() {
   group('ThinkingTagParser.hasInlineThinkTags', () {

--- a/test/thinking_tag_regex_test.dart
+++ b/test/thinking_tag_regex_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:Cuplivo/features/chat/utils/thinking_tag_parser.dart';
+import 'package:Cuplivo/core/utils/thinking_tag_parser.dart';
 
 void main() {
   group('ThinkingTagParser', () {
@@ -89,6 +89,57 @@ void main() {
 
       expect(parsed.visibleContent, input);
       expect(parsed.thinkingTexts, isEmpty);
+    });
+  });
+
+  group('ThinkingTagParser.stripUtilityThinking', () {
+    test('strips closed block and keeps visible content', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking('<think>why</think>Title'),
+        'Title',
+      );
+    });
+
+    test('strips multiple interleaved blocks', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking(
+          '<think>a</think>mid<thought>b</thought>end',
+        ),
+        'midend',
+      );
+    });
+
+    test('drops unclosed trailing block to end', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking('<think>partial reasoning'),
+        '',
+      );
+    });
+
+    test('unclosed block truncates visible content after it', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking('Title<think>truncated'),
+        'Title',
+      );
+    });
+
+    test('only-thinking closed block yields empty string', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking('<thinking>done</thinking>'),
+        '',
+      );
+    });
+
+    test('mixed-case tags stripped', () {
+      expect(
+        ThinkingTagParser.stripUtilityThinking('<THINK>hmm</THINK>answer'),
+        'answer',
+      );
+    });
+
+    test('plain text passes through unchanged', () {
+      const input = 'just a normal message';
+      expect(ThinkingTagParser.stripUtilityThinking(input), input);
     });
   });
 }


### PR DESCRIPTION
## Problem

MiniMax 标题生成出现未处理的 `<think>...</think>` 思维链 (Fixes #579).

Root cause: MiniMax (OpenAI-compatible endpoint) returns interleaved thinking inline in non-streaming `content` as `<think>...</think>`, and it has no branch in `_applyVendorReasoningKnobs`, so thinking stays on for utility generation.

The July 2026 strip (`40492f31`) pinned the fix to a **single call site** (`home_view_model._maybeGenerateTitleFor`). Title generation logic exists in parallel surfaces:

- `side_drawer._regenerateTitle` (Regenerate Title menu) — never stripped → guaranteed raw CoT with MiniMax
- Summary generation ×2, suggestions ×1 — never stripped (same bug class)
- Additionally `parseLegacyInlineBlocks` deliberately keeps **unclosed** `<think>` visible (asserted by tests), so a truncated CoT leaked even through the supposedly-fixed paths — which is why the issue reporter said "仍然存在".

## Fix

Centralize per AGENTS.md 3.20 (parallel surfaces): strip thinking tokens **once** in `ChatApiService.generateText`, then drop the divergent per-site strips.

- `ThinkingTagParser.stripUtilityThinking()` — new method: strips balanced `<think>/<thinking>/<thought>` blocks; an unclosed open tag discards the remainder (truncated CoT has no visible-value in titles/summaries/suggestions). `parseLegacyInlineBlocks` semantics unchanged (chat rendering untouched).
- `ChatApiService.generateText` — wraps the (renamed) `_generateTextRaw`; all 6 consumers (title ×3, summary ×2, suggestions ×1) are covered by one choke point.
- Removed redundant strips from `home_view_model` / `handoff_tool_service`.
- Moved `thinking_tag_parser.dart` → `lib/core/utils/` (it was already cross-feature shared logic used by features/chat + features/home; core could not import features without inverting the layering boundary; AGENTS 3.17).
- Tests: 7 parser unit tests for `stripUtilityThinking` + 3 loopback `HttpServer` tests for `generateText` with MiniMax-style content (balanced, truncated, passthrough).

## Verification

- `dart analyze --fatal-infos lib test` — no issues
- `flutter test test/thinking_tag_regex_test.dart test/thinking_tag_interleaved_test.dart test/generate_text_utility_think_strip_test.dart` — 24 passed
- `flutter test test/chat_api_generate_text_encoding_test.dart test/claude_thinking_compat_test.dart test/codex_stream_auth_test.dart` — 50 passed (generateText wrapper regression check)

## Manual test plan (repro path)

1. Add my.miniMax (or any OpenAI-compatible MiniMax M2/M2.1 endpoint) as a provider; set it as the title model.
2. Send a first message → auto title should not contain `<think>...` or any reasoning text.
3. Side drawer menu → 重新生成标题 (Regenerate Title) → title clean.
4. Repeat with a model that produces long CoT; if output is truncated mid-think, the title stays empty rather than showing raw CoT.
