### PR TITLE
fix(minimax): disable thinking via thinking type disabled (issue #576)

### DIFF
--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -1173,6 +1173,13 @@ class _OpenAIProviderInfo {
   bool get isDeepSeek =>
       host.contains('deepseek') ||
       upstreamModelId.toLowerCase().contains('deepseek');
+  bool get isMiniMax =>
+      host.contains('minimax') ||
+      providerId.contains('minimax') ||
+      RegExp(
+        r'(^|[/_:@])minimax-',
+        caseSensitive: false,
+      ).hasMatch(upstreamModelId.trim());
   bool get isDashScope => host.contains('dashscope') || host.contains('aliyun');
   bool get isVolc =>
       host.contains('ark.cn-beijing.volces.com') ||
@@ -1287,6 +1294,13 @@ void _applyVendorReasoningKnobs(
       body.remove('thinking');
       body.remove('reasoning_effort');
     }
+  } else if (info.isMiniMax) {
+    if (isReasoning) {
+      body['thinking'] = {'type': off ? 'disabled' : 'adaptive'};
+    } else {
+      body.remove('thinking');
+    }
+    body.remove('reasoning_effort');
   }
 }
 

--- a/test/openai_minimax_compat_test.dart
+++ b/test/openai_minimax_compat_test.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _minimaxConfig(
+  String baseUrl, {
+  String modelId = 'MiniMax-M3',
+  List<String> abilities = const ['tool', 'reasoning'],
+}) {
+  return ProviderConfig(
+    id: 'MiniMaxTest',
+    enabled: true,
+    name: 'MiniMaxTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    models: const ['MiniMax-M3'],
+    modelOverrides: {
+      modelId: {
+        'type': 'chat',
+        'input': ['text'],
+        'output': ['text'],
+        'abilities': abilities,
+      },
+    },
+  );
+}
+
+Future<HttpServer> _startCaptureServer(
+  List<Map<String, dynamic>> requests,
+) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) async {
+    requests.add(
+      jsonDecode(await utf8.decoder.bind(request).join())
+          as Map<String, dynamic>,
+    );
+
+    request.response.statusCode = HttpStatus.ok;
+    request.response.headers.contentType = ContentType(
+      'text',
+      'event-stream',
+      charset: 'utf-8',
+    );
+    request.response.write(
+      'data: ${jsonEncode({
+        'id': 'cmpl-minimax',
+        'object': 'chat.completion.chunk',
+        'created': 0,
+        'model': 'MiniMax-M3',
+        'choices': [
+          {
+            'index': 0,
+            'delta': {'role': 'assistant', 'content': 'ok'},
+            'finish_reason': 'stop',
+          },
+        ],
+      })}\n\n',
+    );
+    request.response.write('data: [DONE]\n\n');
+    await request.response.close();
+  });
+  return server;
+}
+
+void main() {
+  group('MiniMax thinking control', () {
+    test('MiniMax-M3 with thinking off sends thinking disabled', () async {
+      final requests = <Map<String, dynamic>>[];
+      final server = await _startCaptureServer(requests);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _minimaxConfig(baseUrl),
+        modelId: 'MiniMax-M3',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 0,
+      ).toList();
+
+      expect(requests, hasLength(1));
+      expect(requests[0]['thinking'], {'type': 'disabled'});
+      expect(requests[0].containsKey('reasoning_effort'), isFalse);
+    });
+
+    test('MiniMax-M3 with thinking budget sends thinking adaptive', () async {
+      final requests = <Map<String, dynamic>>[];
+      final server = await _startCaptureServer(requests);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _minimaxConfig(baseUrl),
+        modelId: 'MiniMax-M3',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 1024,
+      ).toList();
+
+      expect(requests, hasLength(1));
+      expect(requests[0]['thinking'], {'type': 'adaptive'});
+      expect(requests[0].containsKey('reasoning_effort'), isFalse);
+    });
+
+    test('non-reasoning MiniMax model gets no thinking key', () async {
+      final requests = <Map<String, dynamic>>[];
+      final server = await _startCaptureServer(requests);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _minimaxConfig(
+          baseUrl,
+          modelId: 'MiniMax-Text-01',
+          abilities: const ['tool'],
+        ),
+        modelId: 'MiniMax-Text-01',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 0,
+      ).toList();
+
+      expect(requests, hasLength(1));
+      expect(requests[0].containsKey('thinking'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #576: MiniMax-M3 still thinks when "no-thinking mode" is enabled.

**Root cause:** MiniMax OpenAI-compatible request bodies carried no thinking-control parameter. When the user turns thinking off (`thinkingBudget = 0`), the generic builder omits `reasoning_effort` (openai_common.dart), and `_applyVendorReasoningKnobs` had vendor branches for OpenRouter / DashScope / Zhipu / Mimo / Volc / Intern / SiliconFlow / DeepSeek but none for MiniMax — nothing matched `api.minimax.io` / `api.minimaxi.com` / `MiniMax-M*`. Per MiniMax official docs, omitting `thinking` means thinking **on by default**, so M3 kept thinking.

**Fix:** per MiniMax docs (`/docs/api-reference/text-openai-api`), M3 supports `thinking: {"type": "disabled"}` (off) / `{"type": "adaptive"}` (on):

- `lib/core/services/api/providers/openai_common.dart`
  - `_OpenAIProviderInfo` gains `isMiniMax` (host / provider id / model id).
  - `_applyVendorReasoningKnobs` gains a MiniMax branch (placed last in the else-if chain so aggregator precedence is preserved): off -> `{"type":"disabled"}`, on -> `{"type":"adaptive"}`, `reasoning_effort` stripped.
- `test/openai_minimax_compat_test.dart` (new): off / on / non-reasoning model cases.

Note: MiniMax M2.x cannot disable thinking at the platform level (param accepted but ignored, per official docs) — no error, no change of behavior there.

## Verification

- `flutter test test/openai_minimax_compat_test.dart` — 3/3 pass
- Regression: `openai_zhipu / openai_deepseek / openai_siliconflow / openai_kimi` compat tests — 24/24 pass
- `dart analyze --fatal-infos lib test` — no issues
- `dart format` — clean

## Manual test plan (not run locally — no MiniMax API key)

1. Add MiniMax provider via OpenAI-compatible `https://api.minimaxi.com/v1`, select `MiniMax-M3`, set thinking off → send a question; confirm no thinking/reasoning output.
2. Same model with a thinking budget > 0 → confirm thinking output returns.
3. Confirm tool-calling follow-ups keep `thinking` in the body (handled by the same single knob function at all 4 call sites).
