### PR TITLE
fix(chat): keep the auto-retry countdown visible after the first round (issue #736)

### DIFF
--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -2464,6 +2464,24 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
     return blocks;
   }
 
+  /// The trailing streaming indicator, plus the auto-retry countdown while a
+  /// round is waiting to be retried. Rounds after the first keep their earlier
+  /// output on screen, so the countdown has to ride along with this indicator
+  /// instead of only the empty waiting bubble.
+  Widget _streamingIndicator() {
+    if (widget.hideStreamingIndicator) return const SizedBox(height: 16);
+    final retryStatus = widget.retryStatus;
+    if (retryStatus == null) return const LoadingIndicator();
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const LoadingIndicator(),
+        const SizedBox(width: 8),
+        _RetryCountdownHint(status: retryStatus),
+      ],
+    );
+  }
+
   Widget _buildAssistantMessage() {
     final cs = Theme.of(context).colorScheme;
     final fg = _chatSurfaceForegroundPalette(context);
@@ -2657,20 +2675,7 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
                                 widget.retryStatus!.maxRetries,
                                 _retrySecondsLeft(widget.retryStatus!),
                               ),
-                        child: widget.hideStreamingIndicator
-                            ? const SizedBox(height: 16)
-                            : Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const LoadingIndicator(),
-                                  if (widget.retryStatus != null) ...[
-                                    const SizedBox(width: 8),
-                                    _RetryCountdownHint(
-                                      status: widget.retryStatus!,
-                                    ),
-                                  ],
-                                ],
-                              ),
+                        child: _streamingIndicator(),
                       ),
                     ),
                   ),
@@ -2707,13 +2712,14 @@ class _ChatMessageWidgetState extends State<ChatMessageWidget> {
               }
             }
 
-            if (widget.message.isStreaming && visualContent.isNotEmpty) {
+            // A round that only called tools leaves no visible text, but a
+            // pending retry still has to say so somewhere.
+            if (widget.message.isStreaming &&
+                (visualContent.isNotEmpty || widget.retryStatus != null)) {
               widgets.add(
                 Padding(
                   padding: const EdgeInsets.only(left: 4, top: 4),
-                  child: widget.hideStreamingIndicator
-                      ? const SizedBox(height: 16)
-                      : const LoadingIndicator(),
+                  child: _streamingIndicator(),
                 ),
               );
             }

--- a/test/features/chat/widgets/chat_message_retry_countdown_test.dart
+++ b/test/features/chat/widgets/chat_message_retry_countdown_test.dart
@@ -2,6 +2,8 @@ import 'package:Cuplivo/core/models/chat_message.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/streaming_content_notifier.dart';
 import 'package:Cuplivo/features/chat/widgets/chat_message_widget.dart';
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
 import 'package:Cuplivo/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,12 +20,16 @@ void main() {
       addTearDown(settings.dispose);
 
       await tester.pumpWidget(
-        ChangeNotifierProvider<SettingsProvider>.value(
-          value: settings,
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: StatusInjectingMessage(),
+        _buildHarness(
+          settings,
+          StatusInjectingMessage(
+            message: ChatMessage(
+              role: 'assistant',
+              content: '',
+              conversationId: 'c1',
+              isStreaming: true,
+            ),
+            status: _status(attempt: 1, maxRetries: 3, seconds: 5),
           ),
         ),
       );
@@ -49,38 +55,286 @@ void main() {
       expect(sem.properties.label, '5s until retry (1/3)');
     },
   );
-}
 
-/// Injects the live [RetryStatus] into an otherwise minimal streaming message
-/// (RetryStatus holds a mutable DateTime, so the outer tree stays const).
-class StatusInjectingMessage extends StatefulWidget {
-  const StatusInjectingMessage({super.key});
+  testWidgets('an empty streaming bubble shows the retry countdown', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
 
-  @override
-  State<StatusInjectingMessage> createState() => _StatusInjectingMessageState();
-}
-
-class _StatusInjectingMessageState extends State<StatusInjectingMessage> {
-  late final RetryStatus _status = RetryStatus(
-    attempt: 1,
-    maxRetries: 3,
-    retryAt: DateTime.now().add(const Duration(seconds: 5)),
-  );
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SingleChildScrollView(
-        child: ChatMessageWidget(
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
           message: ChatMessage(
             role: 'assistant',
             content: '',
             conversationId: 'c1',
             isStreaming: true,
           ),
-          retryStatus: _status,
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('until retry (2/3)'), findsOneWidget);
+  });
+
+  testWidgets('a retry after the first round keeps the countdown visible', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: ChatMessage(
+            role: 'assistant',
+            content: 'partial answer',
+            conversationId: 'c1',
+            isStreaming: true,
+          ),
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('partial answer'), findsOneWidget);
+    expect(find.textContaining('until retry (2/3)'), findsOneWidget);
+  });
+
+  testWidgets('a retry between tool rounds keeps the countdown visible', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: ChatMessage(
+            role: 'assistant',
+            content: 'partial answer',
+            conversationId: 'c1',
+            isStreaming: true,
+          ),
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+          reasoningSegments: const [
+            ReasoningSegment(text: 'plan', expanded: true, loading: false),
+          ],
+          contentSplitOffsets: const [0],
+          reasoningCountAtSplit: const [1],
+          toolCountAtSplit: const [0],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('partial answer'), findsOneWidget);
+    expect(find.textContaining('until retry (2/3)'), findsOneWidget);
+  });
+
+  testWidgets('a tool-only round still shows the retry countdown', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: ChatMessage(
+            role: 'assistant',
+            content: '',
+            conversationId: 'c1',
+            isStreaming: true,
+          ),
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+          toolParts: const [
+            ToolUIPart(
+              id: 'c1',
+              toolName: 'lookup',
+              arguments: {},
+              content: 'ok',
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('lookup'), findsWidgets);
+    expect(find.textContaining('until retry (2/3)'), findsOneWidget);
+  });
+
+  testWidgets('no countdown renders while the stream is healthy', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: ChatMessage(
+            role: 'assistant',
+            content: 'partial answer',
+            conversationId: 'c1',
+            isStreaming: true,
+          ),
+          status: null,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('until retry'), findsNothing);
+  });
+
+  testWidgets('countdown disappears when the retry clears mid-stream', (
+    tester,
+  ) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+    final message = ChatMessage(
+      role: 'assistant',
+      content: 'partial answer',
+      conversationId: 'c1',
+      isStreaming: true,
+    );
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: message,
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.textContaining('until retry (2/3)'), findsOneWidget);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(message: message, status: null),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.textContaining('until retry'), findsNothing);
+  });
+
+  testWidgets('hideStreamingIndicator suppresses the countdown while retry '
+      'waits', (tester) async {
+    final settings = await createBusinessTestPreferences();
+    addTearDown(settings.dispose);
+
+    await tester.pumpWidget(
+      _buildHarness(
+        settings,
+        StatusInjectingMessage(
+          message: ChatMessage(
+            role: 'assistant',
+            content: 'partial answer',
+            conversationId: 'c1',
+            isStreaming: true,
+          ),
+          status: _status(attempt: 2, maxRetries: 3, seconds: 5),
+          hideStreamingIndicator: true,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(find.textContaining('partial answer'), findsOneWidget);
+    expect(find.textContaining('until retry'), findsNothing);
+    expect(find.byType(LoadingIndicator), findsNothing);
+  });
+}
+
+/// Injects the live [RetryStatus] into an otherwise minimal streaming message
+/// (RetryStatus holds a mutable DateTime, so the outer tree stays const where
+/// possible).
+class StatusInjectingMessage extends StatelessWidget {
+  const StatusInjectingMessage({
+    super.key,
+    required this.message,
+    required this.status,
+    this.reasoningSegments,
+    this.contentSplitOffsets,
+    this.reasoningCountAtSplit,
+    this.toolCountAtSplit,
+    this.toolParts,
+    this.hideStreamingIndicator = false,
+  });
+
+  final ChatMessage message;
+  final RetryStatus? status;
+  final List<ReasoningSegment>? reasoningSegments;
+  final List<int>? contentSplitOffsets;
+  final List<int>? reasoningCountAtSplit;
+  final List<int>? toolCountAtSplit;
+  final List<ToolUIPart>? toolParts;
+  final bool hideStreamingIndicator;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: ChatMessageWidget(
+          message: message,
+          retryStatus: status,
+          reasoningSegments: reasoningSegments,
+          contentSplitOffsets: contentSplitOffsets,
+          reasoningCountAtSplit: reasoningCountAtSplit,
+          toolCountAtSplit: toolCountAtSplit,
+          toolParts: toolParts,
+          hideStreamingIndicator: hideStreamingIndicator,
         ),
       ),
     );
   }
+}
+
+RetryStatus _status({
+  required int attempt,
+  required int maxRetries,
+  required int seconds,
+}) {
+  return RetryStatus(
+    attempt: attempt,
+    maxRetries: maxRetries,
+    retryAt: DateTime.now().add(Duration(seconds: seconds)),
+  );
+}
+
+Widget _buildHarness(SettingsProvider settings, Widget child) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+      ChangeNotifierProvider(create: (_) => ToolApprovalService()),
+      ChangeNotifierProvider(create: (_) => AskUserInteractionService()),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    ),
+  );
 }


### PR DESCRIPTION
## Problem

自动重试倒计时只可靠地显示在尚无内容的等待气泡中。若 429 / 可恢复错误发生在工具调用后的后续轮次,assistant 气泡通常已经包含文本、推理块或工具卡片,尾部只显示普通加载指示器,用户看不到正在等待自动重试及剩余时间;工具-only 轮次也没有任何可承载倒计时的可见尾部指示器。

## Fix

- 提取共享的 _streamingIndicator() builder:隐藏占位(hideStreamingIndicator)/ 健康流裸指示器 / 重试中指示器 + _RetryCountdownHint 倒计时;空气泡分支与尾部流式指示器分支统一走该路径。
- 尾部分支条件扩展为 isStreaming && (visualContent.isNotEmpty || retryStatus != null),工具-only 轮次在等待重试时也会渲染指示器与倒计时(工具调用无可见文本时)。
- hideStreamingIndicator 与健康流式状态的现有行为保持不变。

## Test

	est/features/chat/widgets/chat_message_retry_countdown_test.dart 覆盖:空消息、已有部分回答、推理/工具分段、工具-only、健康流不显示、重试中途清除(状态转换)、hideStreamingIndicator 抑制,并保留 Semantics 标签与 attempt / maxRetries / seconds 参数顺序断言。

## Verification

- dart format 两个改动文件
- dart analyze --fatal-infos lib test — 0 error / 0 info(仅剩 quick_instruction_store.dart 既有 warning) 
- lutter test test/features/chat/widgets/ — 94 个测试全部通过(含 8 个倒计时场景)

## Residual risk

- 工具-only 轮次在无 retryStatus 时仍不显示尾部指示器(与上游 Kelivo 修复一致;工具卡在 part.loading 时自带内联加载)。
- hideStreamingIndicator 开启时重试倒计时同样被抑制(与既有空气泡行为、上游修复一致,属于该设置的既定语义)。

Closes #736