### PR TITLE
fix(workspace): make Android dependency installs reliable

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     <!-- Photo access for picking images -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- Read the active network's DNS servers for the workspace sandbox resolver. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.VIBRATE"/>
     <!-- Foreground service + notifications for background execution (Android only) -->

--- a/android/app/src/main/kotlin/com/cup11/cuplivo/LinuxSandboxPlugin.kt
+++ b/android/app/src/main/kotlin/com/cup11/cuplivo/LinuxSandboxPlugin.kt
@@ -2,6 +2,7 @@ package com.cup11.cuplivo
 
 import android.app.Activity
 import android.content.Context
+import android.net.ConnectivityManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -171,6 +172,24 @@ class LinuxSandboxPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Activ
         }
         val linuxDir = File(workspace, ".sandbox/linux")
         result.success(rootfsHasCompatibleShell(linuxDir, currentSandboxAbi()))
+      }
+      "refreshDns" -> {
+        val workspace = call.argument<String>("workspacePath")
+        if (workspace.isNullOrBlank()) {
+          result.error("bad_args", "workspacePath required", null)
+          return
+        }
+        val linuxDir = File(workspace, ".sandbox/linux")
+        if (!linuxDir.isDirectory) {
+          result.success(false)
+          return
+        }
+        try {
+          patchDns(linuxDir, force = true)
+          result.success(true)
+        } catch (e: Exception) {
+          result.error("dns_refresh_failed", e.message ?: "failed", null)
+        }
       }
       "extractRootfs" -> {
         val workspace = call.argument<String>("workspacePath")
@@ -545,20 +564,64 @@ class LinuxSandboxPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, Activ
     }
   }
 
-  /** Rewrite resolv.conf unless it already points at a usable DNS. */
-  private fun patchDns(linuxDir: File) {
+  /**
+   * Rewrite resolv.conf with the active network's DNS first and the public
+   * resolvers as fallback. The tarball ships an empty resolv.conf, so the
+   * first extract always writes; [force] (refreshDns) rewrites an existing
+   * file so a device that changed networks after extraction picks up the
+   * current resolver instead of a dead first one.
+   */
+  private fun patchDns(linuxDir: File, force: Boolean = false) {
     val etc = File(linuxDir, "etc")
     etc.mkdirs()
     val resolv = File(etc, "resolv.conf")
-    val body = if (resolv.isFile) resolv.readText() else ""
-    val hasNameserver = body.lineSequence().any { it.trimStart().startsWith("nameserver") }
-    val pointsAtStub = body.contains("127.0.0.53") || body.contains("systemd")
-    if (hasNameserver && !pointsAtStub) return
+    if (!force && resolv.isFile) {
+      val body = try {
+        resolv.readText()
+      } catch (e: Exception) {
+        ""
+      }
+      val hasNameserver = body.lineSequence().any { it.trimStart().startsWith("nameserver") }
+      val pointsAtStub = body.contains("127.0.0.53") || body.contains("systemd")
+      if (hasNameserver && !pointsAtStub) return
+    }
     resolv.writeText(
       buildString {
-        PUBLIC_DNS.forEach { append("nameserver $it\n") }
+        resolveNameservers().forEach { append("nameserver $it\n") }
       },
     )
+  }
+
+  /**
+   * Active-network DNS (Android resolver) first, then PUBLIC_DNS as
+   * fallback, capped at glibc MAXNS (3). glibc tries resolvers in order, so
+   * a blackholed first resolver would make every lookup pay its full
+   * timeout. IPv4 resolvers go first: on some mobile networks a hanging
+   * AAAA query stalls lookups even when IPv4 works.
+   */
+  private fun resolveNameservers(): List<String> {
+    val system = mutableListOf<String>()
+    try {
+      val cm =
+        appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+      val link = cm?.activeNetwork?.let { cm.getLinkProperties(it) }
+      link?.dnsServers?.forEach { dns ->
+        val host = dns.hostAddress ?: return@forEach
+        if (host.contains(':')) system.add(host) else system.add(0, host)
+      }
+    } catch (t: Throwable) {
+      Log.w(TAG, "query system DNS: ${t.message}")
+    }
+    val out = LinkedHashSet<String>()
+    for (dns in system) {
+      out.add(dns)
+      if (out.size >= 3) break
+    }
+    for (dns in PUBLIC_DNS) {
+      out.add(dns)
+      if (out.size >= 3) break
+    }
+    return out.toList()
   }
 
   private fun ensureGuestDirs(linuxDir: File) {

--- a/lib/core/services/workspace/linux_sandbox_service.dart
+++ b/lib/core/services/workspace/linux_sandbox_service.dart
@@ -303,6 +303,12 @@ class LinuxSandboxService {
       <String, CancelToken>{};
   int _requestCounter = 0;
 
+  /// Ref-counted keep-screen-on: the window flag is activity-global, so the
+  /// dependency-install queue (detail page) and the terminal session both
+  /// hold it concurrently; the flag stays on while any holder is active and
+  /// turns off only when the last one releases.
+  int _keepScreenOnCount = 0;
+
   String _newRequestId(String prefix) {
     _requestCounter++;
     return '${prefix}_${DateTime.now().microsecondsSinceEpoch}_$_requestCounter';
@@ -1000,7 +1006,10 @@ class LinuxSandboxService {
       ),
       PackageInstallStep(
         stage: 'update',
-        timeoutSeconds: 600,
+        // ports.ubuntu.com can be slow enough on 32-bit/arm64 that 600s
+        // kills a healthy slow-but-progressing `apt-get update` on a low-end
+        // device (issue #531); the native exec cap stays at 3600s.
+        timeoutSeconds: 1200,
         command:
             '${mirrorSetup.isEmpty ? '' : mirrorSetup}'
             'apt-get $lockTimeout update -y',
@@ -1060,6 +1069,78 @@ class LinuxSandboxService {
         "'$mirrorUrl/v$alpineVersion/community' > /etc/apk/repositories && ";
   }
 
+  /// Android apt repository base URLs for named sources by sandbox ABI.
+  ///
+  /// Ubuntu serves non-amd64 architectures (armhf, arm64) from the
+  /// `ubuntu-ports` mirror family; amd64 from `ubuntu`.
+  static const Map<String, Map<String, String>> aptMirrorBaseUrls = {
+    'arm64-v8a': {
+      'tuna': 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+      'aliyun': 'https://mirrors.aliyun.com/ubuntu-ports',
+    },
+    'armeabi-v7a': {
+      'tuna': 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+      'aliyun': 'https://mirrors.aliyun.com/ubuntu-ports',
+    },
+    'x86_64': {
+      'tuna': 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu',
+      'aliyun': 'https://mirrors.aliyun.com/ubuntu',
+    },
+  };
+
+  /// Android apt mirror setup: rewrite the deb822 sources file the Ubuntu
+  /// base rootfs ships (`/etc/apt/sources.list.d/ubuntu.sources`) with
+  /// [mirrorUrl] as the sole repository, and drop the legacy one-line
+  /// `/etc/apt/sources.list` (noble only carries a comment stub there, but a
+  /// leftover one-line file would add the default mirror back as a second
+  /// source). All four suites and the full component set are kept so the
+  /// mirrored archive behaves like the default sources. [mirrorUrl] must be
+  /// the repository base (e.g. `https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports`)
+  /// and must have been passed through [_sanitizeMirrorUrl].
+  static String aptMirrorSetup(String mirrorUrl) {
+    final buffer = StringBuffer()
+      ..writeln("cat > /etc/apt/sources.list.d/ubuntu.sources <<'EOF'")
+      ..writeln('Types: deb')
+      ..writeln('URIs: $mirrorUrl/')
+      ..writeln('Suites: noble noble-updates noble-backports')
+      ..writeln('Components: main universe restricted multiverse')
+      ..writeln('Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg')
+      ..writeln()
+      ..writeln('Types: deb')
+      ..writeln('URIs: $mirrorUrl/')
+      ..writeln('Suites: noble-security')
+      ..writeln('Components: main universe restricted multiverse')
+      ..writeln('Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg')
+      ..writeln('EOF')
+      ..writeln('rm -f /etc/apt/sources.list');
+    return buffer.toString();
+  }
+
+  /// Resolve the Android apt repository base URL a per-dependency install
+  /// should use for [pref] on [abi]. Returns null for 'auto'/'official'
+  /// (keep the rebuilt sources from the rootfs) and for unknown named
+  /// sources; named sources fall back to the ABI mirror map, a non-empty
+  /// custom URL is sanitized and used as-is, and a malformed custom URL
+  /// throws so the user sees the misconfiguration instead of a silent
+  /// slow-and-failing update. Exposed for tests.
+  static String? resolveAptMirrorFor({
+    required String abi,
+    required DependencyInstallPref pref,
+  }) {
+    final named = aptMirrorBaseUrls[abi]?[pref.sourceId.trim()];
+    if (named != null) return named;
+    if (pref.sourceId == 'custom' &&
+        pref.customUrl != null &&
+        pref.customUrl!.trim().isNotEmpty) {
+      final mirror = _sanitizeMirrorUrl(pref.customUrl!.trim());
+      if (mirror == null) {
+        throw StateError('Invalid custom mirror URL');
+      }
+      return mirror;
+    }
+    return null;
+  }
+
   static String packageNamesForDependency(
     String dependencyId, {
     required bool ios,
@@ -1114,20 +1195,30 @@ class LinuxSandboxService {
     final ios = Platform.isIOS;
     final packages = packageNamesForDependency(depId, ios: ios);
     var mirrorSetup = '';
-    if (pref.sourceId == 'custom' &&
-        pref.customUrl != null &&
-        pref.customUrl!.trim().isNotEmpty) {
-      final url = _sanitizeMirrorUrl(pref.customUrl!.trim());
-      if (url == null) {
-        throw StateError('Invalid custom mirror URL');
+    if (ios) {
+      if (pref.sourceId == 'custom' &&
+          pref.customUrl != null &&
+          pref.customUrl!.trim().isNotEmpty) {
+        final url = _sanitizeMirrorUrl(pref.customUrl!.trim());
+        if (url == null) {
+          throw StateError('Invalid custom mirror URL');
+        }
+        mirrorSetup = apkMirrorSetup(url);
+      } else {
+        final named = apkMirrorBaseUrls[pref.sourceId.trim()];
+        if (named != null) {
+          mirrorSetup = apkMirrorSetup(named);
+        }
       }
-      mirrorSetup = ios
-          ? apkMirrorSetup(url)
-          : "printf '%s\\n' 'deb $url noble main universe' > /etc/apt/sources.list && ";
-    } else if (ios) {
-      final named = apkMirrorBaseUrls[pref.sourceId.trim()];
-      if (named != null) {
-        mirrorSetup = apkMirrorSetup(named);
+    } else {
+      // Android: a stored named source must actually rewrite the apt
+      // sources, or apt keeps fetching the ports.ubuntu.com default shipped
+      // in the rootfs deb822 file and the whole `apt-get update` stalls on
+      // slow paths then fails the step timeout (issue #531).
+      final abi = await detectAbi();
+      final mirror = resolveAptMirrorFor(abi: abi, pref: pref);
+      if (mirror != null) {
+        mirrorSetup = aptMirrorSetup(mirror);
       }
     }
     final steps = ios
@@ -1145,6 +1236,13 @@ class LinuxSandboxService {
                 ? 2700
                 : 1800,
           );
+    if (Platform.isAndroid) {
+      // Re-patch the resolver before touching the network: the rootfs was
+      // fixed at extraction time with the DNS active then, and a device
+      // that changed networks since keeps a dead first resolver that makes
+      // every lookup pay its full timeout (issue #531).
+      await refreshSandboxDns(workspaceHostPath);
+    }
     final requestId = _newRequestId('install_$depId');
     await _withWorkspaceExecution<void>(
       workspaceHostPath: workspaceHostPath,
@@ -1328,6 +1426,50 @@ class LinuxSandboxService {
       map,
       fallbackWorkingDirectory: workspaceHostPath,
     );
+  }
+
+  /// Refresh the guest resolv.conf with the host's current resolvers
+  /// (active-network DNS first, public DNS fallback). The rootfs is patched
+  /// once at extraction; a device that changed networks afterwards keeps a
+  /// stale resolver, so installs re-invoke this before apt touches the
+  /// network. Failures are non-fatal: the existing resolv.conf was written
+  /// by the same logic at extraction time.
+  Future<void> refreshSandboxDns(String workspaceHostPath) async {
+    if (!Platform.isAndroid) return;
+    try {
+      await _channel.invokeMethod<void>('refreshDns', {
+        'workspacePath': workspaceHostPath,
+      });
+    } on MissingPluginException {
+      // Custom/legacy build without native sandbox glue: installs will fail
+      // later with a clear 'runtime missing' state anyway.
+    } on PlatformException catch (e) {
+      debugPrint(
+        'LinuxSandboxService.refreshSandboxDns: ${e.code} ${e.message}',
+      );
+    } catch (e) {
+      debugPrint('LinuxSandboxService.refreshSandboxDns: $e');
+    }
+  }
+
+  /// Hold the keep-screen-on flag. Safe to call multiple times; each holder
+  /// pairs the call with [releaseKeepScreenOn].
+  Future<void> acquireKeepScreenOn() async {
+    _keepScreenOnCount++;
+    if (_keepScreenOnCount == 1) {
+      await setKeepScreenOn(true);
+    }
+  }
+
+  /// Release one keep-screen-on hold from [acquireKeepScreenOn]. The flag
+  /// turns off only when the last holder releases, so an install queue
+  /// finishing underneath an open terminal cannot switch the screen off
+  /// mid-session.
+  Future<void> releaseKeepScreenOn() async {
+    if (_keepScreenOnCount > 0) _keepScreenOnCount--;
+    if (_keepScreenOnCount == 0) {
+      await setKeepScreenOn(false);
+    }
   }
 
   Future<void> setKeepScreenOn(bool enabled) async {

--- a/lib/core/services/workspace/linux_sandbox_service.dart
+++ b/lib/core/services/workspace/linux_sandbox_service.dart
@@ -1061,6 +1061,33 @@ class LinuxSandboxService {
     'aliyun': 'https://mirrors.aliyun.com/alpine',
   };
 
+  /// Official Alpine repository base (what the bundled fakefs ships,
+  /// `tools/ios_rootfs/prepare_alpine_fakefs.py`).
+  static const String apkOfficialBaseUrl =
+      'https://dl-cdn.alpinelinux.org/alpine';
+
+  /// Resolve the Alpine repository base URL a per-dependency install must
+  /// use for [pref]. Named sources map to [apkMirrorBaseUrls], a non-empty
+  /// custom URL is sanitized and used as-is, and every other mode ('auto',
+  /// 'official', unknown or empty custom) resolves to [apkOfficialBaseUrl] so
+  /// a previous dependency's mirror is never left active for the next one; a
+  /// malformed custom URL throws instead of silently falling back. Exposed
+  /// for tests.
+  static String resolveApkMirrorFor(DependencyInstallPref pref) {
+    final named = apkMirrorBaseUrls[pref.sourceId.trim()];
+    if (named != null) return named;
+    if (pref.sourceId == 'custom' &&
+        pref.customUrl != null &&
+        pref.customUrl!.trim().isNotEmpty) {
+      final mirror = _sanitizeMirrorUrl(pref.customUrl!.trim());
+      if (mirror == null) {
+        throw StateError('Invalid custom mirror URL');
+      }
+      return mirror;
+    }
+    return apkOfficialBaseUrl;
+  }
+
   /// apk mirror setup: rewrite /etc/apk/repositories for the bundled
   /// Alpine version. [mirrorUrl] must be the repository base (e.g.
   /// `https://mirrors.aliyun.com/alpine`).
@@ -1088,17 +1115,42 @@ class LinuxSandboxService {
     },
   };
 
+  /// Official Ubuntu repository base+security URLs by sandbox ABI, matching
+  /// what the corresponding ubuntu-base tarball ships (verified against
+  /// ubuntu-base-24.04.3): armhf/arm64 use `ports.ubuntu.com` for all suites,
+  /// amd64 splits security onto `security.ubuntu.com`.
+  static const Map<String, ({String base, String security})>
+  aptOfficialBaseUrls = {
+    'arm64-v8a': (
+      base: 'http://ports.ubuntu.com/ubuntu-ports',
+      security: 'http://ports.ubuntu.com/ubuntu-ports',
+    ),
+    'armeabi-v7a': (
+      base: 'http://ports.ubuntu.com/ubuntu-ports',
+      security: 'http://ports.ubuntu.com/ubuntu-ports',
+    ),
+    'x86_64': (
+      base: 'http://archive.ubuntu.com/ubuntu',
+      security: 'http://security.ubuntu.com/ubuntu',
+    ),
+  };
+
   /// Android apt mirror setup: rewrite the deb822 sources file the Ubuntu
   /// base rootfs ships (`/etc/apt/sources.list.d/ubuntu.sources`) with
   /// [mirrorUrl] as the sole repository, and drop the legacy one-line
   /// `/etc/apt/sources.list` (noble only carries a comment stub there, but a
   /// leftover one-line file would add the default mirror back as a second
   /// source). All four suites and the full component set are kept so the
-  /// mirrored archive behaves like the default sources. [mirrorUrl] must be
-  /// the repository base (e.g. `https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports`)
-  /// and must have been passed through [_sanitizeMirrorUrl].
-  static String aptMirrorSetup(String mirrorUrl) {
+  /// mirrored archive behaves like the default sources. [securityMirrorUrl]
+  /// defaults to [mirrorUrl] (mirrors serve every suite from one base); the
+  /// amd64 official setup passes a distinct security URL. The whole block is
+  /// run under `set -e` so a failed rewrite aborts `apt-get update` instead
+  /// of updating the package lists from stale or merged sources. [mirrorUrl]
+  /// must have been passed through [_sanitizeMirrorUrl].
+  static String aptMirrorSetup(String mirrorUrl, {String? securityMirrorUrl}) {
+    final security = securityMirrorUrl ?? mirrorUrl;
     final buffer = StringBuffer()
+      ..writeln('set -e')
       ..writeln("cat > /etc/apt/sources.list.d/ubuntu.sources <<'EOF'")
       ..writeln('Types: deb')
       ..writeln('URIs: $mirrorUrl/')
@@ -1107,7 +1159,7 @@ class LinuxSandboxService {
       ..writeln('Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg')
       ..writeln()
       ..writeln('Types: deb')
-      ..writeln('URIs: $mirrorUrl/')
+      ..writeln('URIs: $security/')
       ..writeln('Suites: noble-security')
       ..writeln('Components: main universe restricted multiverse')
       ..writeln('Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg')
@@ -1116,19 +1168,20 @@ class LinuxSandboxService {
     return buffer.toString();
   }
 
-  /// Resolve the Android apt repository base URL a per-dependency install
-  /// should use for [pref] on [abi]. Returns null for 'auto'/'official'
-  /// (keep the rebuilt sources from the rootfs) and for unknown named
-  /// sources; named sources fall back to the ABI mirror map, a non-empty
-  /// custom URL is sanitized and used as-is, and a malformed custom URL
-  /// throws so the user sees the misconfiguration instead of a silent
-  /// slow-and-failing update. Exposed for tests.
-  static String? resolveAptMirrorFor({
+  /// Resolve the Android apt repository URLs a per-dependency install must
+  /// use for [pref] on [abi]. Named sources map per ABI, a non-empty custom
+  /// URL is sanitized and used for all suites, and every other mode
+  /// ('auto', 'official', unknown or empty custom) resolves to the
+  /// ABI-appropriate official archive so a previous dependency's mirror is
+  /// never left active for the next one; a malformed custom URL throws so
+  /// the user sees the misconfiguration instead of a silent slow-and-failing
+  /// update. Exposed for tests.
+  static ({String base, String security}) resolveAptMirrorFor({
     required String abi,
     required DependencyInstallPref pref,
   }) {
     final named = aptMirrorBaseUrls[abi]?[pref.sourceId.trim()];
-    if (named != null) return named;
+    if (named != null) return (base: named, security: named);
     if (pref.sourceId == 'custom' &&
         pref.customUrl != null &&
         pref.customUrl!.trim().isNotEmpty) {
@@ -1136,9 +1189,9 @@ class LinuxSandboxService {
       if (mirror == null) {
         throw StateError('Invalid custom mirror URL');
       }
-      return mirror;
+      return (base: mirror, security: mirror);
     }
-    return null;
+    return aptOfficialBaseUrls[abi] ?? aptOfficialBaseUrls['arm64-v8a']!;
   }
 
   static String packageNamesForDependency(
@@ -1194,32 +1247,23 @@ class LinuxSandboxService {
     onProgress?.call(const SandboxInstallProgress(stage: 'installing'));
     final ios = Platform.isIOS;
     final packages = packageNamesForDependency(depId, ios: ios);
-    var mirrorSetup = '';
+    String mirrorSetup;
     if (ios) {
-      if (pref.sourceId == 'custom' &&
-          pref.customUrl != null &&
-          pref.customUrl!.trim().isNotEmpty) {
-        final url = _sanitizeMirrorUrl(pref.customUrl!.trim());
-        if (url == null) {
-          throw StateError('Invalid custom mirror URL');
-        }
-        mirrorSetup = apkMirrorSetup(url);
-      } else {
-        final named = apkMirrorBaseUrls[pref.sourceId.trim()];
-        if (named != null) {
-          mirrorSetup = apkMirrorSetup(named);
-        }
-      }
+      // Deterministic per-install repositories: a named or custom mirror of
+      // a previous dependency must never stay active for this one, so every
+      // mode (including 'official') rewrites /etc/apk/repositories.
+      mirrorSetup = apkMirrorSetup(resolveApkMirrorFor(pref));
     } else {
-      // Android: a stored named source must actually rewrite the apt
-      // sources, or apt keeps fetching the ports.ubuntu.com default shipped
-      // in the rootfs deb822 file and the whole `apt-get update` stalls on
-      // slow paths then fails the step timeout (issue #531).
+      // Android: every mode must deterministically establish the intended
+      // apt sources — or apt keeps the mirror the previous dependency left
+      // in the workspace-global deb822 file and `apt-get update` stalls on
+      // a stale/slow path then fails the step timeout (issue #531).
       final abi = await detectAbi();
       final mirror = resolveAptMirrorFor(abi: abi, pref: pref);
-      if (mirror != null) {
-        mirrorSetup = aptMirrorSetup(mirror);
-      }
+      mirrorSetup = aptMirrorSetup(
+        mirror.base,
+        securityMirrorUrl: mirror.security,
+      );
     }
     final steps = ios
         ? buildApkInstallSteps(

--- a/lib/features/workspace/controllers/dependency_install_controller.dart
+++ b/lib/features/workspace/controllers/dependency_install_controller.dart
@@ -160,6 +160,16 @@ class DependencyInstallController extends ChangeNotifier {
         }
       }
     } finally {
+      // Hand worker ownership back BEFORE the asynchronous release: an
+      // enqueue landing while `_keepScreenOn(false)` is awaiting the method
+      // channel must create a fresh queue and start its own pump, not be
+      // appended to a queue this pump is about to delete (review race: a
+      // dep enqueued during the release window was left idle forever).
+      _running.remove(workspaceId);
+      // The queue list is empty here (loop drained it); drop it so the
+      // controller does not accumulate per-workspace entries over the app
+      // lifetime. The next enqueue recreates it via putIfAbsent.
+      _queues.remove(workspaceId);
       try {
         await _keepScreenOn(false);
       } catch (e) {
@@ -167,11 +177,6 @@ class DependencyInstallController extends ChangeNotifier {
           'DependencyInstallController: keep-screen-on release failed: $e',
         );
       }
-      _running.remove(workspaceId);
-      // The queue list is empty here (loop drained it); drop it so the
-      // controller does not accumulate per-workspace entries over the app
-      // lifetime. The next enqueue recreates it via putIfAbsent.
-      _queues.remove(workspaceId);
     }
   }
 }

--- a/lib/features/workspace/controllers/dependency_install_controller.dart
+++ b/lib/features/workspace/controllers/dependency_install_controller.dart
@@ -27,17 +27,37 @@ typedef DependencyInstallRunner =
       void Function(SandboxInstallProgress)? onProgress,
     });
 
+/// Keep-screen-on switch for one workspace queue, injectable so tests can
+/// record holds without platform channels. [hold] true = acquire, false =
+/// release (ref-counted in the service, so multiple concurrent holders —
+/// other workspace queues and the terminal session — compose).
+typedef KeepScreenOnSwitch = Future<void> Function(bool hold);
+
 /// Serialized per-workspace dependency install queue.
 ///
 /// Users may tap "Install" on several dependencies in a row; each workspace
 /// runs at most one `apt-get` at a time (apt/dpkg are not concurrency-safe
 /// inside one rootfs), and the rest wait in order. Cross-workspace installs
 /// are independent (each workspace owns its own rootfs).
+///
+/// The queue itself owns the keep-screen-on hold (acquired when a workspace
+/// starts pumping, released when its queue drains — success or failure), so
+/// a long install keeps the screen on even after the observing detail page
+/// is gone, which aggressive One UI app freezing would otherwise stall
+/// mid-transaction.
 class DependencyInstallController extends ChangeNotifier {
-  DependencyInstallController({DependencyInstallRunner? installer})
-    : _runner = installer ?? LinuxSandboxService.instance.installPackage;
+  DependencyInstallController({
+    DependencyInstallRunner? installer,
+    KeepScreenOnSwitch? keepScreenOn,
+  }) : _runner = installer ?? LinuxSandboxService.instance.installPackage,
+       _keepScreenOn = keepScreenOn ?? _serviceKeepScreenOn;
+
+  static Future<void> _serviceKeepScreenOn(bool hold) => hold
+      ? LinuxSandboxService.instance.acquireKeepScreenOn()
+      : LinuxSandboxService.instance.releaseKeepScreenOn();
 
   final DependencyInstallRunner _runner;
+  final KeepScreenOnSwitch _keepScreenOn;
 
   final Map<String, List<_DepEntry>> _queues = <String, List<_DepEntry>>{};
   final Set<String> _running = <String>{};
@@ -95,6 +115,15 @@ class DependencyInstallController extends ChangeNotifier {
   Future<void> _pump(String workspaceId) async {
     if (!_running.add(workspaceId)) return;
     try {
+      try {
+        await _keepScreenOn(true);
+      } catch (e) {
+        // The hold failing must not abort installs: the queue can still
+        // work, it just stops keeping the screen up.
+        debugPrint(
+          'DependencyInstallController: keep-screen-on acquire failed: $e',
+        );
+      }
       final queue = _queues[workspaceId];
       while (queue != null && queue.isNotEmpty) {
         final entry = queue.removeAt(0);
@@ -131,11 +160,17 @@ class DependencyInstallController extends ChangeNotifier {
         }
       }
     } finally {
+      try {
+        await _keepScreenOn(false);
+      } catch (e) {
+        debugPrint(
+          'DependencyInstallController: keep-screen-on release failed: $e',
+        );
+      }
       _running.remove(workspaceId);
       // The queue list is empty here (loop drained it); drop it so the
       // controller does not accumulate per-workspace entries over the app
-      // lifetime. The next enqueue recreates it via putIfAbsent. No awaits
-      // below this point, so no enqueue can interleave.
+      // lifetime. The next enqueue recreates it via putIfAbsent.
       _queues.remove(workspaceId);
     }
   }

--- a/lib/features/workspace/pages/workspace_detail_page.dart
+++ b/lib/features/workspace/pages/workspace_detail_page.dart
@@ -43,6 +43,7 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   bool _depProbeFailed = false;
   bool _hasRuntime = true;
   int _depStatusRefreshGeneration = 0;
+  bool _keepScreenOnHeld = false;
   DependencyInstallController? _installController;
 
   @override
@@ -75,7 +76,53 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   void dispose() {
     routeObserver.unsubscribe(this);
     _installController?.removeListener(_onInstallChanged);
+    // Release a keep-screen-on held for dependency installs (the window
+    // flag is activity-global, ref-counted in the service, and the terminal
+    // page holds its own session flag through the same counter).
+    if (_keepScreenOnHeld) {
+      _keepScreenOnHeld = false;
+      LinuxSandboxService.instance.releaseKeepScreenOn().catchError((Object e) {
+        debugPrint('WorkspaceDetailPage.releaseKeepScreenOn(dispose): $e');
+      });
+    }
     super.dispose();
+  }
+
+  /// Keep the screen on while a dependency install is queued or running so
+  /// aggressive One UI app freezing (Samsung Android 14) cannot stall apt
+  /// mid-transaction, then release when the queue drains. The hold is
+  /// ref-counted together with the terminal page's session flag in
+  /// [LinuxSandboxService], so releasing here never clears a flag an open
+  /// terminal still owns.
+  void _syncKeepScreenOn(
+    DependencyInstallController controller,
+    String workspaceId,
+  ) {
+    final anyWorking = WorkspaceDependencyIds.ordered.any((id) {
+      final status = controller.statusFor(workspaceId, id);
+      return status == DepInstallStatus.queued ||
+          status == DepInstallStatus.installing;
+    });
+    if (anyWorking && !_keepScreenOnHeld) {
+      _keepScreenOnHeld = true;
+      unawaited(
+        LinuxSandboxService.instance.acquireKeepScreenOn().catchError((
+          Object e,
+        ) {
+          _keepScreenOnHeld = false;
+          debugPrint('WorkspaceDetailPage.acquireKeepScreenOn: $e');
+        }),
+      );
+    } else if (!anyWorking && _keepScreenOnHeld) {
+      _keepScreenOnHeld = false;
+      unawaited(
+        LinuxSandboxService.instance.releaseKeepScreenOn().catchError((
+          Object e,
+        ) {
+          debugPrint('WorkspaceDetailPage.releaseKeepScreenOn: $e');
+        }),
+      );
+    }
   }
 
   void _onInstallChanged() {
@@ -108,6 +155,7 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
         }
       }
     }
+    _syncKeepScreenOn(controller, ws.id);
     setState(() {});
   }
 

--- a/lib/features/workspace/pages/workspace_detail_page.dart
+++ b/lib/features/workspace/pages/workspace_detail_page.dart
@@ -43,7 +43,6 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   bool _depProbeFailed = false;
   bool _hasRuntime = true;
   int _depStatusRefreshGeneration = 0;
-  bool _keepScreenOnHeld = false;
   DependencyInstallController? _installController;
 
   @override
@@ -76,53 +75,7 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
   void dispose() {
     routeObserver.unsubscribe(this);
     _installController?.removeListener(_onInstallChanged);
-    // Release a keep-screen-on held for dependency installs (the window
-    // flag is activity-global, ref-counted in the service, and the terminal
-    // page holds its own session flag through the same counter).
-    if (_keepScreenOnHeld) {
-      _keepScreenOnHeld = false;
-      LinuxSandboxService.instance.releaseKeepScreenOn().catchError((Object e) {
-        debugPrint('WorkspaceDetailPage.releaseKeepScreenOn(dispose): $e');
-      });
-    }
     super.dispose();
-  }
-
-  /// Keep the screen on while a dependency install is queued or running so
-  /// aggressive One UI app freezing (Samsung Android 14) cannot stall apt
-  /// mid-transaction, then release when the queue drains. The hold is
-  /// ref-counted together with the terminal page's session flag in
-  /// [LinuxSandboxService], so releasing here never clears a flag an open
-  /// terminal still owns.
-  void _syncKeepScreenOn(
-    DependencyInstallController controller,
-    String workspaceId,
-  ) {
-    final anyWorking = WorkspaceDependencyIds.ordered.any((id) {
-      final status = controller.statusFor(workspaceId, id);
-      return status == DepInstallStatus.queued ||
-          status == DepInstallStatus.installing;
-    });
-    if (anyWorking && !_keepScreenOnHeld) {
-      _keepScreenOnHeld = true;
-      unawaited(
-        LinuxSandboxService.instance.acquireKeepScreenOn().catchError((
-          Object e,
-        ) {
-          _keepScreenOnHeld = false;
-          debugPrint('WorkspaceDetailPage.acquireKeepScreenOn: $e');
-        }),
-      );
-    } else if (!anyWorking && _keepScreenOnHeld) {
-      _keepScreenOnHeld = false;
-      unawaited(
-        LinuxSandboxService.instance.releaseKeepScreenOn().catchError((
-          Object e,
-        ) {
-          debugPrint('WorkspaceDetailPage.releaseKeepScreenOn: $e');
-        }),
-      );
-    }
   }
 
   void _onInstallChanged() {
@@ -155,7 +108,6 @@ class _WorkspaceDetailPageState extends State<WorkspaceDetailPage>
         }
       }
     }
-    _syncKeepScreenOn(controller, ws.id);
     setState(() {});
   }
 

--- a/lib/features/workspace/pages/workspace_terminal_page.dart
+++ b/lib/features/workspace/pages/workspace_terminal_page.dart
@@ -67,6 +67,7 @@ class _WorkspaceTerminalPageState extends State<WorkspaceTerminalPage>
   String? _startError;
   bool _exited = false;
   bool _starting = false;
+  bool _keepOnHeld = false;
   double _fontSize = 12;
   double _pinchBase = 12;
   StreamSubscription<bool>? _volumeSub;
@@ -97,16 +98,29 @@ class _WorkspaceTerminalPageState extends State<WorkspaceTerminalPage>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Re-assert on resume (the OS may have cleared the flag while the app
+    // was backgrounded), drop on any other transition. The hold participates
+    // in the service-wide refcount, so it never stomps a dependency-install
+    // hold held by the pages below this route.
     final keepOn =
         state == AppLifecycleState.resumed &&
         _gate == WorkspaceTerminalGate.ready &&
         !_exited;
-    unawaited(_sandbox.setKeepScreenOn(keepOn));
+    if (keepOn && !_keepOnHeld) {
+      _keepOnHeld = true;
+      unawaited(_sandbox.acquireKeepScreenOn());
+    } else if (!keepOn && _keepOnHeld) {
+      _keepOnHeld = false;
+      unawaited(_sandbox.releaseKeepScreenOn());
+    }
   }
 
   Future<void> _teardownNative() async {
     await _sandbox.setVolumeCtrlIntercept(false);
-    await _sandbox.setKeepScreenOn(false);
+    if (_keepOnHeld) {
+      _keepOnHeld = false;
+      await _sandbox.releaseKeepScreenOn();
+    }
   }
 
   Future<void> _evaluateAndMaybeStart() async {
@@ -191,10 +205,16 @@ class _WorkspaceTerminalPageState extends State<WorkspaceTerminalPage>
           debugPrint('WorkspaceTerminalPage.exit: $code');
           if (!mounted) return;
           setState(() => _exited = true);
-          unawaited(_sandbox.setKeepScreenOn(false));
+          if (_keepOnHeld) {
+            _keepOnHeld = false;
+            unawaited(_sandbox.releaseKeepScreenOn());
+          }
         }),
       );
-      await _sandbox.setKeepScreenOn(true);
+      if (!_keepOnHeld) {
+        _keepOnHeld = true;
+        await _sandbox.acquireKeepScreenOn();
+      }
       await _volumeSub?.cancel();
       _volumeSub = _sandbox.volumeCtrlEvents().listen(
         (down) {

--- a/test/core/services/workspace/apk_install_steps_test.dart
+++ b/test/core/services/workspace/apk_install_steps_test.dart
@@ -124,4 +124,92 @@ void main() {
     expect(LinuxSandboxService.apkMirrorBaseUrls, isNot(contains('auto')));
     expect(LinuxSandboxService.apkMirrorBaseUrls, isNot(contains('official')));
   });
+
+  group('LinuxSandboxService.resolveApkMirrorFor', () {
+    test('resolves a named mirror', () {
+      expect(
+        LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(sourceId: 'aliyun'),
+        ),
+        'https://mirrors.aliyun.com/alpine',
+      );
+    });
+
+    test('auto and official restore the official Alpine CDN', () {
+      for (final source in ['auto', 'official']) {
+        expect(
+          LinuxSandboxService.resolveApkMirrorFor(
+            DependencyInstallPref(sourceId: source),
+          ),
+          'https://dl-cdn.alpinelinux.org/alpine',
+        );
+      }
+    });
+
+    test('unknown named sources restore the official CDN', () {
+      expect(
+        LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(sourceId: 'somebody'),
+        ),
+        'https://dl-cdn.alpinelinux.org/alpine',
+      );
+    });
+
+    test('custom URL is used after sanitization', () {
+      expect(
+        LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(
+            sourceId: 'custom',
+            customUrl: 'https://mirror.example/alpine',
+          ),
+        ),
+        'https://mirror.example/alpine',
+      );
+    });
+
+    test(
+      'a mirror set by one dependency never leaks into the next install',
+      () {
+        // Sequence regression (issue #531 review, iOS parity): a named mirror
+        // chosen for one dependency must not stay active when the next one
+        // selects the official CDN.
+        final first = LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(sourceId: 'tuna'),
+        );
+        final second = LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(sourceId: 'official'),
+        );
+        expect(first, contains('tuna'));
+        expect(second, 'https://dl-cdn.alpinelinux.org/alpine');
+        expect(
+          LinuxSandboxService.apkMirrorSetup(second),
+          contains(
+            'https://dl-cdn.alpinelinux.org/alpine/v'
+            '${LinuxSandboxService.alpineVersion}/main',
+          ),
+        );
+      },
+    );
+
+    test('malformed custom URL throws instead of silently falling back', () {
+      expect(
+        () => LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(
+            sourceId: 'custom',
+            customUrl: 'https://mirror.example/alpine; rm -rf /',
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('empty custom URL restores the official CDN', () {
+      expect(
+        LinuxSandboxService.resolveApkMirrorFor(
+          const DependencyInstallPref(sourceId: 'custom'),
+        ),
+        'https://dl-cdn.alpinelinux.org/alpine',
+      );
+    });
+  });
 }

--- a/test/core/services/workspace/apt_install_steps_test.dart
+++ b/test/core/services/workspace/apt_install_steps_test.dart
@@ -139,7 +139,6 @@ void main() {
       expect(steps[2].timeoutSeconds, 1800);
     });
   });
-
   group('LinuxSandboxService.aptMirrorSetup', () {
     const tuna = 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports';
 
@@ -164,6 +163,26 @@ void main() {
       // The legacy one-line file must go, or apt merges the default archive
       // back in alongside the configured mirror.
       expect(setup, contains('rm -f /etc/apt/sources.list'));
+    });
+
+    test('runs fail-fast under set -e', () {
+      final setup = LinuxSandboxService.aptMirrorSetup(tuna);
+      expect(setup, startsWith('set -e\n'));
+      // A failed rewrite must abort the chained apt-get update instead of
+      // refreshing package lists from stale or merged sources.
+      expect(
+        setup,
+        startsWith('set -e\ncat > /etc/apt/sources.list.d/ubuntu.sources'),
+      );
+    });
+
+    test('splits the security suite onto its own mirror URL when provided', () {
+      final setup = LinuxSandboxService.aptMirrorSetup(
+        'http://archive.ubuntu.com/ubuntu',
+        securityMirrorUrl: 'http://security.ubuntu.com/ubuntu',
+      );
+      expect(setup, contains('URIs: http://archive.ubuntu.com/ubuntu/'));
+      expect(setup, contains('URIs: http://security.ubuntu.com/ubuntu/'));
     });
 
     test('composes with the update command on a new line', () {
@@ -203,36 +222,61 @@ void main() {
           abi: 'armeabi-v7a',
           pref: const DependencyInstallPref(sourceId: 'tuna'),
         ),
-        'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+        (
+          base: 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+          security: 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+        ),
       );
       expect(
         LinuxSandboxService.resolveAptMirrorFor(
           abi: 'x86_64',
           pref: const DependencyInstallPref(sourceId: 'aliyun'),
         ),
-        'https://mirrors.aliyun.com/ubuntu',
+        (
+          base: 'https://mirrors.aliyun.com/ubuntu',
+          security: 'https://mirrors.aliyun.com/ubuntu',
+        ),
       );
     });
 
-    test('auto and official keep the rootfs default sources', () {
+    test('auto and official restore the ABI official archive', () {
       for (final source in ['auto', 'official']) {
         expect(
           LinuxSandboxService.resolveAptMirrorFor(
             abi: 'arm64-v8a',
             pref: DependencyInstallPref(sourceId: source),
           ),
-          isNull,
+          (
+            base: 'http://ports.ubuntu.com/ubuntu-ports',
+            security: 'http://ports.ubuntu.com/ubuntu-ports',
+          ),
         );
       }
     });
 
-    test('unknown named sources fall back to the default sources', () {
+    test('amd64 official splits the security suite', () {
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'x86_64',
+          pref: const DependencyInstallPref(sourceId: 'official'),
+        ),
+        (
+          base: 'http://archive.ubuntu.com/ubuntu',
+          security: 'http://security.ubuntu.com/ubuntu',
+        ),
+      );
+    });
+
+    test('unknown named sources restore the official archive', () {
       expect(
         LinuxSandboxService.resolveAptMirrorFor(
           abi: 'arm64-v8a',
           pref: const DependencyInstallPref(sourceId: 'somebody'),
         ),
-        isNull,
+        (
+          base: 'http://ports.ubuntu.com/ubuntu-ports',
+          security: 'http://ports.ubuntu.com/ubuntu-ports',
+        ),
       );
     });
 
@@ -245,11 +289,38 @@ void main() {
             customUrl: 'https://mirror.example/ubuntu-ports',
           ),
         ),
-        'https://mirror.example/ubuntu-ports',
+        (
+          base: 'https://mirror.example/ubuntu-ports',
+          security: 'https://mirror.example/ubuntu-ports',
+        ),
       );
     });
 
-    test('malformed custom URL throws instead of silently using defaults', () {
+    test(
+      'a mirror set by one dependency never leaks into the next install',
+      () {
+        // Sequence regression (issue #531 review): dependency 1 picks TUNA,
+        // dependency 2 picks Official — the generated sources must restore
+        // ports.ubuntu.com, not keep the TUNA rewrite the first install left
+        // in the workspace-global deb822 file.
+        final first = LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'armeabi-v7a',
+          pref: const DependencyInstallPref(sourceId: 'tuna'),
+        );
+        final second = LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'armeabi-v7a',
+          pref: const DependencyInstallPref(sourceId: 'official'),
+        );
+        expect(first.base, contains('tuna'));
+        expect(second.base, 'http://ports.ubuntu.com/ubuntu-ports');
+        expect(
+          LinuxSandboxService.aptMirrorSetup(second.base),
+          contains('URIs: http://ports.ubuntu.com/ubuntu-ports/'),
+        );
+      },
+    );
+
+    test('malformed custom URL throws instead of silently falling back', () {
       expect(
         () => LinuxSandboxService.resolveAptMirrorFor(
           abi: 'arm64-v8a',
@@ -262,13 +333,16 @@ void main() {
       );
     });
 
-    test('empty custom URL behaves like no mirror', () {
+    test('empty custom URL restores the official archive', () {
       expect(
         LinuxSandboxService.resolveAptMirrorFor(
           abi: 'arm64-v8a',
           pref: const DependencyInstallPref(sourceId: 'custom'),
         ),
-        isNull,
+        (
+          base: 'http://ports.ubuntu.com/ubuntu-ports',
+          security: 'http://ports.ubuntu.com/ubuntu-ports',
+        ),
       );
     });
   });

--- a/test/core/services/workspace/apt_install_steps_test.dart
+++ b/test/core/services/workspace/apt_install_steps_test.dart
@@ -132,11 +132,144 @@ void main() {
       expect(steps.last.command, contains('pandoc poppler-utils'));
     });
 
-    test('uses fixed staged timeouts', () {
+    test('uses fixed staged timings', () {
       final steps = LinuxSandboxService.buildAptInstallSteps(packages: 'git');
       expect(steps[0].timeoutSeconds, 900);
-      expect(steps[1].timeoutSeconds, 600);
+      expect(steps[1].timeoutSeconds, 1200);
       expect(steps[2].timeoutSeconds, 1800);
+    });
+  });
+
+  group('LinuxSandboxService.aptMirrorSetup', () {
+    const tuna = 'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports';
+
+    test('rewrites the deb822 sources file with the given mirror', () {
+      final setup = LinuxSandboxService.aptMirrorSetup(tuna);
+      expect(
+        setup,
+        contains("cat > /etc/apt/sources.list.d/ubuntu.sources <<'EOF'"),
+      );
+      expect(setup, contains('URIs: $tuna/'));
+      expect(setup, contains('Types: deb'));
+      expect(setup, contains('Suites: noble noble-updates noble-backports'));
+      expect(setup, contains('Suites: noble-security'));
+      expect(
+        setup,
+        contains('Components: main universe restricted multiverse'),
+      );
+      expect(
+        setup,
+        contains('Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg'),
+      );
+      // The legacy one-line file must go, or apt merges the default archive
+      // back in alongside the configured mirror.
+      expect(setup, contains('rm -f /etc/apt/sources.list'));
+    });
+
+    test('composes with the update command on a new line', () {
+      final setup = LinuxSandboxService.aptMirrorSetup(tuna);
+      final steps = LinuxSandboxService.buildAptInstallSteps(
+        packages: 'git',
+        mirrorSetup: setup,
+      );
+      expect(steps[1].command, startsWith(setup));
+      expect(
+        steps[1].command,
+        contains('\napt-get -o Acquire::Lock::Timeout=600 update -y'),
+      );
+      expect(setup.endsWith('\n'), isTrue);
+    });
+
+    test('maps named mirrors per ABI: ports for ARM, ubuntu for amd64', () {
+      expect(
+        LinuxSandboxService.aptMirrorBaseUrls['armeabi-v7a']?['tuna'],
+        'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+      );
+      expect(
+        LinuxSandboxService.aptMirrorBaseUrls['arm64-v8a']?['aliyun'],
+        'https://mirrors.aliyun.com/ubuntu-ports',
+      );
+      expect(
+        LinuxSandboxService.aptMirrorBaseUrls['x86_64']?['tuna'],
+        'https://mirrors.tuna.tsinghua.edu.cn/ubuntu',
+      );
+    });
+  });
+
+  group('LinuxSandboxService.resolveAptMirrorFor', () {
+    test('resolves a named mirror for the ABI', () {
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'armeabi-v7a',
+          pref: const DependencyInstallPref(sourceId: 'tuna'),
+        ),
+        'https://mirrors.tuna.tsinghua.edu.cn/ubuntu-ports',
+      );
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'x86_64',
+          pref: const DependencyInstallPref(sourceId: 'aliyun'),
+        ),
+        'https://mirrors.aliyun.com/ubuntu',
+      );
+    });
+
+    test('auto and official keep the rootfs default sources', () {
+      for (final source in ['auto', 'official']) {
+        expect(
+          LinuxSandboxService.resolveAptMirrorFor(
+            abi: 'arm64-v8a',
+            pref: DependencyInstallPref(sourceId: source),
+          ),
+          isNull,
+        );
+      }
+    });
+
+    test('unknown named sources fall back to the default sources', () {
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'arm64-v8a',
+          pref: const DependencyInstallPref(sourceId: 'somebody'),
+        ),
+        isNull,
+      );
+    });
+
+    test('custom URL is used after sanitization', () {
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'arm64-v8a',
+          pref: const DependencyInstallPref(
+            sourceId: 'custom',
+            customUrl: 'https://mirror.example/ubuntu-ports',
+          ),
+        ),
+        'https://mirror.example/ubuntu-ports',
+      );
+    });
+
+    test('malformed custom URL throws instead of silently using defaults', () {
+      expect(
+        () => LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'arm64-v8a',
+          pref: const DependencyInstallPref(
+            sourceId: 'custom',
+            customUrl: 'https://mirror.example/ubuntu; rm -rf /',
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('empty custom URL behaves like no mirror', () {
+      expect(
+        LinuxSandboxService.resolveAptMirrorFor(
+          abi: 'arm64-v8a',
+          pref: const DependencyInstallPref(sourceId: 'custom'),
+        ),
+        isNull,
+      );
     });
   });
 }

--- a/test/features/workspace/controllers/dependency_install_controller_test.dart
+++ b/test/features/workspace/controllers/dependency_install_controller_test.dart
@@ -76,6 +76,14 @@ void main() {
       pref: pref,
     );
 
+    // The pump acquires its keep-screen-on hold first, so the first
+    // install starts asynchronously; wait for it instead of asserting in
+    // the same frame.
+    await _pumpUntil(
+      () =>
+          controller.statusFor(wsId, WorkspaceDependencyIds.nodejs) ==
+          DepInstallStatus.installing,
+    );
     expect(
       controller.statusFor(wsId, WorkspaceDependencyIds.nodejs),
       DepInstallStatus.installing,
@@ -288,6 +296,11 @@ void main() {
       hostPath: '/ws',
       pref: pref,
     );
+    await _pumpUntil(
+      () =>
+          controller.statusFor(wsId, WorkspaceDependencyIds.git) ==
+          DepInstallStatus.installing,
+    );
     expect(
       controller.statusFor(wsId, WorkspaceDependencyIds.git),
       DepInstallStatus.installing,
@@ -337,5 +350,150 @@ void main() {
     expect(fake.order, containsAll([WorkspaceDependencyIds.git, 'git2']));
     // Each workspace's install must run against its own rootfs path.
     expect(fake.hostPaths, containsAll(['/ws_a', '/ws_b']));
+  });
+
+  group('keep-screen-on queue hold', () {
+    test('spans the whole queue and survives listeners detaching', () async {
+      final holds = <bool>[];
+      final fake = _FakeInstaller()
+        ..gate[WorkspaceDependencyIds.git] = Completer<void>()
+        ..gate[WorkspaceDependencyIds.python] = Completer<void>();
+      final controller = DependencyInstallController(
+        installer: fake.call,
+        keepScreenOn: (hold) async => holds.add(hold),
+      );
+
+      // No observer ever attaches (standing in for a detail page already
+      // popped): the queue must still keep the screen on by itself.
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.git,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.python,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      await _pumpUntil(() => holds.contains(true));
+      expect(holds, [true]);
+
+      // Between dependencies the hold must not flicker: queue still busy.
+      fake.gate[WorkspaceDependencyIds.git]!.complete();
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.git) ==
+            DepInstallStatus.idle,
+      );
+      expect(holds, [true]);
+
+      // Last dependency finishes: hold releases exactly once.
+      fake.gate[WorkspaceDependencyIds.python]!.complete();
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.python) ==
+            DepInstallStatus.idle,
+      );
+      expect(holds, [true, false]);
+    });
+
+    test('releases on runner failure even without any listener', () async {
+      final holds = <bool>[];
+      final fake = _FakeInstaller()
+        ..failures[WorkspaceDependencyIds.nodejs] = 'apt lock held';
+      final controller = DependencyInstallController(
+        installer: fake.call,
+        keepScreenOn: (hold) async => holds.add(hold),
+      );
+
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.nodejs,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      await _pumpUntil(() => holds.contains(false));
+      expect(holds, [true, false]);
+      expect(
+        controller.takeCompleted(wsId)[WorkspaceDependencyIds.nodejs],
+        isA<StateError>(),
+      );
+    });
+
+    test('acquires once per pump and composes across workspaces', () async {
+      final holds = <bool>[];
+      final fake = _FakeInstaller()
+        ..gate[WorkspaceDependencyIds.git] = Completer<void>()
+        ..gate['git2'] = Completer<void>();
+      final controller = DependencyInstallController(
+        installer: fake.call,
+        keepScreenOn: (hold) async => holds.add(hold),
+      );
+
+      controller.enqueue(
+        workspaceId: 'ws_a',
+        depId: WorkspaceDependencyIds.git,
+        hostPath: '/ws_a',
+        pref: pref,
+      );
+      controller.enqueue(
+        workspaceId: 'ws_b',
+        depId: 'git2',
+        hostPath: '/ws_b',
+        pref: pref,
+      );
+      await _pumpUntil(() => fake.concurrent == 2);
+      // Two concurrent pumps -> two acquires; the service refcount keeps the
+      // flag until the last release (composition with the terminal hold).
+      expect(holds, [true, true]);
+
+      fake.gate[WorkspaceDependencyIds.git]!.complete();
+      fake.gate['git2']!.complete();
+      await _pumpUntil(
+        () =>
+            controller.statusFor('ws_a', WorkspaceDependencyIds.git) ==
+                DepInstallStatus.idle &&
+            controller.statusFor('ws_b', 'git2') == DepInstallStatus.idle,
+      );
+      expect(holds, [true, true, false, false]);
+    });
+
+    test('a failing keep-screen-on switch never aborts the install', () async {
+      final fake = _FakeInstaller()
+        ..gate[WorkspaceDependencyIds.git] = Completer<void>();
+      final controller = DependencyInstallController(
+        installer: fake.call,
+        keepScreenOn: (hold) async => throw StateError('no activity'),
+      );
+
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.git,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.git) ==
+            DepInstallStatus.installing,
+      );
+      expect(
+        controller.statusFor(wsId, WorkspaceDependencyIds.git),
+        DepInstallStatus.installing,
+      );
+      fake.gate[WorkspaceDependencyIds.git]!.complete();
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.git) ==
+            DepInstallStatus.idle,
+      );
+      expect(fake.order, [WorkspaceDependencyIds.git]);
+      expect(
+        controller.takeCompleted(wsId)[WorkspaceDependencyIds.git],
+        isNull,
+      );
+    });
   });
 }

--- a/test/features/workspace/controllers/dependency_install_controller_test.dart
+++ b/test/features/workspace/controllers/dependency_install_controller_test.dart
@@ -495,5 +495,71 @@ void main() {
         isNull,
       );
     });
+
+    test('an enqueue during the async release runs in a fresh pump', () async {
+      // Regression (review): the pump used to await `keepScreenOn(false)`
+      // BEFORE releasing worker ownership, so a dependency enqueued while
+      // that release was in flight landed in a queue the finishing pump was
+      // about to delete — it stayed idle forever. The first release is
+      // gated to widen that window deterministically.
+      final holds = <bool>[];
+      final gateRelease = Completer<void>();
+      var releases = 0;
+      final fake = _FakeInstaller()
+        ..gate[WorkspaceDependencyIds.git] = Completer<void>();
+      final controller = DependencyInstallController(
+        installer: fake.call,
+        keepScreenOn: (hold) async {
+          holds.add(hold);
+          if (!hold) {
+            releases++;
+            if (releases == 1) await gateRelease.future;
+          }
+        },
+      );
+
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.git,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.git) ==
+            DepInstallStatus.installing,
+      );
+      fake.gate[WorkspaceDependencyIds.git]!.complete();
+      // The drain finished and the release is in flight, still gated.
+      await _pumpUntil(() => holds.contains(false));
+
+      controller.enqueue(
+        workspaceId: wsId,
+        depId: WorkspaceDependencyIds.python,
+        hostPath: '/ws',
+        pref: pref,
+      );
+      gateRelease.complete();
+      await _pumpUntil(
+        () =>
+            controller.statusFor(wsId, WorkspaceDependencyIds.python) ==
+            DepInstallStatus.idle,
+      );
+      expect(fake.order, [
+        WorkspaceDependencyIds.git,
+        WorkspaceDependencyIds.python,
+      ]);
+      expect(
+        controller.statusFor(wsId, WorkspaceDependencyIds.python),
+        DepInstallStatus.idle,
+      );
+      expect(
+        controller.takeCompleted(wsId)[WorkspaceDependencyIds.python],
+        isNull,
+      );
+      // Holds stay balanced: one acquire/release per queue the controller
+      // actually ran.
+      expect(holds, [true, false, true, false]);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes issue #531: on Android, dependency installs in the workspace sandbox loop forever in "Updating package lists…" and then fall back to "Install", while the runtime itself works. Reproduced on a Samsung Galaxy A13 4G (Android 14, 32-bit runtime path).

## Root cause

1. **Mirror selection was a no-op on Android.** The Ubuntu base rootfs (24.04 noble) ships apt sources only in the deb822 file `/etc/apt/sources.list.d/ubuntu.sources` → `http://ports.ubuntu.com/ubuntu-ports/`. On Android:
   - named sources (TUNA/Aliyun) did nothing (only iOS `apk` handled them);
   - the custom-source path wrote a one-line `/etc/apt/sources.list` that apt merges alongside the deb822 file, so ports.ubuntu.com stayed active.

   On slow paths (typical for `ports.ubuntu.com`, armhf in particular), `apt-get update` then eats the whole step timeout.

2. The `update` step timeout was 600 s, killing a healthy but slow progress.

3. `resolv.conf` was pinned to `1.1.1.1` first (public DNS only, written once at extraction); a network that blackholes the first resolver makes lookups stall.

4. No keep-screen-on during installs: One UI (Samsung Android 14) aggressively freezes apps, which can stall the apt process mid-transaction.

## Changes

### Deterministic per-install sources (review fix)

- **Android apt**: every install deterministically establishes its intended sources:
  - named sources (TUNA/Aliyun) map per ABI (`ubuntu-ports` for armhf/arm64, `ubuntu` for amd64);
  - `auto`/`official` (and unknown or empty custom) restore the ABI-appropriate **official archive** (`ports.ubuntu.com` for armhf/arm64; amd64 splits security onto `security.ubuntu.com`, matching the shipped ubuntu-base default) — a mirror chosen for one dependency can never stay active for the next (named → official sequence regression covered);
  - `aptMirrorSetup` rewrites the deb822 `ubuntu.sources` (all four suites, full component set) and removes the legacy `sources.list`, **fail-fast under `set -e`** so a failed rewrite aborts `apt-get update` instead of continuing with stale/merged sources;
  - malformed custom URLs throw instead of silently falling back.
- **iOS apk parity**: `auto`/`official` restore the official Alpine CDN (`dl-cdn.alpinelinux.org`), so a previous dependency's apk mirror is never left active.
- **apt**: update stage timeout 600 s → 1200 s (native exec cap stays 3600 s).

### DNS (Android plugin)

`patchDns` now writes the active network's DNS via `ConnectivityManager` first (IPv4-first, MAXNS-capped at 3), public DNS as fallback; a new `refreshDns` channel method re-patches an already-extracted rootfs and is invoked before every install; added `ACCESS_NETWORK_STATE` (normal permission).

### Keep-screen-on owned by the install queue (review fix)

The queue (`DependencyInstallController`) acquires the keep-screen-on hold per workspace pump start and releases it when the queue drains (success **or** failure), so a long install keeps the screen on even after the detail page is popped — the page no longer manages the flag. The hold is ref-counted in `LinuxSandboxService` (`acquireKeepScreenOn`/`releaseKeepScreenOn`), composing with the terminal session hold and across concurrent workspace queues; hold failures are logged and never abort installs.

## Verification

Run:
- `dart analyze --fatal-infos lib test` — clean
- `flutter test test/core/services/workspace/` — 105 pass
- `flutter test test/features/workspace/` — 43 pass (incl. new queue-hold behavioral tests)
- `dart format` on changed paths

Not run locally:
- Android Kotlin build/compile — deferred to CI (local standalone gradle cannot drive a Flutter Android project).
- On-device verification — no affected device (A13 / Android 14) available.
- iOS — analyzer + CI only (no local simulator on Windows), apk changes are pure Dart mirror-string logic covered by unit tests.

## Manual test plan

1. On an armhf/arm64 device: install `git` with Source = `TUNA` → `apt-get update` completes quickly, install succeeds; verify in the terminal that `/etc/apt/sources.list.d/ubuntu.sources` contains only the mirror and `/etc/apt/sources.list` no longer exists.
2. Then install `python` with Source = `Official` → sources restore `ports.ubuntu.com` (no stale TUNA state).
3. Custom URL → install succeeds with only that URL in the sources file; malformed URL → clear error, no silent fallback.
4. Switch Wi-Fi → cellular before retrying an install → succeeds (resolv.conf refreshed at install time).
5. Long install with screen-off on One UI → screen stays on; navigating back to the workspace list mid-install keeps the screen on until the queue drains; opening the terminal during an install does not lose keep-screen-on.

## Notes / known behavior

- The sources file is workspace-global: each dependency's install applies its own source preference, and the **last install's mirror remains active** for later shell/LLM `apt-get` calls until the next install or terminal `apt-get` run — `auto`/`official` installs restore the official archive.
- `refreshDns` rewrites the guest `resolv.conf` on every install; a user who manually edited DNS inside the sandbox via the terminal will have it overwritten on the next dependency install (system DNS first, public fallback).

Closes #531.
