### PR TITLE
fix(backup): skip Unix sockets in workspace export (issue #732)

### DIFF
--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -765,6 +765,11 @@ class DataSync {
   /// traversed at all. The output set is identical to a full-recursive walk
   /// with a per-file dot filter; only the traversal work differs. Symlinks
   /// are never followed. Returns empty when the directory does not exist.
+  ///
+  /// Only regular files are collected. Special nodes (Unix domain sockets —
+  /// e.g. a qBittorrent `ipc-socket` in a workspace — pipes, device nodes)
+  /// are skipped with a debug log: they cannot be opened as regular files and
+  /// would otherwise abort the whole backup/export.
   static List<({File file, String rel})> _listFiles(
     Directory dir, {
     bool skipDot = false,
@@ -790,8 +795,33 @@ class DataSync {
       if (ent is Directory) {
         _listFilesInto(ent, rel, skipDot, out);
       } else if (ent is File) {
+        if (!_isRegularFile(ent)) continue;
         out.add((file: ent, rel: rel));
       }
+    }
+  }
+
+  /// True when [file] is a regular file (not a socket, pipe, device node,
+  /// or a path that vanished between listing and stat).
+  static bool _isRegularFile(File file) {
+    try {
+      final stat = file.statSync();
+      if (stat.type == FileSystemEntityType.file) return true;
+      // Unix sockets and FIFOs cannot be opened as regular files; they must
+      // never reach the ZIP packer, whose open would fail and abort the
+      // whole export. Devices (e.g. /dev) are equally unpublishable.
+      debugPrint(
+        'DataSync: skipping non-regular file in backup tree: '
+        '${file.path} (${stat.type})',
+      );
+      return false;
+    } on FileSystemException catch (e) {
+      // Listed but gone before stat — the file cannot be packed anyway.
+      debugPrint(
+        'DataSync: skipping unreadable file in backup tree: '
+        '${file.path}: $e',
+      );
+      return false;
     }
   }
 

--- a/test/core/services/backup/data_sync_backup_file_test.dart
+++ b/test/core/services/backup/data_sync_backup_file_test.dart
@@ -576,6 +576,67 @@ void main() {
     );
 
     test(
+      'pack skips Unix domain socket files (qBittorrent ipc-socket)',
+      skip: Platform.isWindows
+          ? 'Unix domain sockets are unavailable on Windows'
+          : false,
+      () async {
+        final wsDir = Directory('${root.path}/workspaces/default');
+        await wsDir.create(recursive: true);
+        await File('${wsDir.path}/qBittorrent.conf').writeAsString('bt = 1');
+
+        // A live AF_UNIX socket in the workspace tree — exactly what a
+        // proot/qbittorrent setup leaves behind (config/ipc-socket). Opening
+        // it as a regular file fails with ENOENT and used to abort the export.
+        final socketDir = Directory('${wsDir.path}/proton/qBittorrent/config');
+        await socketDir.create(recursive: true);
+        final socketPath = '${socketDir.path}/ipc-socket';
+        final server = await ServerSocket.bind(
+          InternetAddress(socketPath, type: InternetAddressType.unix),
+          0,
+        );
+        addTearDown(() => server.close());
+
+        final sync = DataSync(
+          preferences: businessPrefs,
+          chatService: ChatService(),
+        );
+        final zipFile = await sync.prepareBackupFile(
+          const WebDavConfig(
+            content: BackupContentScope(
+              chatsAndAssistants: false,
+              attachments: true,
+              workspaces: true,
+              fontsAndAvatars: true,
+              settings: true,
+              skills: true,
+            ),
+          ),
+        );
+
+        final input = InputFileStream(zipFile.path);
+        final Archive archive;
+        try {
+          archive = ZipDecoder().decodeStream(input);
+        } finally {
+          await input.close();
+        }
+        expect(
+          archive.findFile('workspaces/default/qBittorrent.conf'),
+          isNotNull,
+        );
+        expect(
+          archive.findFile(
+            'workspaces/default/proton/qBittorrent/config/ipc-socket',
+          ),
+          isNull,
+        );
+
+        await DataSync.cleanupTemporaryBackupFile(zipFile);
+      },
+    );
+
+    test(
       'prepareBackupFile reports stages in order (generating, packing)',
       () async {
         final uploadDir = Directory('${root.path}/upload');


### PR DESCRIPTION
## Problem

导出失败：`PathNotFoundException: Cannot open file, path = '.../workspaces/default/qbittorrent/profile/qBittorrent/config/ipc-socket' (OS Error: No such file or directory, errno = 2)`。

The backup/export walker (`DataSync._listFilesInto`) treats every non-directory, non-link entry of the workspace tree as a regular file. A qBittorrent profile left inside a workspace contains an **AF_UNIX socket node** (`config/ipc-socket`). `File.statSync()` succeeds on it, but `File.openSync()` (in `_StreamingZipWriter._writeDeflatedFile`) fails with ENOENT, aborting the **whole** backup/export.

## Fix

Filter at the single walk choke-point, `_listFilesInto` (shared by full backup, incremental backup, LAN-sync file manifest + pack, and the size preview — no parallel surface left behind):

- Skip entries whose `statSync().type != FileSystemEntityType.file` (Unix sockets, FIFOs, device nodes) with a `debugPrint` of the skipped path.
- Skip entries that vanish between listing and stat (same recoverable treatment).

Regular-file behavior is unchanged; symlinks were already excluded (`followLinks: false`).

## Test

Regression test in `data_sync_backup_file_test.dart`: places a live AF_UNIX socket at `workspaces/default/proton/qBittorrent/config/ipc-socket` via `ServerSocket.bind(InternetAddress(..., type: InternetAddressType.unix), 0)`, runs `prepareBackupFile(workspaces: true)` and asserts:

- the export succeeds;
- the regular workspace file is packed;
- the `ipc-socket` entry is absent from the zip.

Skipped on Windows (no AF_UNIX); runs and is validated on Linux CI (`ubuntu-latest`).

## Verification

- `dart format` on both changed files
- `dart analyze --fatal-infos lib test` — 0 issues
- `flutter test` on `data_sync_backup_file_test`, `data_sync_priority_test`, `data_sync_jsonl_lww_test`, `lan_sync_client_test` — all pass (socket case auto-skipped locally on Windows)

## Residual risk

A file deleted between walk and open (a race all packers share) can still fail a run; deliberately not swallowed.

Closes #732

## Pre-launch Checklist (Flutter)

- [x] I have reviewed the change for the affected platform(s)
- [x] I have run the tests (`flutter test` subset + `dart analyze --fatal-infos lib test`)
- [x] I have verified file formatting
- [x] I have verified all new user-facing text is localized (n/a — no user-facing text)
