### PR TITLE
fix(markdown): preserve table scroll and HTML preview state during streaming

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -3669,7 +3669,7 @@ class _LoadingIndicatorState extends State<LoadingIndicator>
 /// Goals:
 /// - Make streaming output feel less "chunky" by smoothing size growth.
 /// - Respect reduce-motion settings.
-class _StreamingAssistantMessageMotion extends StatelessWidget {
+class _StreamingAssistantMessageMotion extends StatefulWidget {
   const _StreamingAssistantMessageMotion({
     required this.enabled,
     required this.child,
@@ -3679,8 +3679,20 @@ class _StreamingAssistantMessageMotion extends StatelessWidget {
   final Widget child;
 
   @override
+  State<_StreamingAssistantMessageMotion> createState() =>
+      _StreamingAssistantMessageMotionState();
+}
+
+class _StreamingAssistantMessageMotionState
+    extends State<_StreamingAssistantMessageMotion> {
+  final _contentKey = GlobalKey();
+
+  @override
   Widget build(BuildContext context) {
-    if (!enabled) return child;
+    // Reparent the same content when motion stops, retaining table gestures
+    // and offsets without leaving an AnimatedSize on completed messages.
+    final child = KeyedSubtree(key: _contentKey, child: widget.child);
+    if (!widget.enabled) return child;
 
     return AnimatedSize(
       key: const ValueKey('streaming-assistant-message-motion'),

--- a/lib/shared/widgets/html_preview_block.dart
+++ b/lib/shared/widgets/html_preview_block.dart
@@ -18,6 +18,7 @@ import '../../icons/lucide_adapter.dart';
 import 'export_capture_scope.dart';
 import 'snackbar.dart';
 import 'tabbed_preview_block.dart';
+import 'webview_gesture_claim.dart';
 
 enum _HtmlTab { preview, code }
 
@@ -517,10 +518,22 @@ class _HtmlPreviewBlockState extends State<HtmlPreviewBlock> {
     if (Platform.isWindows) {
       final c = _winCtrl;
       if (c == null) return const SizedBox.shrink();
-      return winweb.Webview(c);
+      // The texture-composited Windows WebView forwards wheel/drag events
+      // through a passive Listener, so without the claim the same gesture
+      // also scrolls the enclosing message list. Keep HTML scrolling inside
+      // the box and the list untouched.
+      return WebviewScrollClaim(child: winweb.Webview(c));
     }
     final c = _flutterCtrl;
     if (c == null) return const SizedBox.shrink();
+    if (Platform.isAndroid) {
+      // On Android the surrounding list's drag recognizer otherwise wins the
+      // arena and the embedded WebView never scrolls its HTML.
+      return WebViewWidget(
+        controller: c,
+        gestureRecognizers: WebviewEagerGestureRecognizer.recognizers,
+      );
+    }
     return WebViewWidget(controller: c);
   }
 

--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -125,10 +125,10 @@ class MarkdownWithCodeHighlight extends StatefulWidget {
 }
 
 class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
-  // Streamed text of 512+ chars is rendered as committed blocks plus a live
-  // tail (issue #334): committed blocks are parsed once and never re-parsed,
-  // so the debounce below only gates how often the whole document refreshes,
-  // not the per-tick parse cost (issue #232's original concern).
+  // Streamed text is rendered as committed blocks plus a live tail (issue
+  // #334): committed blocks are parsed once and never re-parsed, so the
+  // debounce below only gates how often the whole document refreshes, not the
+  // per-tick parse cost (issue #232's original concern).
   static const int _streamingDebounceThresholdChars = 8000;
   // Matches the stream controller's publish interval. A longer window would
   // batch several publishes into one render, and since the timeline is pinned
@@ -207,10 +207,11 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
       return value;
     }
 
-    // 512+ chars engage the incremental splitter; below that a full parse per
-    // tick is cheap and the tail behavior (no block boundaries yet) is simpler.
+    // Keep the same block tree from the first streaming frame through
+    // completion, so growing replies do not dispose interactive children
+    // (table scroll offsets, HTML preview state, code-block expansion).
     final useIncrementalBlocks =
-        widget.streaming && sanitizedText.length >= 512;
+        widget.streaming || _incrementalDocument.blocks.isNotEmpty;
     final sourceBlocks = useIncrementalBlocks
         ? _incrementalDocument.update(sanitizedText)
         : const <IncrementalMarkdownBlock>[];
@@ -596,10 +597,9 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                 // Rendering the document as one string keeps the blank run
                 // between two blocks as a real line box. Rendering block by
                 // block drops it, so a long reply is laid out tighter while it
-                // streams and then grows the moment it finishes and switches to
-                // the whole-document render. Put the line back so both paths
-                // agree — unless the block before it ends in something whose own
-                // renderer eats the run.
+                // streams compared with a freshly loaded completed reply. Put
+                // the line back so both paths agree — unless the preceding
+                // block's renderer eats the run.
                 if (i > 0 &&
                     !_swallowsTrailingBlankLine(
                       blockContents[i - 1].text,
@@ -615,6 +615,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
                   key: ValueKey(
                     'markdown-source-block-${sourceBlocks[i].start}',
                   ),
+                  source: sourceBlocks[i].text,
                   payload: blockContents[i],
                   signature: themeSignature,
                   builder: buildMarkdown,
@@ -623,6 +624,7 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
             ],
           )
         : _CachedMarkdownBlock(
+            source: sanitizedText,
             payload: normalized!,
             signature: themeSignature,
             builder: buildMarkdown,
@@ -676,11 +678,15 @@ typedef _MarkdownBlockBuilder =
 class _CachedMarkdownBlock extends StatefulWidget {
   const _CachedMarkdownBlock({
     super.key,
+    required this.source,
     required this.payload,
     required this.signature,
     required this.builder,
   });
 
+  /// The raw block source before preprocessing. Append-only while streaming;
+  /// replaced wholesale when the message content is edited.
+  final String source;
   final MarkdownCodePayload payload;
   final String signature;
   final _MarkdownBlockBuilder builder;
@@ -697,7 +703,8 @@ class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
   @override
   void didUpdateWidget(covariant _CachedMarkdownBlock oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.payload.text != widget.payload.text ||
+    if (oldWidget.source != widget.source ||
+        oldWidget.payload.text != widget.payload.text ||
         oldWidget.signature != widget.signature) {
       _rendered = null;
     }
@@ -718,7 +725,10 @@ class _CachedMarkdownBlockState extends State<_CachedMarkdownBlock> {
   Widget build(BuildContext context) {
     return _rendered ??= widget.builder(
       widget.payload,
-      _parseIdentity(widget.payload.text),
+      // Synthetic table cells and math delimiters change as tokens arrive;
+      // only a replacement of the source should reset interactive state.
+      // The splitter removes trailing newlines when a block becomes stable.
+      _parseIdentity(widget.source.trimRight()),
     );
   }
 }

--- a/lib/shared/widgets/webview_gesture_claim.dart
+++ b/lib/shared/widgets/webview_gesture_claim.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+/// A WebView gesture recognizer that eagerly accepts every pointer and
+/// trackpad pan/zoom sequence, so the WebView never loses a gesture to an
+/// enclosing `Scrollable`.
+///
+/// The vendored `webview_windows` `Webview` forwards pointer events to the
+/// native side through a passive `Listener` — which does not take part in the
+/// gesture arena — while the enclosing chat list's drag recognizer races the
+/// same events. Without an immediate accept the list wins and the HTML
+/// underneath never scrolls (Android) or the gesture goes to both (Windows
+/// touch input).
+class WebviewEagerGestureRecognizer extends EagerGestureRecognizer {
+  /// Recognizer set for platform WebViews that should own every gesture, fit
+  /// for [WebViewWidget.gestureRecognizers]. Uses the foundation `Factory`
+  /// type that webview_flutter expects.
+  static Set<Factory<OneSequenceGestureRecognizer>> get recognizers => {
+    Factory<OneSequenceGestureRecognizer>(WebviewEagerGestureRecognizer.new),
+  };
+
+  @override
+  String get debugDescription => 'eager-webview';
+
+  @override
+  void addAllowedPointerPanZoom(PointerPanZoomStartEvent event) {
+    startTrackingPointer(event.pointer, event.transform);
+    resolve(GestureDisposition.accepted);
+    stopTrackingPointer(event.pointer);
+  }
+}
+
+/// Wraps a platform WebView so wheel signals and touch/trackpad drags over it
+/// never reach the enclosing `Scrollable`.
+///
+/// `webview_windows` renders via a texture and forwards wheel deltas to the
+/// native side through a passive `Listener`, so the same `PointerScrollEvent`
+/// keeps bubbling to the message list's `Scrollable` and scrolls both (issue
+/// #706 follow-up). [Listener.onPointerSignal] registers a no-op with the
+/// [PointerSignalResolver] first — the resolver only runs the first
+/// registration, which is the deepest widget in the hierarchy — and the eager
+/// recognizer below claims drags on touch and trackpad input. The WebView
+/// itself is unaffected: it still receives every forwarded event.
+class WebviewScrollClaim extends StatelessWidget {
+  const WebviewScrollClaim({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: (event) {
+        GestureBinding.instance.pointerSignalResolver.register(
+          event,
+          (PointerSignalEvent _) {},
+        );
+      },
+      child: RawGestureDetector(
+        gestures: {
+          WebviewEagerGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<WebviewEagerGestureRecognizer>(
+                WebviewEagerGestureRecognizer.new,
+                (WebviewEagerGestureRecognizer _) {},
+              ),
+        },
+        child: child,
+      ),
+    );
+  }
+}

--- a/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_streaming_markdown_test.dart
@@ -49,6 +49,69 @@ String _allRichTextPlainText(WidgetTester tester) {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  testWidgets('ChatMessageWidget preserves table scroll when streaming ends', (
+    tester,
+  ) async {
+    markdownTableTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => markdownTableTargetPlatformOverride = null);
+    final streaming = ValueNotifier(true);
+    addTearDown(streaming.dispose);
+    await tester.pumpWidget(
+      _buildHarness(
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: SizedBox(
+            width: 360,
+            child: ValueListenableBuilder<bool>(
+              valueListenable: streaming,
+              builder: (context, value, _) => ChatMessageWidget(
+                message: ChatMessage(
+                  id: 'table-scroll',
+                  role: 'assistant',
+                  content:
+                      '| A | B | C | D | E |\n'
+                      '| --- | --- | --- | --- | --- |\n'
+                      '| apple | banana | cherry | date | elderberry |',
+                  conversationId: 'conversation-1',
+                  isStreaming: value,
+                ),
+                enableStreamingTextMotion: true,
+                showModelIcon: false,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    final viewport = find.byKey(
+      const ValueKey('markdown-table-horizontal-scroll'),
+    );
+    final scroll = find.descendant(
+      of: viewport,
+      matching: find.byType(Scrollable),
+    );
+    final state = tester.state<ScrollableState>(scroll);
+    await tester.drag(viewport, const Offset(-100, 0));
+    await tester.pump(const Duration(milliseconds: 300));
+    final offset = state.position.pixels;
+    expect(offset, greaterThan(50));
+
+    final gesture = await tester.startGesture(tester.getCenter(viewport));
+    await gesture.moveBy(const Offset(-40, 0));
+    await tester.pump();
+    final beforeComplete = state.position.pixels;
+    streaming.value = false;
+    await tester.pumpAndSettle();
+    expect(tester.state<ScrollableState>(scroll), same(state));
+    expect(state.position.pixels, beforeComplete);
+    await gesture.moveBy(const Offset(-40, 0));
+    await tester.pump();
+    expect(state.position.pixels, greaterThan(beforeComplete));
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets(
     'ChatMessageWidget keeps a partial streaming table row in table layout',
     (tester) async {

--- a/test/shared/widgets/html_preview_block_streaming_state_test.dart
+++ b/test/shared/widgets/html_preview_block_streaming_state_test.dart
@@ -1,0 +1,91 @@
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/html_preview_block.dart';
+import 'package:Cuplivo/shared/widgets/markdown_with_highlight.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+/// Streaming HTML fences must not remount `HtmlPreviewBlock` on every chunk:
+/// the preprocessing token embeds the content length and hash, so the
+/// tokenized payload changes non-appending while the raw fence source only
+/// grows. A remount restarts the preview spinner and resets the selected tab
+/// (issue #706 follow-up).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget harness(ValueListenable<String> html) {
+    final businessPrefs = BusinessPreferences.memoryForTests();
+    return ChangeNotifierProvider(
+      create: (_) => SettingsProvider(preferences: businessPrefs),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ValueListenableBuilder<String>(
+            valueListenable: html,
+            builder: (context, value, _) =>
+                MarkdownWithCodeHighlight(text: value, streaming: true),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('HtmlPreviewBlock keeps its state while a stream grows', (
+    tester,
+  ) async {
+    final html = ValueNotifier<String>('```html\n<div>\n  <p>hello</p>');
+    addTearDown(html.dispose);
+    await tester.pumpWidget(harness(html));
+    await tester.pump();
+
+    final blockFinder = find.byType(HtmlPreviewBlock);
+    expect(blockFinder, findsOneWidget);
+    final blockState = tester.state<State<HtmlPreviewBlock>>(blockFinder);
+    final spinner = find.byType(CircularProgressIndicator);
+    expect(spinner, findsOneWidget);
+    final spinnerElement = tester.element(spinner);
+
+    html.value += '\n  <p>more</p>';
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      tester.state<State<HtmlPreviewBlock>>(blockFinder),
+      same(blockState),
+    );
+    expect(
+      tester.element(find.byType(CircularProgressIndicator)),
+      same(spinnerElement),
+    );
+  });
+
+  testWidgets('HtmlPreviewBlock keeps the user-selected tab while streaming', (
+    tester,
+  ) async {
+    final html = ValueNotifier<String>('```html\n<div>\n  <p>hello</p>');
+    addTearDown(html.dispose);
+    await tester.pumpWidget(harness(html));
+    await tester.pump();
+
+    final blockFinder = find.byType(HtmlPreviewBlock);
+    final blockState = tester.state<State<HtmlPreviewBlock>>(blockFinder);
+
+    await tester.tap(find.text('Code'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const ValueKey('html-code-body')), findsOneWidget);
+
+    html.value += '\n  <p>even more</p>';
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.state<State<HtmlPreviewBlock>>(blockFinder),
+      same(blockState),
+    );
+    expect(find.byKey(const ValueKey('html-code-body')), findsOneWidget);
+  });
+}

--- a/test/shared/widgets/markdown_with_highlight_test.dart
+++ b/test/shared/widgets/markdown_with_highlight_test.dart
@@ -993,6 +993,165 @@ Inline ***strong emphasis*** text.
     expect(scrollView.physics, isA<ClampingScrollPhysics>());
   });
 
+  for (final longReply in [false, true]) {
+    testWidgets(
+      'streaming table preserves its offset and active drag (long=$longReply)',
+      (tester) async {
+        _overrideMarkdownTablePlatform(TargetPlatform.iOS);
+        await tester.binding.setSurfaceSize(const Size(800, 1600));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        final prefix = longReply ? '${'Intro text. ' * 50}\n\n' : '';
+        final text = ValueNotifier(
+          '$prefix| A | B | C | D | E |\n'
+          '| --- | --- | --- | --- | --- |\n| apple',
+        );
+        addTearDown(text.dispose);
+        await tester.pumpWidget(_streamingMarkdownHarness(text, width: 320));
+        await tester.pump();
+        final viewport = find.byKey(
+          const ValueKey('markdown-table-horizontal-scroll'),
+        );
+        final scroll = find.descendant(
+          of: viewport,
+          matching: find.byType(Scrollable),
+        );
+        final state = tester.state<ScrollableState>(scroll);
+        await tester.drag(viewport, const Offset(-100, 0));
+        await tester.pumpAndSettle();
+        final offset = state.position.pixels;
+        expect(offset, greaterThan(50));
+
+        text.value += ' banana';
+        await tester.pump();
+        expect(tester.state<ScrollableState>(scroll), same(state));
+        expect(state.position.pixels, offset);
+        expect(
+          find.textContaining('apple banana', findRichText: true),
+          findsWidgets,
+        );
+
+        final gesture = await tester.startGesture(tester.getCenter(viewport));
+        await gesture.moveBy(const Offset(-40, 0));
+        await tester.pump();
+        final duringDrag = state.position.pixels;
+        text.value += ' cherry';
+        await tester.pump();
+        expect(tester.state<ScrollableState>(scroll), same(state));
+        expect(state.position.pixels, duringDrag);
+        await gesture.moveBy(const Offset(-40, 0));
+        await tester.pump();
+        expect(state.position.pixels, greaterThan(duringDrag));
+        await gesture.up();
+        await tester.pumpAndSettle();
+      },
+    );
+  }
+
+  testWidgets(
+    'table offset survives stream growth, block close and completion',
+    (tester) async {
+      _overrideMarkdownTablePlatform(TargetPlatform.iOS);
+      var text =
+          '| A | B | C | D | E |\n'
+          '| --- | --- | --- | --- | --- |\n| apple';
+      Future<void> render({bool streaming = true}) async {
+        await tester.pumpWidget(
+          _markdownHarness(text, width: 320, streaming: streaming),
+        );
+        await tester.pump();
+      }
+
+      await render();
+      final viewport = find.byKey(
+        const ValueKey('markdown-table-horizontal-scroll'),
+      );
+      final scroll = find.descendant(
+        of: viewport,
+        matching: find.byType(Scrollable),
+      );
+      final state = tester.state<ScrollableState>(scroll);
+      await tester.drag(viewport, const Offset(-100, 0));
+      await tester.pumpAndSettle();
+      final offset = state.position.pixels;
+      expect(offset, greaterThan(50));
+
+      // Cross the old whole-document / incremental rendering threshold.
+      text += ' | ${'wide ' * 100} | C | D | E |';
+      expect(text.length, greaterThan(512));
+      await render();
+      expect(tester.state<ScrollableState>(scroll), same(state));
+      expect(state.position.pixels, offset);
+      for (final suffix in ['\n', '\nFollowing paragraph']) {
+        text += suffix;
+        await render();
+        expect(tester.state<ScrollableState>(scroll), same(state));
+        expect(state.position.pixels, offset);
+      }
+      await render(streaming: false);
+      expect(tester.state<ScrollableState>(scroll), same(state));
+      expect(state.position.pixels, offset);
+      expect(
+        find.textContaining('Following paragraph', findRichText: true),
+        findsWidgets,
+      );
+
+      text = text.replaceFirst('apple', 'replacement');
+      await render(streaming: false);
+      expect(tester.state<ScrollableState>(scroll).position.pixels, 0);
+      expect(
+        find.textContaining('replacement', findRichText: true),
+        findsWidgets,
+      );
+    },
+  );
+
+  testWidgets('appending to a table reuses the earlier table and its offset', (
+    tester,
+  ) async {
+    _overrideMarkdownTablePlatform(TargetPlatform.iOS);
+    const header =
+        '| A | B | C | D | E |\n'
+        '| --- | --- | --- | --- | --- |\n';
+    final text = ValueNotifier(
+      '$header| apple | B | C | D | E |\n\n$header| banana',
+    );
+    addTearDown(text.dispose);
+    await tester.pumpWidget(_streamingMarkdownHarness(text, width: 320));
+    await tester.pump();
+    final viewports = find.byKey(
+      const ValueKey('markdown-table-horizontal-scroll'),
+    );
+    expect(viewports, findsNWidgets(2));
+    final states = <ScrollableState>[];
+    for (var i = 0; i < 2; i++) {
+      states.add(
+        tester.state<ScrollableState>(
+          find.descendant(
+            of: viewports.at(i),
+            matching: find.byType(Scrollable),
+          ),
+        ),
+      );
+      await tester.drag(viewports.at(i), Offset(-80.0 * (i + 1), 0));
+      await tester.pumpAndSettle();
+    }
+    final offsets = states.map((state) => state.position.pixels).toList();
+    expect(offsets.first, greaterThan(0));
+    expect(offsets.last, greaterThan(offsets.first));
+    final cached = tester.widget<GptMarkdown>(find.byType(GptMarkdown).first);
+
+    text.value += ' cherry';
+    await tester.pump();
+    expect(tester.widget(find.byType(GptMarkdown).first), same(cached));
+    for (var i = 0; i < 2; i++) {
+      final state = tester.state<ScrollableState>(
+        find.descendant(of: viewports.at(i), matching: find.byType(Scrollable)),
+      );
+      expect(state, same(states[i]));
+      expect(state.position.pixels, offsets[i]);
+    }
+  });
+
   testWidgets(
     'MarkdownWithCodeHighlight does not add a bottom fade while streaming',
     (tester) async {

--- a/test/shared/widgets/webview_gesture_claim_test.dart
+++ b/test/shared/widgets/webview_gesture_claim_test.dart
@@ -1,0 +1,87 @@
+import 'package:Cuplivo/shared/widgets/webview_gesture_claim.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The wrapped WebView forwards pointer events to the native side through a
+/// passive `Listener`, so without the claim every wheel signal and touch drag
+/// also reaches the enclosing `Scrollable` — the chat list scrolls alongside
+/// the HTML (Windows) or eats the drag entirely (Android). These cases pin
+/// the claim behavior: over the WebView only the HTML scrolls, never the list.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Widget harness({required Widget child}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: [
+            const SizedBox(height: 200, child: Text('top')),
+            SizedBox(height: 300, child: child),
+            const SizedBox(height: 800, child: Text('bottom')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> pumpClaim(WidgetTester tester, {required bool claim}) async {
+    await tester.pumpWidget(
+      harness(
+        child: claim
+            ? WebviewScrollClaim(
+                child: Container(color: const Color(0xFF00FF00)),
+              )
+            : Container(color: const Color(0xFF00FF00)),
+      ),
+    );
+    await tester.pump();
+  }
+
+  ScrollableState listState(WidgetTester tester) {
+    return tester.state<ScrollableState>(find.byType(Scrollable).first);
+  }
+
+  testWidgets('wheel over the claim never scrolls the outer list', (
+    tester,
+  ) async {
+    await pumpClaim(tester, claim: true);
+    final target = find.byType(WebviewScrollClaim);
+    final center = tester.getCenter(target);
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(center));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 300)));
+    await tester.pumpAndSettle();
+
+    expect(listState(tester).position.pixels, 0);
+  });
+
+  testWidgets('wheel without the claim scrolls the outer list', (tester) async {
+    await pumpClaim(tester, claim: false);
+    final center = tester.getCenter(find.byType(Container));
+
+    final pointer = TestPointer(1, PointerDeviceKind.mouse);
+    await tester.sendEventToBinding(pointer.hover(center));
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, 300)));
+    await tester.pumpAndSettle();
+
+    expect(listState(tester).position.pixels, greaterThan(0));
+  });
+
+  testWidgets('drag over the claim never drags the outer list', (tester) async {
+    await pumpClaim(tester, claim: true);
+    await tester.drag(find.byType(WebviewScrollClaim), const Offset(0, -300));
+    await tester.pumpAndSettle();
+
+    expect(listState(tester).position.pixels, 0);
+  });
+
+  testWidgets('drag without the claim drags the outer list', (tester) async {
+    await pumpClaim(tester, claim: false);
+    await tester.drag(find.byType(Container), const Offset(0, -300));
+    await tester.pumpAndSettle();
+
+    expect(listState(tester).position.pixels, greaterThan(0));
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #706 — streaming Markdown tables lose their horizontal scroll offset when content grows or completes — plus the follow-up feedback items in the issue thread:

- In-chat HTML preview spinner restarts constantly during streaming.
- Switching the HTML preview to the Code tab is reverted on the next frame.
- Scrolling inside the HTML preview also scrolls the message list (Windows) or does nothing at all to the HTML (Android).

## Root cause

`MarkdownWithCodeHighlight` keyed `GptMarkdown` by the **preprocessed** payload text, which changes non-appending on most streaming frames:

- streaming table stabilization rewrites rows (`| a |  |  |` → `| ap |  |  |`),
- code-fence tokens embed length + FNV-1a hash, so every appended HTML/代码 chunk produces a new token string.

Each non-prefix change bumped the identity epoch → new `GptMarkdown` key → **the whole interactive subtree remounted** every few tokens: table `Scrollable` state (offset + active drag) reset, `HtmlPreviewBlock` State was recreated (spinner restarted, selected tab reverted). The whole-document ↔ incremental block switch at 512 chars and the switch back at generation-completion replaced the tree again, and `_StreamingAssistantMessageMotion` reparented its content without a key when `AnimatedSize` was removed.

Separately, the in-chat Windows `webview_windows` WebView forwards wheel/drag events through a passive `Listener` (texture composition), so the same `PointerScrollEvent` also reached the enclosing message-list `Scrollable` (double scroll); on Android the surrounding list's drag recognizer won the arena and the HTML never scrolled.

## Changes

- **`markdown_with_highlight.dart`** — use the incremental block tree from the first streaming frame and keep it through completion (`streaming || blocks.isNotEmpty`); key the parse identity on the raw block `source` (`trimRight`) instead of the preprocessed payload; only a true non-append source replacement resets interactive state. Mirrors upstream Kelivo `af10494` adapted for the payload-based cache.
- **`chat_message_widget.dart`** — `_StreamingAssistantMessageMotion` is now stateful and reparents the same content via `KeyedSubtree(GlobalKey)` when motion stops, retaining table gestures/offsets without leaving an `AnimatedSize` on completed messages.
- **`webview_gesture_claim.dart`** (new) — eager WebView gesture recognizer + `PointerSignalResolver` wheel claim; wired into `html_preview_block.dart` for Windows (`WebviewScrollClaim`) and Android (`WebViewWidget.gestureRecognizers`). Native input to the WebView is untouched; only the Flutter side stops leaking to the chat list. Mermaid/SVG previews and the desktop full-screen dialog are unaffected.

## Tests

- Ported upstream regression tests: streaming table offset + active drag preserved (short & long replies), offset survives growth/block-close/completion, appending reuses earlier tables, and `ChatMessageWidget` keeps its table scroll when streaming ends mid-drag.
- New: `HtmlPreviewBlock` State / spinner / selected tab identity across streaming growth (regression for the threading feedback items).
- New: `WebviewScrollClaim` pins wheel + drag behavior with controls (list scrolls without the claim, stays put with it).
- Verified: `dart analyze --fatal-infos lib test` clean; target suites pass (`markdown_with_highlight_test` 187, `markdown_streaming_height_stability_test`, `chat_message_widget_streaming_markdown_test`, `html_preview_block_streaming_state_test`, `webview_gesture_claim_test`, `reading_mode_page_test`).

## Manual testing

Desktop (Windows) checks 2 and 3 pass: HTML preview spinner keeps animating during streaming, Code tab selection sticks, and wheel over the preview only scrolls the HTML, never the message list.

Remaining manual verification (will update after): Android touch drag inside the HTML preview should scroll the HTML, not the list; primary Issue #706 flow (scroll a wide table while streaming, across threshold/completion, regenerate to confirm reset).

## Checklist

- [x] `flutter gen-l10n` not needed (no ARB changes)
- [x] `dart format` on changed paths
- [x] `dart analyze --fatal-infos lib test` passes
- [x] Related `flutter test` subset passes
- [x] No new user-visible strings
- [x] No generated files hand-edited
- [x] Desktop task confirmed entry boundary (`lib/desktop/**` untouched)
- [x] Self-review: compatibility — non-streaming renders (history/reading mode/export) keep the whole-document path; true content replacement still resets scroll state
