### PR TITLE
fix(gemini): port upstream #953 thought-signature artifact storage (#220, #260)

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -23,6 +23,7 @@ import '../../../utils/markdown_code_scanner.dart';
 import '../../../utils/unicode_sanitizer.dart';
 import 'builtin_tools.dart';
 import 'gemini_tool_config.dart';
+import 'providers/gemini_thought_signature.dart';
 import '../logging/flutter_logger.dart';
 import '../model_override_resolver.dart';
 import '../model_override_payload_parser.dart';
@@ -1581,23 +1582,6 @@ class _ParsedTextAndImages {
   final String text;
   final List<_ImageRef> images;
   const _ParsedTextAndImages(this.text, this.images);
-}
-
-class _GeminiSignatureMeta {
-  final String cleanedText;
-  final String? textKey;
-  final dynamic textValue;
-  final List<Map<String, dynamic>> images;
-  const _GeminiSignatureMeta({
-    required this.cleanedText,
-    this.textKey,
-    this.textValue,
-    this.images = const <Map<String, dynamic>>[],
-  });
-
-  bool get hasText => (textKey ?? '').isNotEmpty && textValue != null;
-  bool get hasImages => images.isNotEmpty;
-  bool get hasAny => hasText || hasImages;
 }
 
 class _ResponsesImageGenerationResult {

--- a/lib/core/services/api/providers/gemini_thought_signature.dart
+++ b/lib/core/services/api/providers/gemini_thought_signature.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+/// Legacy tag used by comment-based Gemini thought signature storage
+/// (messages saved before the payload format existed); still decoded for old
+/// data.
+const String geminiThoughtSignatureTag = 'gemini_thought_signatures';
+
+final RegExp _geminiThoughtSigComment = RegExp(
+  r'<!--\s*gemini_thought_signatures:(.*?)-->',
+  dotAll: true,
+);
+
+/// Parsed Gemini thought signatures of one model turn.
+class GeminiSignatureMeta {
+  final String cleanedText;
+  final String? textKey;
+  final dynamic textValue;
+  final List<Map<String, dynamic>> images;
+
+  const GeminiSignatureMeta({
+    required this.cleanedText,
+    this.textKey,
+    this.textValue,
+    this.images = const <Map<String, dynamic>>[],
+  });
+
+  bool get hasText => (textKey ?? '').isNotEmpty && textValue != null;
+  bool get hasImages => images.isNotEmpty;
+  bool get hasAny => hasText || hasImages;
+}
+
+/// Encodes a turn's thought signatures as the artifact payload: a bare JSON
+/// object `{"text": {"k", "v"}, "images": [{"k", "v"}]}`. Returns '' when
+/// there is nothing to keep.
+///
+/// Payloads written before the payload format existed wrapped the same JSON in
+/// an HTML comment that travelled inside the message text;
+/// [decodeGeminiThoughtSignature] still reads those.
+String encodeGeminiThoughtSignature({
+  String? textKey,
+  dynamic textValue,
+  List<Map<String, dynamic>> imageSigs = const <Map<String, dynamic>>[],
+}) {
+  final imgs = imageSigs
+      .where((e) => (e['k'] ?? '').toString().isNotEmpty && e.containsKey('v'))
+      .toList();
+  final hasText = (textKey ?? '').isNotEmpty && textValue != null;
+  if (!hasText && imgs.isEmpty) return '';
+  final payload = <String, dynamic>{};
+  if (hasText) payload['text'] = {'k': textKey, 'v': textValue};
+  if (imgs.isNotEmpty) payload['images'] = imgs;
+  return jsonEncode(payload);
+}
+
+/// Decodes an artifact payload written by [encodeGeminiThoughtSignature] or by
+/// the legacy comment format, paired with [cleanedText]. Null when [payload]
+/// holds no signature.
+GeminiSignatureMeta? decodeGeminiThoughtSignature(
+  Object? payload, {
+  String cleanedText = '',
+}) {
+  if (payload is! String) return null;
+  final trimmed = payload.trim();
+  if (trimmed.isEmpty) return null;
+  String json = trimmed;
+  if (!trimmed.startsWith('{')) {
+    final legacy = _geminiThoughtSigComment.firstMatch(trimmed);
+    if (legacy == null) return null;
+    json = (legacy.group(1) ?? '').trim();
+  }
+  final meta = _geminiMetaFromJson(json, cleanedText: cleanedText);
+  return meta.hasAny ? meta : null;
+}
+
+/// Splits a legacy message text that still carries the signature comment into
+/// the clean text and the signatures.
+GeminiSignatureMeta extractGeminiThoughtMeta(String raw) {
+  final m = _geminiThoughtSigComment.firstMatch(raw);
+  if (m == null) return GeminiSignatureMeta(cleanedText: raw);
+  final cleaned = raw.replaceRange(m.start, m.end, '').trimRight();
+  return _geminiMetaFromJson((m.group(1) ?? '').trim(), cleanedText: cleaned);
+}
+
+GeminiSignatureMeta _geminiMetaFromJson(
+  String json, {
+  required String cleanedText,
+}) {
+  Map<String, dynamic> data = const <String, dynamic>{};
+  try {
+    data = (jsonDecode(json) as Map).cast<String, dynamic>();
+  } catch (_) {
+    return GeminiSignatureMeta(cleanedText: cleanedText);
+  }
+  String? textKey;
+  dynamic textVal;
+  final text = data['text'];
+  if (text is Map) {
+    textKey = (text['k'] ?? text['key'])?.toString();
+    textVal = text['v'] ?? text['val'];
+    if (textKey != null && textKey.trim().isEmpty) {
+      textKey = null;
+    }
+  }
+  final images = <Map<String, dynamic>>[];
+  final imgList = data['images'];
+  if (imgList is List) {
+    for (final e in imgList) {
+      if (e is! Map) continue;
+      final k = (e['k'] ?? e['key'])?.toString() ?? '';
+      final v = e['v'] ?? e['val'];
+      if (k.isEmpty || v == null) continue;
+      images.add({'k': k, 'v': v});
+    }
+  }
+  return GeminiSignatureMeta(
+    cleanedText: cleanedText,
+    textKey: textKey,
+    textValue: textVal,
+    images: images,
+  );
+}

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -202,6 +202,22 @@ Map<String, dynamic>? _googleFunctionCallPartFromToolCall(Map toolCall) {
   return part;
 }
 
+/// The thought signatures a history message carries: the stored payload under
+/// [multimodalInternalGeminiThoughtSignatureKey], or — for messages saved
+/// before the payload existed — the comment still embedded in its text.
+GeminiSignatureMeta _geminiHistoryMeta(Map<String, dynamic> msg) {
+  final fromText = extractGeminiThoughtMeta((msg['content'] ?? '').toString());
+  return decodeGeminiThoughtSignature(
+        msg[multimodalInternalGeminiThoughtSignatureKey],
+        cleanedText: fromText.cleanedText,
+      ) ??
+      fromText;
+}
+
+/// A history message's text without any legacy signature comment.
+String _geminiHistoryText(Map<String, dynamic> msg) =>
+    extractGeminiThoughtMeta((msg['content'] ?? '').toString()).cleanedText;
+
 /// Gemini 3 validates that the first functionCall part of a replayed model
 /// turn carries a thought signature; a missing one fails the whole request
 /// with "Function call is missing a thought_signature in functionCall parts".
@@ -385,9 +401,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       final role = roleRaw == 'assistant' ? 'model' : 'user';
       if (roleRaw == 'assistant' && msg['tool_calls'] is List) {
         final parts = <Map<String, dynamic>>[];
-        final raw = _extractGeminiThoughtMeta(
-          (msg['content'] ?? '').toString(),
-        ).cleanedText;
+        final raw = _geminiHistoryText(msg);
         if (raw.trim().isNotEmpty && raw.trim() != '\n\n') {
           parts.add({'text': raw});
         }
@@ -404,7 +418,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       final isLast = i == messages.length - 1;
       final parts = <Map<String, dynamic>>[];
-      final meta = _extractGeminiThoughtMeta((msg['content'] ?? '').toString());
+      final meta = _geminiHistoryMeta(msg);
       final raw = meta.cleanedText;
       final seenSources = <String>{};
       String normalizeSrc(String src) {
@@ -779,7 +793,9 @@ Stream<ChatStreamChunk> _sendGoogleStream(
       }
       var contentStr = buf.toString();
       if (persistGeminiThoughtSigs) {
-        final metaComment = _collectThoughtSigCommentFromParts(parts);
+        final metaComment = _wrapGeminiThoughtSigComment(
+          collectGeminiThoughtSignatureFromParts(parts),
+        );
         if (metaComment.isNotEmpty) contentStr += metaComment;
       }
       final fr = (cand['finishReason'] ?? cand['finish_reason'] ?? '')
@@ -853,7 +869,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     final role = roleRaw == 'assistant' ? 'model' : 'user';
     if (roleRaw == 'assistant' && msg['tool_calls'] is List) {
       final parts = <Map<String, dynamic>>[];
-      final raw = (msg['content'] ?? '').toString();
+      final raw = _geminiHistoryText(msg);
       if (raw.trim().isNotEmpty && raw.trim() != '\n\n') {
         parts.add({'text': raw});
       }
@@ -868,7 +884,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     }
     final isLast = i == messages.length - 1;
     final parts = <Map<String, dynamic>>[];
-    final meta = _extractGeminiThoughtMeta((msg['content'] ?? '').toString());
+    final meta = _geminiHistoryMeta(msg);
     final raw = meta.cleanedText;
     final seenSources = <String>{};
     String normalizeSrc(String src) {
@@ -1267,21 +1283,28 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 final t = (p['text'] ?? '') as String? ?? '';
                 final thought = p['thought'] as bool? ?? false;
                 final fc = p['functionCall'];
+                final inline = (p['inlineData'] ?? p['inline_data']);
+                final hasFile = p['fileData'] is Map || p['file_data'] is Map;
                 final rawPart = Map<String, dynamic>.from(p);
 
                 if (isGemini3 && !thought && rawPart.isNotEmpty) {
                   roundModelParts.add(rawPart);
                 }
 
-                // Capture thought signature for text part (Gemini 3 image/editing)
+                // Capture thought signature for text parts (Gemini 3 hangs the
+                // turn's signature on a trailing part whose text may be empty,
+                // so the text guard must not require a body). One text
+                // signature is kept per turn — the first.
                 if (persistGeminiThoughtSigs &&
                     !thought &&
+                    fc == null &&
+                    inline is! Map &&
+                    !hasFile &&
                     partThoughtSigKey != null &&
-                    partThoughtSigVal != null) {
-                  if (t.isNotEmpty && responseTextThoughtSigKey == null) {
-                    responseTextThoughtSigKey = partThoughtSigKey;
-                    responseTextThoughtSigVal = partThoughtSigVal;
-                  }
+                    partThoughtSigVal != null &&
+                    responseTextThoughtSigKey == null) {
+                  responseTextThoughtSigKey = partThoughtSigKey;
+                  responseTextThoughtSigVal = partThoughtSigVal;
                 }
 
                 if (t.isNotEmpty) {
@@ -1295,7 +1318,6 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 }
                 // Parse inline image data from Gemini (inlineData)
                 // Response shape: { inlineData: { mimeType: 'image/png', data: '...base64...' } }
-                final inline = (p['inlineData'] ?? p['inline_data']);
                 if (inline is Map) {
                   final mime =
                       (inline['mimeType'] ?? inline['mime_type'] ?? 'image/png')
@@ -1590,10 +1612,12 @@ Stream<ChatStreamChunk> _sendGoogleStream(
                 );
               }
               if (persistGeminiThoughtSigs) {
-                final metaComment = _buildGeminiThoughtSigComment(
-                  textKey: responseTextThoughtSigKey,
-                  textValue: responseTextThoughtSigVal,
-                  imageSigs: responseImageThoughtSigs,
+                final metaComment = _wrapGeminiThoughtSigComment(
+                  encodeGeminiThoughtSignature(
+                    textKey: responseTextThoughtSigKey,
+                    textValue: responseTextThoughtSigVal,
+                    imageSigs: responseImageThoughtSigs,
+                  ),
                 );
                 if (metaComment.isNotEmpty) {
                   yield ChatStreamChunk(
@@ -1638,10 +1662,12 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     if (calls.isEmpty) {
       // No tool calls; this round finished
       if (persistGeminiThoughtSigs) {
-        final metaComment = _buildGeminiThoughtSigComment(
-          textKey: responseTextThoughtSigKey,
-          textValue: responseTextThoughtSigVal,
-          imageSigs: responseImageThoughtSigs,
+        final metaComment = _wrapGeminiThoughtSigComment(
+          encodeGeminiThoughtSignature(
+            textKey: responseTextThoughtSigKey,
+            textValue: responseTextThoughtSigVal,
+            imageSigs: responseImageThoughtSigs,
+          ),
         );
         if (metaComment.isNotEmpty) {
           yield ChatStreamChunk(

--- a/lib/core/services/api/providers/google_gemini.dart
+++ b/lib/core/services/api/providers/google_gemini.dart
@@ -1,16 +1,20 @@
 part of '../chat_api_service.dart';
 
-const String _geminiThoughtSigTag = 'gemini_thought_signatures';
-
 /// Placeholder thought signature accepted by the Gemini API when the original
 /// signature is unavailable (e.g. legacy history persisted before signatures
-/// were captured). Same value used by Google's own Gemini CLI.
+/// were captured). Google once documented this value and its own Gemini CLI
+/// still sends it; the current docs no longer list it, but the API keeps
+/// accepting it.
 const String _geminiDummyThoughtSignature =
     'context_engineering_is_the_way_to_go';
-final RegExp _geminiThoughtSigComment = RegExp(
-  r'<!--\s*gemini_thought_signatures:(.*?)-->',
-  dotAll: true,
-);
+
+/// Wraps a bare payload (as produced by [encodeGeminiThoughtSignature]) in the
+/// legacy transport comment that travels inside the streamed content until the
+/// capture layer strips and normalizes it.
+String _wrapGeminiThoughtSigComment(String payload) {
+  if (payload.isEmpty) return '';
+  return '\n<!-- $geminiThoughtSignatureTag:$payload -->';
+}
 
 // YouTube URL regex: watch, shorts, embed, youtu.be (with optional timestamps)
 final RegExp _youtubeUrlRegex = RegExp(
@@ -34,66 +38,8 @@ List<String> _extractYouTubeUrls(String text) {
   return out;
 }
 
-_GeminiSignatureMeta _extractGeminiThoughtMeta(String raw) {
-  try {
-    final m = _geminiThoughtSigComment.firstMatch(raw);
-    if (m == null) return _GeminiSignatureMeta(cleanedText: raw);
-    final payloadRaw = (m.group(1) ?? '').trim();
-    Map<String, dynamic> data = const <String, dynamic>{};
-    try {
-      data = (jsonDecode(payloadRaw) as Map).cast<String, dynamic>();
-    } catch (_) {}
-    String? textKey;
-    dynamic textVal;
-    final text = data['text'];
-    if (text is Map) {
-      textKey = (text['k'] ?? text['key'])?.toString();
-      textVal = text['v'] ?? text['val'];
-      if (textKey != null && textKey.trim().isEmpty) {
-        textKey = null;
-      }
-    }
-    final images = <Map<String, dynamic>>[];
-    final imgList = data['images'];
-    if (imgList is List) {
-      for (final e in imgList) {
-        if (e is! Map) continue;
-        final k = (e['k'] ?? e['key'])?.toString() ?? '';
-        final v = e['v'] ?? e['val'];
-        if (k.isEmpty || v == null) continue;
-        images.add({'k': k, 'v': v});
-      }
-    }
-    final cleaned = raw.replaceRange(m.start, m.end, '').trimRight();
-    return _GeminiSignatureMeta(
-      cleanedText: cleaned,
-      textKey: textKey,
-      textValue: textVal,
-      images: images,
-    );
-  } catch (_) {
-    return _GeminiSignatureMeta(cleanedText: raw);
-  }
-}
-
-String _buildGeminiThoughtSigComment({
-  String? textKey,
-  dynamic textValue,
-  List<Map<String, dynamic>> imageSigs = const <Map<String, dynamic>>[],
-}) {
-  final imgs = imageSigs
-      .where((e) => (e['k'] ?? '').toString().isNotEmpty && e.containsKey('v'))
-      .toList();
-  final hasText = (textKey ?? '').isNotEmpty && textValue != null;
-  if (!hasText && imgs.isEmpty) return '';
-  final payload = <String, dynamic>{};
-  if (hasText) payload['text'] = {'k': textKey, 'v': textValue};
-  if (imgs.isNotEmpty) payload['images'] = imgs;
-  return '\n<!-- $_geminiThoughtSigTag:${jsonEncode(payload)} -->';
-}
-
 void _applyGeminiThoughtSignatures(
-  _GeminiSignatureMeta meta,
+  GeminiSignatureMeta meta,
   List<Map<String, dynamic>> parts, {
   bool attachDummyWhenMissing = false,
 }) {
@@ -149,7 +95,7 @@ void _applyGeminiThoughtSignatures(
   }
 }
 
-String _collectThoughtSigCommentFromParts(List<dynamic> parts) {
+String collectGeminiThoughtSignatureFromParts(List<dynamic> parts) {
   String? textKey;
   dynamic textVal;
   final images = <Map<String, dynamic>>[];
@@ -164,13 +110,17 @@ String _collectThoughtSigCommentFromParts(List<dynamic> parts) {
       sigKey = 'thought_signature';
       sigVal = p['thought_signature'];
     }
-    final hasText = ((p['text'] ?? '') as String? ?? '').isNotEmpty;
     final hasInline =
         p['inlineData'] is Map ||
         p['inline_data'] is Map ||
         p['fileData'] is Map ||
         p['file_data'] is Map;
-    if (hasText && sigKey != null && textKey == null) {
+    // Gemini 3 hangs the turn's signature on a trailing text part whose text
+    // may be empty, so the text guard must not require a body. The first
+    // signed text part is the turn's, as in the streaming decoder.
+    final isText =
+        !hasInline && p['thought'] != true && p['functionCall'] is! Map;
+    if (isText && sigKey != null && sigVal != null && textKey == null) {
       textKey = sigKey;
       textVal = sigVal;
     }
@@ -178,14 +128,12 @@ String _collectThoughtSigCommentFromParts(List<dynamic> parts) {
       images.add({'k': sigKey, 'v': sigVal});
     }
   }
-  return _buildGeminiThoughtSigComment(
+  return encodeGeminiThoughtSignature(
     textKey: textKey,
     textValue: textVal,
     imageSigs: images,
   );
 }
-
-// Simple container for parsed text + image refs
 
 Stream<ChatStreamChunk> _sendGoogleGeminiStream(
   http.Client client,

--- a/lib/core/services/generation_engine.dart
+++ b/lib/core/services/generation_engine.dart
@@ -13,6 +13,7 @@ import '../models/token_usage.dart';
 import '../providers/download_progress_store.dart';
 import '../providers/settings_provider.dart';
 import 'api/chat_api_service.dart';
+import 'api/providers/gemini_thought_signature.dart';
 import 'chat/chat_service.dart';
 import 'workspace/linux_sandbox_service.dart';
 import 'streaming_content_notifier.dart';
@@ -953,20 +954,31 @@ class GenerationEngine extends ChangeNotifier {
     dotAll: true,
   );
 
-  /// Capture and strip a Gemini thought signature from content; persists it
-  /// so follow-up API calls in the conversation can echo it.
+  /// Capture and strip a Gemini thought signature from content; persists the
+  /// normalized payload (bare JSON) so follow-up API calls in the conversation
+  /// can echo it without leaking the comment into message text.
   String _captureGeminiThoughtSignature(String content, _SlotRuntime rt) {
     final m = _geminiThoughtSigRe.firstMatch(content);
     if (m != null) {
       final sig = m.group(0) ?? '';
       if (sig.isNotEmpty) {
-        rt.geminiThoughtSig = sig;
-        unawaited(
-          _chatService.setGeminiThoughtSignature(
-            rt.slot.assistantMessageId,
-            sig,
-          ),
-        );
+        final meta = decodeGeminiThoughtSignature(sig);
+        final payload = meta == null
+            ? ''
+            : encodeGeminiThoughtSignature(
+                textKey: meta.textKey,
+                textValue: meta.textValue,
+                imageSigs: meta.images,
+              );
+        if (payload.isNotEmpty) {
+          rt.geminiThoughtSig = payload;
+          unawaited(
+            _chatService.setGeminiThoughtSignature(
+              rt.slot.assistantMessageId,
+              payload,
+            ),
+          );
+        }
         content = content.replaceAll(_geminiThoughtSigRe, '').trimRight();
       }
     }
@@ -1388,7 +1400,7 @@ class _SlotRuntime {
   /// `max_tokens` / `context_exceeded` when the response was truncated.
   String? truncationReason;
 
-  /// Gemini thought signature captured from the stream, if any.
+  /// Gemini thought signature payload captured from the stream, if any.
   String? geminiThoughtSig;
 
   Timer? reasoningFlushTimer;

--- a/lib/core/utils/multimodal_input_utils.dart
+++ b/lib/core/utils/multimodal_input_utils.dart
@@ -2,6 +2,12 @@ import '../models/chat_input_data.dart';
 
 const String multimodalInternalMediaPathsKey = '_kelivo_media_paths';
 
+/// Provider state stored against an assistant message and carried into the
+/// next request under an internal key, which every provider strips before
+/// anything reaches the wire.
+const String multimodalInternalGeminiThoughtSignatureKey =
+    '_kelivo_gemini_thought_signature';
+
 bool isImageMime(String mime) => mime.toLowerCase().startsWith('image/');
 
 bool isAudioMime(String mime) => mime.toLowerCase().startsWith('audio/');

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -441,7 +441,7 @@ class HomePageController extends ChangeNotifier {
       preferences: _context.read<BusinessPreferences>(),
       ocrHandler: (imagePaths) =>
           _ocrService.getOcrTextForImages(imagePaths, _context),
-      geminiThoughtSignatureHandler: _appendGeminiThoughtSignatureForApi,
+      geminiThoughtSignatureProvider: _geminiThoughtSignatureForApi,
     );
     _messageBuilderService.ocrTextWrapper = _ocrService.wrapOcrBlock;
     _generationController = GenerationController(
@@ -2887,15 +2887,8 @@ class HomePageController extends ChangeNotifier {
     }
   }
 
-  String _appendGeminiThoughtSignatureForApi(
-    ChatMessage message,
-    String content,
-  ) {
-    return _streamController.appendGeminiThoughtSignatureForApi(
-      message,
-      content,
-    );
-  }
+  String? _geminiThoughtSignatureForApi(ChatMessage message) =>
+      _streamController.geminiThoughtSignatureForApi(message);
 
   Future<void> _onMcpChanged() async {
     // Kept for potential future use

--- a/lib/features/home/controllers/stream_controller.dart
+++ b/lib/features/home/controllers/stream_controller.dart
@@ -5,6 +5,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/reasoning_payload.dart';
 import '../../../core/providers/settings_provider.dart';
 import '../../../core/services/api/chat_api_service.dart';
+import '../../../core/services/api/providers/gemini_thought_signature.dart';
 import '../../../core/services/chat/chat_service.dart';
 import '../../../core/services/generation_engine.dart';
 import '../../../core/services/streaming_content_notifier.dart';
@@ -265,16 +266,30 @@ class StreamController {
   // Gemini Thought Signature Handling
   // ============================================================================
 
-  /// Capture and strip Gemini thought signature from content.
+  /// Capture and strip Gemini thought signature from content; persists the
+  /// normalized payload (bare JSON) so follow-up API calls in the conversation
+  /// can echo it without leaking the comment into message text.
   String captureGeminiThoughtSignature(String content, String messageId) {
     if (content.isEmpty) return content;
     final m = _geminiThoughtSigRe.firstMatch(content);
     if (m != null) {
       final sig = m.group(0) ?? '';
       if (sig.isNotEmpty) {
-        if (_geminiThoughtSigs[messageId] != sig) {
-          _geminiThoughtSigs[messageId] = sig;
-          unawaited(_chatService.setGeminiThoughtSignature(messageId, sig));
+        final meta = decodeGeminiThoughtSignature(sig, cleanedText: '');
+        final payload = meta == null
+            ? ''
+            : encodeGeminiThoughtSignature(
+                textKey: meta.textKey,
+                textValue: meta.textValue,
+                imageSigs: meta.images,
+              );
+        if (payload.isNotEmpty) {
+          if (_geminiThoughtSigs[messageId] != payload) {
+            _geminiThoughtSigs[messageId] = payload;
+            unawaited(
+              _chatService.setGeminiThoughtSignature(messageId, payload),
+            );
+          }
         }
       }
       content = content.replaceAll(_geminiThoughtSigRe, '').trimRight();
@@ -282,20 +297,14 @@ class StreamController {
     return content;
   }
 
-  /// Append Gemini thought signature for API calls (when sending history).
-  String appendGeminiThoughtSignatureForApi(
-    ChatMessage message,
-    String content,
-  ) {
-    String? sig = _geminiThoughtSigs[message.id];
-    sig ??= _chatService.getGeminiThoughtSignature(message.id);
-    if (sig != null &&
-        sig.isNotEmpty &&
-        !content.contains('gemini_thought_signatures:')) {
-      if (content.isEmpty) return sig;
-      return '$content\n$sig';
-    }
-    return content;
+  /// The Gemini thought signature payload for [message], or null. Reads the
+  /// in-memory capture first, then the persisted row. Legacy comment shells
+  /// are decoded at the Google history builder, so both formats are
+  /// faithfully returned as-is.
+  String? geminiThoughtSignatureForApi(ChatMessage message) {
+    final sig = _geminiThoughtSigs[message.id];
+    if (sig != null && sig.isNotEmpty) return sig;
+    return _chatService.getGeminiThoughtSignature(message.id);
   }
 
   /// Clear Gemini thought signatures map.

--- a/lib/features/home/services/message_builder_service.dart
+++ b/lib/features/home/services/message_builder_service.dart
@@ -56,7 +56,7 @@ class MessageBuilderService {
     required this.contextProvider,
     required BusinessPreferences preferences,
     this.ocrHandler,
-    this.geminiThoughtSignatureHandler,
+    this.geminiThoughtSignatureProvider,
   }) : _worldBookStore = WorldBookStore.shared(preferences),
        _instructionInjectionStore = InstructionInjectionStore.shared(
          preferences,
@@ -73,9 +73,10 @@ class MessageBuilderService {
   /// OCR text wrapper function
   String Function(String ocrText)? ocrTextWrapper;
 
-  /// Handler to append Gemini thought signatures for API calls
-  final String Function(ChatMessage message, String content)?
-  geminiThoughtSignatureHandler;
+  /// Handler to provide the Gemini thought signature payload (artifact JSON or
+  /// legacy comment shell) for API calls; carried under an internal key so the
+  /// message text stays clean for every provider.
+  final String? Function(ChatMessage message)? geminiThoughtSignatureProvider;
 
   final WorldBookStore _worldBookStore;
   final InstructionInjectionStore _instructionInjectionStore;
@@ -230,9 +231,6 @@ class MessageBuilderService {
       }
 
       var content = m.content;
-      if (m.role == 'assistant' && geminiThoughtSignatureHandler != null) {
-        content = geminiThoughtSignatureHandler!(m, content);
-      }
       if (content.isEmpty) continue;
       final isUser = m.role != 'assistant';
       if (isUser && content.trim().isNotEmpty) {
@@ -248,6 +246,12 @@ class MessageBuilderService {
         'role': isUser ? 'user' : 'assistant',
         'content': content,
       };
+      if (!isUser && geminiThoughtSignatureProvider != null) {
+        final payload = geminiThoughtSignatureProvider!(m);
+        if (payload != null && payload.trim().isNotEmpty) {
+          message[multimodalInternalGeminiThoughtSignatureKey] = payload;
+        }
+      }
       if (isUser) {
         message[_isPresetKey] = m.isPreset;
         message[_timestampKey] = m.timestamp.toIso8601String();

--- a/test/features/home/services/message_builder_service_test.dart
+++ b/test/features/home/services/message_builder_service_test.dart
@@ -5,8 +5,10 @@ import 'package:Cuplivo/core/models/assistant.dart';
 import 'package:Cuplivo/core/models/chat_message.dart';
 import 'package:Cuplivo/core/models/conversation.dart';
 import 'package:Cuplivo/core/models/workspace.dart';
+import 'package:Cuplivo/core/services/api/providers/gemini_thought_signature.dart';
 import 'package:Cuplivo/core/services/chat/chat_service.dart';
 import 'package:Cuplivo/core/services/workspace/workspace_execution_context.dart';
+import 'package:Cuplivo/core/utils/multimodal_input_utils.dart';
 import 'package:Cuplivo/features/home/services/message_builder_service.dart';
 import 'package:Cuplivo/core/database/business_preferences.dart';
 
@@ -320,6 +322,77 @@ void main() {
       // carry it.
       expect(assistantToolMessage.containsKey('reasoning_details'), isFalse);
       expect(finalAssistantMessage['reasoning_details'], reasoningDetails);
+    });
+
+    test('Gemini 签名经内部 key 只挂最终 assistant 消息', () {
+      final payload = encodeGeminiThoughtSignature(
+        textKey: 'thoughtSignature',
+        textValue: 'sig-stored',
+      );
+      final service = MessageBuilderService(
+        preferences: businessPrefs,
+        chatService: _FakeChatService({
+          'a1': [
+            {
+              'id': 'call_1',
+              'name': 'get_weather',
+              'arguments': {'location': 'Hangzhou'},
+              'content': 'Cloudy 7~13°C',
+            },
+          ],
+        }),
+        contextProvider: _FakeBuildContext(),
+        geminiThoughtSignatureProvider: (message) =>
+            message.id == 'a1' ? payload : null,
+      );
+
+      final apiMessages = service.buildApiMessages(
+        messages: [
+          _message(id: 'u1', role: 'user', content: '杭州明天天气怎么样？'),
+          _message(id: 'a1', role: 'assistant', content: '明天多云，7 到 13 度。'),
+          _message(id: 'a2', role: 'assistant', content: '好的，随时再问。'),
+        ],
+        versionSelections: const {},
+        currentConversation: Conversation(title: 'test'),
+        includeToolMessages: true,
+      );
+
+      final signedMessage = apiMessages.firstWhere(
+        (message) => message['content'] == '明天多云，7 到 13 度。',
+      );
+      final toolCallStub = apiMessages.firstWhere(
+        (message) =>
+            message['role'] == 'assistant' && message['tool_calls'] is List,
+      );
+      final unsignedMessage = apiMessages.firstWhere(
+        (message) => message['content'] == '好的，随时再问。',
+      );
+      final userMessage = apiMessages.firstWhere(
+        (message) => message['role'] == 'user',
+      );
+
+      expect(
+        signedMessage[multimodalInternalGeminiThoughtSignatureKey],
+        payload,
+      );
+      expect(
+        signedMessage[multimodalInternalGeminiThoughtSignatureKey],
+        isNot(contains('<!--')),
+      );
+      expect(
+        toolCallStub.containsKey(multimodalInternalGeminiThoughtSignatureKey),
+        isFalse,
+      );
+      expect(
+        unsignedMessage.containsKey(
+          multimodalInternalGeminiThoughtSignatureKey,
+        ),
+        isFalse,
+      );
+      expect(
+        userMessage.containsKey(multimodalInternalGeminiThoughtSignatureKey),
+        isFalse,
+      );
     });
 
     test('恢复工具回答续写时只发送 tool call 和 tool result', () {

--- a/test/gemini_thought_signature_artifact_test.dart
+++ b/test/gemini_thought_signature_artifact_test.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+import 'package:Cuplivo/core/services/api/providers/gemini_thought_signature.dart';
+import 'package:Cuplivo/core/utils/multimodal_input_utils.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiTest',
+    enabled: true,
+    name: 'GeminiTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+String _streamChunk(List<Map<String, dynamic>> parts, {String? finishReason}) {
+  return 'data: ${jsonEncode({
+    'candidates': [
+      {
+        'content': {'parts': parts},
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+    'usageMetadata': {'promptTokenCount': 1, 'candidatesTokenCount': 1, 'totalTokenCount': 2},
+  })}\n\n';
+}
+
+const _legacyComment =
+    '\n<!-- gemini_thought_signatures:{"text":{"k":"thoughtSignature","v":"sig-legacy"}} -->';
+
+void main() {
+  group('Gemini thought signature payload', () {
+    test('encodes as bare JSON', () {
+      final payload = encodeGeminiThoughtSignature(
+        textKey: 'thoughtSignature',
+        textValue: 'sig-text',
+        imageSigs: const [
+          {'k': 'thoughtSignature', 'v': 'sig-img'},
+        ],
+      );
+      expect(jsonDecode(payload), {
+        'text': {'k': 'thoughtSignature', 'v': 'sig-text'},
+        'images': [
+          {'k': 'thoughtSignature', 'v': 'sig-img'},
+        ],
+      });
+      expect(encodeGeminiThoughtSignature(), '');
+    });
+
+    test('a legacy comment re-encodes as bare JSON', () {
+      final legacy = extractGeminiThoughtMeta('Answer.$_legacyComment');
+      final migrated = encodeGeminiThoughtSignature(
+        textKey: legacy.textKey,
+        textValue: legacy.textValue,
+        imageSigs: legacy.images,
+      );
+      expect(legacy.cleanedText, 'Answer.');
+      expect(migrated, startsWith('{'));
+      expect(decodeGeminiThoughtSignature(migrated)?.textValue, 'sig-legacy');
+    });
+
+    test('collects the signature from a trailing empty part', () {
+      final payload = collectGeminiThoughtSignatureFromParts([
+        {
+          'text': 'Thinking',
+          'thought': true,
+          'thoughtSignature': 'sig-thought',
+        },
+        {'text': 'Answer.'},
+        {'text': '', 'thoughtSignature': 'sig-trailing'},
+      ]);
+      expect(jsonDecode(payload), {
+        'text': {'k': 'thoughtSignature', 'v': 'sig-trailing'},
+      });
+    });
+
+    test('decodes bare JSON and the legacy comment alike', () {
+      final fresh = decodeGeminiThoughtSignature(
+        '{"text":{"k":"thoughtSignature","v":"sig-new"}}',
+      );
+      expect(fresh?.textValue, 'sig-new');
+
+      final legacy = decodeGeminiThoughtSignature(_legacyComment);
+      expect(legacy?.textKey, 'thoughtSignature');
+      expect(legacy?.textValue, 'sig-legacy');
+
+      expect(decodeGeminiThoughtSignature(''), isNull);
+      expect(decodeGeminiThoughtSignature('not a signature'), isNull);
+      expect(decodeGeminiThoughtSignature('{}'), isNull);
+    });
+  });
+
+  group('Gemini thought signature request transport', () {
+    late HttpServer server;
+    late List<Map<String, dynamic>> requestBodies;
+    late List<Map<String, dynamic>> responseParts;
+    late String? responseFinishReason;
+
+    setUp(() async {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      requestBodies = [];
+      responseParts = [
+        {'text': 'Answer.', 'thoughtSignature': 'sig-answer'},
+      ];
+      responseFinishReason = 'STOP';
+      server.listen((request) async {
+        final body = await utf8.decoder.bind(request).join();
+        requestBodies.add(jsonDecode(body) as Map<String, dynamic>);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        request.response.write(
+          _streamChunk(responseParts, finishReason: responseFinishReason),
+        );
+        request.response.write('data: [DONE]');
+        await request.response.close();
+      });
+    });
+
+    tearDown(() => server.close(force: true));
+
+    Future<List<ChatStreamChunk>> send(List<Map<String, dynamic>> messages) {
+      return ChatApiService.sendMessageStream(
+        config: _geminiConfig(
+          'http://${server.address.address}:${server.port}/v1beta',
+        ),
+        modelId: 'gemini-3.1-pro-preview',
+        messages: messages,
+      ).toList();
+    }
+
+    List<Map> modelParts(Map<String, dynamic> body) {
+      final contents = (body['contents'] as List).cast<Map>();
+      return (contents[1]['parts'] as List).cast<Map>();
+    }
+
+    test(
+      'keeps the signature Gemini 3 hangs on a trailing empty part',
+      () async {
+        responseParts = [
+          {
+            'text': 'Thinking',
+            'thought': true,
+            'thoughtSignature': 'sig-thought',
+          },
+          {'text': 'Answer.'},
+          {'text': '', 'thoughtSignature': 'sig-trailing'},
+        ];
+
+        final chunks = await send(const [
+          {'role': 'user', 'content': 'Hello'},
+        ]);
+
+        final comment = chunks
+            .map((c) => c.content)
+            .firstWhere(
+              (c) => c.contains('gemini_thought_signatures:'),
+              orElse: () => '',
+            );
+        expect(comment, isNotEmpty);
+        final meta = extractGeminiThoughtMeta(comment);
+        expect(meta.textValue, 'sig-trailing');
+      },
+    );
+
+    test('replays a stored signature from the internal key', () async {
+      await send([
+        {'role': 'user', 'content': 'Hello'},
+        {
+          'role': 'assistant',
+          'content': 'Earlier answer.',
+          multimodalInternalGeminiThoughtSignatureKey:
+              encodeGeminiThoughtSignature(
+                textKey: 'thoughtSignature',
+                textValue: 'sig-stored',
+              ),
+        },
+        {'role': 'user', 'content': 'Go on'},
+      ]);
+
+      final body = requestBodies.single;
+      final model = modelParts(body).single;
+      expect(model['text'], 'Earlier answer.');
+      expect(model['thoughtSignature'], 'sig-stored');
+      expect(
+        jsonEncode(body),
+        isNot(contains(multimodalInternalGeminiThoughtSignatureKey)),
+      );
+      expect(jsonEncode(body), isNot(contains('<!--')));
+      expect(jsonEncode(body), isNot(contains('gemini_thought_signatures:')));
+    });
+
+    test('still reads a legacy comment left in the message text', () async {
+      await send(const [
+        {'role': 'user', 'content': 'Hello'},
+        {'role': 'assistant', 'content': 'Earlier answer.$_legacyComment'},
+        {'role': 'user', 'content': 'Go on'},
+      ]);
+
+      final model = modelParts(requestBodies.single).single;
+      expect(model['text'], 'Earlier answer.');
+      expect(model['thoughtSignature'], 'sig-legacy');
+    });
+
+    test('preserves signed parts order across a tool-call round', () async {
+      await server.close(force: true);
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((request) async {
+        final body = await utf8.decoder.bind(request).join();
+        requestBodies.add(jsonDecode(body) as Map<String, dynamic>);
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        if (requestBodies.length == 1) {
+          request.response.write(
+            _streamChunk([
+              {'text': '', 'thoughtSignature': 'sig-text'},
+              {
+                'functionCall': {
+                  'name': 'fetch_markdown',
+                  'args': {'url': 'https://example.com'},
+                },
+                'thoughtSignature': 'sig-fetch',
+              },
+            ]),
+          );
+        } else {
+          request.response.write(
+            _streamChunk([
+              {'text': 'ok'},
+            ], finishReason: 'STOP'),
+          );
+        }
+        request.response.write('data: [DONE]');
+        await request.response.close();
+      });
+
+      await send(const [
+        {'role': 'user', 'content': 'Fetch it and summarize.'},
+      ]);
+
+      expect(requestBodies.length, 2);
+      final parts = modelParts(requestBodies[1]);
+      expect(parts.length, 2);
+      expect(parts[0]['text'], '');
+      expect(parts[0]['thoughtSignature'], 'sig-text');
+      expect(parts[1]['functionCall']['name'], 'fetch_markdown');
+      expect(parts[1]['thoughtSignature'], 'sig-fetch');
+      final body = jsonEncode(requestBodies[1]);
+      expect(body, isNot(contains('<!--')));
+      expect(body, isNot(contains('gemini_thought_signatures:')));
+      expect(
+        body,
+        isNot(contains(multimodalInternalGeminiThoughtSignatureKey)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概述

将上游 Kelivo **PR #953**（`feat(gemini): store thought signatures as a provider artifact, not in the text`，27982ac7，v1.2.5）的核心行为移植到 Cuplivo（重构前架构）。本仓库 #220 / #260 与上游 #908 / #639 / #487 同源：Gemini 3 的 thought_signature 在工具调用历史中的缺失/泄漏导致请求 400。

## 修复内容

1. **文本轮签名从未被收集**（上游 6d7716e5）
   - Gemini 3 将整轮签名挂在 `text: ''` 尾部 part 上，旧实现要求 part 有正文（`hasText` / `t.isNotEmpty`）才收集 → 签名丢失 → 后续轮次 400（"Function call is missing a thought_signature in functionCall parts"）。
   - 流式 decoder 与非流式 collect 均已修复：文本 part 分类不再要求正文，并按 turn 只保留首个签名。

2. **签名不再以 HTML 注释形式进入消息文本/请求体**
   - 旧实现：签名以 `<!-- gemini_thought_signatures:{json} -->` 注入正文 → 回放时拼接进 content → **所有供应商/网关**（含 OAI 兼容网关）都会收到该注释（切渠道 400、网关空回风险）。
   - 新实现：存储改为**裸 JSON payload**（`{"text":{"k","v"},"images":[…]}`）写入既有的 `gemini_thought_signature_rows`；回放经内部 key `_kelivo_gemini_thought_signature` 传递，仅 Gemini 历史构建器读取；其他 provider 逐字段拷贝 message map，key 不上线。

3. **旧数据兼容**
   - 读取端同时识别裸 JSON 与旧注释壳；正文仍残留注释的旧消息在恢复会话时剥离并归一化入库（StreamController + GenerationEngine 双捕获管线同步）。

## 测试

- 新增 `test/gemini_thought_signature_artifact_test.dart`（8 例）：
  - codec：裸 JSON 编码 / 旧注释重编码 / 尾部空 part 收集 / 双格式解码 + 垃圾数据 → null
  - HttpServer E2E：末尾 `text:''` 签名被收集回放；内部 key 回放且请求体无 `<!--` / `gemini_thought_signatures:` / `_kelivo_gemini_thought_signature`；旧注释正文回放；混合工具轮（text + functionCall）part 顺序与签名保持
- `dart analyze --fatal-infos lib test`：0 issues
- 相关子集测试 48 例通过

## 明确的非目标 / 残余边界

- **#264（OAI 记忆网关调用工具空回）不在本次范围**：上游无对应修复（类似 issue #209/#527/#560/#820 仍开放）。`supportsGoogleOpenAIThoughtSignatures`（上游 537ef396，OpenAI 兼容口 Gemini 签名传输）亦未移植。
- **DB schema 无变更**：沿用 `gemini_thought_signature_rows`，未移植 ProviderArtifact 基础设施。
- **跨版本兼容**：旧版 App 读取裸 JSON payload（降级运行 / 跨设备同步）不会解析——与上游 #953 同款取舍，跨设备同步前请先升级。
- dummy 兜底（`_ensureGeminiFunctionCallThoughtSig`）保留作为 legacy 历史安全网。
- 建议真机验证：Gemini 3 + 内置搜索 + skills 混用多轮（#260）；同会话在两个 Google 渠道间切换（#220）。

## 关联

Closes #220
Closes #260
（#264 保持开放）

来源：https://github.com/Chevey339/kelivo/pull/953
