### PR TITLE
feat(group-chat): align composer and unify image context

### DIFF
--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -2028,6 +2028,46 @@ class ChatService extends ChangeNotifier {
     return skip;
   }
 
+  /// Single canonical version-collapse implementation: groups messages by
+  /// `groupId ?? id`, keeps the first-occurrence order, sorts each group by
+  /// version and returns the selected-index (defaulting to the last) version
+  /// per group. All other collapsers in the repo delegate here.
+  static List<ChatMessage> collapseMessageVersions(
+    List<ChatMessage> items,
+    Map<String, int> versionSelections,
+  ) {
+    final Map<String, List<ChatMessage>> byGroup =
+        <String, List<ChatMessage>>{};
+    final List<String> order = <String>[];
+
+    for (final m in items) {
+      final gid = (m.groupId ?? m.id);
+      final list = byGroup.putIfAbsent(gid, () {
+        order.add(gid);
+        return <ChatMessage>[];
+      });
+      list.add(m);
+    }
+
+    // Sort each group by version
+    for (final e in byGroup.entries) {
+      e.value.sort((a, b) => a.version.compareTo(b.version));
+    }
+
+    // Select the appropriate version from each group
+    final out = <ChatMessage>[];
+    for (final gid in order) {
+      final vers = byGroup[gid]!;
+      final sel = versionSelections[gid];
+      final idx = (sel != null && sel >= 0 && sel < vers.length)
+          ? sel
+          : (vers.length - 1);
+      out.add(vers[idx]);
+    }
+
+    return out;
+  }
+
   Future<void> deleteMessage(String messageId) async {
     if (!_initialized) return;
 

--- a/lib/core/services/proactive_care_message_flow.dart
+++ b/lib/core/services/proactive_care_message_flow.dart
@@ -288,39 +288,13 @@ class ProactiveCareMessageFlow {
   }
 
   /// Collapses message versions, keeping the selected (or latest) version per
-  /// group. Same semantics as MessageBuilderService.collapseVersions.
+  /// group. Same semantics as ChatService.collapseMessageVersions.
   @visibleForTesting
   static List<ChatMessage> collapseMessageVersions(
     List<ChatMessage> items,
     Map<String, int> versionSelections,
   ) {
-    final Map<String, List<ChatMessage>> byGroup =
-        <String, List<ChatMessage>>{};
-    final List<String> order = <String>[];
-
-    for (final m in items) {
-      final gid = (m.groupId ?? m.id);
-      final list = byGroup.putIfAbsent(gid, () {
-        order.add(gid);
-        return <ChatMessage>[];
-      });
-      list.add(m);
-    }
-
-    for (final e in byGroup.entries) {
-      e.value.sort((a, b) => a.version.compareTo(b.version));
-    }
-
-    final out = <ChatMessage>[];
-    for (final gid in order) {
-      final vers = byGroup[gid]!;
-      final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
-    }
-    return out;
+    return ChatService.collapseMessageVersions(items, versionSelections);
   }
 
   /// Builds the plain-text LLM history for [conversation]: collapsed versions,

--- a/lib/features/group_chat/controllers/group_chat_orchestrator.dart
+++ b/lib/features/group_chat/controllers/group_chat_orchestrator.dart
@@ -143,7 +143,9 @@ class GroupChatOrchestrator {
               ? ''
               : _contextBuilder.contentForDirector(pending),
           userName: userName,
-          newUserMessageText: userMessage.content,
+          newUserMessageText: DirectorContextBuilder.plainTextForDirector(
+            userMessage.content,
+          ),
         );
         g = g.copyWith(
           pendingCapAssistantMessageId: null,
@@ -153,7 +155,9 @@ class GroupChatOrchestrator {
       } else {
         directorUserContent = _contextBuilder.buildUserTurnE1(
           userName: userName,
-          userMessageText: userMessage.content,
+          userMessageText: DirectorContextBuilder.plainTextForDirector(
+            userMessage.content,
+          ),
         );
         g = g.copyWith(assistantMessagesThisRound: 0);
         await groupChatProvider.persistGroupState(g);

--- a/lib/features/group_chat/controllers/group_chat_orchestrator.dart
+++ b/lib/features/group_chat/controllers/group_chat_orchestrator.dart
@@ -680,6 +680,7 @@ class GroupChatOrchestrator {
       ),
       completeMessages: privateMessages,
       inputData: inputData,
+      allowImagesApiRouting: inputData?.allowImagesApiRouting ?? true,
       generateTitleOnFinish: false,
       onStreamComplete: () {
         if (!done.isCompleted) done.complete();

--- a/lib/features/group_chat/pages/group_chat_page.dart
+++ b/lib/features/group_chat/pages/group_chat_page.dart
@@ -123,8 +123,11 @@ class _GroupChatPageState extends State<GroupChatPage> {
       chatService: _chatService,
       contextProvider: context,
       preferences: context.read<BusinessPreferences>(),
-      ocrHandler: (imagePaths) =>
-          _ocrService.getOcrTextForImages(imagePaths, context),
+      ocrHandler: (imagePaths, {requestId}) => _ocrService.getOcrTextForImages(
+        imagePaths,
+        context,
+        requestId: requestId,
+      ),
     );
     _messageBuilderService.ocrTextWrapper = _ocrService.wrapOcrBlock;
     _generationController = GenerationController(

--- a/lib/features/group_chat/pages/group_chat_page.dart
+++ b/lib/features/group_chat/pages/group_chat_page.dart
@@ -10,29 +10,39 @@ import 'package:super_sliver_list/super_sliver_list.dart';
 import '../../../core/models/assistant.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/quick_phrase.dart';
+import '../../../core/providers/asr_provider.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/providers/group_chat_provider.dart';
+import '../../../core/providers/quick_phrase_provider.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/providers/user_provider.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../desktop/message_edit_dialog.dart';
+import '../../../desktop/quick_phrase_popover.dart';
 import '../../../icons/lucide_adapter.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/snackbar.dart';
+import '../../../utils/platform_utils.dart';
 import '../../chat/models/message_edit_result.dart';
 import '../../chat/widgets/message_edit_sheet.dart';
 import '../../chat/widgets/message_more_sheet.dart';
 import '../../home/controllers/chat_controller.dart';
 import '../../home/controllers/generation_controller.dart';
+import '../../home/controllers/home_view_model.dart';
 import '../../home/controllers/stream_controller.dart' as stream_ctrl;
 import '../../home/services/ask_user_interaction_service.dart';
+import '../../home/services/file_upload_service.dart';
 import '../../home/services/message_builder_service.dart';
 import '../../home/services/message_generation_service.dart';
+import '../../home/services/ocr_service.dart';
 import '../../home/services/tool_approval_service.dart';
 import '../../home/widgets/chat_input_bar.dart';
 import '../../home/widgets/message_list_view.dart';
+import '../../quick_phrase/pages/quick_phrases_page.dart';
+import '../../quick_phrase/widgets/quick_phrase_menu.dart';
 import '../controllers/group_chat_orchestrator.dart';
 import '../models/chat_input_mode.dart';
 import '../services/group_chat_slot_runner.dart';
@@ -48,6 +58,8 @@ class GroupChatPage extends StatefulWidget {
 
 class _GroupChatPageState extends State<GroupChatPage> {
   final _inputController = TextEditingController();
+  final _mediaController = ChatInputBarController();
+  final _inputBarKey = GlobalKey();
   final _scrollController = ScrollController();
   final _inputFocus = FocusNode();
   final _isProcessingFiles = ValueNotifier<bool>(false);
@@ -62,9 +74,16 @@ class _GroupChatPageState extends State<GroupChatPage> {
   late MessageGenerationService _messageGenerationService;
   late GroupChatSlotRunner _slotRunner;
   late GroupChatOrchestrator _orchestrator;
+  late FileUploadService _fileUploadService;
+  late OcrService _ocrService;
 
   bool _loading = false;
   bool _initialized = false;
+
+  /// One-slot pending send while a round is running (mirrors single-chat
+  /// per-conversation queue semantics — see queueIfCurrentConversationBusy).
+  /// Drained by [_maybeDrainQueue] when the round ends.
+  ChatInputData? _queuedInput;
 
   bool get _isDesktop =>
       defaultTargetPlatform == TargetPlatform.macOS ||
@@ -78,6 +97,12 @@ class _GroupChatPageState extends State<GroupChatPage> {
     _initialized = true;
     _listController = ListController();
     _chatService = context.read<ChatService>();
+    _ocrService = OcrService(chatService: _chatService);
+    _fileUploadService = FileUploadService(
+      getContext: () => context,
+      mediaController: _mediaController,
+      preferences: context.read<BusinessPreferences>(),
+    );
     _streamController = stream_ctrl.StreamController(
       chatService: _chatService,
       onStateChanged: () {
@@ -98,7 +123,10 @@ class _GroupChatPageState extends State<GroupChatPage> {
       chatService: _chatService,
       contextProvider: context,
       preferences: context.read<BusinessPreferences>(),
+      ocrHandler: (imagePaths) =>
+          _ocrService.getOcrTextForImages(imagePaths, context),
     );
+    _messageBuilderService.ocrTextWrapper = _ocrService.wrapOcrBlock;
     _generationController = GenerationController(
       chatService: _chatService,
       chatController: _chatController,
@@ -169,16 +197,39 @@ class _GroupChatPageState extends State<GroupChatPage> {
     if (convo != null) {
       _chatController.setCurrentConversation(convo);
     }
-    // KNOWN GAP: normal chat restores per-message UI state (reasoning text /
-    // timers, tool events, content splits, gemini thought signatures) on
-    // conversation open via home_view_model._restoreMessageUiState ->
-    // StreamController.restoreMessageUiState, which copies the persisted
-    // message-row fields back into the in-memory maps the widgets read.
-    // This page never calls it, so reopening a group chat loses the
-    // reasoning panels of historical assistant messages. The equivalent
-    // hook here is _bindConversation (NOT _refreshList, which would clobber
-    // live streaming state). Not fixed yet — tracked as a comment per user
-    // decision.
+    // Restore per-message UI state (reasoning panels, tool events, content
+    // splits, Gemini thought signatures, translation markers) exactly like
+    // normal chat does via home_view_model._restoreMessageUiState. This hook
+    // is _bindConversation (NOT _refreshList; the latter must not clobber
+    // live streaming state after send/regenerate).
+    _restoreMessageUiState();
+  }
+
+  void _restoreMessageUiState() {
+    final messages = _chatController.messages;
+    for (var i = 0; i < messages.length; i++) {
+      final m = messages[i];
+      if (m.role == 'assistant') {
+        _streamController.restoreMessageUiState(
+          m,
+          getToolEventsFromDb: (id) => _chatService.getToolEvents(id),
+          getGeminiThoughtSigFromDb: (id) =>
+              _chatService.getGeminiThoughtSignature(id),
+        );
+        final cleanedContent = _streamController.captureGeminiThoughtSignature(
+          m.content,
+          m.id,
+        );
+        if (cleanedContent != m.content) {
+          final updated = m.copyWith(content: cleanedContent);
+          messages[i] = updated;
+          unawaited(_chatService.updateMessage(m.id, content: cleanedContent));
+        }
+      }
+      if (m.translation != null && m.translation!.isNotEmpty) {
+        _translations[m.id] = const TranslationUiState(expanded: false);
+      }
+    }
   }
 
   void _refreshList() {
@@ -231,10 +282,10 @@ class _GroupChatPageState extends State<GroupChatPage> {
 
     setState(() => _loading = true);
     try {
-      final userMsg = await _chatService.addMessage(
+      final userMsg = await _messageGenerationService.createUserMessage(
         conversationId: group.conversationId,
-        role: 'user',
-        content: text,
+        input: data,
+        assistant: null,
       );
       await gp.touchUpdatedAt(group.id);
       _refreshList();
@@ -251,7 +302,87 @@ class _GroupChatPageState extends State<GroupChatPage> {
         });
         _refreshList();
       }
+      _maybeDrainQueue();
     }
+  }
+
+  /// Fires the queued send (if any) once the current round has fully ended.
+  /// Mirrors the single-chat drain hook (_onLoadingChanged). Calls [_send]
+  /// which re-set [_loading] synchronously, so the queue slot can never
+  /// double-drain.
+  void _maybeDrainQueue() {
+    if (!mounted) return;
+    if (_queuedInput == null) return;
+    if (_loading || _orchestrator.isBusy) return;
+    final q = _queuedInput!;
+    _queuedInput = null;
+    setState(() {});
+    unawaited(_send(q));
+  }
+
+  /// Restores a cancelled queued send back into the composer (text + media),
+  /// mirroring single-chat cancelQueuedMessage.
+  void _cancelQueuedInput() {
+    final q = _queuedInput;
+    if (q == null) return;
+    _queuedInput = null;
+    _inputController.value = TextEditingValue(
+      text: q.text,
+      selection: TextSelection.collapsed(offset: q.text.length),
+      composing: TextRange.empty,
+    );
+    _mediaController.restoreInput(q);
+    if (mounted) setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _inputFocus.requestFocus();
+    });
+  }
+
+  Future<void> _showQuickPhraseMenu() async {
+    final quickPhraseProvider = context.read<QuickPhraseProvider>();
+    final phrases = quickPhraseProvider.globalPhrases;
+    if (phrases.isEmpty) return;
+
+    final RenderBox? inputBox =
+        _inputBarKey.currentContext?.findRenderObject() as RenderBox?;
+    if (inputBox == null) return;
+    final topLeft = inputBox.localToGlobal(Offset.zero);
+    final position = Offset(topLeft.dx, inputBox.size.height);
+
+    _inputFocus.unfocus();
+
+    final QuickPhrase? selected;
+    if (PlatformUtils.isDesktop) {
+      selected = await showDesktopQuickPhrasePopover(
+        context,
+        anchorKey: _inputBarKey,
+        phrases: phrases,
+      );
+    } else {
+      selected = await showQuickPhraseMenu(
+        context: context,
+        phrases: phrases,
+        position: position,
+      );
+    }
+    if (selected == null || !mounted) return;
+
+    final text = _inputController.text;
+    final sel = _inputController.selection;
+    final start = (sel.start >= 0 && sel.start <= text.length)
+        ? sel.start
+        : text.length;
+    final end = (sel.end >= 0 && sel.end <= text.length && sel.end >= start)
+        ? sel.end
+        : start;
+    final newText = text.replaceRange(start, end, selected.content);
+    _inputController.value = _inputController.value.copyWith(
+      text: newText,
+      selection: TextSelection.collapsed(
+        offset: start + selected.content.length,
+      ),
+      composing: TextRange.empty,
+    );
   }
 
   Assistant? _resolveSpeaker(ChatMessage m) {
@@ -280,6 +411,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
         setState(() => _loading = false);
         _refreshList();
       }
+      _maybeDrainQueue();
     }
   }
 
@@ -294,6 +426,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
         setState(() => _loading = false);
         _refreshList();
       }
+      _maybeDrainQueue();
     }
   }
 
@@ -344,6 +477,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
         setState(() => _loading = false);
         _refreshList();
       }
+      _maybeDrainQueue();
     }
   }
 
@@ -374,6 +508,21 @@ class _GroupChatPageState extends State<GroupChatPage> {
     }
   }
 
+  /// Maps the persisted raw-space truncation index (set by "clear context")
+  /// to a collapsed message index for the context boundary divider. Reuses
+  /// the canonical single-chat mapping; group chat has no preset folding or
+  /// paged window, so those adjustments do not apply.
+  int _computeTruncCollapsedIndex() {
+    final g = context.read<GroupChatProvider>().getById(widget.groupChatId);
+    if (g == null) return -1;
+    final convo = _chatService.getConversation(g.conversationId);
+    if (convo == null || convo.truncateIndex <= 0) return -1;
+    return HomeViewModel.computeTruncCollapsedIndex(
+      truncRaw: convo.truncateIndex,
+      rawMessages: _chatService.getMessages(g.conversationId),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -394,6 +543,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
     final currentAssistant = context
         .watch<AssistantProvider>()
         .currentAssistant;
+    final quickPhrases = context.watch<QuickPhraseProvider>().globalPhrases;
 
     return Scaffold(
       appBar: AppBar(
@@ -439,6 +589,7 @@ class _GroupChatPageState extends State<GroupChatPage> {
                     messages: messages,
                     byGroup: byGroup,
                     versionSelections: _chatController.versionSelections,
+                    truncCollapsedIndex: _computeTruncCollapsedIndex(),
                     reasoning: _streamController.reasoning,
                     reasoningSegments: _streamController.reasoningSegments,
                     contentSplits: _streamController.contentSplits,
@@ -498,14 +649,33 @@ class _GroupChatPageState extends State<GroupChatPage> {
           SafeArea(
             top: false,
             child: ChatInputBar(
+              key: _inputBarKey,
               controller: _inputController,
+              mediaController: _mediaController,
               focusNode: _inputFocus,
               loading: _loading || _orchestrator.isBusy,
               mode: ChatInputMode.groupChat,
               showToolsHubButton: false,
               supportsReasoning: false,
               showMoreButton: false,
-              showQuickPhraseButton: false,
+              showQuickPhraseButton: quickPhrases.isNotEmpty,
+              asrProvider: context.read<AsrProvider>(),
+              onQuickPhrase: () => unawaited(_showQuickPhraseMenu()),
+              onLongPressQuickPhrase: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const QuickPhrasesPage()),
+                );
+              },
+              onPickCamera: _isDesktop
+                  ? null
+                  : () => _fileUploadService.onPickCamera(context),
+              onPickPhotos: _isDesktop
+                  ? null
+                  : () => _fileUploadService.onPickPhotos(),
+              onUploadFiles: () => _fileUploadService.onPickFiles(),
+              hasQueuedInput: _queuedInput != null,
+              queuedPreviewText: _queuedInput?.text,
+              onCancelQueuedInput: _cancelQueuedInput,
               onStop: () {
                 _orchestrator.requestStop();
                 setState(() => _loading = false);
@@ -514,6 +684,14 @@ class _GroupChatPageState extends State<GroupChatPage> {
                 unawaited(_clearContext());
               },
               onSend: (data) async {
+                if (_loading || _orchestrator.isBusy) {
+                  if (_queuedInput != null) {
+                    return ChatInputSubmissionResult.rejected;
+                  }
+                  _queuedInput = data;
+                  if (mounted) setState(() {});
+                  return ChatInputSubmissionResult.queued;
+                }
                 unawaited(_send(data));
                 return ChatInputSubmissionResult.sent;
               },

--- a/lib/features/group_chat/services/assistant_private_context_builder.dart
+++ b/lib/features/group_chat/services/assistant_private_context_builder.dart
@@ -60,10 +60,14 @@ class AssistantPrivateContextBuilder {
     // Per-message request metadata (AD-0033) rides on the original public
     // user message; the rewritten user bubble must carry it so the pipeline
     // can replay the send-time routing decision and extra body on later
-    // turns, resend and regenerate. When several user lines coalesce into
-    // one buffer, the LAST user message's metadata wins — the same "last
-    // user message" rule MessageGenerationService.resolveRequestOptionsFromMessages
-    // applies to the rewritten history.
+    // turns, resend and regenerate. The values always describe the LATEST
+    // real human user message seen so far: a real user line overwrites them,
+    // but a flush never resets them, so a trailing buffer that contains only
+    // intervening member output (user -> Alice -> Bob -> Alice) still
+    // inherits the current human turn's request options. This matches the
+    // "last user message" rule
+    // MessageGenerationService.resolveRequestOptionsFromMessages applies to
+    // the rewritten history.
     bool? bufferedAllowImagesApiRouting;
     String? bufferedRequestExtraBodyJson;
 
@@ -79,8 +83,6 @@ class AssistantPrivateContextBuilder {
         ),
       );
       buffer.clear();
-      bufferedAllowImagesApiRouting = null;
-      bufferedRequestExtraBodyJson = null;
     }
 
     for (final msg in slice) {

--- a/lib/features/group_chat/services/assistant_private_context_builder.dart
+++ b/lib/features/group_chat/services/assistant_private_context_builder.dart
@@ -38,8 +38,8 @@ class AssistantPrivateContextBuilder {
     required String userName,
     required Map<String, Assistant> assistantsById,
   }) {
-    // Version collapse
-    final selected = _collapseVersions(
+    // Version collapse (canonical implementation in ChatService).
+    final selected = ChatService.collapseMessageVersions(
       publicMessages,
       conversation.versionSelections,
     );
@@ -101,36 +101,6 @@ class AssistantPrivateContextBuilder {
         speaker.contextMessageSize > 0 &&
         out.length > speaker.contextMessageSize) {
       return out.sublist(out.length - speaker.contextMessageSize);
-    }
-    return out;
-  }
-
-  /// Index into sorted versions; default last (matches ChatController).
-  List<ChatMessage> _collapseVersions(
-    List<ChatMessage> messages,
-    Map<String, int> versionSelections,
-  ) {
-    final byGroup = <String, List<ChatMessage>>{};
-    final order = <String>[];
-    for (final m in messages) {
-      final gid = m.groupId ?? m.id;
-      final list = byGroup.putIfAbsent(gid, () {
-        order.add(gid);
-        return <ChatMessage>[];
-      });
-      list.add(m);
-    }
-    for (final e in byGroup.entries) {
-      e.value.sort((a, b) => a.version.compareTo(b.version));
-    }
-    final out = <ChatMessage>[];
-    for (final gid in order) {
-      final vers = byGroup[gid]!;
-      final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
     }
     return out;
   }

--- a/lib/features/group_chat/services/assistant_private_context_builder.dart
+++ b/lib/features/group_chat/services/assistant_private_context_builder.dart
@@ -57,6 +57,16 @@ class AssistantPrivateContextBuilder {
     final out = <ChatMessage>[];
     final speakerId = speaker.id;
 
+    // Per-message request metadata (AD-0033) rides on the original public
+    // user message; the rewritten user bubble must carry it so the pipeline
+    // can replay the send-time routing decision and extra body on later
+    // turns, resend and regenerate. When several user lines coalesce into
+    // one buffer, the LAST user message's metadata wins — the same "last
+    // user message" rule MessageGenerationService.resolveRequestOptionsFromMessages
+    // applies to the rewritten history.
+    bool? bufferedAllowImagesApiRouting;
+    String? bufferedRequestExtraBodyJson;
+
     void flushBufferAsUser() {
       if (buffer.isEmpty) return;
       out.add(
@@ -64,15 +74,21 @@ class AssistantPrivateContextBuilder {
           role: 'user',
           content: buffer.join('\n'),
           conversationId: conversation.id,
+          requestAllowImagesApiRouting: bufferedAllowImagesApiRouting,
+          requestExtraBodyJson: bufferedRequestExtraBodyJson,
         ),
       );
       buffer.clear();
+      bufferedAllowImagesApiRouting = null;
+      bufferedRequestExtraBodyJson = null;
     }
 
     for (final msg in slice) {
       if (msg.role == 'user') {
         final text = _directorCtx.contentForDirector(msg);
         buffer.add('[$userName]: $text');
+        bufferedAllowImagesApiRouting = msg.requestAllowImagesApiRouting;
+        bufferedRequestExtraBodyJson = msg.requestExtraBodyJson;
       } else if (msg.role == 'assistant') {
         final sid = msg.speakerAssistantId;
         final content = _directorCtx.contentForDirector(msg);

--- a/lib/features/group_chat/services/assistant_private_context_builder.dart
+++ b/lib/features/group_chat/services/assistant_private_context_builder.dart
@@ -29,6 +29,10 @@ class AssistantPrivateContextBuilder {
   final ChatService chatService;
   final DirectorContextBuilder _directorCtx;
 
+  /// In-band media markers ([image:...] / [file:...]). Same form the app
+  /// persists and MessageBuilderService.parseInputFromRaw parses.
+  static final RegExp _mediaMarkerRe = RegExp(r'\[(?:image|file):[^\]]*\]');
+
   /// Returns logical ChatMessages for MessagePipeline (user/assistant roles
   /// from the selected speaker's POV).
   List<ChatMessage> build({
@@ -71,24 +75,47 @@ class AssistantPrivateContextBuilder {
     bool? bufferedAllowImagesApiRouting;
     String? bufferedRequestExtraBodyJson;
 
+    // Same principle for in-band media markers ([image:...] / [file:...]):
+    // the last user message in the rewritten list is the only one whose
+    // markers MessageBuilderService.processUserMessagesForApi turns into
+    // lastUserMediaPaths (which becomes GenerationContext.userMediaPaths
+    // when the pipeline runs with inputData == null). A trailing member-only
+    // bubble therefore re-attaches the current human turn's markers, or the
+    // repeated member turn silently loses the uploaded media. A real user
+    // line overwrites the markers (empty when that message has no media);
+    // null means no real user line was seen yet (truncation window).
+    String? latestHumanMediaMarkers;
+    var bufferHasHumanLine = false;
+
     void flushBufferAsUser() {
       if (buffer.isEmpty) return;
+      var content = buffer.join('\n');
+      if (!bufferHasHumanLine &&
+          (latestHumanMediaMarkers?.isNotEmpty ?? false)) {
+        content = '$content\n$latestHumanMediaMarkers';
+      }
       out.add(
         ChatMessage(
           role: 'user',
-          content: buffer.join('\n'),
+          content: content,
           conversationId: conversation.id,
           requestAllowImagesApiRouting: bufferedAllowImagesApiRouting,
           requestExtraBodyJson: bufferedRequestExtraBodyJson,
         ),
       );
       buffer.clear();
+      bufferHasHumanLine = false;
     }
 
     for (final msg in slice) {
       if (msg.role == 'user') {
         final text = _directorCtx.contentForDirector(msg);
         buffer.add('[$userName]: $text');
+        bufferHasHumanLine = true;
+        latestHumanMediaMarkers = _mediaMarkerRe
+            .allMatches(msg.content)
+            .map((match) => match.group(0)!)
+            .join('\n');
         bufferedAllowImagesApiRouting = msg.requestAllowImagesApiRouting;
         bufferedRequestExtraBodyJson = msg.requestExtraBodyJson;
       } else if (msg.role == 'assistant') {

--- a/lib/features/group_chat/services/director_context_builder.dart
+++ b/lib/features/group_chat/services/director_context_builder.dart
@@ -13,6 +13,22 @@ class DirectorContextBuilder {
   static const toolOnlyReminder =
       'Respond only by calling select_speaker or end_turn.';
 
+  /// Strips in-band media markers (`[image:...]` / `[file:...]`) from a user
+  /// message before it enters the Director's text-only protocol, replacing
+  /// each with a bare placeholder. The Director never sees the raw content
+  /// (it only produces speaker-selection tool calls), so the actual image
+  /// bytes are handled per member by the private context pipeline.
+  ///
+  /// Deliberately NOT applied inside [contentForDirector]: that method is
+  /// also used by [AssistantPrivateContextBuilder] to rebuild the member
+  /// private context, where the markers MUST survive so the pipeline can
+  /// parse them back into per-message media paths.
+  static String plainTextForDirector(String content) {
+    return content
+        .replaceAllMapped(RegExp(r'\[image:[^\]]*\]'), (_) => '[image]')
+        .replaceAllMapped(RegExp(r'\[file:[^\]]*\]'), (_) => '[file]');
+  }
+
   /// Tool titles only — shared with private context builder.
   String contentForDirector(ChatMessage message) {
     final body = message.content.trim();
@@ -143,34 +159,16 @@ class DirectorContextBuilder {
         .length;
   }
 
-  /// Collapse using index-into-sorted-versions (default last).
+  /// Collapse using index-into-sorted-versions (default last). Delegates to
+  /// the canonical [ChatService.collapseMessageVersions].
   List<ChatMessage> collapsePublicVersions(
     List<ChatMessage> publicMessages,
     Map<String, int> versionSelections,
   ) {
-    final byGroup = <String, List<ChatMessage>>{};
-    final order = <String>[];
-    for (final m in publicMessages) {
-      final gid = m.groupId ?? m.id;
-      final list = byGroup.putIfAbsent(gid, () {
-        order.add(gid);
-        return <ChatMessage>[];
-      });
-      list.add(m);
-    }
-    for (final e in byGroup.entries) {
-      e.value.sort((a, b) => a.version.compareTo(b.version));
-    }
-    final out = <ChatMessage>[];
-    for (final gid in order) {
-      final vers = byGroup[gid]!;
-      final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
-    }
-    return out;
+    return ChatService.collapseMessageVersions(
+      publicMessages,
+      versionSelections,
+    );
   }
 
   /// Build API messages from the public transcript (no director DB history).
@@ -247,7 +245,7 @@ class DirectorContextBuilder {
           'role': 'user',
           'content': buildUserTurnE1(
             userName: userName,
-            userMessageText: contentFor(m),
+            userMessageText: plainTextForDirector(contentFor(m)),
           ),
         });
       } else if (m.role == 'assistant') {

--- a/lib/features/group_chat/services/director_log_builder.dart
+++ b/lib/features/group_chat/services/director_log_builder.dart
@@ -104,11 +104,15 @@ class DirectorLogBuilder {
                   lastAssistant,
                 ),
                 userName: userName,
-                newUserMessageText: message.content,
+                newUserMessageText: DirectorContextBuilder.plainTextForDirector(
+                  message.content,
+                ),
               )
             : _contextBuilder.buildUserTurnE1(
                 userName: userName,
-                userMessageText: message.content,
+                userMessageText: DirectorContextBuilder.plainTextForDirector(
+                  message.content,
+                ),
               );
         final apiMessages = _buildApiMessages(
           group: group,
@@ -129,7 +133,9 @@ class DirectorLogBuilder {
             sourceMessageId: message.id,
             timestamp: message.timestamp,
             trigger: trigger,
-            triggerContent: message.content,
+            triggerContent: DirectorContextBuilder.plainTextForDirector(
+              message.content,
+            ),
             contextMessages: _contextMessages(apiMessages),
             outcome: nextAssistant == null
                 ? DirectorLogOutcome.noObservedFollowUp

--- a/lib/features/home/controllers/chat_controller.dart
+++ b/lib/features/home/controllers/chat_controller.dart
@@ -771,8 +771,9 @@ class ChatController extends ChangeNotifier {
   /// This groups messages by their groupId and returns only the message
   /// at the selected version index for each group.
   ///
-  /// Single canonical implementation: [collapseWithSelections] holds the
-  /// logic; this instance method feeds it the live in-memory selections.
+  /// Single canonical implementation: [ChatService.collapseMessageVersions]
+  /// holds the logic; this instance method feeds it the live in-memory
+  /// selections.
   List<ChatMessage> collapseVersions(List<ChatMessage> items) {
     return collapseWithSelections(items, _versionSelections);
   }
@@ -786,36 +787,7 @@ class ChatController extends ChangeNotifier {
     List<ChatMessage> items,
     Map<String, int> versionSelections,
   ) {
-    final Map<String, List<ChatMessage>> byGroup =
-        <String, List<ChatMessage>>{};
-    final List<String> order = <String>[];
-
-    for (final m in items) {
-      final gid = (m.groupId ?? m.id);
-      final list = byGroup.putIfAbsent(gid, () {
-        order.add(gid);
-        return <ChatMessage>[];
-      });
-      list.add(m);
-    }
-
-    // Sort each group by version
-    for (final e in byGroup.entries) {
-      e.value.sort((a, b) => a.version.compareTo(b.version));
-    }
-
-    // Select the appropriate version from each group
-    final out = <ChatMessage>[];
-    for (final gid in order) {
-      final vers = byGroup[gid]!;
-      final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
-    }
-
-    return out;
+    return ChatService.collapseMessageVersions(items, versionSelections);
   }
 
   /// Get messages collapsed by version (cached).

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -88,40 +88,12 @@ class MessageBuilderService {
       <String, _DocTextCacheEntry>{};
 
   /// Collapse message versions to show only selected version per group.
+  /// Delegates to the canonical [ChatService.collapseMessageVersions].
   List<ChatMessage> collapseVersions(
     List<ChatMessage> items,
     Map<String, int> versionSelections,
   ) {
-    final Map<String, List<ChatMessage>> byGroup =
-        <String, List<ChatMessage>>{};
-    final List<String> order = <String>[];
-
-    for (final m in items) {
-      final gid = (m.groupId ?? m.id);
-      final list = byGroup.putIfAbsent(gid, () {
-        order.add(gid);
-        return <ChatMessage>[];
-      });
-      list.add(m);
-    }
-
-    // Sort each group by version
-    for (final e in byGroup.entries) {
-      e.value.sort((a, b) => a.version.compareTo(b.version));
-    }
-
-    // Select the appropriate version from each group
-    final out = <ChatMessage>[];
-    for (final gid in order) {
-      final vers = byGroup[gid]!;
-      final sel = versionSelections[gid];
-      final idx = (sel != null && sel >= 0 && sel < vers.length)
-          ? sel
-          : (vers.length - 1);
-      out.add(vers[idx]);
-    }
-
-    return out;
+    return ChatService.collapseMessageVersions(items, versionSelections);
   }
 
   /// Build API messages list from current conversation state.

--- a/lib/features/home/services/message_pipeline.dart
+++ b/lib/features/home/services/message_pipeline.dart
@@ -147,11 +147,30 @@ class MessagePipeline {
         assistant: assistant,
       );
 
+      // When there is no live composer input (group second turns, resend,
+      // regenerate or Multi-AI retries), the per-message request metadata
+      // persisted at send time (AD-0033) is the source of truth: replay it
+      // from the history like single chat's regenerate/continue paths do.
+      // The skip-free list keeps the anchor bounding: the last user message
+      // in [completeMessages] is the one that produced this turn.
+      final (
+        allowImagesApiRouting: resolvedRouting,
+        requestExtraBody: resolvedExtraBody,
+      ) = inputData == null
+          ? MessageGenerationService.resolveRequestOptionsFromMessages(
+              completeMessages,
+              fallbackAllowImagesApiRouting: allowImagesApiRouting,
+            )
+          : (
+              allowImagesApiRouting: allowImagesApiRouting,
+              requestExtraBody: requestExtraBody ?? inputData.extraBody,
+            );
+
       final ctx = _messageGenerationService.buildGenerationContext(
         assistantMessage: assistantMessage,
         prepared: prepared,
         userMediaPaths: userMediaPaths,
-        allowImagesApiRouting: allowImagesApiRouting,
+        allowImagesApiRouting: resolvedRouting,
         providerKey: providerKey,
         modelId: modelId,
         assistant: assistant,
@@ -159,7 +178,7 @@ class MessagePipeline {
         supportsReasoning: supportsReasoning,
         enableReasoning: enableReasoning,
         generateTitleOnFinish: generateTitleOnFinish,
-        requestExtraBody: requestExtraBody ?? inputData?.extraBody,
+        requestExtraBody: resolvedExtraBody,
       );
 
       unawaited(

--- a/lib/features/home/services/message_pipeline.dart
+++ b/lib/features/home/services/message_pipeline.dart
@@ -138,16 +138,14 @@ class MessagePipeline {
             askUserService: context.askUserService,
           );
 
-      final userMediaPaths = inputData != null
-          ? _messageGenerationService.buildUserMediaPaths(
-              input: inputData,
-              lastUserMediaPaths: prepared.lastUserImagePaths,
-              settings: settings,
-              providerKey: providerKey,
-              modelId: modelId,
-              assistant: assistant,
-            )
-          : const <String>[];
+      final userMediaPaths = _messageGenerationService.buildUserMediaPaths(
+        input: inputData,
+        lastUserMediaPaths: prepared.lastUserImagePaths,
+        settings: settings,
+        providerKey: providerKey,
+        modelId: modelId,
+        assistant: assistant,
+      );
 
       final ctx = _messageGenerationService.buildGenerationContext(
         assistantMessage: assistantMessage,

--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -391,6 +391,17 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   bool _supportsImagesApiRouting(BuildContext context) {
+    // Group chat chooses the generating model per member assistant, so the
+    // global 1:1 model is meaningless here. Every member resolves image
+    // routing against its own model inside the API layer; the composer keeps
+    // the default allow (single ChatInputData produced by _handleSend).
+    if (widget.mode == ChatInputMode.groupChat) {
+      _inputStatus.updateImageModeKey(
+        null,
+        conversationId: widget.conversationId,
+      );
+      return false;
+    }
     final settings = context.watch<SettingsProvider>();
     final ap = context.watch<AssistantProvider>();
     final a = ap.currentAssistant;
@@ -423,6 +434,10 @@ class _ChatInputBarState extends State<ChatInputBar>
   }
 
   void _checkImageWarning(BuildContext context) {
+    if (widget.mode == ChatInputMode.groupChat) {
+      _inputStatus.updateImageWarningKey(null);
+      return;
+    }
     if (_images.isEmpty) {
       _inputStatus.updateImageWarningKey(null);
       return;

--- a/test/features/group_chat/assistant_private_context_builder_test.dart
+++ b/test/features/group_chat/assistant_private_context_builder_test.dart
@@ -317,4 +317,100 @@ void main() {
     expect(options.allowImagesApiRouting, isFalse);
     expect(options.requestExtraBody, {'quality': 'high'});
   });
+
+  test('private rewrite re-attaches the human turn media markers on trailing '
+      'member-only user bubbles (user image -> Alice -> Bob)', () {
+    final service = _FakeChatService();
+    final builder = AssistantPrivateContextBuilder(chatService: service);
+    final conv = Conversation(
+      id: 'c1',
+      title: 'g',
+      conversationKind: Conversation.kindGroup,
+    );
+    final alice = Assistant(id: 'a1', name: 'Alice', systemPrompt: 'A');
+    final bob = Assistant(id: 'a2', name: 'Bob', systemPrompt: 'B');
+    final public = [
+      ChatMessage(
+        role: 'user',
+        content: '看图 [image:C:/tmp/photo.png]',
+        conversationId: 'c1',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '好的',
+        conversationId: 'c1',
+        speakerAssistantId: 'a1',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '补充一点',
+        conversationId: 'c1',
+        speakerAssistantId: 'a2',
+      ),
+    ];
+
+    final private = builder.build(
+      conversation: conv,
+      publicMessages: public,
+      speaker: alice,
+      userName: 'User',
+      assistantsById: {'a1': alice, 'a2': bob},
+    );
+
+    // The trailing Bob-only bubble re-attaches the current human turn's
+    // image marker. Without it the pipeline's media extraction (which only
+    // inspects the last user message) would hand Alice's repeated turn an
+    // empty GenerationContext.userMediaPaths.
+    final userBubbles = private.where((m) => m.role == 'user').toList();
+    expect(userBubbles, hasLength(2));
+    expect(userBubbles.last.content, contains('[Bob]: 补充一点'));
+    expect(userBubbles.last.content, contains('[image:C:/tmp/photo.png]'));
+  });
+
+  test('private rewrite does not leak the previous turn media into a new '
+      'media-less human turn', () {
+    final service = _FakeChatService();
+    final builder = AssistantPrivateContextBuilder(chatService: service);
+    final conv = Conversation(
+      id: 'c1',
+      title: 'g',
+      conversationKind: Conversation.kindGroup,
+    );
+    final alice = Assistant(id: 'a1', name: 'Alice', systemPrompt: 'A');
+    final bob = Assistant(id: 'a2', name: 'Bob', systemPrompt: 'B');
+    final public = [
+      ChatMessage(
+        role: 'user',
+        content: '看图 [image:C:/tmp/photo.png]',
+        conversationId: 'c1',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '好的',
+        conversationId: 'c1',
+        speakerAssistantId: 'a1',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '补充一点',
+        conversationId: 'c1',
+        speakerAssistantId: 'a2',
+      ),
+      ChatMessage(role: 'user', content: '继续', conversationId: 'c1'),
+    ];
+
+    final private = builder.build(
+      conversation: conv,
+      publicMessages: public,
+      speaker: alice,
+      userName: 'User',
+      assistantsById: {'a1': alice, 'a2': bob},
+    );
+
+    // The final bubble contains the new media-less human turn: the earlier
+    // image must not be re-attached.
+    final lastUser = private.where((m) => m.role == 'user').last;
+    expect(lastUser.content, contains('[User]: 继续'));
+    expect(lastUser.content, isNot(contains('[image:')));
+  });
 }

--- a/test/features/group_chat/assistant_private_context_builder_test.dart
+++ b/test/features/group_chat/assistant_private_context_builder_test.dart
@@ -4,6 +4,7 @@ import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/models/group_chat.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/features/group_chat/services/assistant_private_context_builder.dart';
+import 'package:Cuplivo/features/home/services/message_generation_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class _FakeChatService extends ChatService {
@@ -206,5 +207,54 @@ void main() {
     );
     expect(injection, isNotNull);
     expect(injection, contains('Alpha'));
+  });
+
+  test('private rewrite preserves send-time request metadata and the pipeline '
+      'resolver replays it', () {
+    final service = _FakeChatService();
+    final builder = AssistantPrivateContextBuilder(chatService: service);
+    final conv = Conversation(
+      id: 'c1',
+      title: 'g',
+      conversationKind: Conversation.kindGroup,
+    );
+    final alice = Assistant(id: 'a1', name: 'Alice', systemPrompt: 'A');
+    final public = [
+      ChatMessage(
+        role: 'user',
+        content: '看图 [image:C:/tmp/photo.png]',
+        conversationId: 'c1',
+        requestAllowImagesApiRouting: false,
+        requestExtraBodyJson: '{"quality":"high"}',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '好的',
+        conversationId: 'c1',
+        speakerAssistantId: 'a1',
+      ),
+    ];
+
+    final private = builder.build(
+      conversation: conv,
+      publicMessages: public,
+      speaker: alice,
+      userName: 'User',
+      assistantsById: {'a1': alice},
+    );
+
+    // The rewritten user bubble must keep the anchor's metadata (this is the
+    // exact history the pipeline resolves against when inputData == null).
+    final rewrittenUser = private.where((m) => m.role == 'user').single;
+    expect(rewrittenUser.content, contains('[User]: 看图'));
+    expect(rewrittenUser.requestAllowImagesApiRouting, isFalse);
+    expect(rewrittenUser.requestExtraBody, {'quality': 'high'});
+
+    final options = MessageGenerationService.resolveRequestOptionsFromMessages(
+      private,
+      fallbackAllowImagesApiRouting: true,
+    );
+    expect(options.allowImagesApiRouting, isFalse);
+    expect(options.requestExtraBody, {'quality': 'high'});
   });
 }

--- a/test/features/group_chat/assistant_private_context_builder_test.dart
+++ b/test/features/group_chat/assistant_private_context_builder_test.dart
@@ -257,4 +257,64 @@ void main() {
     expect(options.allowImagesApiRouting, isFalse);
     expect(options.requestExtraBody, {'quality': 'high'});
   });
+
+  test('private rewrite keeps the human turn request metadata on trailing '
+      'member-only user bubbles (user -> Alice -> Bob)', () {
+    final service = _FakeChatService();
+    final builder = AssistantPrivateContextBuilder(chatService: service);
+    final conv = Conversation(
+      id: 'c1',
+      title: 'g',
+      conversationKind: Conversation.kindGroup,
+    );
+    final alice = Assistant(id: 'a1', name: 'Alice', systemPrompt: 'A');
+    final bob = Assistant(id: 'a2', name: 'Bob', systemPrompt: 'B');
+    final public = [
+      ChatMessage(
+        role: 'user',
+        content: '看图 [image:C:/tmp/photo.png]',
+        conversationId: 'c1',
+        requestAllowImagesApiRouting: false,
+        requestExtraBodyJson: '{"quality":"high"}',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '好的',
+        conversationId: 'c1',
+        speakerAssistantId: 'a1',
+      ),
+      ChatMessage(
+        role: 'assistant',
+        content: '补充一点',
+        conversationId: 'c1',
+        speakerAssistantId: 'a2',
+      ),
+    ];
+
+    final private = builder.build(
+      conversation: conv,
+      publicMessages: public,
+      speaker: alice,
+      userName: 'User',
+      assistantsById: {'a1': alice, 'a2': bob},
+    );
+
+    // Both user bubbles — the one flushed before Alice's message AND the
+    // trailing Bob-only bubble — must inherit the current human turn's
+    // request metadata. The resolver stops at the trailing bubble, so if
+    // its metadata got reset, the rewrite would fall back to routing=true.
+    final userBubbles = private.where((m) => m.role == 'user').toList();
+    expect(userBubbles, hasLength(2));
+    for (final bubble in userBubbles) {
+      expect(bubble.requestAllowImagesApiRouting, isFalse);
+      expect(bubble.requestExtraBody, {'quality': 'high'});
+    }
+
+    final options = MessageGenerationService.resolveRequestOptionsFromMessages(
+      private,
+      fallbackAllowImagesApiRouting: true,
+    );
+    expect(options.allowImagesApiRouting, isFalse);
+    expect(options.requestExtraBody, {'quality': 'high'});
+  });
 }

--- a/test/features/group_chat/director_context_builder_public_test.dart
+++ b/test/features/group_chat/director_context_builder_public_test.dart
@@ -219,4 +219,53 @@ void main() {
     expect(userContents[0], contains('[Alice]: new version'));
     expect(userContents[0], isNot(contains('Old start')));
   });
+
+  test('director history strips media markers from historical user turns', () {
+    final service = _FakeChatService();
+    final builder = DirectorContextBuilder(chatService: service);
+    final alice = Assistant(id: 'a1', name: 'Alice', systemPrompt: 'A');
+    final group = GroupChat(
+      id: 'g1',
+      name: 'Room',
+      conversationId: 'c1',
+      directorSystemPrompt: 'You are the director.',
+    );
+
+    final u0 = ChatMessage(
+      id: 'u0',
+      role: 'user',
+      content:
+          '看图 [image:C:/tmp/photo.png]\n附件 [file:/tmp/r.pdf|r.pdf|application/pdf]',
+      conversationId: 'c1',
+    );
+    final a0 = ChatMessage(
+      id: 'a0',
+      role: 'assistant',
+      content: '好的',
+      conversationId: 'c1',
+      speakerAssistantId: 'a1',
+    );
+
+    final api = builder.buildApiMessagesFromPublic(
+      group: group,
+      publicMessages: [u0, a0],
+      versionSelections: const {},
+      newUserContent: 'tip',
+      rosterAssistants: [alice],
+      userName: 'User',
+      memberNames: const ['User', 'Alice'],
+      assistantsById: {'a1': alice},
+    );
+
+    final userContents = api
+        .where((m) => m['role'] == 'user')
+        .map((m) => m['content'] as String)
+        .toList();
+    expect(userContents.length, 3); // E1 history, E2, tip
+    // Raw local paths must never leak into the Director's request.
+    expect(userContents[0], isNot(contains('C:/tmp/photo.png')));
+    expect(userContents[0], isNot(contains('r.pdf')));
+    expect(userContents[0], contains('[image]'));
+    expect(userContents[0], contains('[file]'));
+  });
 }

--- a/test/features/group_chat/director_context_builder_test.dart
+++ b/test/features/group_chat/director_context_builder_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/group_chat/services/director_context_builder.dart';
+
+void main() {
+  group('DirectorContextBuilder.plainTextForDirector', () {
+    test('strips image markers to bare placeholder', () {
+      expect(
+        DirectorContextBuilder.plainTextForDirector(
+          '看这张 [image:/data/a/b.png] 然后说',
+        ),
+        '看这张 [image] 然后说',
+      );
+    });
+
+    test('strips file markers with pipe-separated metadata', () {
+      expect(
+        DirectorContextBuilder.plainTextForDirector(
+          '附件 [file:/tmp/r.pdf|report.pdf|application/pdf] 已上传',
+        ),
+        '附件 [file] 已上传',
+      );
+    });
+
+    test('strips multiple markers preserving surrounding text', () {
+      expect(
+        DirectorContextBuilder.plainTextForDirector(
+          '[image:/x/1.jpg] 与 [image:/x/2.jpg]\n[file:/x/3.txt|a.txt|text/plain]',
+        ),
+        '[image] 与 [image]\n[file]',
+      );
+    });
+
+    test('returns input unchanged when no markers', () {
+      const raw = '普通消息 没有标记';
+      expect(DirectorContextBuilder.plainTextForDirector(raw), raw);
+    });
+
+    test('handles empty and marker-only strings', () {
+      expect(DirectorContextBuilder.plainTextForDirector(''), '');
+      expect(
+        DirectorContextBuilder.plainTextForDirector('[image:/a/b]'),
+        '[image]',
+      );
+    });
+
+    test('does not touch unrelated bracket content', () {
+      const raw = '[User]: 提到 [image]/不是标记';
+      expect(DirectorContextBuilder.plainTextForDirector(raw), raw);
+    });
+  });
+}

--- a/test/features/home/services/message_builder_ocr_mode_test.dart
+++ b/test/features/home/services/message_builder_ocr_mode_test.dart
@@ -65,15 +65,19 @@ Future<String> _processContent({
   required SettingsProvider settings,
   required Assistant? assistant,
   required String modelId,
+  bool provideOcrHandler = true,
+  String rawContent = 'hello $_imageMarker',
 }) async {
   final builder = MessageBuilderService(
     preferences: businessPrefs,
     chatService: _FakeChatService(),
     contextProvider: _FakeBuildContext(),
-    ocrHandler: (_, {requestId}) async => _ocrText,
+    ocrHandler: provideOcrHandler
+        ? (_, {requestId}) async => _ocrText
+        : null,
   );
   final apiMessages = <Map<String, dynamic>>[
-    {'role': 'user', 'content': 'hello $_imageMarker'},
+    {'role': 'user', 'content': rawContent},
   ];
   await builder.processUserMessagesForApi(
     apiMessages,
@@ -155,5 +159,59 @@ void main() {
       expect(content, contains(_imageMarker));
       expect(content, isNot(contains('<image_file_ocr>')));
     });
+  });
+
+  group('processUserMessagesForApi — group chat private context', () {
+    // Group user messages are persisted with the raw `[image:]` marker and
+    // rewritten by AssistantPrivateContextBuilder as `[User]: content`; the
+    // pipeline must parse it out of that prefixed shape.
+    const groupContent = '[User]: 看看这张 $_imageMarker';
+
+    test('vision member keeps the marker through the [User]: prefix', () async {
+      final settings = await _settingsWithOcrModel();
+      final content = await _processContent(
+        settings: settings,
+        assistant: Assistant(id: 'g1', name: 'Vision', ocrMode: 'auto'),
+        modelId: 'vision-model',
+        rawContent: groupContent,
+      );
+      expect(content, contains(_imageMarker));
+      expect(content, isNot(contains('<image_file_ocr>')));
+    });
+
+    test(
+      'text member OCRs the image inside the [User]: prefixed message',
+      () async {
+        final settings = await _settingsWithOcrModel();
+        final content = await _processContent(
+          settings: settings,
+          assistant: Assistant(id: 'g2', name: 'Text', ocrMode: 'auto'),
+          modelId: 'text-model',
+          rawContent: groupContent,
+        );
+        expect(content, isNot(contains(_imageMarker)));
+        expect(content, contains('<image_file_ocr>'));
+        expect(content, contains(_ocrText));
+      },
+    );
+
+    test(
+      'text member without an OCR handler loses the image (B4 guard)',
+      () async {
+        final settings = await _settingsWithOcrModel();
+        final content = await _processContent(
+          settings: settings,
+          assistant: Assistant(id: 'g3', name: 'NoOcr', ocrMode: 'auto'),
+          modelId: 'text-model',
+          rawContent: groupContent,
+          provideOcrHandler: false,
+        );
+        // ocrActive is true but no handler: markers are dropped and no OCR
+        // text is injected — must at least not crash, and the request keeps
+        // the role prefix with the remaining text.
+        expect(content, isNot(contains(_imageMarker)));
+        expect(content, startsWith('[User]:'));
+      },
+    );
   });
 }

--- a/test/features/home/services/message_builder_ocr_mode_test.dart
+++ b/test/features/home/services/message_builder_ocr_mode_test.dart
@@ -3,8 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Cuplivo/core/database/business_preferences.dart';
 
 import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/features/group_chat/services/assistant_private_context_builder.dart';
 import 'package:Cuplivo/features/home/services/message_builder_service.dart';
 
 var businessPrefs = BusinessPreferences.memoryForTests();
@@ -213,5 +216,74 @@ void main() {
         expect(content, startsWith('[User]:'));
       },
     );
+
+    // Reviewer scenario: the human image survives Alice's first turn, but a
+    // repeat-select of Alice after Bob (user -> Alice -> Bob -> Alice) hands
+    // the pipeline a trailing member-only user bubble. The rewritten bubble
+    // must re-attach the human turn's media marker, otherwise
+    // processUserMessagesForApi (which only inspects the last user message)
+    // returns no lastUserImagePaths and GenerationContext.userMediaPaths is
+    // empty on that repeated turn.
+    test('vision member repeated turn keeps the uploaded image across a '
+        'member-only trailing bubble', () async {
+      final settings = await _settingsWithOcrModel();
+      final conv = Conversation(
+        id: 'c1',
+        title: 'g',
+        conversationKind: Conversation.kindGroup,
+      );
+      final alice = Assistant(id: 'a1', name: 'Alice', ocrMode: 'auto');
+      final bob = Assistant(id: 'a2', name: 'Bob');
+      final public = [
+        ChatMessage(
+          role: 'user',
+          content: '看看这张 $_imageMarker',
+          conversationId: 'c1',
+        ),
+        ChatMessage(
+          role: 'assistant',
+          content: '好的',
+          conversationId: 'c1',
+          speakerAssistantId: 'a1',
+        ),
+        ChatMessage(
+          role: 'assistant',
+          content: '补充一点',
+          conversationId: 'c1',
+          speakerAssistantId: 'a2',
+        ),
+      ];
+
+      final private =
+          AssistantPrivateContextBuilder(chatService: _FakeChatService()).build(
+            conversation: conv,
+            publicMessages: public,
+            speaker: alice,
+            userName: 'User',
+            assistantsById: {'a1': alice, 'a2': bob},
+          );
+      final apiMessages = <Map<String, dynamic>>[
+        for (final m in private) {'role': m.role, 'content': m.content},
+      ];
+
+      final messageBuilder = MessageBuilderService(
+        preferences: businessPrefs,
+        chatService: _FakeChatService(),
+        contextProvider: _FakeBuildContext(),
+        ocrHandler: (_) async => 'no ocr',
+      );
+      final lastUserImagePaths = await messageBuilder.processUserMessagesForApi(
+        apiMessages,
+        settings,
+        alice,
+        providerKey: 'OcrProvider',
+        modelId: 'vision-model',
+      );
+
+      // This return value is PreparedGeneration.lastUserImagePaths and,
+      // with inputData == null, the direct source of
+      // GenerationContext.userMediaPaths.
+      expect(lastUserImagePaths, contains('C:/tmp/photo.png'));
+    });
   });
 }

--- a/test/features/home/services/message_builder_ocr_mode_test.dart
+++ b/test/features/home/services/message_builder_ocr_mode_test.dart
@@ -75,9 +75,7 @@ Future<String> _processContent({
     preferences: businessPrefs,
     chatService: _FakeChatService(),
     contextProvider: _FakeBuildContext(),
-    ocrHandler: provideOcrHandler
-        ? (_, {requestId}) async => _ocrText
-        : null,
+    ocrHandler: provideOcrHandler ? (_, {requestId}) async => _ocrText : null,
   );
   final apiMessages = <Map<String, dynamic>>[
     {'role': 'user', 'content': rawContent},
@@ -270,7 +268,7 @@ void main() {
         preferences: businessPrefs,
         chatService: _FakeChatService(),
         contextProvider: _FakeBuildContext(),
-        ocrHandler: (_) async => 'no ocr',
+        ocrHandler: (_, {requestId}) async => 'no ocr',
       );
       final lastUserImagePaths = await messageBuilder.processUserMessagesForApi(
         apiMessages,

--- a/test/features/home/services/message_generation_service_request_metadata_test.dart
+++ b/test/features/home/services/message_generation_service_request_metadata_test.dart
@@ -89,5 +89,53 @@ void main() {
       expect(options.allowImagesApiRouting, isTrue);
       expect(options.requestExtraBody, isNull);
     });
+
+    test(
+      'group resend: [User]: prefixed anchor message replays routing=false and body',
+      () {
+        final anchor = userMessage(
+          id: 'anchor',
+          requestAllowImagesApiRouting: false,
+          requestExtraBodyJson: '{"quality":"high"}',
+        ).copyWith(content: '[User]: 看图 [image:C:/tmp/photo.png]');
+        final options =
+            MessageGenerationService.resolveRequestOptionsFromMessages([
+              ChatMessage(
+                role: 'assistant',
+                content: '[Alice]: 好的',
+                conversationId: 'c1',
+                speakerAssistantId: 'a1',
+              ),
+              anchor,
+            ], fallbackAllowImagesApiRouting: true);
+
+        expect(options.allowImagesApiRouting, isFalse);
+        expect(options.requestExtraBody, {'quality': 'high'});
+      },
+    );
+
+    test(
+      'group regenerate: prefix-truncated history replays the anchor metadata',
+      () {
+        final options =
+            MessageGenerationService.resolveRequestOptionsFromMessages([
+              userMessage(),
+              ChatMessage(
+                role: 'assistant',
+                content: '旧回答',
+                conversationId: 'c1',
+                speakerAssistantId: 'a1',
+              ),
+              userMessage(
+                id: 'anchor',
+                requestAllowImagesApiRouting: false,
+                requestExtraBodyJson: '{"size":"1024x1024"}',
+              ).copyWith(content: '[User]: 再来一张'),
+            ], fallbackAllowImagesApiRouting: true);
+
+        expect(options.allowImagesApiRouting, isFalse);
+        expect(options.requestExtraBody, {'size': '1024x1024'});
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes #604: group chat composer no longer lags single chat, and image/context building is unified so group chat handles pictures the same way single chat does.

## What changed

### Composer (buttons alignment)
- Group chat now wires the input-side buttons: photo picker, camera (mobile), file upload, quick phrases, voice input — same components/order/customization as single chat (`FileUploadService`, `QuickPhraseProvider`, `AsrProvider` reused; zero new widgets).
- Per-member buttons (model select, search, reasoning, tools hub, etc.) stay hidden — group chat has no single assistant to configure them for.
- Group-mode image warning/API-routing short-circuited: it previously computed against the globally selected 1:1 assistant. Each member now resolves image handling against its own model inside the API layer.

### Image context unification
- **Persistence (B1)**: group user messages go through `createUserMessage` — `[image:]`/`[file:]` markers, quote, and per-message request metadata are persisted like single chat. History, export, resend and regenerate can now see images.
- **Pipeline fallback (B2)**: `MessagePipeline` no longer maps `inputData == null` to no media; it falls back to `prepared.lastUserImagePaths` (same semantics single-chat regenerate/continue hand-roll). Fixes group images lost after the first speaker, on resend, on regenerate — and Multi-AI history retries sharing the same path.
- **OCR (B4)**: group `MessageBuilderService` now has `ocrHandler` + wrapper, so non-vision members receive OCR text (DB-cached, shared across members/rounds) instead of silently losing the image. Group's director stays text-only and never OCRs.
- **Director sanitization (B3)**: media markers are stripped to `[image]`/`[file]` placeholders in every director user turn — live tip (E1/E3), rebuilt history, and the director-log replay/trigger content. Local filesystem paths never reach the Director or the logs UI.

### Interaction fixes
- **Queued send (A4)**: sending while a round runs now queues (one slot) with the existing banner + composer lock, draining automatically when the round ends — mirroring single-chat semantics. Also fixes a silent message-swallow: previously Enter mid-round persisted the user message but no turn ever ran.
- **Message UI state restore**: reopening a group chat now restores reasoning panels, tool events, content splits, Gemini thought signatures and translation markers (mirrors single chat; hooked in `_bindConversation`, not `_refreshList`, so live streaming state is never clobbered).
- **Context boundary divider**: after "clear context" the truncated-boundary divider now renders in group chat (was missing; truncateIndex was already applied to director/private contexts).

### Cleanup
- Version-collapse dedup: single canonical `ChatService.collapseMessageVersions`; 5 duplicated implementations (ChatController, MessageBuilderService, ProactiveCareMessageFlow, DirectorContextBuilder, AssistantPrivateContextBuilder) now delegate.

## Verification

- `dart analyze --fatal-infos lib test` — 0 issues
- Tests: group_chat suite + OCR/private-context suite + message builder + proactive care — all pass (new tests: `plainTextForDirector` ×6, group private-context OCR dual-view ×3, director history marker stripping)
- Manual (Windows desktop): buttons all present/per-member hidden; image send with vision + OCR members; later turns/regenerate/resend keep images; director logs show no raw paths; queued send + cancel + drain; clear-context divider; history reopen restores reasoning panels.

## Follow-ups (filed)

Design-level unification left as separate issues: #679 (desktop group chat slot instead of Navigator.push), #680 (session-level queued send), #682 (MessagePipeline takeover of single-chat regenerate/continue), #681 (provider-layer image conversion + mime unification).

## Caveats

- No backfill for group messages sent before this change (never persisted markers) — new sends only.
- macOS/Linux manual verification not run (changes are platform-neutral except the desktop popover branch, reviewed logically).
