### PR TITLE
fix(markdown): preserve paragraph breaks and bubble sizing (upstream 88dd7a5c)

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:gpt_markdown/custom_widgets/markdown_config.dart'
     show GptMarkdownConfig;
+import 'package:gpt_markdown/custom_widgets/selectable_adapter.dart';
 import 'package:flutter_highlight/themes/github.dart';
 import 'package:flutter_highlight/themes/atom-one-dark-reasonable.dart';
 import 'package:flutter/rendering.dart';
@@ -819,14 +820,17 @@ class _MarkdownBlockSeparator extends StatelessWidget {
     // The paragraph carries the `NewLines` style, and its one run is a space:
     // the style has to sit on the paragraph because a line box is measured from
     // the paragraph style when there is no run, and that path rounds
-    // differently from a line that has one. A space is invisible, and the
-    // separator stays out of selection so it cannot be copied.
-    return SelectionContainer.disabled(
-      child: Text.rich(
-        const TextSpan(text: ' '),
-        style: (style ?? const TextStyle()).copyWith(
-          fontSize: style?.fontSize ?? _fallbackFontSize,
-          height: _newLinesHeight,
+    // differently from a line that has one. Copy the paragraph break instead
+    // of the invisible space used to measure it.
+    return SelectableAdapter(
+      selectedText: '\n\n',
+      child: SelectionContainer.disabled(
+        child: Text.rich(
+          const TextSpan(text: ' '),
+          style: (style ?? const TextStyle()).copyWith(
+            fontSize: style?.fontSize ?? _fallbackFontSize,
+            height: _newLinesHeight,
+          ),
         ),
       ),
     );
@@ -840,9 +844,11 @@ class _MarkdownBlockColumn extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Let loose-width bubbles hug their content; tight parent constraints
+    // still make the column fill the available width.
     final column = Column(
       mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: children,
     );
     return LayoutBuilder(
@@ -850,9 +856,10 @@ class _MarkdownBlockColumn extends StatelessWidget {
         if (!constraints.hasBoundedHeight) return column;
         return OverflowBox(
           alignment: Alignment.topCenter,
+          fit: OverflowBoxFit.deferToChild,
           minHeight: 0,
           maxHeight: double.infinity,
-          child: SizedBox(width: constraints.maxWidth, child: column),
+          child: column,
         );
       },
     );

--- a/test/features/chat/widgets/assistant_bubble_fit_content_test.dart
+++ b/test/features/chat/widgets/assistant_bubble_fit_content_test.dart
@@ -40,7 +40,7 @@ Widget _buildHarness({
     child: MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: Scaffold(body: child),
+      home: Scaffold(body: SingleChildScrollView(child: child)),
     ),
   );
 }
@@ -82,6 +82,78 @@ Future<double> _bubbleWidth(
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final fitContent in [false, true]) {
+    for (final entry in {
+      // The incremental blocks path needs streaming text of 512+ chars; the
+      // short entry only proves the streaming->completed hand-off is stable.
+      'short': 'OK',
+      'paragraphs':
+          '${'First paragraph with enough text to engage incremental blocks. ' * 10}\n\nSecond paragraph.',
+      'wrapped': 'Long text that wraps across lines. ' * 30,
+      // Many short single-line paragraphs stay under the available width, so
+      // with fit-content enabled the streaming bubble genuinely hugs instead
+      // of being stretched by the block column. A regression back to
+      // full-width stretch breaks the equality assertion below.
+      'many paragraphs': List.generate(
+        17,
+        (i) => 'Hug ${i + 1} sized to a single line.',
+      ).join('\n\n'),
+    }.entries) {
+      testWidgets(
+        '${entry.key} bubble keeps its size through streaming (fitContent=$fitContent)',
+        (tester) async {
+          final settings = _createSettings(fitContent: fitContent);
+          final streaming = ValueNotifier(false);
+          final identity = ValueNotifier(0);
+          addTearDown(streaming.dispose);
+          addTearDown(identity.dispose);
+          await tester.pumpWidget(
+            _buildHarness(
+              settings: settings,
+              child: ListenableBuilder(
+                listenable: Listenable.merge([streaming, identity]),
+                builder: (_, _) => ChatMessageWidget(
+                  key: ValueKey(identity.value),
+                  message: ChatMessage(
+                    id: 'streaming-fit-content',
+                    role: 'assistant',
+                    content: entry.value,
+                    conversationId: 'conversation-fit-content',
+                    isStreaming: streaming.value,
+                  ),
+                  showModelIcon: false,
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          final content = find.byKey(
+            const ValueKey('assistant_streaming-fit-content'),
+          );
+          final completedSize = tester.getSize(content);
+          void expectCompletedSize() {
+            final size = tester.getSize(content);
+            // Separate paragraphs can omit the trailing letter spacing of
+            // an inline newline; allow that subpixel difference only.
+            expect(size.width, closeTo(completedSize.width, 0.1));
+            expect(size.height, closeTo(completedSize.height, 0.1));
+          }
+
+          // Start a new widget so it takes the streaming path from frame one.
+          identity.value++;
+          streaming.value = true;
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+          expectCompletedSize();
+
+          streaming.value = false;
+          await tester.pumpAndSettle();
+          expectCompletedSize();
+        },
+      );
+    }
+  }
 
   testWidgets('fit-content option shrinks the assistant bubble to its text', (
     tester,

--- a/test/shared/widgets/markdown_streaming_height_stability_test.dart
+++ b/test/shared/widgets/markdown_streaming_height_stability_test.dart
@@ -406,6 +406,58 @@ void main() {
       }
     });
 
+    testWidgets('within a bounded-height parent', (tester) async {
+      tester.view.physicalSize = const Size(2400, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      // The block column has a bounded-height branch that used to force the
+      // child to the parent's width. In a bounded parent the paragraphs fill
+      // the full width on both render paths anyway, so the branch contract is
+      // streaming/finished parity and width stability, not hugging. Assert
+      // that pair so a later change to the branch stays consistent.
+      final text = List.filled(20, 'A short hugged line fits.').join('\n\n');
+
+      Future<Size> sizeFor(bool streaming) async {
+        await tester.pumpWidget(
+          ChangeNotifierProvider.value(
+            value: settings,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Center(
+                  child: SizedBox(
+                    width: 600,
+                    height: 1000,
+                    child: MarkdownWithCodeHighlight(
+                      key: ValueKey<String>('bounded-$streaming'),
+                      text: text,
+                      streaming: streaming,
+                      baseStyle: baseStyle,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        return tester.getSize(find.byType(MarkdownWithCodeHighlight));
+      }
+
+      final streamingSize = await sizeFor(true);
+      final finishedSize = await sizeFor(false);
+      // Wrapping under a wide parent costs a few subpixels against the
+      // natural paragraph width; allow that rounding only.
+      expect(streamingSize.width, closeTo(finishedSize.width, 0.1));
+      expect(streamingSize.height, closeTo(finishedSize.height, 0.1));
+      // The bounded parent pins the column to its own full width on both
+      // paths, so the measured sizes must be the box size, not the viewport.
+      expect(streamingSize.width, greaterThan(500));
+      expect(finishedSize.width, greaterThan(500));
+    });
+
     testWidgets('for a long multi-paragraph reply', (tester) async {
       boundTester = tester;
       tester.view.physicalSize = const Size(1170, 2100);

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:Cuplivo/shared/widgets/markdown_line_lexer.dart';
 import 'package:Cuplivo/utils/markdown_code_scanner.dart';
@@ -576,6 +577,74 @@ Inline ***strong emphasis*** text.
       );
     },
   );
+
+  testWidgets('paragraph selection keeps line breaks through streaming', (
+    tester,
+  ) async {
+    // The incremental blocks path only engages for streaming text of 512+
+    // chars, so the paragraph fill is padded past that threshold. Sentences
+    // are joined with a space and none of them trails the blank line, so the
+    // original text has nothing the renderer would trim in either path.
+    final text =
+        '${List.filled(10, 'First paragraph with enough text to engage incremental blocks.').join(' ')}\n\nSecond paragraph.';
+    final streaming = ValueNotifier(true);
+    addTearDown(streaming.dispose);
+    String? selected;
+    await tester.pumpWidget(
+      _settingsHarness(
+        onSettingsReady: (_) {},
+        child: SelectionArea(
+          onSelectionChanged: (content) => selected = content?.plainText,
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: ValueListenableBuilder<bool>(
+              valueListenable: streaming,
+              builder: (_, value, _) =>
+                  MarkdownWithCodeHighlight(text: text, streaming: value),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    for (final value in [true, false]) {
+      streaming.value = value;
+      await tester.pumpAndSettle();
+      final region = tester.state<SelectableRegionState>(
+        find.byType(SelectableRegion),
+      );
+      region.selectAll(SelectionChangedCause.keyboard);
+      await tester.pumpAndSettle();
+      expect(selected, text, reason: 'streaming=$value');
+      region.clearSelection();
+      await tester.pump();
+
+      // A drag across the gap must include the same break as Select All.
+      final first = _paragraphContaining('First paragraph');
+      final second = _paragraphContaining('Second paragraph');
+      final start = first.localToGlobal(const Offset(1, 8));
+      final end = second.localToGlobal(Offset(second.size.width - 1, 8));
+      for (final reverse in [true, false]) {
+        // Separate the gestures so reversing at the previous endpoint does
+        // not become a double click and select a word instead of a range.
+        await tester.pump(const Duration(milliseconds: 400));
+        final gesture = await tester.startGesture(
+          reverse ? end : start,
+          kind: ui.PointerDeviceKind.mouse,
+        );
+        await tester.pump();
+        await gesture.moveTo(reverse ? start : end);
+        await tester.pump();
+        await gesture.up();
+        await gesture.removePointer();
+        await tester.pumpAndSettle();
+        expect(selected, text, reason: 'streaming=$value reverse=$reverse');
+        region.clearSelection();
+        await tester.pump();
+      }
+    }
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets(
     'MarkdownWithCodeHighlight renders grouped raw citation metadata as separate capsules',


### PR DESCRIPTION
## 问题

增量 Markdown 分块渲染在段落选择与宽度约束上仍和整文档渲染不一致:

- 段落间由不可选择的空格组件模拟空行,复制/全选时会丢失原始的两个换行(#707);
- `_MarkdownBlockColumn` 强制横向拉伸,启用"助手气泡适应内容"后,流式状态和完成状态可能得到不同的气泡宽高。

本 PR 移植上游 Kelivo 修复(https://github.com/Chevey339/kelivo/commit/88dd7a5c0aed9b209a9b5c1e4d3cd007c31e3dc2)并适配 Cuplivo 的 512 字符增量渲染阈值。

## 变更

- **`lib/shared/widgets/markdown_with_highlight.dart`**
  - `_MarkdownBlockSeparator`:用 `SelectableAdapter(selectedText: '\n\n')` 包裹原 `SelectionContainer.disabled` 空格行——视觉空行高度不变,选择/复制时补回原始双换行;
  - `_MarkdownBlockColumn`:`CrossAxisAlignment.stretch` → `start`;有界高度分支去掉 `SizedBox(width: constraints.maxWidth)`,改为 `OverflowBox(fit: OverflowBoxFit.deferToChild)`——宽松约束下气泡贴合内容,紧约束下仍填满可用宽度。

## 测试

上游测试基于其"流式即增量块"的路径(Cuplivo 需 512+ 字符才走增量渲染),故均改为长文本来真实覆盖分裂器:

- `markdown_with_highlight_test.dart`:跨段落选择和复制在流式/完成两种状态下保留 `\n\n`(全选 + 正/反向拖动,桌面三平台变体);
- `assistant_bubble_fit_content_test.dart`:流式/完成宽高一致性(short / 多段落 / 换行长文 / 多短段落 × fit-content 开/关)。其中"多短段落"用例中的段落均短于可用宽度,以确保流式气泡真实贴合而非被拉伸——回归到强制拉伸会立即失败;
- `markdown_streaming_height_stability_test.dart`:新增有界高度父级下的流式/完成宽高一致性,覆盖 `LayoutBuilder` 有界分支。

## 验证

- `dart format` 改动文件
- `dart analyze --fatal-infos lib test` → No issues found
- `markdown_with_highlight_test.dart` 全量 186 项通过
- `assistant_bubble_fit_content_test.dart`(10)与 `markdown_streaming_height_stability_test.dart`(6)通过
- 缺陷回退验证:临时恢复 `stretch` + `SizedBox(width:)` 后,新气泡"多短段落"用例失败(流式 736px vs 完成 472px),确认测试有效

## 已知限制

- 与上游一致:3 个以上连续换行的空隙在流式复制时仍补 `\n\n`(上游同一取舍);
- 选择测试覆盖桌面 mouse 手势,移动端长按/手柄拖动走同一 `SelectableRegion` 机制,未自动化覆盖。

Closes #707
