### PR TITLE
test: stabilize CI - align web-chat asset version and close leaked test DBs

### DIFF
--- a/test/core/services/backup/cherry_importer_test.dart
+++ b/test/core/services/backup/cherry_importer_test.dart
@@ -94,6 +94,7 @@ void main() {
       });
 
       final chatService = ChatService();
+      addTearDown(chatService.close);
       await chatService.init();
       final result = await CherryImporter.importFromCherryStudio(
         preferences: businessPrefs,
@@ -198,6 +199,7 @@ void main() {
       });
 
       final chatService = ChatService();
+      addTearDown(chatService.close);
       await chatService.init();
       final result = await CherryImporter.importFromCherryStudio(
         preferences: businessPrefs,
@@ -227,6 +229,7 @@ void main() {
       });
 
       final service = ChatService();
+      addTearDown(service.close);
       await service.init();
       await expectLater(
         CherryImporter.importFromCherryStudio(

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -630,9 +630,11 @@ void main() {
         await liveFile.writeAsString('backup version');
         await liveFile.setLastModified(DateTime(2026, 1, 2, 0, 0, 57));
 
+        final chatService = _InMemoryChatService();
+        addTearDown(chatService.closeDb);
         final sync = DataSync(
           preferences: businessPrefs,
-          chatService: ChatService(),
+          chatService: chatService,
         );
         final zipFile = await sync.prepareBackupFile(
           const WebDavConfig(
@@ -720,9 +722,11 @@ void main() {
             .modified
             .millisecondsSinceEpoch;
 
+        final chatService = _InMemoryChatService();
+        addTearDown(chatService.closeDb);
         final sync = DataSync(
           preferences: businessPrefs,
-          chatService: ChatService(),
+          chatService: chatService,
         );
         final zipFile = await sync.prepareBackupFile(
           const WebDavConfig(
@@ -791,9 +795,11 @@ void main() {
         await target.setLastModified(DateTime(2026, 1, 2, 12, 34, 56, 800));
         final srcMs = target.statSync().modified.millisecondsSinceEpoch;
 
+        final chatService = _InMemoryChatService();
+        addTearDown(chatService.closeDb);
         final sync = DataSync(
           preferences: businessPrefs,
-          chatService: ChatService(),
+          chatService: chatService,
         );
         final zipFile = await sync.prepareBackupFile(
           const WebDavConfig(
@@ -1580,9 +1586,11 @@ void main() {
     test(
       'incremental: since param produces cuplivo_incr_ prefix and includeSettings=false excludes settings.json',
       () async {
+        final chatService = _InMemoryChatService();
+        addTearDown(chatService.closeDb);
         final sync = DataSync(
           preferences: businessPrefs,
-          chatService: ChatService(),
+          chatService: chatService,
         );
         final backupFile = await sync.prepareBackupFile(
           const WebDavConfig(
@@ -1695,9 +1703,11 @@ void main() {
         '${fontsDir.path}/custom.ttf',
       ).writeAsBytes(List<int>.filled(64, 9));
 
+      final chatService = _InMemoryChatService();
+      addTearDown(chatService.closeDb);
       final sync = DataSync(
         preferences: businessPrefs,
-        chatService: ChatService(),
+        chatService: chatService,
       );
       final backupFile = await sync.prepareBackupFile(
         const WebDavConfig(
@@ -1736,9 +1746,11 @@ void main() {
       await uploadDir.create(recursive: true);
       await File('${uploadDir.path}/doc.txt').writeAsString('hello');
 
+      final chatService = _InMemoryChatService();
+      addTearDown(chatService.closeDb);
       final sync = DataSync(
         preferences: businessPrefs,
-        chatService: ChatService(),
+        chatService: chatService,
       );
       final backupFile = await sync.prepareBackupFile(
         const WebDavConfig(

--- a/test/features/home/web_chat_protocol_test.dart
+++ b/test/features/home/web_chat_protocol_test.dart
@@ -5,9 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Cuplivo/features/home/webview/web_chat_protocol.dart';
 
 void main() {
-  test('Web chat uses protocol v5 and bundled assets v20', () {
+  test('Web chat uses protocol v5 and bundled assets v22', () {
     expect(webChatProtocolVersion, 5);
-    expect(webChatAssetVersion, 'web-chat-v20');
+    expect(webChatAssetVersion, 'web-chat-v22');
   });
 
   group('Web streaming patch buffer', () {

--- a/test/features/home/web_chat_snapshot_test.dart
+++ b/test/features/home/web_chat_snapshot_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     final rendered = (snapshot['messages'] as List).single as Map;
     expect(snapshot['protocolVersion'], 5);
-    expect(snapshot['assetVersion'], 'web-chat-v20');
+    expect(snapshot['assetVersion'], 'web-chat-v22');
     expect(snapshot['initialViewportMode'], 'anchor');
     expect(snapshot['locale'], 'zh-Hans');
     expect(snapshot['textDirection'], 'ltr');


### PR DESCRIPTION
test: stabilize CI - align web-chat asset version and close leaked test DBs

Two independent test-suite instabilities:

- web-chat: commit 83c00b32 bumped the bundled asset version to
  web-chat-v22 (protocol.mjs, web_chat_protocol.dart) but the two Dart
  expectations still asserted web-chat-v20, so CI fails on
  web_chat_protocol_test.dart and web_chat_snapshot_test.dart.

- backup: six incremental/LAN-sync tests passed `ChatService()` into
  DataSync with an incremental config whose effectiveScope defaults
  chatsAndAssistants: true; the export path then initialized a
  file-backed SQLite database under the temp root that no test ever
  closed. On Windows the open handle makes tearDown's recursive delete
  fail with PathAccessException (errno 32), flaking the suite locally
  (Linux CI tolerates it via POSIX unlink-with-open-handle). Those six
  tests now use _InMemoryChatService + closeDb teardown, matching the
  restore tests; cherry_importer_test.dart likewise closes its three
  initially-opened ChatService instances.

Verification: dart analyze --fatal-infos lib test clean; the four
touched test files pass on Windows (81 tests).
