### PR TITLE
fix(memory): typed JSON confirmations for memory tool writes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -378,6 +378,12 @@
 - **UI shell**: Dual-shell, same content — centered Dialog on desktop, bottom sheet on mobile (same pattern as `ImageCompressionDialog` / `UpdateChangelogDialog`).
 - **Responses API native image generation (Responses 原生图像生成)**: Distinct from the Images API routing above. When the provider uses the Responses API (`useResponseApi == true`), the model can emit image output natively as output items of type `image_generation_call` (OpenAI) or `openrouter:image_generation` (OpenRouter), whose `result` carries base64 image data — possibly a full `data:` URL — rendered as saved local images. No `/images/generations` or `/images/edits` call is involved. Non-streaming responses must still scan the `output` array for image items even when `output_text` is present; the text short-circuit would otherwise drop the image.
 
+## Memory Tools (记忆工具)
+
+- **Status vs data split (状态与数据划分)**: Memory tool returns follow two distinct contracts. **Status returns** (`create_memory`, `edit_memory`, `delete_memory`) are typed JSON confirmation objects mirroring `_toolError`: `{"type":"memory_created","id":5}`, `{"type":"memory_edited","id":5}`, `{"type":"memory_deleted","id":7}` — a parseable terminal signal the model can recognize as the call having succeeded (issue #584; the historical Kelivo infinite-create loop was a missing success signal: create/edit echoed an unmarked `<record>` XML indistinguishable from the injected context block). **Data return** (`read_memory`) stays `<memories>` XML — its format is deliberately identical to the system-injected memories block (`message_builder_service.dart`), because edit/delete descriptions reference ids "shown in the `<memories>` context"; the success-signal problem does not apply to data payloads.
+- **No content echo**: Status success confirmations never echo the stored content — the model just sent it; the assigned id is the only new information. Echoing invites weak models to re-process the content and costs tokens. Error paths keep the full `_toolError` `{type,error,message,tool,instruction}` shape unchanged.
+- **Landing point**: `_handleMemoryToolCall` in `tool_handler_service.dart` is the single dispatcher. Proactive-care decision flow and group-chat director build their own handlers and never expose memory tools; handoff children run the same `ToolHandlerService`. Tool descriptions and the fixed Memory Tool system block do NOT describe return formats (deliberate — the typed JSON is self-describing; no prompt churn).
+
 ## Skill System
 
 ### Core Concept

--- a/lib/features/home/services/tool_handler_service.dart
+++ b/lib/features/home/services/tool_handler_service.dart
@@ -1047,7 +1047,7 @@ class ToolHandlerService {
           );
         }
         final m = await mp.add(assistantId: assistant!.id, content: content);
-        return AssistantMemory.buildRecordXml(m.id, m.content);
+        return jsonEncode({'type': 'memory_created', 'id': m.id});
       } else if (name == 'edit_memory') {
         final id = (args['id'] as num?)?.toInt() ?? -1;
         final content = (args['content'] ?? '').toString();
@@ -1075,7 +1075,7 @@ class ToolHandlerService {
                 'Use the available memory records shown in context, or create a new memory instead of editing a missing one.',
           );
         }
-        return AssistantMemory.buildRecordXml(m.id, m.content);
+        return jsonEncode({'type': 'memory_edited', 'id': m.id});
       } else if (name == 'delete_memory') {
         final id = (args['id'] as num?)?.toInt() ?? -1;
         if (id <= 0) {
@@ -1095,7 +1095,7 @@ class ToolHandlerService {
                 'Use the available memory records shown in context, or skip deleting a missing memory.',
           );
         }
-        return 'deleted';
+        return jsonEncode({'type': 'memory_deleted', 'id': id});
       } else if (name == 'read_memory') {
         await mp.initialize();
         final mems = mp.getForAssistant(assistant!.id);

--- a/test/features/home/services/tool_handler_service_test.dart
+++ b/test/features/home/services/tool_handler_service_test.dart
@@ -25,7 +25,7 @@ void main() {
       businessPrefs = BusinessPreferences.memoryForTests({});
     });
 
-    testWidgets('edit_memory returns updated content when id exists', (
+    testWidgets('edit_memory returns typed JSON confirmation when id exists', (
       tester,
     ) async {
       final assistant = Assistant(
@@ -62,7 +62,157 @@ void main() {
         'content': 'new memory',
       });
 
-      expect(result, contains('<content>new memory</content>'));
+      final payload = jsonDecode(result) as Map<String, dynamic>;
+      expect(payload, {'type': 'memory_edited', 'id': memory.id});
+      expect(payload, hasLength(2));
+    });
+
+    testWidgets('create_memory returns typed JSON confirmation with new id', (
+      tester,
+    ) async {
+      final assistant = Assistant(
+        id: 'assistant-a',
+        name: 'Assistant',
+        enableMemory: true,
+      );
+
+      await tester.pumpWidget(
+        _ToolHandlerTestScope(
+          child: Builder(
+            builder: (context) {
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final context = tester.element(find.byType(SizedBox));
+      final handler = ToolHandlerService(contextProvider: context)
+          .buildToolCallHandler(
+            SettingsProvider(preferences: businessPrefs),
+            assistant,
+          )!;
+
+      final result = await handler('create_memory', {'content': 'new memory'});
+
+      final payload = jsonDecode(result) as Map<String, dynamic>;
+      expect(payload['type'], 'memory_created');
+      expect(payload['id'], isA<int>());
+      expect(payload['id'], greaterThan(0));
+      expect(payload, hasLength(2));
+      final stored = context.read<MemoryProvider>().getForAssistant(
+        assistant.id,
+      );
+      expect(stored.single.content, 'new memory');
+    });
+
+    testWidgets('create_memory rejects empty content', (tester) async {
+      final assistant = Assistant(
+        id: 'assistant-a',
+        name: 'Assistant',
+        enableMemory: true,
+      );
+
+      await tester.pumpWidget(
+        _ToolHandlerTestScope(
+          child: Builder(
+            builder: (context) {
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final context = tester.element(find.byType(SizedBox));
+      final handler = ToolHandlerService(contextProvider: context)
+          .buildToolCallHandler(
+            SettingsProvider(preferences: businessPrefs),
+            assistant,
+          )!;
+
+      final result = await handler('create_memory', {'content': ''});
+
+      final payload = jsonDecode(result) as Map<String, dynamic>;
+      expect(payload['type'], 'tool_error');
+      expect(payload['error'], 'invalid_memory_content');
+      expect(payload['tool'], 'create_memory');
+    });
+
+    testWidgets('delete_memory returns typed JSON confirmation', (
+      tester,
+    ) async {
+      final assistant = Assistant(
+        id: 'assistant-a',
+        name: 'Assistant',
+        enableMemory: true,
+      );
+
+      await tester.pumpWidget(
+        _ToolHandlerTestScope(
+          child: Builder(
+            builder: (context) {
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final context = tester.element(find.byType(SizedBox));
+      final memoryProvider = context.read<MemoryProvider>();
+      final memory = await memoryProvider.add(
+        assistantId: assistant.id,
+        content: 'doomed memory',
+      );
+      final handler = ToolHandlerService(contextProvider: context)
+          .buildToolCallHandler(
+            SettingsProvider(preferences: businessPrefs),
+            assistant,
+          )!;
+
+      final result = await handler('delete_memory', {'id': memory.id});
+
+      final payload = jsonDecode(result) as Map<String, dynamic>;
+      expect(payload, {'type': 'memory_deleted', 'id': memory.id});
+      expect(payload, hasLength(2));
+      expect(memoryProvider.getForAssistant(assistant.id), isEmpty);
+    });
+
+    testWidgets('read_memory keeps the XML <memories> data payload', (
+      tester,
+    ) async {
+      final assistant = Assistant(
+        id: 'assistant-a',
+        name: 'Assistant',
+        enableMemory: true,
+      );
+
+      await tester.pumpWidget(
+        _ToolHandlerTestScope(
+          child: Builder(
+            builder: (context) {
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final context = tester.element(find.byType(SizedBox));
+      final memoryProvider = context.read<MemoryProvider>();
+      await memoryProvider.add(
+        assistantId: assistant.id,
+        content: 'first memory',
+      );
+      final handler = ToolHandlerService(contextProvider: context)
+          .buildToolCallHandler(
+            SettingsProvider(preferences: businessPrefs),
+            assistant,
+          )!;
+
+      final result = await handler('read_memory', {});
+
+      expect(result, contains('<memories>'));
+      expect(result, contains('<content>first memory</content>'));
+      expect(result, isNot(contains('"type"')));
     });
 
     testWidgets('edit_memory returns tool error when id does not exist', (


### PR DESCRIPTION
## Context

Refs #584: a non-standard tool-return format confuses some models/providers. The historical Kelivo report (issue comment) was models **infinitely creating memories** — the actual root cause is not "not JSON" in general but the **missing success signal** on `create_memory` / `edit_memory` (and the weak `'deleted'` for delete):

- Success returns echoed `<record>\n<id>…</id>\n<content>…</content>\n</record>` — byte-identical to the injected `<memories>` context block, byte-identical between create and edit, with no "created/saved/success" word anywhere.
- Failure returns a typed JSON `_toolError` `{type, error, message, tool, instruction}` — the model gets *unambiguous failure semantics* but *ambiguous success semantics*, exactly the asymmetry that produces retry loops on the success path.
- No in-app consumer parses these strings (display + verbatim history replay only), so the format is safe to change.

## Change

`_handleMemoryToolCall` (single landing point for memory tools; proactive-care and director flows never expose them):

- `create_memory` success → `{"type":"memory_created","id":5}`
- `edit_memory` success → `{"type":"memory_edited","id":5}`
- `delete_memory` success → `{"type":"memory_deleted","id":7}` (was bare `'deleted'`)
- `read_memory` stays `<memories>` XML — it is a **data** payload, deliberately identical to the system-injected memories block (edit/delete descriptions reference ids "shown in the `<memories>` context"); the success-signal problem does not apply.
- No content echo: the model just sent the content; the id is the only new information.
- Tool descriptions and the Memory Tool system block unchanged — the typed return is self-describing (no prompt churn).

## Scope boundary

Memory tools only. The #584 literal ask "workspace tools return standard JSON" stays open — workspace filesystem prose successes are unambiguous (`Wrote N bytes to X`), and errors will be dealt with separately. Also excluded (pre-existing, unaffected): MCP passthrough, `load_skill`/`read_skill_file`, Gemini non-stream wrap-only path (`google_common.dart`).

## Verification

- `flutter test test/features/home/services/tool_handler_service_test.dart` → 15/15 pass
- `dart analyze --fatal-infos lib test` → No issues found
- `dart format` on both changed files
- Full `flutter test` not run locally (CI covers the suite)

Compatibility: recorded history replays old XML verbatim (no migration; mixed formats in one request are historical facts). Gemini streaming/history paths will now unwrap the JSON object into `functionResponse.response` (an improvement over the previous `{'result': "<record>…"}` wrapping).
