### PR TITLE
fix(webview): 修复 Web 对话样式 GitHub 导入对话框满屏高与横排截断

### DIFF
--- a/lib/features/settings/pages/web_conversation_styles_page.dart
+++ b/lib/features/settings/pages/web_conversation_styles_page.dart
@@ -224,6 +224,7 @@ class _WebConversationStylesPageState extends State<WebConversationStylesPage> {
             label: l10n.webConversationStylesImportGithub,
             controller: controller,
             hintText: l10n.webConversationStylesGithubHint,
+            inlineLabel: false,
             autofocus: true,
           ),
         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4228,7 +4228,7 @@
   "webConversationStylesImportFile": "Local file or ZIP",
   "webConversationStylesImportGithub": "GitHub repository or style file",
   "webConversationStylesGithubTitle": "Import from GitHub",
-  "webConversationStylesGithubHint": "GitHub repository, tree, blob, or raw style file URL",
+  "webConversationStylesGithubHint": "Repo or style file URL",
   "webConversationStylesSelectTitle": "Select styles to import",
   "webConversationStylesSelectAll": "Select all",
   "webConversationStylesDeselectAll": "Deselect all",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17596,7 +17596,7 @@ abstract class AppLocalizations {
   /// No description provided for @webConversationStylesGithubHint.
   ///
   /// In en, this message translates to:
-  /// **'GitHub repository, tree, blob, or raw style file URL'**
+  /// **'Repo or style file URL'**
   String get webConversationStylesGithubHint;
 
   /// No description provided for @webConversationStylesSelectTitle.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9826,8 +9826,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get webConversationStylesGithubTitle => 'Import from GitHub';
 
   @override
-  String get webConversationStylesGithubHint =>
-      'GitHub repository, tree, blob, or raw style file URL';
+  String get webConversationStylesGithubHint => 'Repo or style file URL';
 
   @override
   String get webConversationStylesSelectTitle => 'Select styles to import';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9366,8 +9366,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get webConversationStylesGithubTitle => '从 GitHub 导入';
 
   @override
-  String get webConversationStylesGithubHint =>
-      'GitHub 仓库、tree、blob 或 raw 样式文件 URL';
+  String get webConversationStylesGithubHint => '仓库或样式文件 URL';
 
   @override
   String get webConversationStylesSelectTitle => '选择要导入的样式';
@@ -18971,8 +18970,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get webConversationStylesGithubTitle => '从 GitHub 导入';
 
   @override
-  String get webConversationStylesGithubHint =>
-      'GitHub 仓库、tree、blob 或 raw 样式文件 URL';
+  String get webConversationStylesGithubHint => '仓库或样式文件 URL';
 
   @override
   String get webConversationStylesSelectTitle => '选择要导入的样式';
@@ -28578,8 +28576,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get webConversationStylesGithubTitle => '從 GitHub 匯入';
 
   @override
-  String get webConversationStylesGithubHint =>
-      'GitHub 儲存庫、tree、blob 或 raw 樣式檔案 URL';
+  String get webConversationStylesGithubHint => '儲存庫或樣式檔案 URL';
 
   @override
   String get webConversationStylesSelectTitle => '選擇要匯入的樣式';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -3630,7 +3630,7 @@
   "webConversationStylesImportFile": "本地文件或 ZIP",
   "webConversationStylesImportGithub": "GitHub 仓库或样式文件",
   "webConversationStylesGithubTitle": "从 GitHub 导入",
-  "webConversationStylesGithubHint": "GitHub 仓库、tree、blob 或 raw 样式文件 URL",
+  "webConversationStylesGithubHint": "仓库或样式文件 URL",
   "webConversationStylesSelectTitle": "选择要导入的样式",
   "webConversationStylesSelectAll": "全选",
   "webConversationStylesDeselectAll": "取消全选",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -3631,7 +3631,7 @@
   "webConversationStylesImportFile": "本地文件或 ZIP",
   "webConversationStylesImportGithub": "GitHub 仓库或样式文件",
   "webConversationStylesGithubTitle": "从 GitHub 导入",
-  "webConversationStylesGithubHint": "GitHub 仓库、tree、blob 或 raw 样式文件 URL",
+  "webConversationStylesGithubHint": "仓库或样式文件 URL",
   "webConversationStylesSelectTitle": "选择要导入的样式",
   "webConversationStylesSelectAll": "全选",
   "webConversationStylesDeselectAll": "取消全选",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -3631,7 +3631,7 @@
   "webConversationStylesImportFile": "本機檔案或 ZIP",
   "webConversationStylesImportGithub": "GitHub 儲存庫或樣式檔案",
   "webConversationStylesGithubTitle": "從 GitHub 匯入",
-  "webConversationStylesGithubHint": "GitHub 儲存庫、tree、blob 或 raw 樣式檔案 URL",
+  "webConversationStylesGithubHint": "儲存庫或樣式檔案 URL",
   "webConversationStylesSelectTitle": "選擇要匯入的樣式",
   "webConversationStylesSelectAll": "全選",
   "webConversationStylesDeselectAll": "取消全選",

--- a/lib/shared/widgets/ios_form_text_field.dart
+++ b/lib/shared/widgets/ios_form_text_field.dart
@@ -155,18 +155,26 @@ class IosFormTextField extends StatelessWidget {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       );
-      final fieldWidget = Container(
+      // heightFactor 1.0 forces the Align to shrink-wrap its child instead of
+      // expanding to fill bounded loose height (e.g. inside AlertDialog
+      // content), which used to stretch the whole dialog to full screen height.
+      final fieldWidget = ConstrainedBox(
         constraints: const BoxConstraints(minHeight: 40),
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: enabled ? fieldBg : fieldBg.withValues(alpha: 0.55),
-          borderRadius: BorderRadius.circular(10),
+        child: Align(
+          alignment: Alignment.center,
+          heightFactor: 1.0,
+          child: Container(
+            decoration: BoxDecoration(
+              color: enabled ? fieldBg : fieldBg.withValues(alpha: 0.55),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            padding: EdgeInsets.symmetric(
+              horizontal: fieldHorizontalPadding,
+              vertical: 9,
+            ),
+            child: field,
+          ),
         ),
-        padding: EdgeInsets.symmetric(
-          horizontal: fieldHorizontalPadding,
-          vertical: 9,
-        ),
-        child: field,
       );
       return Padding(
         padding: resolvedOuterPadding,
@@ -189,6 +197,9 @@ class IosFormTextField extends StatelessWidget {
     return Padding(
       padding: resolvedOuterPadding,
       child: Column(
+        // Must shrink to content: a max-height Column would otherwise fill any
+        // bounded loose height (e.g. inside AlertDialog content).
+        mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
@@ -200,20 +211,28 @@ class IosFormTextField extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          Container(
+          // Same bounded-height expansion guard as the inline branch.
+          ConstrainedBox(
             constraints: maxLines == 1
                 ? const BoxConstraints(minHeight: 40)
-                : null,
-            alignment: maxLines == 1 ? Alignment.centerLeft : Alignment.topLeft,
-            decoration: BoxDecoration(
-              color: enabled ? fieldBg : fieldBg.withValues(alpha: 0.55),
-              borderRadius: BorderRadius.circular(12),
+                : const BoxConstraints(),
+            child: Align(
+              alignment: maxLines == 1
+                  ? Alignment.centerLeft
+                  : Alignment.topLeft,
+              heightFactor: 1.0,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: enabled ? fieldBg : fieldBg.withValues(alpha: 0.55),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                padding: EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: maxLines > 1 ? 12 : 9,
+                ),
+                child: field,
+              ),
             ),
-            padding: EdgeInsets.symmetric(
-              horizontal: 12,
-              vertical: maxLines > 1 ? 12 : 9,
-            ),
-            child: field,
           ),
         ],
       ),

--- a/test/features/settings/pages/web_conversation_styles_page_test.dart
+++ b/test/features/settings/pages/web_conversation_styles_page_test.dart
@@ -5,7 +5,9 @@ import 'package:Cuplivo/core/models/web_conversation_style.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/features/settings/pages/display_settings_page.dart';
 import 'package:Cuplivo/features/settings/pages/web_conversation_styles_page.dart';
+import 'package:Cuplivo/icons/lucide_adapter.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/shared/widgets/ios_form_text_field.dart';
 import 'package:Cuplivo/shared/widgets/ios_switch.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -97,6 +99,36 @@ void main() {
     await pumpPage(tester, const WebConversationStylesPage());
 
     expect(find.text('Experimental: WebView rendering'), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets('github import dialog stays compact and stacks vertically', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    // Narrow-surface expansion of the bounded field itself is covered by
+    // test/shared/widgets/ios_form_text_field_test.dart; this end-to-end
+    // test uses the default width because the FlutterTest/Ahem glyph squares
+    // make the import-source tiles overflow on narrow test surfaces.
+    await pumpPage(tester, const WebConversationStylesPage());
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(WebConversationStylesPage)),
+    )!;
+    await tester.tap(find.byIcon(Lucide.Download));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.webConversationStylesImportGithub));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    final label = find.text(l10n.webConversationStylesImportGithub);
+    final field = find.byType(TextField);
+    expect(label, findsOneWidget);
+    expect(field, findsOneWidget);
+    expect(find.text(l10n.webConversationStylesGithubHint), findsOneWidget);
+    expect(tester.getTopLeft(label).dy, lessThan(tester.getTopLeft(field).dy));
+    expect(tester.getSize(find.byType(IosFormTextField)).height, lessThan(250));
+    expect(tester.takeException(), isNull);
     debugDefaultTargetPlatformOverride = null;
   });
 

--- a/test/shared/widgets/ios_form_text_field_test.dart
+++ b/test/shared/widgets/ios_form_text_field_test.dart
@@ -1,0 +1,77 @@
+import 'package:Cuplivo/shared/widgets/ios_form_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget boundedHarness(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320, maxHeight: 360),
+          child: child,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('inline mode does not expand under bounded loose height', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      boundedHarness(
+        IosFormTextField(
+          label: 'Label',
+          controller: controller,
+          hintText: 'Hint text',
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(IosFormTextField)).height, lessThan(150));
+  });
+
+  testWidgets('column mode single-line does not expand under bounded height', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      boundedHarness(
+        IosFormTextField(
+          label: 'Label',
+          controller: controller,
+          hintText: 'Hint text',
+          inlineLabel: false,
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(IosFormTextField)).height, lessThan(150));
+    expect(tester.getSize(find.byType(TextField)).width, greaterThan(260));
+  });
+
+  testWidgets('multi-line mode grows to content, not bounded height', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      boundedHarness(
+        IosFormTextField(
+          label: 'Label',
+          controller: controller,
+          maxLines: 3,
+          minLines: 3,
+          inlineLabel: false,
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(IosFormTextField)).height, lessThan(250));
+  });
+}


### PR DESCRIPTION
## 问题

手机端/电脑端 Web 对话样式页「从 GitHub 导入」对话框存在三个毛病：

1. **满屏高**：`IosFormTextField` 的 `Container(alignment:)`（`RenderPositionedBox`）在 AlertDialog 的**有界宽松高度**下会取 `maxHeight` 撑满（`shifted_box.dart`: `shrinkWrapHeight=false` → `constrain(∞)=maxHeight`），整个 dialog 被撑到全屏高；页面/滚动视图等无界高度场景不受影响，故只在 dialog 内爆发。
2. **横排截断**：inline 布局把 label（flex 3 ≈ 57px）输入框（flex 8 ≈ 143px）挤在一起，label 被 ellipsis，placeholder（约 334px）裁切。
3. 桌面端与手机端共用同一 `_importGithub` 代码路径，桌面同样中招（label 只分到约 135px，英文文案照样截断）。

## 修复

- **根修** `IosFormTextField`（`lib/shared/widgets/ios_form_text_field.dart`）：
  - 字段容器改为 `ConstrainedBox(minHeight: 40) + Align(heightFactor: 1.0) + Container`，高度永远 shrink-wrap 到内容，居中/全宽渲染逐像素不变；
  - 竖排分支外层 `Column` 补 `mainAxisSize: MainAxisSize.min`（此为第二扩张源）；
  - 无界上下文（world_book / lan_sync / workspace / group_chat 等）渲染不变；手动导入、SAF 挂载添加、压缩上下文等有界 dialog 的同类满屏问题一并修复。
- **竖排**：GitHub 导入 dialog 增加 `inlineLabel: false`（沿用 world_book/workspace 既有模式）。
- **placeholder**：缩短 4 个 ARB 的 `webConversationStylesGithubHint`（en: `Repo or style file URL`；zh/zh_Hans: `仓库或样式文件 URL`；zh_Hant: `儲存庫或樣式檔案 URL`），竖排全宽下单行显示完全。
- **测试**：
  - 新增 `test/shared/widgets/ios_form_text_field_test.dart`：320×360 有界宽松高度下 inline / 竖排单行 / 多行三模式不扩张 + 全宽回归；
  - 扩展 `test/features/settings/pages/web_conversation_styles_page_test.dart`：GitHub 对话框紧凑（高度 < 250）且 label 在输入框上方。

## 验证

- `flutter gen-l10n` ✓（4 个 ARB 同步，`desiredFileName.txt` 无未翻译条目）
- `dart analyze --fatal-infos lib test` ✓
- `flutter test`（新组件测试 + 页面测试 + tools_hub 相关回归，17 例）✓
- 用户本地真机/桌面验证通过。

## 备注

- 测试环境 Ahem 字形方框导致的选择来源对话框横溢出为测试环境固有现象，页面测试使用默认宽度，窄屏扩张行为由 320×360 组件测试覆盖。
- 已知既存小问题（未纳入本次改动）：窄屏 360dp 下导入来源选择对话框英文 `IosTileButton` 文案略溢出，与本次修复无关，建议另行处理。
