### PR TITLE
feat(chat): save temporary conversations to history

### DIFF
--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -47,6 +47,9 @@ class ChatService extends ChangeNotifier {
   final Set<String> _temporaryConversationIds = <String>{};
   final Map<String, Future<void>> _proactiveCareOperationTails =
       <String, Future<void>>{};
+  // Evicting these ids could reopen persistence races with background work.
+  final Set<String> _discardedTemporaryConversationIds = <String>{};
+  final Set<String> _discardedTemporaryMessageIds = <String>{};
   final Map<String, List<Map<String, dynamic>>> _temporaryToolEvents =
       <String, List<Map<String, dynamic>>>{};
   final Map<String, String> _temporaryGeminiThoughtSigs = <String, String>{};
@@ -64,7 +67,9 @@ class ChatService extends ChangeNotifier {
   String? get currentConversationId => _currentConversationId;
 
   bool isTemporaryConversation(String? id) {
-    return id != null && _temporaryConversationIds.contains(id);
+    return id != null &&
+        (_temporaryConversationIds.contains(id) ||
+            _discardedTemporaryConversationIds.contains(id));
   }
 
   bool isDraftConversation(String? id) {
@@ -132,7 +137,7 @@ class ChatService extends ChangeNotifier {
     }
     _repo.reopenSyncConnection();
     await _loadConversationsCache();
-    _messagesCache.clear();
+    _clearPersistedMessageCache();
     notifyListeners();
   }
 
@@ -157,6 +162,15 @@ class ChatService extends ChangeNotifier {
       unawaited(_repo.close());
     }
     super.dispose();
+  }
+
+  /// Drop cached messages for persisted conversations only. Active temporary
+  /// conversations keep their in-memory messages across reload/restore.
+  void _clearPersistedMessageCache() {
+    _messagesCache.removeWhere(
+      (conversationId, _) =>
+          !_temporaryConversationIds.contains(conversationId),
+    );
   }
 
   Future<void> _loadConversationsCache() async {
@@ -568,6 +582,79 @@ class ChatService extends ChangeNotifier {
     }
   }
 
+  /// Convert the active temporary conversation [conversationId] into a
+  /// persisted conversation (issue #726).
+  ///
+  /// Persists the conversation row, every cached message in order, and
+  /// migrates the temp-only tool events / Gemini signatures to the repository
+  /// (message ids stay identical, so the migration is a direct move). Returns
+  /// false when [conversationId] is not an active temporary conversation or
+  /// holds no messages.
+  Future<bool> persistTemporaryConversation(
+    String conversationId, {
+    String? newTitle,
+  }) async {
+    if (!_initialized) await init();
+    if (!_temporaryConversationIds.contains(conversationId)) return false;
+    final conversation = _draftConversations[conversationId];
+    if (conversation == null) return false;
+    final messages = _messagesCache[conversationId] ?? const <ChatMessage>[];
+    if (messages.isEmpty) return false;
+
+    if (newTitle != null && newTitle.trim().isNotEmpty) {
+      conversation.title = newTitle.trim();
+    }
+
+    // Persist rows while the temp flag is still on: any in-flight streaming
+    // update keeps hitting the temp cache path, then gets re-captured below.
+    await _repo.putConversation(conversation);
+    final initialById = {for (final message in messages) message.id: message};
+    for (var i = 0; i < conversation.messageIds.length; i++) {
+      final id = conversation.messageIds[i];
+      final message = initialById[id];
+      if (message == null) continue;
+      await _repo.putMessage(message, messageOrder: i);
+    }
+
+    // Flip bookkeeping: from this point every write path (_saveConversation,
+    // addMessage, setToolEvents...) targets the repository for this id.
+    _temporaryConversationIds.remove(conversationId);
+    _draftConversations.remove(conversationId);
+    _conversationsCache[conversationId] = conversation;
+
+    // Re-capture: a streaming update may have landed in the cache while rows
+    // were being written; converge the repository to the latest cached state.
+    final latest = _messagesCache[conversationId] ?? const <ChatMessage>[];
+    final byId = {for (final message in latest) message.id: message};
+    var order = 0;
+    for (final id in conversation.messageIds) {
+      final message = byId[id];
+      if (message == null) continue;
+      await _repo.putMessage(message, messageOrder: order);
+      order++;
+    }
+    // Migrate temp-only fidelity data (same ids -> direct move).
+    for (final message in latest) {
+      final events = _temporaryToolEvents.remove(message.id);
+      if (events != null && events.isNotEmpty) {
+        await _repo.setToolEvents(message.id, events);
+      }
+      final signature = _temporaryGeminiThoughtSigs.remove(message.id);
+      if (signature != null && signature.trim().isNotEmpty) {
+        await _repo.setGeminiThoughtSignature(message.id, signature);
+      }
+    }
+    // Streaming messages now have persisted rows but were never tracked (temp
+    // writes skipped _trackStreamingId); track them so the boot-time stale
+    // flag reset can still clean up after a crash.
+    for (final message in latest) {
+      if (message.isStreaming) _trackStreamingId(message.id);
+    }
+
+    notifyListeners();
+    return true;
+  }
+
   // Create a draft conversation that is not persisted until first message arrives.
   Future<Conversation> createDraftConversation({
     String? title,
@@ -590,8 +677,15 @@ class ChatService extends ChangeNotifier {
     return conversation;
   }
 
+  void _rememberDiscardedTemporaryConversation(String id) {
+    _discardedTemporaryConversationIds.add(id);
+    final messages = _messagesCache[id] ?? const <ChatMessage>[];
+    _discardedTemporaryMessageIds.addAll(messages.map((message) => message.id));
+  }
+
   void _discardTemporaryConversation(String? id) {
     if (id == null || !_temporaryConversationIds.remove(id)) return;
+    _rememberDiscardedTemporaryConversation(id);
     final messages = _messagesCache[id] ?? const <ChatMessage>[];
     for (final message in messages) {
       _temporaryToolEvents.remove(message.id);
@@ -648,7 +742,9 @@ class ChatService extends ChangeNotifier {
     if (!_draftConversations.containsKey(id)) return false;
 
     _draftConversations.remove(id);
-    _temporaryConversationIds.remove(id);
+    if (_temporaryConversationIds.remove(id)) {
+      _rememberDiscardedTemporaryConversation(id);
+    }
     final messages = _messagesCache[id] ?? const <ChatMessage>[];
     for (final message in messages) {
       _temporaryToolEvents.remove(message.id);
@@ -1551,6 +1647,32 @@ class ChatService extends ChangeNotifier {
   }) async {
     if (!_initialized) await init();
 
+    // Late message for a discarded temporary conversation: sink it so the id
+    // becomes a discard tombstone, never touching the repository (a discarded
+    // temp conversation must not re-create a phantom conversation row).
+    if (_discardedTemporaryConversationIds.contains(conversationId)) {
+      final discarded = ChatMessage(
+        role: role,
+        content: content,
+        conversationId: conversationId,
+        modelId: modelId,
+        providerId: providerId,
+        totalTokens: totalTokens,
+        isStreaming: isStreaming,
+        reasoningText: reasoningText,
+        reasoningStartAt: reasoningStartAt,
+        reasoningFinishedAt: reasoningFinishedAt,
+        groupId: groupId,
+        subgroupId: subgroupId,
+        version: version,
+        isPreset: isPreset,
+        speakerAssistantId: speakerAssistantId,
+        quoteJson: quoteJson,
+      );
+      _discardedTemporaryMessageIds.add(discarded.id);
+      return discarded;
+    }
+
     var conversation = _conversationsCache[conversationId];
     var promotedDraft = false;
     final temporary = _temporaryConversationIds.contains(conversationId);
@@ -1821,6 +1943,10 @@ class ChatService extends ChangeNotifier {
     List<Map<String, dynamic>> events,
   ) async {
     if (!_initialized) await init();
+    // Late write for a discarded temporary message: its row never exists, and
+    // the tool-event PK is FK-bound to message_rows, so skip instead of
+    // letting the repo throw a foreign-key violation.
+    if (_discardedTemporaryMessageIds.contains(assistantMessageId)) return;
     if (_isTemporaryMessageId(assistantMessageId)) {
       _temporaryToolEvents[assistantMessageId] = List<Map<String, dynamic>>.of(
         events,
@@ -1841,6 +1967,8 @@ class ChatService extends ChangeNotifier {
     Map<String, dynamic>? metadata,
   }) async {
     if (!_initialized) await init();
+    // See setToolEvents: a discarded temporary message must not write rows.
+    if (_discardedTemporaryMessageIds.contains(assistantMessageId)) return;
     final list = List<Map<String, dynamic>>.of(
       getToolEvents(assistantMessageId),
     );
@@ -1900,6 +2028,7 @@ class ChatService extends ChangeNotifier {
     String signature,
   ) async {
     if (!_initialized) await init();
+    if (_discardedTemporaryMessageIds.contains(assistantMessageId)) return;
     if (_isTemporaryMessageId(assistantMessageId)) {
       _temporaryGeminiThoughtSigs[assistantMessageId] = signature;
       notifyListeners();
@@ -2509,6 +2638,9 @@ class ChatService extends ChangeNotifier {
       await ProactiveCareAlarmService.cancelFor(conversationId);
     }
     await _repo.clearAllData();
+    for (final id in _temporaryConversationIds) {
+      _rememberDiscardedTemporaryConversation(id);
+    }
     _messagesCache.clear();
     _conversationsCache.clear();
     _draftConversations.clear();

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -605,50 +605,94 @@ class ChatService extends ChangeNotifier {
       conversation.title = newTitle.trim();
     }
 
-    // Persist rows while the temp flag is still on: any in-flight streaming
-    // update keeps hitting the temp cache path, then gets re-captured below.
-    await _repo.putConversation(conversation);
-    final initialById = {for (final message in messages) message.id: message};
-    for (var i = 0; i < conversation.messageIds.length; i++) {
-      final id = conversation.messageIds[i];
-      final message = initialById[id];
-      if (message == null) continue;
-      await _repo.putMessage(message, messageOrder: i);
-    }
-
-    // Flip bookkeeping: from this point every write path (_saveConversation,
-    // addMessage, setToolEvents...) targets the repository for this id.
-    _temporaryConversationIds.remove(conversationId);
-    _draftConversations.remove(conversationId);
-    _conversationsCache[conversationId] = conversation;
-
-    // Re-capture: a streaming update may have landed in the cache while rows
-    // were being written; converge the repository to the latest cached state.
-    final latest = _messagesCache[conversationId] ?? const <ChatMessage>[];
-    final byId = {for (final message in latest) message.id: message};
-    var order = 0;
-    for (final id in conversation.messageIds) {
-      final message = byId[id];
-      if (message == null) continue;
-      await _repo.putMessage(message, messageOrder: order);
-      order++;
-    }
-    // Migrate temp-only fidelity data (same ids -> direct move).
-    for (final message in latest) {
-      final events = _temporaryToolEvents.remove(message.id);
-      if (events != null && events.isNotEmpty) {
-        await _repo.setToolEvents(message.id, events);
+    try {
+      // Persist rows while the temp flag is still on: any in-flight streaming
+      // update keeps hitting the temp cache path, then gets captured below.
+      await _repo.putConversation(conversation);
+      final initialById = {for (final message in messages) message.id: message};
+      for (var i = 0; i < conversation.messageIds.length; i++) {
+        final id = conversation.messageIds[i];
+        final message = initialById[id];
+        if (message == null) continue;
+        await _repo.putMessage(message, messageOrder: i);
       }
-      final signature = _temporaryGeminiThoughtSigs.remove(message.id);
-      if (signature != null && signature.trim().isNotEmpty) {
-        await _repo.setGeminiThoughtSignature(message.id, signature);
+
+      // Flip bookkeeping: from this point every write path (_saveConversation,
+      // addMessage, setToolEvents...) targets the repository for this id.
+      _temporaryConversationIds.remove(conversationId);
+      _draftConversations.remove(conversationId);
+      _conversationsCache[conversationId] = conversation;
+
+      // Converge atomically: snapshot the live cache synchronously (no await
+      // between reading the cache and enqueuing the batch), then write the
+      // freshest state in a single transaction. A streaming update is either
+      // enqueued before the batch (its content is inside the snapshot) or
+      // after it (it overwrites the batch) — never lost.
+      final latest = _messagesCache[conversationId] ?? const <ChatMessage>[];
+      final byId = {for (final message in latest) message.id: message};
+      final finalMessages = <({ChatMessage message, int messageOrder})>[];
+      var order = 0;
+      for (final id in conversation.messageIds) {
+        final message = byId[id];
+        if (message == null) continue;
+        finalMessages.add((message: message, messageOrder: order));
+        order++;
       }
-    }
-    // Streaming messages now have persisted rows but were never tracked (temp
-    // writes skipped _trackStreamingId); track them so the boot-time stale
-    // flag reset can still clean up after a crash.
-    for (final message in latest) {
-      if (message.isStreaming) _trackStreamingId(message.id);
+      final toolEventsByMessageId = <String, List<Map<String, dynamic>>>{};
+      for (final message in latest) {
+        final events = _temporaryToolEvents[message.id];
+        if (events != null && events.isNotEmpty) {
+          toolEventsByMessageId[message.id] = events;
+        }
+      }
+      final geminiSignaturesByMessageId = <String, String>{};
+      for (final message in latest) {
+        final signature = _temporaryGeminiThoughtSigs[message.id];
+        if (signature != null && signature.trim().isNotEmpty) {
+          geminiSignaturesByMessageId[message.id] = signature;
+        }
+      }
+      await _repo.putMigrationBatch(
+        conversations: const [],
+        messages: finalMessages,
+        toolEventsByMessageId: toolEventsByMessageId,
+        geminiSignaturesByMessageId: geminiSignaturesByMessageId,
+      );
+      // Fidelity data moved: drop the temp-only entries now that the batch
+      // committed them.
+      for (final message in latest) {
+        _temporaryToolEvents.remove(message.id);
+        _temporaryGeminiThoughtSigs.remove(message.id);
+      }
+      // Streaming messages now have persisted rows but were never tracked
+      // (temp writes skipped _trackStreamingId); track them so the boot-time
+      // stale flag reset can still clean up after a crash.
+      for (final message in latest) {
+        if (message.isStreaming) {
+          await _trackStreamingId(message.id);
+        }
+      }
+    } catch (e, st) {
+      // Roll back half-written rows (FK cascade removes messages, tool events
+      // and signatures) and restore the temporary bookkeeping: the
+      // conversation stays active and retryable in memory.
+      debugPrint(
+        'persistTemporaryConversation failed for $conversationId: $e\n$st',
+      );
+      _temporaryConversationIds.add(conversationId);
+      _draftConversations[conversationId] = conversation;
+      _conversationsCache.remove(conversationId);
+      try {
+        await _repo.deleteConversation(conversationId);
+      } catch (cleanupError) {
+        // The save failure is already logged above; surface the cleanup
+        // failure too instead of swallowing it.
+        debugPrint(
+          'persistTemporaryConversation cleanup failed for '
+          '$conversationId: $cleanupError',
+        );
+      }
+      return false;
     }
 
     notifyListeners();
@@ -986,23 +1030,24 @@ class ChatService extends ChangeNotifier {
   }
 
   /// Record a message ID as actively streaming.
-  void _trackStreamingId(String messageId) {
+  Future<void> _trackStreamingId(String messageId) async {
     try {
-      final ids = _repo.getActiveStreamingIds().then((value) => value.toList());
-      ids.then((list) {
-        if (!list.contains(messageId)) {
-          list.add(messageId);
-          _repo.setActiveStreamingIds(list);
-        }
-      });
-    } catch (_) {}
+      final ids = await _repo.getActiveStreamingIds();
+      if (!ids.contains(messageId)) {
+        await _repo.setActiveStreamingIds([...ids, messageId]);
+      }
+    } catch (e) {
+      debugPrint('[ChatService] trackStreamingId failed for $messageId: $e');
+    }
   }
 
   /// Remove a message ID from the active streaming set.
-  void _untrackStreamingId(String messageId) {
+  Future<void> _untrackStreamingId(String messageId) async {
     try {
-      _repo.untrackActiveStreamingId(messageId);
-    } catch (_) {}
+      await _repo.untrackActiveStreamingId(messageId);
+    } catch (e) {
+      debugPrint('[ChatService] untrackStreamingId failed for $messageId: $e');
+    }
   }
 
   Future<void> _cleanupOrphanUploads() async {
@@ -1668,6 +1713,7 @@ class ChatService extends ChangeNotifier {
         isPreset: isPreset,
         speakerAssistantId: speakerAssistantId,
         quoteJson: quoteJson,
+        quickInstructionInvocationsJson: quickInstructionInvocationsJson,
       );
       _discardedTemporaryMessageIds.add(discarded.id);
       return discarded;
@@ -1730,7 +1776,7 @@ class ChatService extends ChangeNotifier {
 
     // Track streaming state for crash-recovery cleanup
     if (isStreaming && !temporary) {
-      _trackStreamingId(message.id);
+      await _trackStreamingId(message.id);
     }
 
     conversation.messageIds.add(message.id);
@@ -1848,7 +1894,7 @@ class ChatService extends ChangeNotifier {
     await _repo.updateMessage(updatedMessage);
     // Update streaming tracking for crash-recovery
     if (isStreaming == false) {
-      _untrackStreamingId(messageId);
+      await _untrackStreamingId(messageId);
     }
 
     // Update cache
@@ -1915,7 +1961,7 @@ class ChatService extends ChangeNotifier {
 
     // Update streaming tracking for crash-recovery
     if (isStreaming == false) {
-      _untrackStreamingId(messageId);
+      await _untrackStreamingId(messageId);
     }
 
     // Update cache

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -1088,6 +1088,14 @@ class HomePageController extends ChangeNotifier {
     await _viewModel.toggleTemporaryConversation();
   }
 
+  /// Whether the current temporary conversation holds content worth saving.
+  bool get canSaveTemporaryConversation =>
+      isTemporaryConversation && messages.isNotEmpty;
+
+  Future<bool> saveTemporaryConversation() async {
+    return _viewModel.saveTemporaryConversation();
+  }
+
   void cancelQueuedMessage() {
     final restored = _viewModel.cancelCurrentQueuedInput();
     if (restored == null) return;

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1210,6 +1210,39 @@ class HomeViewModel extends ChangeNotifier {
     onScrollToBottom?.call();
   }
 
+  /// Convert the current temporary conversation into a persisted one (issue
+  /// #726). Returns true when a conversation was actually saved.
+  Future<bool> saveTemporaryConversation() async {
+    final convo = currentConversation;
+    if (convo == null || !_chatService.isTemporaryConversation(convo.id)) {
+      return false;
+    }
+
+    // Only reset a title that is still the placeholder: a manually renamed
+    // temporary conversation keeps its preferred name untouched.
+    final isPlaceholderTitle =
+        convo.title ==
+        AppLocalizations.of(_contextProvider)?.temporaryChatTitle;
+    final saved = await _chatService.persistTemporaryConversation(
+      convo.id,
+      newTitle: isPlaceholderTitle ? getTitleForLocale(_contextProvider) : null,
+    );
+    if (!saved) return false;
+
+    // Refresh the controller's view of the now-persisted conversation.
+    _chatController.updateCurrentConversation(
+      _chatService.getConversation(convo.id),
+    );
+    notifyListeners();
+
+    // A placeholder title was reset to the default: generate a meaningful one,
+    // like any normal conversation. A kept title needs no regeneration.
+    if (isPlaceholderTitle) {
+      unawaited(_maybeGenerateTitleFor(convo.id, force: true));
+    }
+    return true;
+  }
+
   /// Fork conversation at a specific message.
   Future<void> forkConversation(ChatMessage message) async {
     final preserveVersions = _contextProvider
@@ -1683,6 +1716,9 @@ class HomeViewModel extends ChangeNotifier {
   Future<void> _maybeGenerateSummaryFor(String conversationId) async {
     final convo = _chatService.getConversation(conversationId);
     if (convo == null) return;
+    // Summaries only feed past-conversation search; temporary chats are never
+    // searchable and their summary lives on a draft that is discarded anyway.
+    if (_chatService.isTemporaryConversation(convo.id)) return;
 
     final settings = _contextProvider.read<SettingsProvider>();
     final msgCount = convo.messageIds.length;

--- a/lib/features/home/pages/home_desktop_layout.dart
+++ b/lib/features/home/pages/home_desktop_layout.dart
@@ -51,6 +51,8 @@ class HomeDesktopScaffold extends StatelessWidget {
     required this.onNewConversation,
     required this.onCreateNewConversation,
     required this.onToggleTemporaryConversation,
+    required this.onSaveTemporaryConversation,
+    required this.canSaveTemporaryConversation,
     required this.onSelectModel,
     required this.canToggleTemporaryConversation,
     required this.temporaryConversationEnabled,
@@ -89,6 +91,8 @@ class HomeDesktopScaffold extends StatelessWidget {
   final VoidCallback onNewConversation;
   final Future<void> Function() onCreateNewConversation;
   final Future<void> Function() onToggleTemporaryConversation;
+  final Future<void> Function() onSaveTemporaryConversation;
+  final bool canSaveTemporaryConversation;
   final VoidCallback onSelectModel;
   final bool canToggleTemporaryConversation;
   final bool temporaryConversationEnabled;
@@ -549,6 +553,15 @@ class HomeDesktopScaffold extends StatelessWidget {
           onTap: onToggleRightSidebar,
         ),
       const SizedBox(width: 2),
+      if (canSaveTemporaryConversation)
+        IosIconButton(
+          size: 20,
+          padding: const EdgeInsets.all(8),
+          minSize: 40,
+          semanticLabel: AppLocalizations.of(context)!.temporaryChatSaveTooltip,
+          icon: Lucide.Save,
+          onTap: onSaveTemporaryConversation,
+        ),
       IosIconButton(
         size: 20,
         padding: const EdgeInsets.all(8),

--- a/lib/features/home/pages/home_mobile_layout.dart
+++ b/lib/features/home/pages/home_mobile_layout.dart
@@ -43,6 +43,8 @@ class HomeMobileScaffold extends StatelessWidget {
     required this.onOpenMiniMap,
     required this.onCreateNewConversation,
     required this.onToggleTemporaryConversation,
+    required this.onSaveTemporaryConversation,
+    required this.canSaveTemporaryConversation,
     required this.onSelectModel,
     required this.canToggleTemporaryConversation,
     required this.temporaryConversationEnabled,
@@ -70,6 +72,8 @@ class HomeMobileScaffold extends StatelessWidget {
   final VoidCallback onOpenMiniMap;
   final Future<void> Function() onCreateNewConversation;
   final Future<void> Function() onToggleTemporaryConversation;
+  final Future<void> Function() onSaveTemporaryConversation;
+  final bool canSaveTemporaryConversation;
   final VoidCallback onSelectModel;
   final bool canToggleTemporaryConversation;
   final bool temporaryConversationEnabled;
@@ -268,6 +272,16 @@ class HomeMobileScaffold extends StatelessWidget {
           semanticLabel: AppLocalizations.of(context)!.miniMapTooltip,
           icon: Lucide.Map,
         ),
+        if (canSaveTemporaryConversation)
+          IosIconButton(
+            size: 22,
+            minSize: 44,
+            onTap: onSaveTemporaryConversation,
+            semanticLabel: AppLocalizations.of(
+              context,
+            )!.temporaryChatSaveTooltip,
+            icon: Lucide.Save,
+          ),
         IosIconButton(
           size: 22,
           minSize: 44,

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -909,6 +909,17 @@ class _HomePageState extends State<HomePage>
           _controller.forceScrollToBottomSoon(animate: false);
         }
       },
+      onSaveTemporaryConversation: () async {
+        final l10n = AppLocalizations.of(context);
+        final messenger = ScaffoldMessenger.of(context);
+        final saved = await _controller.saveTemporaryConversation();
+        if (saved && mounted) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n!.temporaryChatSaved)),
+          );
+        }
+      },
+      canSaveTemporaryConversation: _controller.canSaveTemporaryConversation,
       canToggleTemporaryConversation:
           _controller.canToggleTemporaryConversation,
       temporaryConversationEnabled: _controller.isTemporaryConversation,
@@ -1054,6 +1065,17 @@ class _HomePageState extends State<HomePage>
         await _controller.toggleTemporaryConversation();
         if (mounted) _controller.forceScrollToBottomSoon(animate: false);
       },
+      onSaveTemporaryConversation: () async {
+        final l10n = AppLocalizations.of(context);
+        final messenger = ScaffoldMessenger.of(context);
+        final saved = await _controller.saveTemporaryConversation();
+        if (saved && mounted) {
+          messenger.showSnackBar(
+            SnackBar(content: Text(l10n!.temporaryChatSaved)),
+          );
+        }
+      },
+      canSaveTemporaryConversation: _controller.canSaveTemporaryConversation,
       canToggleTemporaryConversation:
           _controller.canToggleTemporaryConversation,
       temporaryConversationEnabled: _controller.isTemporaryConversation,

--- a/lib/icons/lucide_adapter.dart
+++ b/lib/icons/lucide_adapter.dart
@@ -12,6 +12,7 @@ class Lucide {
       lucide.LucideIcons.messageCirclePlus;
   static const IconData MessageCircleDashed =
       lucide.LucideIcons.messageCircleDashed;
+  static const IconData Save = lucide.LucideIcons.save;
   static const IconData HatGlasses = lucide.LucideIcons.hatGlasses;
   static const IconData Box = lucide.LucideIcons.box;
   static const IconData Globe = lucide.LucideIcons.earth;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2739,6 +2739,8 @@
   "temporaryChatTitle": "Temporary Chat",
   "temporaryChatEmptyMessage": "Temporary chats do not appear in history and will be deleted completely after you leave.",
   "temporaryChatToggleTooltip": "Toggle temporary chat",
+  "temporaryChatSaveTooltip": "Save temporary chat to history",
+  "temporaryChatSaved": "Saved to history",
   "quickPhraseBackTooltip": "Back",
   "quickPhraseGlobalTitle": "Quick Phrase",
   "quickPhraseAssistantTitle": "Assistant Quick Phrase",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12256,6 +12256,18 @@ abstract class AppLocalizations {
   /// **'Toggle temporary chat'**
   String get temporaryChatToggleTooltip;
 
+  /// No description provided for @temporaryChatSaveTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Save temporary chat to history'**
+  String get temporaryChatSaveTooltip;
+
+  /// No description provided for @temporaryChatSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to history'**
+  String get temporaryChatSaved;
+
   /// No description provided for @quickPhraseBackTooltip.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6817,6 +6817,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get temporaryChatToggleTooltip => 'Toggle temporary chat';
 
   @override
+  String get temporaryChatSaveTooltip => 'Save temporary chat to history';
+
+  @override
+  String get temporaryChatSaved => 'Saved to history';
+
+  @override
   String get quickPhraseBackTooltip => 'Back';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6512,6 +6512,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get temporaryChatToggleTooltip => '切换临时对话';
 
   @override
+  String get temporaryChatSaveTooltip => '将临时对话保存为正式对话';
+
+  @override
+  String get temporaryChatSaved => '已保存到历史记录';
+
+  @override
   String get quickPhraseBackTooltip => '返回';
 
   @override
@@ -16375,6 +16381,12 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
   String get temporaryChatToggleTooltip => '切换临时对话';
 
   @override
+  String get temporaryChatSaveTooltip => '将临时对话保存为正式对话';
+
+  @override
+  String get temporaryChatSaved => '已保存到历史记录';
+
+  @override
   String get quickPhraseBackTooltip => '返回';
 
   @override
@@ -26235,6 +26247,12 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get temporaryChatToggleTooltip => '切換臨時對話';
+
+  @override
+  String get temporaryChatSaveTooltip => '將臨時對話儲存為正式對話';
+
+  @override
+  String get temporaryChatSaved => '已儲存到歷史記錄';
 
   @override
   String get quickPhraseBackTooltip => '返回';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2275,6 +2275,8 @@
   "temporaryChatTitle": "临时对话",
   "temporaryChatEmptyMessage": "临时对话不显示在历史记录，退出后将被完全删除",
   "temporaryChatToggleTooltip": "切换临时对话",
+  "temporaryChatSaveTooltip": "将临时对话保存为正式对话",
+  "temporaryChatSaved": "已保存到历史记录",
   "displaySettingsPageEnableDollarLatexTitle": "启用 $...$ 渲染",
   "displaySettingsPageEnableDollarLatexSubtitle": "将 $...$ 之间的内容按行内数学公式渲染",
   "displaySettingsPageEnableMathTitle": "启用数学公式渲染",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2299,6 +2299,8 @@
   "temporaryChatTitle": "临时对话",
   "temporaryChatEmptyMessage": "临时对话不显示在历史记录，退出后将被完全删除",
   "temporaryChatToggleTooltip": "切换临时对话",
+  "temporaryChatSaveTooltip": "将临时对话保存为正式对话",
+  "temporaryChatSaved": "已保存到历史记录",
   "miniMapTitle": "迷你地图",
   "miniMapTooltip": "迷你地图",
   "miniMapScrollToBottomTooltip": "滚动到底部",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2254,6 +2254,8 @@
   "temporaryChatTitle": "臨時對話",
   "temporaryChatEmptyMessage": "臨時對話不會顯示在歷史記錄中，退出後將被完全刪除",
   "temporaryChatToggleTooltip": "切換臨時對話",
+  "temporaryChatSaveTooltip": "將臨時對話儲存為正式對話",
+  "temporaryChatSaved": "已儲存到歷史記錄",
   "miniMapTitle": "迷你地圖",
   "miniMapTooltip": "迷你地圖",
   "miniMapScrollToBottomTooltip": "捲動到底部",

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -350,6 +350,297 @@ void main() {
         expect(edited!.timestamp.isBefore(before), isFalse);
       },
     );
+
+    test(
+      'late message cannot revive a discarded temporary conversation',
+      () async {
+        final service = createService();
+        await service.init();
+
+        final temporary = await service.createDraftConversation(
+          title: 'Temporary Chat',
+          temporary: true,
+        );
+        await service.createDraftConversation(title: 'Next Chat');
+
+        final lateMessage = await service.addMessage(
+          conversationId: temporary.id,
+          role: 'assistant',
+          content: 'late secret',
+        );
+        await service.setGeminiThoughtSignature(
+          lateMessage.id,
+          'late signature',
+        );
+
+        expect(service.isTemporaryConversation(temporary.id), isTrue);
+        expect(service.getConversation(temporary.id), isNull);
+        expect(service.getMessages(temporary.id), isEmpty);
+        expect(service.getGeminiThoughtSignature(lateMessage.id), isNull);
+        expect(
+          service.getAllConversations().map((conversation) => conversation.id),
+          isNot(contains(temporary.id)),
+        );
+      },
+    );
+
+    test('late Gemini signature is ignored after temporary discard', () async {
+      final service = createService();
+      await service.init();
+
+      final temporary = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final assistantMessage = await service.addMessage(
+        conversationId: temporary.id,
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+      await service.createDraftConversation(title: 'Next Chat');
+
+      await service.setGeminiThoughtSignature(
+        assistantMessage.id,
+        'late signature',
+      );
+
+      expect(service.getGeminiThoughtSignature(assistantMessage.id), isNull);
+    });
+
+    test('late tool event is ignored after temporary discard', () async {
+      final service = createService();
+      await service.init();
+
+      final temporary = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final assistantMessage = await service.addMessage(
+        conversationId: temporary.id,
+        role: 'assistant',
+        content: '',
+        isStreaming: true,
+      );
+      await service.createDraftConversation(title: 'Next Chat');
+
+      await service.setToolEvents(assistantMessage.id, [
+        {'id': 'tool-1', 'name': 'search'},
+      ]);
+      await service.upsertToolEvent(
+        assistantMessage.id,
+        id: 'tool-2',
+        name: 'memory_read',
+        arguments: const <String, dynamic>{},
+      );
+
+      expect(service.getToolEvents(assistantMessage.id), isEmpty);
+    });
+
+    test(
+      'late update leaves no artifacts for a discarded temporary conversation',
+      () async {
+        final service = createService();
+        await service.init();
+
+        final temporary = await service.createDraftConversation(
+          title: 'Temporary Chat',
+          temporary: true,
+        );
+        final assistantMessage = await service.addMessage(
+          conversationId: temporary.id,
+          role: 'assistant',
+          content: '',
+          isStreaming: true,
+        );
+        await service.createDraftConversation(title: 'Next Chat');
+
+        await service.updateMessageSilent(
+          assistantMessage.id,
+          content: 'late secret',
+        );
+
+        expect(service.getConversation(temporary.id), isNull);
+        expect(service.getMessages(temporary.id), isEmpty);
+      },
+    );
+
+    test(
+      'clearing data keeps discarded temporary conversations protected',
+      () async {
+        final service = createService();
+        await service.init();
+
+        final temporary = await service.createDraftConversation(
+          title: 'Temporary Chat',
+          temporary: true,
+        );
+        await service.createDraftConversation(title: 'Next Chat');
+
+        await service.clearAllData();
+
+        expect(service.isTemporaryConversation(temporary.id), isTrue);
+        await service.addMessage(
+          conversationId: temporary.id,
+          role: 'assistant',
+          content: 'late secret',
+        );
+        expect(service.getConversation(temporary.id), isNull);
+        expect(service.getAllConversations(), isEmpty);
+      },
+    );
+
+    test('cache reload preserves an active temporary conversation', () async {
+      final service = createService();
+      await service.init();
+
+      final temporary = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final assistantMessage = await service.addMessage(
+        conversationId: temporary.id,
+        role: 'assistant',
+        content: 'still streaming',
+        isStreaming: true,
+      );
+
+      await service.reloadCachesFromDb();
+
+      expect(service.isTemporaryConversation(temporary.id), isTrue);
+      expect(
+        service.getMessages(temporary.id).map((message) => message.content),
+        ['still streaming'],
+      );
+      await service.setGeminiThoughtSignature(
+        assistantMessage.id,
+        'live signature',
+      );
+      expect(
+        service.getGeminiThoughtSignature(assistantMessage.id),
+        'live signature',
+      );
+    });
+
+    test('persistTemporaryConversation converts the conversation', () async {
+      final service = createService();
+      await service.init();
+
+      final conversation = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      await service.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'hello',
+      );
+      final assistantMessage = await service.addMessage(
+        conversationId: conversation.id,
+        role: 'assistant',
+        content: 'hi',
+      );
+      await service.setToolEvents(assistantMessage.id, [
+        {'id': 'tool-1', 'name': 'search'},
+      ]);
+      await service.setGeminiThoughtSignature(assistantMessage.id, 'sig-1');
+
+      final saved = await service.persistTemporaryConversation(conversation.id);
+
+      expect(saved, isTrue);
+      expect(service.isTemporaryConversation(conversation.id), isFalse);
+      expect(
+        service.getAllConversations().map((conversation) => conversation.id),
+        contains(conversation.id),
+      );
+      expect(service.getMessageCount(conversation.id), 2);
+      expect(service.getMessages(conversation.id).map((m) => m.content), [
+        'hello',
+        'hi',
+      ]);
+      // Fidelity data moved to the repository, retrievable by the same ids.
+      expect(service.getToolEvents(assistantMessage.id), isNotEmpty);
+      expect(service.getGeminiThoughtSignature(assistantMessage.id), 'sig-1');
+    });
+
+    test('persistTemporaryConversation applies the new title', () async {
+      final service = createService();
+      await service.init();
+
+      final conversation = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      await service.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'hello',
+      );
+
+      final saved = await service.persistTemporaryConversation(
+        conversation.id,
+        newTitle: 'New Chat',
+      );
+
+      expect(saved, isTrue);
+      expect(service.getConversation(conversation.id)?.title, 'New Chat');
+    });
+
+    test('persistTemporaryConversation refuses empty and non-temporary '
+        'conversations', () async {
+      final service = createService();
+      await service.init();
+
+      final empty = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final ordinary = await service.createDraftConversation(title: 'Ordinary');
+      await service.addMessage(
+        conversationId: ordinary.id,
+        role: 'user',
+        content: 'hello',
+      );
+
+      expect(await service.persistTemporaryConversation(empty.id), isFalse);
+      expect(await service.persistTemporaryConversation(ordinary.id), isFalse);
+      expect(service.isTemporaryConversation(empty.id), isTrue);
+    });
+
+    test('saved conversation keeps persisting like an ordinary one', () async {
+      final service = createService();
+      await service.init();
+
+      final conversation = await service.createDraftConversation(
+        title: 'Temporary Chat',
+        temporary: true,
+      );
+      final userMessage = await service.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'hello',
+      );
+      await service.persistTemporaryConversation(conversation.id);
+
+      await service.addMessage(
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'after save',
+      );
+      expect(service.getMessageCount(conversation.id), 2);
+
+      final edited = await service.appendMessageVersion(
+        messageId: userMessage.id,
+        content: 'hello, edited',
+      );
+      expect(edited, isNotNull);
+      expect(edited!.version, 1);
+      expect(service.getMessageCount(conversation.id), 3);
+      expect(
+        service.getAllConversations().map((conversation) => conversation.id),
+        contains(conversation.id),
+      );
+    });
   });
 
   group('ChatService fork conversations', () {

--- a/test/core/services/chat/chat_service_temporary_conversation_test.dart
+++ b/test/core/services/chat/chat_service_temporary_conversation_test.dart
@@ -641,6 +641,60 @@ void main() {
         contains(conversation.id),
       );
     });
+
+    test(
+      'saving an in-stream conversation converges to the final content',
+      () async {
+        final service = createService();
+        await service.init();
+
+        final conversation = await service.createDraftConversation(
+          title: 'Temporary Chat',
+          temporary: true,
+        );
+        await service.addMessage(
+          conversationId: conversation.id,
+          role: 'user',
+          content: 'hello',
+        );
+        final streaming = await service.addMessage(
+          conversationId: conversation.id,
+          role: 'assistant',
+          content: 'part one',
+          isStreaming: true,
+        );
+        await service.setToolEvents(streaming.id, [
+          {'id': 'tool-1', 'name': 'search'},
+        ]);
+
+        expect(
+          await service.persistTemporaryConversation(conversation.id),
+          isTrue,
+        );
+
+        // The stream finishes after the save: the final update must win.
+        await service.updateMessageSilent(
+          streaming.id,
+          content: 'final answer',
+          isStreaming: false,
+        );
+
+        // getMessages on a persisted conversation reads the repository, so
+        // this asserts the committed rows (same path as after a restart).
+        final messages = service.getMessages(conversation.id);
+        expect(messages.map((message) => message.content), [
+          'hello',
+          'final answer',
+        ]);
+        expect(messages.last.isStreaming, isFalse);
+        expect(service.getMessageCount(conversation.id), 2);
+        expect(service.getToolEvents(streaming.id), isNotEmpty);
+        expect(
+          service.getAllConversations().map((conversation) => conversation.id),
+          contains(conversation.id),
+        );
+      },
+    );
   });
 
   group('ChatService fork conversations', () {


### PR DESCRIPTION
Fixes #726

## Summary

Issue #726: 临时对话模式保存 — 在右上角临时对话图标左侧新增「保存」按钮，点击将当前临时对话转为正式对话（持久化到历史记录）。

同时纳入 upstream/master 中尚未并入的临时对话修复：
- `b37590c2` fix(chat): close temporary conversation persistence races（适配 Drift 架构）
- `97eb73c3` fix(memory) 中与临时对话相关的守卫部分（跳过临时对话的 summary 生成）

## Changes

### 保存功能（#726）
- `ChatService.persistTemporaryConversation`: 将临时对话的会话行 + 全部消息（同 id）写入仓库；temp-only 的 tool events / Gemini 签名直接迁移；流式中保存通过「先写后翻+末次重捕」收敛仓库与缓存最终状态；追踪 `isStreaming` 消息保证崩溃后启动清理仍生效
- `HomeViewModel.saveTemporaryConversation`: 仅当标题仍为「临时对话」占位符时重置为默认标题并触发 LLM 重新生成；用户已改名的标题原样保留
- 顶栏：临时对话启用且有消息时，toggle 左侧显示 `Lucide.Save` 图标（移动/桌面共享布局），点击后弹「已保存到历史记录」提示
- l10n：`temporaryChatSaveTooltip` / `temporaryChatSaved`（4 个 ARB 均已同步，无未翻译项）

### Upstream 临时对话修复移植
- **`b37590c2`（竞态守卫）**：新增 `_discardedTemporaryConversationIds` / `_discardedTemporaryMessageIds` 墓碑集；`_discardTemporaryConversation` / `_deleteDraftConversation` / `clearAllData` 记账；`addMessage` 对丢弃会话 sink（不再产生幻影会话行）；`setGeminiThoughtSignature` / `setToolEvents` / `upsertToolEvent` / `updateMessageSilent` 对丢弃消息早退（tool_event_rows 与 gemini 表 messageId 均 FK 绑定 message_rows，迟到写入会抛 SQLite FK 异常）
- `reloadCachesFromDb` 改为只清持久化会话的消息缓存（等价 upstream `_clearPersistedMessageCache`；fork 无 `mergeDatabaseSnapshot`/`_resetAfterOverwriteRestore`，用 `reloadCachesFromDb` 对应）
- **`97eb73c3`（守卫部分）**：`_maybeGenerateSummaryFor` 跳过临时对话（临时对话不可检索，summary 只会写在被丢弃的 draft 上）

### 已存在于 fork、无需移植
- `2e77a3e6`（临时对话消息读取，fork 的 Drift 版 `getMessagesRange` 已处理）
- `4c67c281` / `3eb4df5f`（临时对话编辑，PR #215 已并入）

### 跳过（fork 无对应子系统）
- `148e4fac` / `31b6b238` / `72ad784c` / `97eb73c3` 测试部分 — 依赖 fork 不存在的 memory pipeline / trace recorder（`memory_provider_v2`、`memory_pipeline`、`MemoryTraceRecorder`），移植等于整建 memory 功能

## Verification

- `dart analyze --fatal-infos lib test` → 0 issues
- `flutter test` 临时对话测试 25 例 + 相关测试（preset-recycle / init-concurrency / lazy-history / cascade-delete）41 例全绿
- `flutter build windows --debug` 成功；Windows 真机手动验证通过（保存按钮显示/点击、历史列表出现新对话、snackbar 提示、手动改标题保留）

## Manual test plan

1. 空对话点击临时对话 toggle 启用 → 无保存按钮（空会话无内容可保存）
2. 发送消息后保存按钮出现在 temp toggle 左侧 → 点击 → snackbar「已保存到历史记录」→ 临时标记消失，历史列表出现该对话
3. 临时对话内手动改名后再保存 → 保留用户标题
4. 离开临时对话（不保存）→ 对话消失，不进入历史；且无迟到写入导致的崩溃（tool 事件竞态守卫）
