### PR TITLE
fix(group-chat): desktop group creation dialog uses disposed TextEditingController

### DIFF
--- a/lib/desktop/setting/assistants_pane.dart
+++ b/lib/desktop/setting/assistants_pane.dart
@@ -201,218 +201,256 @@ class _AddGroupChatButtonState extends State<_AddGroupChatButton> {
   }
 }
 
-Future<String?> _showAddGroupChatDesktopDialog(BuildContext context) async {
-  final l10n = AppLocalizations.of(context)!;
-  final cs = Theme.of(context).colorScheme;
-  final controller = TextEditingController();
-  String? result;
-  await showDialog<String>(
+Future<String?> _showAddGroupChatDesktopDialog(BuildContext context) {
+  return showDialog<String>(
     context: context,
     barrierDismissible: true,
-    builder: (ctx) {
-      return Dialog(
-        backgroundColor: cs.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 440),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              SizedBox(
-                height: 44,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          l10n.groupChatCreate,
-                          style: TextStyle(
-                            fontSize: 13.5,
-                            fontWeight: AppFontWeights.emphasis,
-                          ),
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: MaterialLocalizations.of(
-                          ctx,
-                        ).closeButtonTooltip,
-                        icon: const Icon(lucide.Lucide.X, size: 18),
-                        color: cs.onSurface,
-                        onPressed: () => Navigator.of(ctx).maybePop(),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
+    builder: (_) => const _AddGroupChatDesktopDialog(),
+  );
+}
+
+class _AddGroupChatDesktopDialog extends StatefulWidget {
+  const _AddGroupChatDesktopDialog();
+
+  @override
+  State<_AddGroupChatDesktopDialog> createState() =>
+      _AddGroupChatDesktopDialogState();
+}
+
+class _AddGroupChatDesktopDialogState
+    extends State<_AddGroupChatDesktopDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Dialog(
+      backgroundColor: cs.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 440),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              height: 44,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
                   children: [
-                    TextField(
-                      controller: controller,
-                      autofocus: true,
-                      decoration: InputDecoration(
-                        hintText: l10n.groupChatNameHint,
-                        filled: true,
-                        fillColor: ctx.appColors.surfaceFill,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: cs.outlineVariant.withValues(alpha: 0.2),
-                          ),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: cs.primary.withValues(alpha: 0.4),
-                          ),
+                    Expanded(
+                      child: Text(
+                        l10n.groupChatCreate,
+                        style: TextStyle(
+                          fontSize: 13.5,
+                          fontWeight: AppFontWeights.emphasis,
                         ),
                       ),
-                      onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
                     ),
-                    const SizedBox(height: 12),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        _DeskIosButton(
-                          label: l10n.groupChatCancel,
-                          filled: false,
-                          dense: true,
-                          onTap: () => Navigator.of(ctx).pop(),
-                        ),
-                        const SizedBox(width: 8),
-                        _DeskIosButton(
-                          label: l10n.groupChatConfirm,
-                          filled: true,
-                          dense: true,
-                          onTap: () =>
-                              Navigator.of(ctx).pop(controller.text.trim()),
-                        ),
-                      ],
+                    IconButton(
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      icon: const Icon(lucide.Lucide.X, size: 18),
+                      color: cs.onSurface,
+                      onPressed: () => Navigator.of(context).maybePop(),
                     ),
                   ],
                 ),
               ),
-            ],
-          ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _controller,
+                    autofocus: true,
+                    decoration: InputDecoration(
+                      hintText: l10n.groupChatNameHint,
+                      filled: true,
+                      fillColor: context.appColors.surfaceFill,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: cs.outlineVariant.withValues(alpha: 0.2),
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: cs.primary.withValues(alpha: 0.4),
+                        ),
+                      ),
+                    ),
+                    onSubmitted: (v) => Navigator.of(context).pop(v.trim()),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      _DeskIosButton(
+                        label: l10n.groupChatCancel,
+                        filled: false,
+                        dense: true,
+                        onTap: () => Navigator.of(context).pop(),
+                      ),
+                      const SizedBox(width: 8),
+                      _DeskIosButton(
+                        label: l10n.groupChatConfirm,
+                        filled: true,
+                        dense: true,
+                        onTap: () =>
+                            Navigator.of(context).pop(_controller.text.trim()),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
-      );
-    },
-  );
-  controller.dispose();
-  return result;
+      ),
+    );
+  }
 }
 
 Future<String?> _showAddAssistantDesktopDialog(BuildContext context) async {
-  final l10n = AppLocalizations.of(context)!;
-  final cs = Theme.of(context).colorScheme;
-  final controller = TextEditingController();
-  String? result;
-  await showDialog<String>(
+  final result = await showDialog<String>(
     context: context,
     barrierDismissible: true,
-    builder: (ctx) {
-      return Dialog(
-        backgroundColor: cs.surface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 440),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              SizedBox(
-                height: 44,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          l10n.assistantSettingsAddSheetTitle,
-                          style: TextStyle(
-                            fontSize: 13.5,
-                            fontWeight: AppFontWeights.emphasis,
-                          ),
-                        ),
-                      ),
-                      IconButton(
-                        tooltip: MaterialLocalizations.of(
-                          ctx,
-                        ).closeButtonTooltip,
-                        icon: const Icon(lucide.Lucide.X, size: 18),
-                        color: cs.onSurface,
-                        onPressed: () => Navigator.of(ctx).maybePop(),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    TextField(
-                      controller: controller,
-                      autofocus: true,
-                      decoration: InputDecoration(
-                        hintText: l10n.assistantSettingsAddSheetHint,
-                        filled: true,
-                        fillColor: ctx.appColors.surfaceFill,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: cs.outlineVariant.withValues(alpha: 0.2),
-                          ),
-                        ),
-                        focusedBorder: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(12),
-                          borderSide: BorderSide(
-                            color: cs.primary.withValues(alpha: 0.4),
-                          ),
-                        ),
-                      ),
-                      onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
-                    ),
-                    const SizedBox(height: 12),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        _DeskIosButton(
-                          label: l10n.assistantSettingsAddSheetCancel,
-                          filled: false,
-                          dense: true,
-                          onTap: () => Navigator.of(ctx).pop(),
-                        ),
-                        const SizedBox(width: 8),
-                        _DeskIosButton(
-                          label: l10n.assistantSettingsAddSheetSave,
-                          filled: true,
-                          dense: true,
-                          onTap: () =>
-                              Navigator.of(ctx).pop(controller.text.trim()),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      );
-    },
-  ).then((v) => result = v);
+    builder: (_) => const _AddAssistantDesktopDialog(),
+  );
   final s = (result ?? '').trim();
   if (s.isEmpty) return null;
   return s;
+}
+
+class _AddAssistantDesktopDialog extends StatefulWidget {
+  const _AddAssistantDesktopDialog();
+
+  @override
+  State<_AddAssistantDesktopDialog> createState() =>
+      _AddAssistantDesktopDialogState();
+}
+
+class _AddAssistantDesktopDialogState
+    extends State<_AddAssistantDesktopDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Dialog(
+      backgroundColor: cs.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 440),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              height: 44,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        l10n.assistantSettingsAddSheetTitle,
+                        style: TextStyle(
+                          fontSize: 13.5,
+                          fontWeight: AppFontWeights.emphasis,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      icon: const Icon(lucide.Lucide.X, size: 18),
+                      color: cs.onSurface,
+                      onPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _controller,
+                    autofocus: true,
+                    decoration: InputDecoration(
+                      hintText: l10n.assistantSettingsAddSheetHint,
+                      filled: true,
+                      fillColor: context.appColors.surfaceFill,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: cs.outlineVariant.withValues(alpha: 0.2),
+                        ),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                        borderSide: BorderSide(
+                          color: cs.primary.withValues(alpha: 0.4),
+                        ),
+                      ),
+                    ),
+                    onSubmitted: (v) => Navigator.of(context).pop(v.trim()),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      _DeskIosButton(
+                        label: l10n.assistantSettingsAddSheetCancel,
+                        filled: false,
+                        dense: true,
+                        onTap: () => Navigator.of(context).pop(),
+                      ),
+                      const SizedBox(width: 8),
+                      _DeskIosButton(
+                        label: l10n.assistantSettingsAddSheetSave,
+                        filled: true,
+                        dense: true,
+                        onTap: () =>
+                            Navigator.of(context).pop(_controller.text.trim()),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _DeleteAssistantIcon extends StatefulWidget {

--- a/lib/features/assistant/pages/assistant_settings_page.dart
+++ b/lib/features/assistant/pages/assistant_settings_page.dart
@@ -460,30 +460,10 @@ class _TactileCardState extends State<_TactileCard> {
 
 Future<void> _createGroupChat(BuildContext context) async {
   final l10n = AppLocalizations.of(context)!;
-  final controller = TextEditingController();
   final name = await showDialog<String>(
     context: context,
-    builder: (ctx) => AlertDialog(
-      title: Text(l10n.groupChatCreate),
-      content: TextField(
-        controller: controller,
-        autofocus: true,
-        decoration: InputDecoration(hintText: l10n.groupChatNameHint),
-        onSubmitted: (v) => Navigator.of(ctx).pop(v),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(),
-          child: Text(l10n.groupChatCancel),
-        ),
-        TextButton(
-          onPressed: () => Navigator.of(ctx).pop(controller.text),
-          child: Text(l10n.groupChatConfirm),
-        ),
-      ],
-    ),
+    builder: (_) => const _CreateGroupChatDialog(),
   );
-  controller.dispose();
   if (name == null || !context.mounted) return;
   final group = await context.read<GroupChatProvider>().createGroup(
     name: name.trim().isEmpty ? l10n.groupChatDefaultName : name.trim(),
@@ -494,6 +474,47 @@ Future<void> _createGroupChat(BuildContext context) async {
       builder: (_) => GroupChatSettingsPage(groupChatId: group.id),
     ),
   );
+}
+
+class _CreateGroupChatDialog extends StatefulWidget {
+  const _CreateGroupChatDialog();
+
+  @override
+  State<_CreateGroupChatDialog> createState() => _CreateGroupChatDialogState();
+}
+
+class _CreateGroupChatDialogState extends State<_CreateGroupChatDialog> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return AlertDialog(
+      title: Text(l10n.groupChatCreate),
+      content: TextField(
+        controller: _controller,
+        autofocus: true,
+        decoration: InputDecoration(hintText: l10n.groupChatNameHint),
+        onSubmitted: (v) => Navigator.of(context).pop(v),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.groupChatCancel),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(_controller.text),
+          child: Text(l10n.groupChatConfirm),
+        ),
+      ],
+    );
+  }
 }
 
 Future<String?> _showAddAssistantSheet(BuildContext context) async {

--- a/test/desktop_group_chat_create_regression_test.dart
+++ b/test/desktop_group_chat_create_regression_test.dart
@@ -1,0 +1,162 @@
+import 'package:Cuplivo/core/database/app_database.dart';
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/database/chat_database_repository.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/group_chat_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/user_provider.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/desktop/desktop_settings_page.dart';
+import 'package:Cuplivo/features/group_chat/pages/group_chat_settings_page.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+var businessPrefs = BusinessPreferences.memoryForTests();
+
+/// A [ChatService] backed by an in-memory database. Drift on
+/// [NativeDatabase.memory] executes on the calling isolate, so every query
+/// settles within the microtask pumps of `testWidgets` (no `runAsync` needed
+/// for the group-creation flow).
+///
+/// Only the members the desktop group-creation flow touches are overridden:
+/// the base [ChatService._saveConversation] reads the private `_repo` field
+/// directly (virtual dispatch does not apply), so `createConversation` is
+/// also overridden to write through the repository.
+class _InMemoryChatService extends ChatService {
+  late final AppDatabase db = AppDatabase(NativeDatabase.memory());
+  late final ChatDatabaseRepository _testRepo = ChatDatabaseRepository(db);
+
+  @override
+  bool get initialized => true;
+
+  @override
+  ChatDatabaseRepository get repo => _testRepo;
+
+  @override
+  Future<Conversation> createConversation({
+    String? title,
+    String? assistantId,
+    List<String>? mcpServerIds,
+    String? parentConversationId,
+    String conversationKind = Conversation.kindNormal,
+    bool setAsCurrent = true,
+  }) async {
+    final conversation = Conversation(
+      title: title ?? 'New Chat',
+      assistantId: assistantId,
+      mcpServerIds: mcpServerIds,
+      parentConversationId: parentConversationId,
+      conversationKind: conversationKind,
+    );
+    await _testRepo.putConversation(conversation);
+    return conversation;
+  }
+
+  Future<void> closeDb() async {
+    await _testRepo.close();
+  }
+}
+
+Future<void> _waitForSettingsLoad() async {
+  for (var i = 0; i < 25; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+Widget _harness(SettingsProvider settings, _InMemoryChatService chatService) {
+  return MultiProvider(
+    providers: [
+      Provider<BusinessPreferences>.value(value: businessPrefs),
+      ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+      ChangeNotifierProvider<AssistantProvider>(
+        create: (_) => AssistantProvider(preferences: businessPrefs),
+      ),
+      ChangeNotifierProvider<UserProvider>(
+        create: (_) => UserProvider(preferences: businessPrefs),
+      ),
+      ChangeNotifierProvider<GroupChatProvider>(
+        create: (_) => GroupChatProvider(chatService: chatService),
+      ),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Scaffold(body: DesktopSettingsPage()),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('desktop group chat creation completes without controller '
+      'use-after-dispose (issue #698)', (tester) async {
+    businessPrefs = BusinessPreferences.memoryForTests();
+    final settings = SettingsProvider(preferences: businessPrefs);
+    await tester.runAsync(_waitForSettingsLoad);
+    addTearDown(settings.dispose);
+
+    final chatService = _InMemoryChatService();
+    addTearDown(chatService.closeDb);
+
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(_harness(settings, chatService));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(DesktopSettingsPage)),
+    )!;
+
+    // Open the assistants / group-chats pane.
+    await tester.tap(find.text(l10n.settingsPageAssistant));
+    await tester.pumpAndSettle();
+
+    // Open the create group-chat dialog, type a name, confirm.
+    await tester.tap(find.byTooltip(l10n.groupChatCreate));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.descendant(
+        of: find.byType(Dialog),
+        matching: find.byType(TextField),
+      ),
+      'Automated Group',
+    );
+    await tester.pump();
+
+    await tester.tap(find.text(l10n.groupChatConfirm));
+    // Pump through the dialog dismissal AND the settings-page push:
+    // the pre-fix code disposed the TextEditingController as soon as the
+    // dialog future completed, throwing a use-after-dispose during the
+    // exit transition (plus a null return that skipped createGroup).
+    await tester.pumpAndSettle();
+
+    // 1) No framework exception — in particular no use-after-dispose.
+    expect(tester.takeException(), isNull);
+
+    // 2) The group was created exactly once with the entered name.
+    final groups = await chatService.repo.getAllGroupChats();
+    expect(groups, hasLength(1));
+    expect(groups.single.name, 'Automated Group');
+    // Async lookup via the Drift connection; the sync connection path
+    // requires a file-backed database (in-memory repos have none).
+    final conversation = await chatService.repo.getConversation(
+      groups.single.conversationId,
+    );
+    expect(conversation, isNotNull);
+    expect(conversation!.title, 'Automated Group');
+    expect(conversation.conversationKind, Conversation.kindGroup);
+
+    // 3) The group settings destination was reached.
+    expect(find.byType(GroupChatSettingsPage), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #698

## Problem

On Windows (3.1.2), creating a group chat fails silently: after naming the group and confirming, the group never appears and the settings page closes back to the main window.

## Root cause

`_showAddGroupChatDesktopDialog` disposed its `TextEditingController` immediately after `showDialog`'s future completed — which fires **when the route is popped**, i.e. while the dialog's exit transition is still animating and the `TextField` is still mounted. On the next frame the framework called `addListener` on the disposed controller:

```
A TextEditingController was used after being disposed.
The relevant error-causing widget was:
  TextField:.../lib/desktop/setting/assistants_pane.dart:255
```

That build failure cascaded:

1. `A RenderFlex overflowed by 99302 pixels on the bottom` (broken layout during teardown)
2. `'_dependents.isEmpty'` assertion (element-tree teardown corrupted)
3. the corrupted route transition popped the whole **desktop settings page** back to the main window
4. the `onTap` continuation bailed on `!context.mounted`, so `GroupChatSettingsPage` was never pushed — "created but not displayed"

The DB writes themselves succeed (no `[Uncaught]` in the log): the group data is persisted, the failure is purely in the dialog/route teardown.

## Fix

The three dialogs now own their controller in a `StatefulWidget` and dispose it in `State.dispose()`, which runs only after the exit animation completes and the widget is fully unmounted:

- `_showAddGroupChatDesktopDialog` → `_AddGroupChatDesktopDialog` (the reported bug)
- `_showAddAssistantDesktopDialog` → `_AddAssistantDesktopDialog` (identical pattern in the same pane; its controller was leaked, never disposed)
- mobile `_createGroupChat` → `_CreateGroupChatDialog` (same dispose-during-transition race on the same feature path `features/assistant`)

Dialog UI, l10n keys, pop semantics (trimmed value on desktop; raw text on mobile with caller-side trim/default-name fallback) are unchanged.

## Test

- `dart analyze --fatal-infos lib test`: no issues
- Manual on Windows (`flutter run -d windows`): confirm → no exceptions in console, group settings page opens, group appears in the assistants/group-chat pane and in the side drawer. Verified locally by the reporter flow.
- No directly related unit test exists for the private `part` dialog; manual desktop verification is the acceptance (repro was a transition-timing race).

## Note

Other repositories-wide dialogs with the same `dispose()`-right-after-`await showDialog` pattern (e.g. `search_service_editor_page`, `web_conversation_styles_page`, `display_pane`) exist and could use a follow-up sweep; not included here to keep this PR minimal.
