### PR TITLE
fix(desktop): dedupe deletion conflict snackbar

### DIFF
--- a/lib/desktop/desktop_home_page.dart
+++ b/lib/desktop/desktop_home_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:Cuplivo/theme/app_font_weights.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform;
@@ -11,7 +10,6 @@ import 'desktop_translate_page.dart';
 import '../features/settings/pages/storage_space_page.dart';
 import '../l10n/app_localizations.dart';
 import '../core/services/storage/message_locate_bus.dart';
-import '../core/services/trash_restore_coordinator.dart';
 import 'package:window_manager/window_manager.dart';
 import 'dart:async';
 import 'hotkeys/hotkey_event_bus.dart';
@@ -57,10 +55,6 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
       });
     }
 
-    // Startup conflict check: show SnackBar if there are pending deletions.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkConflicts();
-    });
     // Listen to global hotkey actions affecting the main tabs/window
     _hotkeySub = HotkeyEventBus.instance.stream.listen((action) async {
       switch (action) {
@@ -301,31 +295,6 @@ class _DesktopHomePageState extends State<DesktopHomePage> {
           ),
         );
       },
-    );
-  }
-
-  Future<void> _checkConflicts() async {
-    if (!mounted) return;
-    final l10n = AppLocalizations.of(context);
-    if (l10n == null) return;
-    final coordinator = context.read<TrashRestoreCoordinator>();
-    final count = await coordinator.countConflicts();
-    if (!mounted || count == 0) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(l10n.trashConflictSnackBar(count)),
-        duration: const Duration(seconds: 8),
-        action: SnackBarAction(
-          label: l10n.trashConflictSnackBarAction,
-          onPressed: () {
-            setState(() {
-              _tabIndex = 2;
-              _storageVisited = true;
-            });
-            ChatActionBus.instance.fire(ChatAction.exitGlobalSearch);
-          },
-        ),
-      ),
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #740 — after a deletion conflict appears, clicking **View** on desktop took the user to the storage page first; only after going back and clicking **View** again did the correct deletion-conflict page open.

## Root cause

On desktop, `HomePage` is always mounted inside the desktop shell (`DesktopChatPage` is IndexedStack child 0 of `DesktopHomePage`), and `HomePage._checkConflicts()` already fires at startup. `DesktopHomePage._checkConflicts()` ran the same check a second time, queueing two identical-looking snackbars in the same root `ScaffoldMessenger`:

1. The desktop snackbar's **View** action only switched to the storage tab (`_tabIndex = 2`) — landing on the storage overview, not the conflict view.
2. After it was dismissed, the queued shared snackbar appeared; clicking **View** then pushed `TrashDetailPage(initialTab: 1)` — the correct page.

## Fix

Remove the duplicate `_checkConflicts()` from `DesktopHomePage` (plus its post-frame trigger and the now-unused `provider` / `trash_restore_coordinator` imports). The shared `HomePage` check becomes the single source of truth on all platforms:

- Desktop: exactly one snackbar; **View** pushes `TrashDetailPage` directly on the conflicts tab.
- Mobile / web: unchanged.

## Test plan

- [ ] Desktop (Windows): with a pending deletion conflict, launch the app → exactly one snackbar appears → click **View** → `TrashDetailPage` opens on the Pending tab directly.
- [ ] No conflicts → no snackbar.
- [ ] Mobile / web behavior unchanged.

## Verification

- `dart format` — 0 changes
- `dart analyze --fatal-infos lib test` — clean for changed scope; 1 pre-existing warning in `lib/core/services/quick_instruction_store.dart:316` (verified present on base, unrelated to this change)
