### PR TITLE
fix(models): 补齐 GLM-5.2、Kimi K2.6 与 DashScope thinking-only 模型兼容

### DIFF
--- a/lib/core/services/api/chat_api_service.dart
+++ b/lib/core/services/api/chat_api_service.dart
@@ -1546,7 +1546,6 @@ class ChatApiService {
     ProviderConfig? config,
   }) {
     if (_isClaudeThinkingAlwaysOnModel(modelId)) {
-      if (!_isClaudeReasoningEnabled(budget)) return null;
       return <String, dynamic>{'type': 'adaptive', 'display': 'summarized'};
     }
     if (!_isClaudeReasoningEnabled(budget)) {
@@ -1570,11 +1569,12 @@ class ChatApiService {
     ProviderConfig? config,
   }) {
     if (_isClaudeThinkingAlwaysOnModel(modelId)) {
-      final effort = _normalizeClaudeEffort(
-        _claudeEffortForBudget(budget),
-        modelId,
-      );
-      if (effort == 'auto' || effort == 'off') return null;
+      // Adaptive thinking cannot be disabled. Omitting effort defaults to high,
+      // so UI "off" must send the lowest legal level instead.
+      var effort = _claudeEffortForBudget(budget);
+      if (effort == 'off') effort = 'low';
+      effort = _normalizeClaudeEffort(effort, modelId);
+      if (effort == 'auto') return null;
       return <String, dynamic>{'effort': effort};
     }
     if (_isDeepSeekClaudeCompatible(modelId, config: config)) {

--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -108,7 +108,15 @@ Map<String, dynamic> _googleThinkingConfig(
 ) {
   final off = _isOff(budget);
   if (_isGemma4Model(upstreamModelId)) {
-    if (off) return const <String, dynamic>{};
+    // Official toggle is thinkingLevel high/minimal. Omitting the config
+    // leaves thinking on; off must send minimal.
+    // https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api
+    if (off) {
+      return const <String, dynamic>{
+        'includeThoughts': false,
+        'thinkingLevel': 'minimal',
+      };
+    }
     return const <String, dynamic>{
       'includeThoughts': true,
       'thinkingLevel': 'high',

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -140,11 +140,35 @@ void _applyCompatibleResponsesReasoning(
   final forceThinkingForQwen3Max =
       builtInSearchEnabled &&
       upstreamModelId.toLowerCase().startsWith('qwen3-max');
+  if (_isDashScopeThinkingOnlyModel(upstreamModelId)) {
+    body.remove('enable_thinking');
+    return;
+  }
   body['enable_thinking'] = forceThinkingForQwen3Max || !_isOff(thinkingBudget);
 }
 
-bool _isKimiK25Model(String upstreamModelId) {
-  return upstreamModelId.toLowerCase().contains('kimi-k2.5');
+bool _isDashScopeThinkingOnlyModel(String modelId) {
+  final lower = modelId.trim().toLowerCase();
+  if (lower.contains('qwen3.7-max-preview') ||
+      lower.contains('qwen3.7-max-2026-05-17')) {
+    return true;
+  }
+  if (RegExp(r'(^|[/_:@])qwq(?:$|[-.])').hasMatch(lower)) return true;
+  if (RegExp(r'(^|[/_:@])deepseek-r1(?:$|[-.])').hasMatch(lower)) {
+    return true;
+  }
+  if (lower.contains('kimi-k2.7-code') || lower.contains('kimi-k2-thinking')) {
+    return true;
+  }
+  if (RegExp(r'(^|[/_:@])minimax-m2\.(?:1|5)(?:$|[-.])').hasMatch(lower)) {
+    return true;
+  }
+  return lower.contains('-thinking');
+}
+
+bool _isKimiHybridThinkingModel(String upstreamModelId) {
+  final lower = upstreamModelId.toLowerCase();
+  return lower.contains('kimi-k2.5') || lower.contains('kimi-k2.6');
 }
 
 bool _isKimiK3Model(String upstreamModelId) {
@@ -255,11 +279,13 @@ void _normalizeMoonshotKimiChatBody(
     return;
   }
 
-  if (_isKimiK25Model(upstreamModelId)) {
+  if (_isKimiHybridThinkingModel(upstreamModelId)) {
     body['thinking'] = {
       'type': _isOff(thinkingBudget) ? 'disabled' : 'enabled',
     };
-    _removeMoonshotKimiUnsupportedSamplingParams(body);
+    if (upstreamModelId.toLowerCase().contains('kimi-k2.5')) {
+      _removeMoonshotKimiUnsupportedSamplingParams(body);
+    }
     return;
   }
 
@@ -1237,7 +1263,11 @@ void _applyVendorReasoningKnobs(
     }
   } else if (info.isDashScope) {
     if (isReasoning) {
-      body['enable_thinking'] = !off;
+      if (_isDashScopeThinkingOnlyModel(info.upstreamModelId)) {
+        body.remove('enable_thinking');
+      } else {
+        body['enable_thinking'] = !off;
+      }
       if (!off && thinkingBudget != null && thinkingBudget > 0) {
         body['thinking_budget'] = thinkingBudget;
       } else {
@@ -1248,6 +1278,26 @@ void _applyVendorReasoningKnobs(
       body.remove('thinking_budget');
     }
     body.remove('reasoning_effort');
+  } else if (isGlm52FamilyModel(info.upstreamModelId)) {
+    if (isReasoning) {
+      body['thinking'] = {'type': off ? 'disabled' : 'enabled'};
+      if (off) {
+        body.remove('reasoning_effort');
+      } else {
+        final effort = _openAIEffortForBudget(
+          thinkingBudget,
+          info.upstreamModelId,
+        );
+        if (effort == 'auto') {
+          body.remove('reasoning_effort');
+        } else {
+          body['reasoning_effort'] = effort;
+        }
+      }
+    } else {
+      body.remove('thinking');
+      body.remove('reasoning_effort');
+    }
   } else if (info.isZhipu || info.isMimo) {
     if (isGlm53FamilyModel(info.upstreamModelId)) {
       // GLM-5.3 / 5.3-Flash always think. disabled returns 400; off maps to low.

--- a/lib/core/utils/openai_model_compat.dart
+++ b/lib/core/utils/openai_model_compat.dart
@@ -23,12 +23,25 @@ const OpenAIReasoningSupport _gpt5Support = OpenAIReasoningSupport(
 );
 const OpenAIReasoningSupport _gpt5ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['high'],
+  offFallback: 'high',
+);
+const OpenAIReasoningSupport _gpt5CodexSupport = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high'],
+  offFallback: 'low',
 );
 const OpenAIReasoningSupport _gpt51Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high'],
 );
 const OpenAIReasoningSupport _gpt51ChatLatestSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high'],
+);
+const OpenAIReasoningSupport _gpt51CodexSupport = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high'],
+  offFallback: 'low',
+);
+const OpenAIReasoningSupport _gpt51CodexMaxSupport = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
+  offFallback: 'low',
 );
 const OpenAIReasoningSupport _gpt52Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh'],
@@ -39,15 +52,18 @@ const OpenAIReasoningSupport _gpt52ChatLatestSupport = OpenAIReasoningSupport(
 );
 const OpenAIReasoningSupport _gpt52ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['medium', 'high', 'xhigh'],
+  offFallback: 'medium',
 );
 const OpenAIReasoningSupport _gpt52CodexSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
+  offFallback: 'low',
 );
 const OpenAIReasoningSupport _gpt53ChatLatestSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh'],
 );
 const OpenAIReasoningSupport _gpt53CodexSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
+  offFallback: 'low',
 );
 const OpenAIReasoningSupport _gpt54Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh'],
@@ -55,6 +71,7 @@ const OpenAIReasoningSupport _gpt54Support = OpenAIReasoningSupport(
 );
 const OpenAIReasoningSupport _gpt54ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['medium', 'high', 'xhigh'],
+  offFallback: 'medium',
 );
 const OpenAIReasoningSupport _gpt55Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh'],
@@ -62,6 +79,7 @@ const OpenAIReasoningSupport _gpt55Support = OpenAIReasoningSupport(
 );
 const OpenAIReasoningSupport _gpt55ProSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['medium', 'high', 'xhigh'],
+  offFallback: 'medium',
 );
 const OpenAIReasoningSupport _gpt56Support = OpenAIReasoningSupport(
   supportedEfforts: <String>['none', 'low', 'medium', 'high', 'xhigh', 'max'],
@@ -98,6 +116,12 @@ const OpenAIReasoningSupport _gpt6AstraSupport = OpenAIReasoningSupport(
   samplingAllowsAuto: false,
   offFallback: 'low',
 );
+// Official 5.2 effort: none/minimal abandon thinking; low/medium map to high;
+// xhigh maps to max. We disable via thinking.type and send the rest as-is.
+// https://docs.bigmodel.cn/cn/guide/start/concept-param
+const OpenAIReasoningSupport _glm52Support = OpenAIReasoningSupport(
+  supportedEfforts: <String>['low', 'medium', 'high', 'xhigh', 'max'],
+);
 const OpenAIReasoningSupport _deepSeekSupport = OpenAIReasoningSupport(
   supportedEfforts: <String>['low', 'medium', 'high', 'xhigh'],
 );
@@ -125,6 +149,13 @@ bool isGlm53FamilyModel(String modelId) {
   return _matchesModel(
     modelId.trim().toLowerCase(),
     r'(^|[/_:@])glm-5\.3(?:$|[-.])',
+  );
+}
+
+bool isGlm52FamilyModel(String modelId) {
+  return _matchesModel(
+    modelId.trim().toLowerCase(),
+    r'(^|[/_:@])glm-5\.2(?:$|[-.])',
   );
 }
 
@@ -265,6 +296,9 @@ OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   if (isGlm53FamilyModel(normalized)) {
     return _glm53Support;
   }
+  if (isGlm52FamilyModel(normalized)) {
+    return _glm52Support;
+  }
   if (isOpenAIGpt6FamilyModel(normalized)) {
     return _gpt6AstraSupport;
   }
@@ -276,64 +310,82 @@ OpenAIReasoningSupport? openAIReasoningSupport(String modelId) {
   )) {
     return _gpt56Support;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.5-pro(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.5-pro(?:$|[-.])')) {
     return _gpt55ProSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.5-(?:codex|chat-latest)(?:$|[-.])')) {
+  if (_matchesModel(
+    normalized,
+    r'(^|[/_:@])gpt-5\.5-(?:codex|chat-latest)(?:$|[-.])',
+  )) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.5(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.5(?:$|[-.])')) {
     return _gpt55Support;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.4-pro(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.4-pro(?:$|[-.])')) {
     return _gpt54ProSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.4-(?:codex|chat-latest)(?:$|[-.])')) {
+  if (_matchesModel(
+    normalized,
+    r'(^|[/_:@])gpt-5\.4-(?:codex|chat-latest)(?:$|[-.])',
+  )) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.4(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.4(?:$|[-.])')) {
     return _gpt54Support;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.3-codex(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.3-codex(?:$|[-.])')) {
     return _gpt53CodexSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.3-chat-latest(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.3-chat-latest(?:$|[-.])')) {
     return _gpt53ChatLatestSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.3-(?:pro|chat-latest)(?:$|[-.])')) {
+  if (_matchesModel(
+    normalized,
+    r'(^|[/_:@])gpt-5\.3-(?:pro|chat-latest)(?:$|[-.])',
+  )) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.3(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.3(?:$|[-.])')) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.2-pro(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.2-pro(?:$|[-.])')) {
     return _gpt52ProSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.2-codex(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.2-codex(?:$|[-.])')) {
     return _gpt52CodexSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.2-chat-latest(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.2-chat-latest(?:$|[-.])')) {
     return _gpt52ChatLatestSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.2(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.2(?:$|[-.])')) {
     return _gpt52Support;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.1-chat-latest(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.1-chat-latest(?:$|[-.])')) {
     return _gpt51ChatLatestSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.1-(?:pro|codex)(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.1-codex-max(?:$|[-.])')) {
+    return _gpt51CodexMaxSupport;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.1-codex(?:$|[-.])')) {
+    return _gpt51CodexSupport;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.1-pro(?:$|[-.])')) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5\.1(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5\.1(?:$|[-.])')) {
     return _gpt51Support;
   }
-  if (_matchesModel(normalized, r'^gpt-5-pro(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5-pro(?:$|[-.])')) {
     return _gpt5ProSupport;
   }
-  if (_matchesModel(normalized, r'^gpt-5-(?:codex|chat-latest)(?:$|[-.])')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5-codex(?:$|[-.])')) {
+    return _gpt5CodexSupport;
+  }
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5-chat-latest(?:$|[-.])')) {
     return null;
   }
-  if (_matchesModel(normalized, r'^gpt-5(?:$|-)')) {
+  if (_matchesModel(normalized, r'(^|[/_:@])gpt-5(?:$|-)')) {
     return _gpt5Support;
   }
   return null;

--- a/test/chat_api_generate_text_encoding_test.dart
+++ b/test/chat_api_generate_text_encoding_test.dart
@@ -266,6 +266,29 @@ void main() {
     );
 
     test(
+      'DashScope thinking-only models omit enable_thinking instead of disabling',
+      () async {
+        final enabledBody = await _captureGenerateTextBody(
+          providerId: 'DashScopeCompatTest',
+          modelId: 'qwen3.7-max-preview',
+          thinkingBudget: 2048,
+          configBaseUrl: 'http://dashscope.aliyuncs.com/compatible-mode/v1',
+        );
+        final disabledBody = await _captureGenerateTextBody(
+          providerId: 'DashScopeCompatTest',
+          modelId: 'qwen3-235b-a22b-thinking-2507',
+          thinkingBudget: 0,
+          configBaseUrl: 'http://dashscope.aliyuncs.com/compatible-mode/v1',
+        );
+
+        expect(enabledBody.containsKey('enable_thinking'), isFalse);
+        expect(enabledBody['thinking_budget'], 2048);
+        expect(disabledBody.containsKey('enable_thinking'), isFalse);
+        expect(disabledBody.containsKey('thinking_budget'), isFalse);
+      },
+    );
+
+    test(
       'maps SiliconFlow reasoning knobs for non-streaming text generation',
       () async {
         final enabledBody = await _captureGenerateTextBody(

--- a/test/claude_thinking_compat_test.dart
+++ b/test/claude_thinking_compat_test.dart
@@ -435,8 +435,11 @@ void main() {
         thinkingBudget: 16000,
       );
 
-      expect(offBody.containsKey('thinking'), isFalse);
-      expect(offBody.containsKey('output_config'), isFalse);
+      expect(offBody['thinking'], {
+        'type': 'adaptive',
+        'display': 'summarized',
+      });
+      expect(offBody['output_config'], {'effort': 'low'});
       expect(offBody.containsKey('temperature'), isFalse);
       expect(offBody.containsKey('top_p'), isFalse);
       expect(mediumBody['thinking'], {
@@ -457,6 +460,64 @@ void main() {
     });
 
     test(
+      'Fable 5.1 maps effort levels and never disables adaptive thinking',
+      () async {
+        const modelId = 'claude-fable-5-1';
+        final offBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: 0,
+        );
+        final autoBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: -1,
+        );
+        final lowBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: 1024,
+        );
+        final highBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: 32000,
+        );
+        final xhighBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: 64000,
+        );
+        final maxBody = await _captureClaudeRequestBody(
+          modelId: modelId,
+          thinkingBudget: 128000,
+        );
+
+        for (final body in [
+          offBody,
+          autoBody,
+          lowBody,
+          highBody,
+          xhighBody,
+          maxBody,
+        ]) {
+          expect(body['thinking'], {
+            'type': 'adaptive',
+            'display': 'summarized',
+          });
+          expect(
+            (body['thinking'] as Map<String, dynamic>).containsKey(
+              'budget_tokens',
+            ),
+            isFalse,
+          );
+        }
+        expect(offBody['output_config'], {'effort': 'low'});
+        expect(autoBody.containsKey('output_config'), isFalse);
+        expect(lowBody['output_config'], {'effort': 'low'});
+        expect(highBody['output_config'], {'effort': 'high'});
+        expect(xhighBody['output_config'], {'effort': 'xhigh'});
+        expect(maxBody['output_config'], {'effort': 'max'});
+        expect(maxBody['max_tokens'], 128000);
+      },
+    );
+
+    test(
       'Mythos 5 never sends disabled thinking and returns summaries',
       () async {
         final offBody = await _captureClaudeRequestBody(
@@ -468,8 +529,11 @@ void main() {
           thinkingBudget: 128000,
         );
 
-        expect(offBody.containsKey('thinking'), isFalse);
-        expect(offBody.containsKey('output_config'), isFalse);
+        expect(offBody['thinking'], {
+          'type': 'adaptive',
+          'display': 'summarized',
+        });
+        expect(offBody['output_config'], {'effort': 'low'});
         expect(maxBody['thinking'], {
           'type': 'adaptive',
           'display': 'summarized',

--- a/test/google_thinking_config_test.dart
+++ b/test/google_thinking_config_test.dart
@@ -173,7 +173,7 @@ void main() {
       );
     });
 
-    test('off budget omits thinking config for Gemma 4', () async {
+    test('off budget sends minimal thinking level for Gemma 4', () async {
       late Map<String, dynamic> capturedBody;
       final server = await _startGeminiServer((body) {
         capturedBody = body;
@@ -194,7 +194,10 @@ void main() {
       ).toList();
 
       expect(chunks.last.isDone, isTrue);
-      expect(_thinkingConfig(capturedBody), isNull);
+      expect(_thinkingConfig(capturedBody), {
+        'includeThoughts': false,
+        'thinkingLevel': 'minimal',
+      });
     });
   });
 

--- a/test/openai_kimi_compat_test.dart
+++ b/test/openai_kimi_compat_test.dart
@@ -202,6 +202,69 @@ void main() {
       },
     );
 
+    test('kimi-k2.6 maps thinking budget to enabled or disabled', () async {
+      final requestBodies = <Map<String, dynamic>>[];
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        requestBodies.add(
+          jsonDecode(await utf8.decoder.bind(request).join())
+              as Map<String, dynamic>,
+        );
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+          charset: 'utf-8',
+        );
+        request.response.write(
+          'data: ${jsonEncode({
+            'id': 'cmpl-k26',
+            'object': 'chat.completion.chunk',
+            'created': 0,
+            'model': 'kimi-k2.6',
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+          })}\n\n',
+        );
+        request.response.write('data: [DONE]\n\n');
+        await request.response.close();
+      });
+
+      final baseUrl = 'http://${server.address.address}:${server.port}/v1';
+      await ChatApiService.sendMessageStream(
+        config: _moonshotConfig(baseUrl),
+        modelId: 'kimi-k2.6',
+        messages: const [
+          {'role': 'user', 'content': 'hello'},
+        ],
+        thinkingBudget: 16000,
+      ).toList();
+      await ChatApiService.sendMessageStream(
+        config: _moonshotConfig(baseUrl),
+        modelId: 'kimi-k2.6',
+        messages: const [
+          {'role': 'user', 'content': 'hello again'},
+        ],
+        thinkingBudget: 0,
+      ).toList();
+
+      expect(requestBodies, hasLength(2));
+      expect(requestBodies[0]['thinking'], {'type': 'enabled'});
+      expect(requestBodies[1]['thinking'], {'type': 'disabled'});
+      for (final body in requestBodies) {
+        expect(body.containsKey('reasoning_effort'), isFalse);
+      }
+    });
+
     test(
       'kimi-k2.7-code omits unsupported thinking and sampling params',
       () async {
@@ -609,7 +672,7 @@ void main() {
 
         expect(chunks.last.isDone, isTrue);
         expect(secondBody.containsKey('reasoning_effort'), isFalse);
-        expect(secondBody.containsKey('thinking'), isFalse);
+        expect(secondBody['thinking'], {'type': 'enabled'});
         expect(assistantToolMessage['content'], '我来帮您查看当前时间。');
         expect(assistantToolMessage['reasoning_content'], '');
         expect(assistantToolMessage['tool_calls'], [

--- a/test/openai_latest_models_compat_test.dart
+++ b/test/openai_latest_models_compat_test.dart
@@ -143,6 +143,33 @@ void main() {
         openAINormalizeReasoningEffort('high', 'meta/muse-glimmer-30b'),
         'auto',
       );
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5-codex'), 'low');
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.1-codex'), 'low');
+      expect(
+        openAINormalizeReasoningEffort('off', 'openai/gpt-5.1-codex-max'),
+        'low',
+      );
+      expect(openAINormalizeReasoningEffort('xhigh', 'gpt-5.1-codex'), 'high');
+      expect(
+        openAINormalizeReasoningEffort('xhigh', 'gpt-5.1-codex-max'),
+        'xhigh',
+      );
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.2-codex'), 'low');
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.3-codex'), 'low');
+      expect(
+        openAINormalizeReasoningEffort('off', 'openai/gpt-5.3-codex'),
+        'low',
+      );
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5-pro'), 'high');
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.2-pro'), 'medium');
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.4-pro'), 'medium');
+      expect(openAINormalizeReasoningEffort('off', 'gpt-5.5-pro'), 'medium');
+      expect(openAISupportsNoneReasoning('gpt-5.3-codex'), isFalse);
+      expect(openAISupportsXhighReasoning('gpt-5.3-codex'), isTrue);
+      expect(openAINormalizeReasoningEffort('off', 'glm-5.2'), 'off');
+      expect(openAINormalizeReasoningEffort('low', 'glm-5.2'), 'low');
+      expect(openAINormalizeReasoningEffort('xhigh', 'z-ai/glm-5.2'), 'xhigh');
+      expect(openAISupportsMaxReasoning('glm-5.2'), isTrue);
     });
 
     test(
@@ -257,6 +284,33 @@ void main() {
       expect(offBody.containsKey('top_p'), isFalse);
       expect(maxBody['reasoning_effort'], 'max');
       expect(maxBody.containsKey('temperature'), isFalse);
+    });
+
+    test('Codex and Pro models clamp off to the lowest legal effort', () async {
+      final codexOff = await _captureChatBody(
+        modelId: 'gpt-5.3-codex',
+        thinkingBudget: 0,
+      );
+      final namespacedCodexOff = await _captureChatBody(
+        modelId: 'openai/gpt-5.2-codex',
+        thinkingBudget: 0,
+      );
+      final proOff = await _captureChatBody(
+        modelId: 'gpt-5.2-pro',
+        thinkingBudget: 0,
+      );
+      final openRouterCodexOff = await _captureChatBody(
+        modelId: 'openai/gpt-5.3-codex',
+        thinkingBudget: 0,
+        providerId: 'OpenRouter',
+      );
+
+      expect(codexOff['reasoning_effort'], 'low');
+      expect(namespacedCodexOff['reasoning_effort'], 'low');
+      expect(proOff['reasoning_effort'], 'medium');
+      expect(openRouterCodexOff['reasoning'], {'effort': 'low'});
+      expect(openRouterCodexOff.containsKey('reasoning_effort'), isFalse);
+      expect(openRouterCodexOff['reasoning'], isNot({'enabled': false}));
     });
 
     test('Grok Responses streams reasoning text and clamps off to low', () async {

--- a/test/openai_zhipu_glm_compat_test.dart
+++ b/test/openai_zhipu_glm_compat_test.dart
@@ -88,7 +88,7 @@ void main() {
 
       expect(requests, hasLength(2));
       expect(requests[0]['thinking'], {'type': 'enabled'});
-      expect(requests[0].containsKey('reasoning_effort'), isFalse);
+      expect(requests[0]['reasoning_effort'], 'low');
       expect(requests[1]['thinking'], {'type': 'disabled'});
       expect(requests[1].containsKey('reasoning_effort'), isFalse);
     });
@@ -279,7 +279,7 @@ void main() {
 
       expect(chunks.last.isDone, isTrue);
       expect(secondBody['thinking'], {'type': 'enabled'});
-      expect(secondBody.containsKey('reasoning_effort'), isFalse);
+      expect(secondBody['reasoning_effort'], 'low');
       expect(assistantToolMessage['content'], '我先查一下日期。');
       expect(assistantToolMessage['reasoning_content'], '先获取当前日期');
       expect(assistantToolMessage['tool_calls'], [

--- a/test/settings_provider_reasoning_support_test.dart
+++ b/test/settings_provider_reasoning_support_test.dart
@@ -145,19 +145,24 @@ void main() {
           settings.supportsMaxReasoning('OpenAI', 'muse-glimmer-30b'),
           isFalse,
         );
-        expect(
-          settings.supportsMaxReasoning('OpenAI', 'muse-spark-1.3'),
-          isTrue,
-        );
-        expect(
-          settings.supportsXhighReasoning('OpenAI', 'gpt-6-astra'),
-          isTrue,
-        );
-        expect(settings.supportsMaxReasoning('OpenAI', 'gpt-6-astra'), isTrue);
         expect(settings.supportsMaxReasoning('OpenAI', 'glm-5.3'), isTrue);
         expect(
           settings.supportsXhighReasoning('OpenAI', 'glm-5.3-flash'),
           isFalse,
+        );
+        expect(settings.supportsXhighReasoning('OpenAI', 'glm-5.2'), isTrue);
+        expect(settings.supportsMaxReasoning('OpenAI', 'glm-5.2'), isTrue);
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'gpt-5.3-codex'),
+          isTrue,
+        );
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'gpt-5.1-codex'),
+          isFalse,
+        );
+        expect(
+          settings.supportsXhighReasoning('OpenAI', 'gpt-5.1-codex-max'),
+          isTrue,
         );
       },
     );
@@ -229,16 +234,25 @@ void main() {
           apiKey: 'test-key',
           baseUrl: 'https://api.anthropic.com/v1',
           providerType: ProviderKind.claude,
-          models: const ['claude-fable-5', 'claude-opus-4-8'],
+          models: const [
+            'claude-fable-5',
+            'claude-fable-5-1',
+            'claude-opus-4-8',
+          ],
         ),
       );
 
-      for (final model in const ['claude-fable-5', 'claude-opus-4-8']) {
+      for (final model in const [
+        'claude-fable-5',
+        'claude-fable-5-1',
+        'claude-opus-4-8',
+      ]) {
         expect(settings.supportsXhighReasoning('Claude', model), isTrue);
         expect(settings.supportsMaxReasoning('Claude', model), isTrue);
       }
       expect(settings.getProviderConfig('Claude').models, [
         'claude-fable-5',
+        'claude-fable-5-1',
         'claude-opus-4-8',
       ]);
     });


### PR DESCRIPTION
## 需求

补齐近期推理模型及供应商兼容规则（[#732](https://github.com/cuplivo/cuplivo/issues/732)），移植上游参考实现 [kelivo@3803580](https://github.com/Chevey339/kelivo/commit/38035806b9ff8402fd34aa19f5b41a46c84918c7) 中与本仓库结构对应的语义。

## 改动

### `lib/core/utils/openai_model_compat.dart`（能力识别规则）
- 新增 GLM-5.2：官方档位 `low/medium/high/xhigh/max`（`isGlm52FamilyModel`），设置页能力展示与请求体共用同一规则
- 全部 GPT-5.x 正则改为支持供应商命名空间 ID（`openai/gpt-5.2-codex`、`z-ai/...` 等），裸 ID 规则不再丢失
- 新增 `gpt-5-codex` / `gpt-5.1-codex` / `gpt-5.1-codex-max` 能力支持；pro/codex 系列补齐 `offFallback`（pro→`medium`、codex→`low`）

### `lib/core/services/api/providers/openai_common.dart`（请求体映射）
- **GLM-5.2**：专属分支发送 `thinking:{type:enabled|disabled}` + `_openAIEffortForBudget` 映射的 `reasoning_effort`；off 仅移除 effort，不再走通用 zhipu 分支丢槽位
- **Kimi K2.6**：与 K2.5 并列走 `thinking:{type:enabled|disabled}` 混合推理路径；保留采样参数（K2.5 仍剥离）
- **DashScope thinking-only**：识别 qwen3.7-max-preview/qwq/deepseek-r1/kimi-k2.7-code/kimi-k2-thinking/minimax-m2.1|2.5/历史 `*-thinking-*` ID，开启与关闭均不再发送不受支持的 `enable_thinking`（关闭档只移除字段）

### `ChatApiService`（Claude 兼容）
- fable/mythos always-on 模型：off 档不再丢弃配置，改为 `thinking:{type:adaptive}` + `output_config:{effort:low}`（此前省略会落到 API 默认 high）

### `google_common.dart`（Gemma 4）
- off 档改为 `includeThoughts:false` + `thinkingLevel:'minimal'`（此前省略配置反而让思考保持开启）

### 测试
7 个兼容性测试文件：glm-5.2（含工具续轮）、k2.6（流式开启/关闭/工具续轮）、DashScope thinking-only（非流式）、codex/pro off 钳制（含 OpenRouter 变体）、Fable 5.1 全档位、Gemma 4 off、设置页能力展示（glm-5.2 / gpt-5.x codex / claude-fable-5-1）。

## 刻意行为变更

- OpenRouter 上 codex/pro 模型 off 档请求体：`reasoning:{enabled:false}` → `reasoning:{effort:low|medium}`（OpenAI codex/pro 无法关闭思考，省略 effort 会命中 API 默认高档）
- Claude fable/mythos off 档：不再忽略，改为 adaptive+`effort:low`
- Gemma 4 off 档：空 → `thinkingLevel:minimal`
- DashScope thinking-only off 档：不再发送 `enable_thinking:false`
- Kimi K2.6 工具续轮开始发送 `thinking:{type:enabled}`

未识别模型保持原有兼容行为；glm-5.3 继续走原有通用 zhipu 分支（不在本次范围）。

## 验证

- `dart format` 已执行（11 个文件）
- `dart analyze --fatal-infos lib test`：零新增问题（唯一 warning 为基线既有 `lib/core/services/quick_instruction_store.dart:316`，已验证 stash 后基线同样存在）
- `flutter test` 相关子集 127 个测试全部通过：7 个兼容性套件 + dashscope 内置搜索 + 推理档位 UI + 模型注册表 + siliconflow 回归
- 未跑完整测试套件（按 AGENTS 3.4 仅需相关子集，CI 全量验证）

## 手动测试计划

- **GLM-5.2**（智谱 API）：开启（1024/高档）→ 请求体含 `thinking:{type:enabled}` + `reasoning_effort`；关闭 → `type:disabled` 且无 effort；工具调用后续轮次保持一致
- **Kimi K2.6**（Moonshot）：开启/关闭流式 chat 的 `thinking` 字段正确；工具调用续轮正确
- **DashScope thinking-only**（如 qwen3.7-max-preview）：开启档请求体无 `enable_thinking`；关闭档同样无 `enable_thinking` 且无 `thinking_budget`
- **Fable 5.1**（Claude）：各档位均发 adaptive thinking，off 档为 `effort:low`
- **GPT-5.x codex/pro**：off 档发送钳制后最低合法 effort；OpenRouter 上为 `reasoning:{effort:...}` shape

Closes #732
