### PR TITLE
feat(models): adapt GPT-6 Astra, Claude Fable 5.1, Qwen 3.8, Muse 1.3, and GLM-5.3

### DIFF
--- a/lib/core/providers/model_provider.dart
+++ b/lib/core/providers/model_provider.dart
@@ -21,15 +21,15 @@ class ModelRegistry {
   // Vision-capable models (text + image input)
   static final RegExp vision = RegExp(
     // GPT family incl. 4o, 4.1, 5 (exclude gpt-5-chat), and OpenAI o* series
-    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|qwen-?3[.-]8(?:$|[-./_:@])|kimi-k2([-.])(?:5|6|7)|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|muse-spark(?:$|[-._:/@]1\.[12](?:$|[/_:@.-]))|muse-glimmer-30b(?:$|[-._:/@])|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite|dots-?3-?note(?:$|[-._:/@])|deepseek-v4-flash-vision(?:-exp)?(?:$|[-._:/@]))',
+    r'(gpt-4o|gpt-4\.1|gpt-5(?!-chat)|gpt-6|o\d|gemini|claude|qwen-?3[.-][5-7](?!.*-max)|qwen-?3[.-]8(?!-2\.4t)(?:$|[-./_:@])|kimi-k2([-.])(?:5|6|7)|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|muse-spark(?:$|[-._:/@]1(?:$|[._:/@-]))|muse-glimmer-30b(?:$|[-._:/@])|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2\.[01])|grok-4|step-3|intern-s1|minimax-m3(?:$|[/_:@])|mimo-v2(?:-omni(?:$|[/_:@])|\.5(?:$|[/_:@]))|sensenova-6\.7-flash-lite|dots-?3-?note(?:$|[-._:/@])|deepseek-v4-flash-vision(?:-exp)?(?:$|[-._:/@]))',
     caseSensitive: false,
   );
   // Tool-using models
   static final RegExp tool = RegExp(
-    (r'(gpt-4o|gpt-4\.1|gpt-oss|gpt-5(?!-chat)|o\d|'
+    (r'(gpt-4o|gpt-4\.1|gpt-oss|gpt-5(?!-chat)|gpt-6|o\d|'
             r'gemini|claude|'
             r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
-            r'muse-spark(?:$|[-._:/@]1\.[12](?:$|[/_:@.-]))|muse-glimmer-30b(?:$|[-._:/@])|'
+            r'muse-spark(?:$|[-._:/@]1(?:$|[._:/@-]))|muse-glimmer-30b(?:$|[-._:/@])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3|chat|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -40,13 +40,13 @@ class ModelRegistry {
     caseSensitive: false,
   );
   static final RegExp reasoning = RegExp(
-    (r'(gpt-oss|gpt-5(?!-chat)|o\d|'
+    (r'(gpt-oss|gpt-5(?!-chat)|gpt-6|o\d|'
             r'gemini-(?:2\.5|3).*|gemini-(?:flash-latest|pro-latest)|'
             r'gemini-3-pro-image-preview|'
             r'gemma[-_]?4|'
             r'claude|'
             r'qwen-?3|doubao(?:.+1(?:[-.])(?:6|8)|.*seed-2)|grok-4|kimi-k2|kimi-k3|(?:^|[-_/])k3(?:$|[-.])|'
-            r'muse-spark(?:$|[-._:/@]1\.[12](?:$|[/_:@.-]))|muse-glimmer-30b(?:$|[-._:/@])|'
+            r'muse-spark(?:$|[-._:/@]1(?:$|[._:/@-]))|muse-glimmer-30b(?:$|[-._:/@])|'
             r'step-3|intern-s1|glm-4([-.])(?:5|6|7)|glm-5|minimax-(?:m2|m3)|'
             r'deepseek-(?:r1|v3\.1|v3\.2|v4)|'
             r'deepseek-reasoner|'
@@ -65,6 +65,27 @@ class ModelRegistry {
   static bool _isGemini35Flash(String id) {
     return RegExp(
       r'(^|[/:_-])gemini-3\.5-flash([._:@/-]|$)',
+      caseSensitive: false,
+    ).hasMatch(id);
+  }
+
+  /// Vision applies to `qwen3.7-max` snapshots dated 2026-06-08 and later;
+  /// plain `/ earlier` max SKUs stay text-only.
+  static bool _isQwen37MaxVisionSnapshot(String id) {
+    final match = RegExp(
+      r'qwen-?3([-.])7-max-(\d{4}-\d{2}-\d{2})',
+      caseSensitive: false,
+    ).firstMatch(id.toLowerCase());
+    if (match == null) return false;
+    final date = DateTime.tryParse(match.group(2) ?? '');
+    if (date == null) return false;
+    return !date.isBefore(DateTime(2026, 6, 8));
+  }
+
+  /// GLM-5.3-Flash is the first native multimodal GLM-5 SKU.
+  static bool _isGlmVisionModel(String id) {
+    return RegExp(
+      r'(^|[/_:@])glm-5\.3-flash(?:$|[-.])',
       caseSensitive: false,
     ).hasMatch(id);
   }
@@ -110,7 +131,9 @@ class ModelRegistry {
       }
       return base.copyWith(input: inMods, output: outMods, abilities: ab);
     }
-    if (vision.hasMatch(id)) {
+    if (vision.hasMatch(id) ||
+        _isQwen37MaxVisionSnapshot(id) ||
+        _isGlmVisionModel(id)) {
       if (!inMods.contains(Modality.image)) inMods.add(Modality.image);
     }
     if (tool.hasMatch(id) && !ab.contains(ModelAbility.tool)) {
@@ -325,6 +348,7 @@ class GoogleProvider extends BaseProvider {
       // we manually inject known supported Claude models for convenience.
       if (cfg.vertexAI == true) {
         final knownClaude = [
+          'claude-fable-5-1',
           'claude-fable-5',
           'claude-opus-5',
           'claude-opus-4-8',

--- a/lib/core/services/api/builtin_tools.dart
+++ b/lib/core/services/api/builtin_tools.dart
@@ -167,7 +167,9 @@ abstract class BuiltInToolsHelper {
   static bool isClaudeBuiltInSearchSupportedModel(String? modelId) {
     final normalized = _normalizedModelId(modelId);
     if (normalized.contains('mythos')) return true;
+    if (normalized.contains('fable')) return true;
     const supported = <String>{
+      'claude-fable-5-1',
       'claude-fable-5',
       'claude-opus-5',
       'claude-opus-4-8',
@@ -189,6 +191,7 @@ abstract class BuiltInToolsHelper {
   static bool isClaudeDynamicWebSearchSupportedModel(String? modelId) {
     final normalized = _normalizedModelId(modelId);
     return normalized.contains('mythos') ||
+        normalized.contains('fable') ||
         normalized == 'claude-fable-5' ||
         normalized == 'claude-opus-5' ||
         normalized == 'claude-opus-4-8' ||
@@ -205,7 +208,8 @@ abstract class BuiltInToolsHelper {
         m.startsWith('o4-mini') ||
         m == 'o3' ||
         m.startsWith('o3-') ||
-        m.startsWith('gpt-5');
+        m.startsWith('gpt-5') ||
+        m.startsWith('gpt-6');
   }
 
   static bool isOpenRouterProvider(ProviderConfig? cfg) {
@@ -266,7 +270,9 @@ abstract class BuiltInToolsHelper {
           minSnapshot: '2025-07-15',
           extraExact: const <String>['qwen-turbo-latest'],
         ) ||
-        m == 'qwq-plus';
+        m == 'qwq-plus' ||
+        _isDashScopeQwen37SearchModel(m) ||
+        _isDashScopeQwen38SearchModel(m);
   }
 
   static bool isDashScopeResponsesBuiltInSearchSupportedModel(String? modelId) {
@@ -295,7 +301,44 @@ abstract class BuiltInToolsHelper {
           m,
           alias: 'qwen3-max',
           minSnapshot: '2026-01-23',
+        ) ||
+        _isDashScopeQwen37SearchModel(m) ||
+        _isDashScopeQwen38SearchModel(m);
+  }
+
+  static bool _isDashScopeQwen37SearchModel(String normalizedModelId) {
+    return _matchesExactOrSnapshot(
+          normalizedModelId,
+          alias: 'qwen3.7-max',
+          minSnapshot: '2026-05-17',
+          extraExact: const <String>['qwen3.7-max-preview'],
+        ) ||
+        _matchesExactOrSnapshot(
+          normalizedModelId,
+          alias: 'qwen3.7-plus',
+          minSnapshot: '2026-05-26',
+        ) ||
+        _matchesExactOrSnapshot(
+          normalizedModelId,
+          alias: 'qwen3.7-flash',
+          minSnapshot: '2026-07-15',
         );
+  }
+
+  static bool _isDashScopeQwen38SearchModel(String normalizedModelId) {
+    return _matchesExactOrSnapshot(
+          normalizedModelId,
+          alias: 'qwen3.8-max',
+          minSnapshot: '2026-08-02',
+          extraExact: const <String>['qwen3.8-max-preview', 'qwen3.8-max-0902'],
+        ) ||
+        _matchesExactOrSnapshot(
+          normalizedModelId,
+          alias: 'qwen3.8-flash',
+          minSnapshot: '2026-08-26',
+        ) ||
+        normalizedModelId == 'qwen3.8-2.4t-a95b' ||
+        normalizedModelId == 'qwen3.8-27b';
   }
 
   static bool supportsBuiltInSearchForModel({

--- a/lib/core/services/api/providers/google_vertex.dart
+++ b/lib/core/services/api/providers/google_vertex.dart
@@ -88,6 +88,7 @@ Future<String?> _maybeVertexAccessToken(ProviderConfig cfg) async {
 int _getMaxOutputTokensForClaudeModel(String modelId) {
   // Limits based on Google Vertex AI documentation
   switch (modelId) {
+    case 'claude-fable-5-1':
     case 'claude-fable-5':
     case 'claude-opus-5':
     case 'claude-opus-4-8':

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -1249,12 +1249,29 @@ void _applyVendorReasoningKnobs(
     }
     body.remove('reasoning_effort');
   } else if (info.isZhipu || info.isMimo) {
-    if (isReasoning) {
+    if (isGlm53FamilyModel(info.upstreamModelId)) {
+      // GLM-5.3 / 5.3-Flash always think. disabled returns 400; off maps to low.
+      body['thinking'] = const <String, dynamic>{'type': 'enabled'};
+      if (isReasoning) {
+        final effort = _openAIEffortForBudget(
+          thinkingBudget,
+          info.upstreamModelId,
+        );
+        if (effort == 'auto') {
+          body.remove('reasoning_effort');
+        } else {
+          body['reasoning_effort'] = effort;
+        }
+      } else {
+        body.remove('reasoning_effort');
+      }
+    } else if (isReasoning) {
       body['thinking'] = {'type': off ? 'disabled' : 'enabled'};
+      body.remove('reasoning_effort');
     } else {
       body.remove('thinking');
+      body.remove('reasoning_effort');
     }
-    body.remove('reasoning_effort');
   } else if (info.isVolc) {
     if (isReasoning) {
       body['thinking'] = {'type': off ? 'disabled' : 'enabled'};

--- a/lib/core/services/quick_instruction_store.dart
+++ b/lib/core/services/quick_instruction_store.dart
@@ -313,7 +313,7 @@ class QuickInstructionStore {
       }
       _cache = items;
       if (upgraded) await save(items);
-      return _seedBuiltInPlanIfNeeded(items);
+      return await _seedBuiltInPlanIfNeeded(items);
     } catch (error, stackTrace) {
       debugPrint(
         'QuickInstructionStore.getAll: invalid persisted payload: '

--- a/lib/core/utils/openai_model_compat.dart
+++ b/lib/core/utils/openai_model_compat.dart
@@ -80,6 +80,24 @@ const OpenAIReasoningSupport _museFamilySupport = OpenAIReasoningSupport(
   supportedEfforts: <String>[],
   effortParameterSupported: false,
 );
+const OpenAIReasoningSupport _museSparkSupport = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _museSpark13Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high', 'xhigh', 'max'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _glm53Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'high', 'max'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _gpt6AstraSupport = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high', 'xhigh', 'max'],
+  samplingRequiresNone: true,
+  samplingAllowsAuto: false,
+  offFallback: 'low',
+);
 const OpenAIReasoningSupport _deepSeekSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
 );
@@ -97,6 +115,17 @@ String resolveApiModelIdOverride(
 
 bool isOpenAIGpt5FamilyModel(String modelId) {
   return RegExp(r'gpt-5(?=$|[-.])', caseSensitive: false).hasMatch(modelId);
+}
+
+bool isOpenAIGpt6FamilyModel(String modelId) {
+  return RegExp(r'gpt-6(?=$|[-.])', caseSensitive: false).hasMatch(modelId);
+}
+
+bool isGlm53FamilyModel(String modelId) {
+  return _matchesModel(
+    modelId.trim().toLowerCase(),
+    r'(^|[/_:@])glm-5\.3(?:$|[-.])',
+  );
 }
 
 bool openAISupportsXhighReasoning(String modelId) {
@@ -218,12 +247,26 @@ OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   if (_matchesModel(normalized, r'(^|[/_:@])grok-4\.(?:5|6)(?:$|[-.])')) {
     return _grok45Support;
   }
+  if (_matchesModel(normalized, r'(^|[/_:@])muse-spark-1\.3(?:$|[-.])')) {
+    return normalized.contains('contributor')
+        ? _museSparkSupport
+        : _museSpark13Support;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])muse-spark-1(?:$|[-.])')) {
+    return _museSparkSupport;
+  }
   if (_matchesModel(
         normalized,
         r'(^|[/_:@])muse-spark(?:$|[-.]1\.[12](?:$|[-.]))',
       ) ||
       _matchesModel(normalized, r'(^|[/_:@])muse-glimmer-30b(?:$|[-.])')) {
     return _museFamilySupport;
+  }
+  if (isGlm53FamilyModel(normalized)) {
+    return _glm53Support;
+  }
+  if (isOpenAIGpt6FamilyModel(normalized)) {
+    return _gpt6AstraSupport;
   }
   if (!isOpenAIGpt5FamilyModel(normalized)) return null;
 

--- a/test/core/services/api/builtin_tools_search_test.dart
+++ b/test/core/services/api/builtin_tools_search_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/services/api/builtin_tools.dart';
+
+void main() {
+  group('Built-in search tools', () {
+    test('enables official Qwen 3.7 / 3.8 search SKUs', () {
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.7-plus',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.7-max',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.7-max-preview',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.7-flash',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.8-max-preview',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.8-max',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.8-max-0902',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.8-flash',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeChatBuiltInSearchSupportedModel(
+          'qwen3.7-max',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeChatBuiltInSearchSupportedModel(
+          'qwen3.8-flash',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isOpenAIResponsesBuiltInSearchSupportedModel(
+          'gpt-6-astra',
+        ),
+        isTrue,
+      );
+    });
+
+    test('keeps unlisted Qwen SKUs closed', () {
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen2.5-max',
+        ),
+        isFalse,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeChatBuiltInSearchSupportedModel(
+          'qwen3.6-max',
+        ),
+        isFalse,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.6-max',
+        ),
+        isFalse,
+      );
+    });
+
+    test('opens text-only qwen3.8-2.4t-a95b for search', () {
+      expect(
+        BuiltInToolsHelper.isDashScopeChatBuiltInSearchSupportedModel(
+          'qwen3.8-2.4t-a95b',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isDashScopeResponsesBuiltInSearchSupportedModel(
+          'qwen3.8-2.4t-a95b',
+        ),
+        isTrue,
+      );
+    });
+
+    test('Claude Fable 5.1 supports built-in and dynamic web search', () {
+      expect(
+        BuiltInToolsHelper.isClaudeBuiltInSearchSupportedModel(
+          'claude-fable-5-1',
+        ),
+        isTrue,
+      );
+      expect(
+        BuiltInToolsHelper.isClaudeDynamicWebSearchSupportedModel(
+          'claude-fable-5-1',
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/google_thinking_config_test.dart
+++ b/test/google_thinking_config_test.dart
@@ -370,6 +370,29 @@ void main() {
       },
     );
 
+    test(
+      'Gemini 3.8 Flash inherits 3.7 thinking levels and default medium',
+      () async {
+        final body = await _capture(
+          modelId: 'gemini-3.8-flash',
+          thinkingBudget: null,
+        );
+        final offBody = await _capture(
+          modelId: 'gemini-3.8-flash',
+          thinkingBudget: 0,
+        );
+
+        expect(_thinkingConfig(body), {
+          'includeThoughts': true,
+          'thinkingLevel': 'medium',
+        });
+        expect(_thinkingConfig(offBody), {
+          'includeThoughts': false,
+          'thinkingLevel': 'low',
+        });
+      },
+    );
+
     test('Gemini 3.7 Flash-Lite floors at low when thinking is off', () async {
       final body = await _capture(
         modelId: 'gemini-3.7-flash-lite',

--- a/test/model_registry_vision_test.dart
+++ b/test/model_registry_vision_test.dart
@@ -67,6 +67,40 @@ void main() {
       expect(info.input, contains(Modality.image));
     });
 
+    test('qwen3.8-27b has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.8-27b', displayName: 'qwen3.8-27b'),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('qwen3.8-2.4t-a95b stays text-only', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'qwen3.8-2.4t-a95b', displayName: 'qwen3.8-2.4t-a95b'),
+      );
+      expect(info.input, isNot(contains(Modality.image)));
+    });
+
+    test('qwen3.7-max-2026-06-08 snapshot has vision', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'qwen3.7-max-2026-06-08',
+          displayName: 'qwen3.7-max-2026-06-08',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+    });
+
+    test('earlier qwen3.7-max snapshot stays text-only', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'qwen3.7-max-2026-05-17',
+          displayName: 'qwen3.7-max-2026-05-17',
+        ),
+      );
+      expect(info.input, isNot(contains(Modality.image)));
+    });
+
     test('qwen3-8b does NOT have vision', () {
       final info = ModelRegistry.infer(
         ModelInfo(id: 'Qwen/Qwen3-8B', displayName: 'Qwen/Qwen3-8B'),
@@ -81,6 +115,18 @@ void main() {
         ModelInfo(
           id: 'doubao-seed-2.0-pro',
           displayName: 'doubao-seed-2.0-pro',
+        ),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+
+    test('doubao-seed-2.0-code has vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(
+          id: 'doubao-seed-2.0-code',
+          displayName: 'doubao-seed-2.0-code',
         ),
       );
       expect(info.input, contains(Modality.image));
@@ -247,5 +293,34 @@ void main() {
         expect(info.abilities, contains(ModelAbility.reasoning));
       },
     );
+  });
+
+  group('ModelRegistry.infer — GPT-6 Astra, Muse 1.3 and GLM-5.3-Flash', () {
+    test('gpt-6-astra has vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'gpt-6-astra', displayName: 'gpt-6-astra'),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+
+    test('muse-spark-1.3 has vision, tool, and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'muse-spark-1.3', displayName: 'muse-spark-1.3'),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
+
+    test('glm-5.3-flash is multimodal with tool and reasoning', () {
+      final info = ModelRegistry.infer(
+        ModelInfo(id: 'glm-5.3-flash', displayName: 'glm-5.3-flash'),
+      );
+      expect(info.input, contains(Modality.image));
+      expect(info.abilities, contains(ModelAbility.tool));
+      expect(info.abilities, contains(ModelAbility.reasoning));
+    });
   });
 }

--- a/test/openai_latest_models_compat_test.dart
+++ b/test/openai_latest_models_compat_test.dart
@@ -110,10 +110,31 @@ void main() {
       expect(openAINormalizeReasoningEffort('off', 'x-ai/grok-4.6'), 'low');
       expect(
         openAINormalizeReasoningEffort('high', 'meta/muse-spark-1.1'),
-        'auto',
+        'high',
       );
+      expect(openAINormalizeReasoningEffort('off', 'muse-spark-1.1'), 'low');
+      expect(openAINormalizeReasoningEffort('max', 'muse-spark-1.3'), 'max');
+      expect(
+        openAINormalizeReasoningEffort('max', 'muse-spark-1.3-contributor'),
+        'xhigh',
+      );
+      expect(openAISupportsMaxReasoning('muse-spark-1.3'), isTrue);
+      expect(openAISupportsMaxReasoning('muse-spark-1.3-contributor'), isFalse);
+      expect(openAINormalizeReasoningEffort('off', 'glm-5.3'), 'low');
+      expect(openAINormalizeReasoningEffort('medium', 'glm-5.3'), 'high');
+      expect(openAINormalizeReasoningEffort('max', 'z-ai/glm-5.3'), 'max');
+      expect(openAISupportsMaxReasoning('z-ai/glm-5.3'), isTrue);
+      expect(openAINormalizeReasoningEffort('off', 'gpt-6-astra'), 'low');
+      expect(
+        openAINormalizeReasoningEffort('none', 'openai/gpt-6-astra'),
+        'low',
+      );
+      expect(openAINormalizeReasoningEffort('max', 'gpt-6-astra'), 'max');
+      expect(openAISupportsNoneReasoning('gpt-6-astra'), isFalse);
+      expect(openAISupportsMaxReasoning('gpt-6-astra'), isTrue);
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.6-sol'), 'none');
       expect(openAINormalizeReasoningEffort('high', 'muse-spark'), 'auto');
-      expect(openAINormalizeReasoningEffort('high', 'muse-spark-1.2'), 'auto');
+      expect(openAINormalizeReasoningEffort('high', 'muse-spark-1.2'), 'high');
       expect(
         openAINormalizeReasoningEffort('high', 'muse-glimmer-30b'),
         'auto',
@@ -192,13 +213,50 @@ void main() {
       expect(body.containsKey('top_p'), isFalse);
     });
 
-    test('Muse Spark does not invent an undocumented effort field', () async {
+    test('Muse Spark 1.3 sends documented effort including max', () async {
       final body = await _captureChatBody(
-        modelId: 'meta/muse-spark-1.1',
+        modelId: 'meta/muse-spark-1.3',
         thinkingBudget: 128000,
       );
+      final offBody = await _captureChatBody(
+        modelId: 'muse-spark-1.1',
+        thinkingBudget: 0,
+      );
 
-      expect(body.containsKey('reasoning_effort'), isFalse);
+      expect(body['reasoning_effort'], 'max');
+      expect(offBody['reasoning_effort'], 'low');
+    });
+
+    test('GPT-6 Astra omits sampling and never sends none', () async {
+      const tools = [
+        {
+          'type': 'function',
+          'function': {
+            'name': 'lookup',
+            'description': 'Look something up',
+            'parameters': {'type': 'object', 'properties': <String, dynamic>{}},
+          },
+        },
+      ];
+      final offBody = await _captureChatBody(
+        modelId: 'gpt-6-astra',
+        thinkingBudget: 0,
+        temperature: 0.7,
+        topP: 0.8,
+        tools: tools,
+      );
+      final maxBody = await _captureChatBody(
+        modelId: 'openai/gpt-6-astra',
+        thinkingBudget: 128000,
+        temperature: 0.7,
+        topP: 0.8,
+      );
+
+      expect(offBody['reasoning_effort'], 'low');
+      expect(offBody.containsKey('temperature'), isFalse);
+      expect(offBody.containsKey('top_p'), isFalse);
+      expect(maxBody['reasoning_effort'], 'max');
+      expect(maxBody.containsKey('temperature'), isFalse);
     });
 
     test('Grok Responses streams reasoning text and clamps off to low', () async {

--- a/test/openai_zhipu_glm_compat_test.dart
+++ b/test/openai_zhipu_glm_compat_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/core/services/api/chat_api_service.dart';
 
-ProviderConfig _zhipuConfig(String baseUrl) {
+ProviderConfig _zhipuConfig(String baseUrl, {String modelId = 'glm-5.2'}) {
   return ProviderConfig(
     id: 'ZhipuTest',
     enabled: true,
@@ -15,9 +15,9 @@ ProviderConfig _zhipuConfig(String baseUrl) {
     apiKey: 'test-key',
     baseUrl: baseUrl,
     providerType: ProviderKind.openai,
-    models: const ['glm-5.2'],
-    modelOverrides: const {
-      'glm-5.2': {
+    models: [modelId],
+    modelOverrides: {
+      modelId: {
         'type': 'chat',
         'input': ['text'],
         'output': ['text'],
@@ -92,73 +92,6 @@ void main() {
       expect(requests[1]['thinking'], {'type': 'disabled'});
       expect(requests[1].containsKey('reasoning_effort'), isFalse);
     });
-
-    test(
-      'glm-5.3 maps reasoning budget to thinking type like glm-5.2',
-      () async {
-        final requests = <Map<String, dynamic>>[];
-        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-        addTearDown(() async {
-          await server.close(force: true);
-        });
-
-        server.listen((request) async {
-          requests.add(
-            jsonDecode(await utf8.decoder.bind(request).join())
-                as Map<String, dynamic>,
-          );
-
-          request.response.statusCode = HttpStatus.ok;
-          request.response.headers.contentType = ContentType(
-            'text',
-            'event-stream',
-            charset: 'utf-8',
-          );
-          request.response.write(
-            'data: ${jsonEncode({
-              'id': 'cmpl-glm53',
-              'object': 'chat.completion.chunk',
-              'created': 0,
-              'model': 'glm-5.3',
-              'choices': [
-                {
-                  'index': 0,
-                  'delta': {'role': 'assistant', 'content': 'ok'},
-                  'finish_reason': 'stop',
-                },
-              ],
-            })}\n\n',
-          );
-          request.response.write('data: [DONE]\n\n');
-          await request.response.close();
-        });
-
-        final baseUrl = 'http://${server.address.address}:${server.port}/v1';
-        await ChatApiService.sendMessageStream(
-          config: _zhipuConfig(baseUrl),
-          modelId: 'glm-5.3',
-          messages: const [
-            {'role': 'user', 'content': 'hello'},
-          ],
-          thinkingBudget: 1024,
-        ).toList();
-
-        await ChatApiService.sendMessageStream(
-          config: _zhipuConfig(baseUrl),
-          modelId: 'glm-5.3',
-          messages: const [
-            {'role': 'user', 'content': 'hello again'},
-          ],
-          thinkingBudget: 0,
-        ).toList();
-
-        expect(requests, hasLength(2));
-        expect(requests[0]['thinking'], {'type': 'enabled'});
-        expect(requests[0].containsKey('reasoning_effort'), isFalse);
-        expect(requests[1]['thinking'], {'type': 'disabled'});
-        expect(requests[1].containsKey('reasoning_effort'), isFalse);
-      },
-    );
 
     test('glm-5.2 preserves additionalProperties in tool schema', () async {
       final requests = <Map<String, dynamic>>[];
@@ -356,6 +289,68 @@ void main() {
           'function': {'name': 'date', 'arguments': '{}'},
         },
       ]);
+    });
+
+    test('glm-5.3 keeps thinking on and maps off to low effort', () async {
+      final requests = <Map<String, dynamic>>[];
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requests.add(
+          jsonDecode(await utf8.decoder.bind(request).join())
+              as Map<String, dynamic>,
+        );
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'id': 'cmpl-glm53',
+            'object': 'chat.completion.chunk',
+            'created': 0,
+            'model': 'glm-5.3',
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _zhipuConfig(baseUrl, modelId: 'glm-5.3'),
+        modelId: 'glm-5.3',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 128000,
+      ).toList();
+      await ChatApiService.sendMessageStream(
+        config: _zhipuConfig(baseUrl, modelId: 'glm-5.3-flash'),
+        modelId: 'glm-5.3-flash',
+        messages: const [
+          {'role': 'user', 'content': 'hello again'},
+        ],
+        thinkingBudget: 0,
+      ).toList();
+
+      expect(requests, hasLength(2));
+      expect(requests[0]['thinking'], {'type': 'enabled'});
+      expect(requests[0]['reasoning_effort'], 'max');
+      expect(requests[1]['thinking'], {'type': 'enabled'});
+      expect(requests[1]['reasoning_effort'], 'low');
     });
   });
 }

--- a/test/settings_provider_reasoning_support_test.dart
+++ b/test/settings_provider_reasoning_support_test.dart
@@ -145,6 +145,20 @@ void main() {
           settings.supportsMaxReasoning('OpenAI', 'muse-glimmer-30b'),
           isFalse,
         );
+        expect(
+          settings.supportsMaxReasoning('OpenAI', 'muse-spark-1.3'),
+          isTrue,
+        );
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'gpt-6-astra'),
+          isTrue,
+        );
+        expect(settings.supportsMaxReasoning('OpenAI', 'gpt-6-astra'), isTrue);
+        expect(settings.supportsMaxReasoning('OpenAI', 'glm-5.3'), isTrue);
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'glm-5.3-flash'),
+          isFalse,
+        );
       },
     );
 


### PR DESCRIPTION
## 概述

移植上游 [Chevey339/kelivo cfb9704e](https://github.com/Chevey339/kelivo/commit/cfb9704e) 的新模型适配到 Cuplivo 代码结构（Issue #742）：

- **GPT-6 Astra** — vision + tool + reasoning；推理档位 low~max，永不发送 `none`；采样参数（temperature/top_p）会被移除
- **Claude Fable 5.1** (`claude-fable-5-1`) — 内置搜索 / 动态网页搜索支持、Vertex 已知模型与 128K 输出上限
- **Qwen 3.8** — vision（max/flash/27b；`2.4t-a95b` 保持纯文本）、官方 3.7/3.8 搜索 SKU 白名单（chat + Responses）
- **Muse Spark 1.3** — 支持 `max` 档位（contributor 变体除外）；1.1/1.2 从无 effort 升为文档化档位
- **GLM-5.3 / 5.3-Flash** — 官方档位 low/high/max；Zhipu 路由上 thinking 常开（disabled 会 400，off 映射为 low）；5.3-Flash 为 GLM-5 首个原生多模态
- **Gemini 3.8 Flash** — 继承 3.7 思考档位（纯测试；版本区间逻辑已覆盖）

## 说明

- 保留 fork 既有测试过的分歧：qwen3.6 / qwen3.8-plus 视觉、bare muse-spark & muse-glimmer 仍无 effort
- 未移植：`38035806`（always-on off→最低档修复）、`0680139e`（Poolside Laguna）、Claude server-tools 提交
- `quick_instruction_store.dart:316` 仅做 lint 修复（`unawaited_return_in_try_block` 阻断 `dart analyze --fatal-infos`，本次为既有问题）

## 验证

- `dart analyze --fatal-infos lib test` — 0 issues
- `flutter test` 相关子集（8 个文件，117 个用例）— 全部通过

Closes #742
