### PR TITLE
fix(google): ignore premature empty STOP frames in Gemini streams

### DIFF
--- a/lib/core/services/api/providers/google_common.dart
+++ b/lib/core/services/api/providers/google_common.dart
@@ -1246,6 +1246,8 @@ Stream<ChatStreamChunk> _sendGoogleStream(
     }
 
     String? finishReason; // detect stream completion from server
+    bool hasSeenPart = false;
+    bool stopAfterPart = false;
     await for (final chunk in _ensureTrailingNewline(sse)) {
       buffer += chunk;
       final lines = buffer.split('\n');
@@ -1279,6 +1281,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
               if (parts is! List) continue;
               for (final p in parts) {
                 if (p is! Map) continue;
+                hasSeenPart = true;
                 String? partThoughtSigKey;
                 dynamic partThoughtSigVal;
                 if (p.containsKey('thoughtSignature')) {
@@ -1535,7 +1538,14 @@ Stream<ChatStreamChunk> _sendGoogleStream(
               }
               // Capture explicit finish reason if present
               final fr = cand['finishReason'];
-              if (fr is String && fr.isNotEmpty) finishReason = fr;
+              if (fr is String && fr.isNotEmpty) {
+                finishReason = fr;
+                // Some proxies send empty STOP frames before any parts. Only a
+                // new STOP received with or after a part may finish the stream;
+                // later parts must not make an earlier empty STOP eligible
+                // retroactively.
+                if (fr == 'STOP') stopAfterPart = hasSeenPart;
+              }
 
               // Parse grounding metadata for citations if present
               final gm = cand['groundingMetadata'] ?? obj['groundingMetadata'];
@@ -1599,6 +1609,7 @@ Stream<ChatStreamChunk> _sendGoogleStream(
 
             // If server signaled finish, end stream immediately
             if (finishReason != null &&
+                (finishReason != 'STOP' || stopAfterPart) &&
                 calls.isEmpty &&
                 (!expectImage || receivedImage)) {
               // Emit final citations if any not emitted

--- a/test/gemini_premature_stop_test.dart
+++ b/test/gemini_premature_stop_test.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _geminiConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'GeminiPrematureStopTest',
+    enabled: true,
+    name: 'GeminiPrematureStopTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.google,
+  );
+}
+
+/// Mirrors the proxy frame shape that triggers the bug: `content` is always
+/// present (its `parts` may be empty) and may carry a `finishReason` while
+/// sending no part at all.
+String _frame({String? text, String? finishReason}) {
+  return 'data: ${jsonEncode({
+    'candidates': [
+      {
+        'content': {
+          'role': 'model',
+          'parts': [
+            if (text != null) {'text': text},
+          ],
+        },
+        if (finishReason != null) 'finishReason': finishReason,
+      },
+    ],
+  })}\n\n';
+}
+
+bool _isGenerationDone(List<ChatStreamChunk> chunks) =>
+    chunks.any((chunk) => chunk.isDone);
+
+String _joinedContent(List<ChatStreamChunk> chunks) =>
+    chunks.map((chunk) => chunk.content).join();
+
+Stream<ChatStreamChunk> _streamFrom(HttpServer server) {
+  return ChatApiService.sendMessageStream(
+    config: _geminiConfig(
+      'http://${server.address.address}:${server.port}/v1beta',
+    ),
+    modelId: 'gemini-2.5-flash',
+    messages: const [
+      {'role': 'user', 'content': 'hi'},
+    ],
+  );
+}
+
+void main() {
+  group('premature empty STOP semantics', () {
+    test(
+      'leading empty STOP cannot finish the stream before a later STOP',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() => server.close(force: true));
+        var requestCount = 0;
+        final finalStop = Completer<void>();
+        server.listen((request) async {
+          requestCount++;
+          await utf8.decoder.bind(request).join();
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..bufferOutput = false
+            ..headers.contentType = ContentType(
+              'text',
+              'event-stream',
+              charset: 'utf-8',
+            );
+          request.response
+            ..write(_frame(finishReason: 'STOP'))
+            ..write(_frame(finishReason: 'STOP'));
+          for (final text in ['Hello', ' world', '!']) {
+            request.response.write(_frame(text: text));
+          }
+          await request.response.flush();
+          await finalStop.future;
+          request.response.write(_frame(finishReason: 'STOP'));
+          await request.response.flush();
+          // Deliberately keep the response open: completion must be driven by
+          // the new STOP, not by EOF.
+        });
+
+        final chunks = <ChatStreamChunk>[];
+        final done = Completer<void>();
+        final textArrived = Completer<void>();
+        const expected = 'Hello world!';
+        final sub = _streamFrom(server).listen((chunk) {
+          chunks.add(chunk);
+          if (chunk.isDone && !done.isCompleted) done.complete();
+          if (!textArrived.isCompleted && _joinedContent(chunks) == expected) {
+            textArrived.complete();
+          }
+        });
+        addTearDown(sub.cancel);
+
+        await textArrived.future.timeout(const Duration(seconds: 5));
+        expect(
+          _isGenerationDone(chunks),
+          isFalse,
+          reason: 'a leading empty STOP must not complete the stream',
+        );
+
+        finalStop.complete();
+        await done.future.timeout(const Duration(seconds: 5));
+        expect(_joinedContent(chunks), expected);
+        expect(_isGenerationDone(chunks), isTrue);
+        expect(requestCount, 1);
+      },
+    );
+
+    test('empty MAX_TOKENS frame still completes immediately', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      var requestCount = 0;
+      server.listen((request) async {
+        requestCount++;
+        await utf8.decoder.bind(request).join();
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..bufferOutput = false
+          ..headers.contentType = ContentType(
+            'text',
+            'event-stream',
+            charset: 'utf-8',
+          );
+        request.response.write(_frame(finishReason: 'MAX_TOKENS'));
+        await request.response.flush();
+        // Keep the response open: completion must come from the frame itself.
+      });
+
+      final chunks = await _streamFrom(
+        server,
+      ).toList().timeout(const Duration(seconds: 5));
+
+      expect(requestCount, 1);
+      expect(_joinedContent(chunks), '');
+      expect(_isGenerationDone(chunks), isTrue);
+      expect(chunks.last.truncationReason, 'max_tokens');
+    });
+  });
+
+  group('premature empty STOP E2E matrix', () {
+    for (final ending in ['STOP', 'EOF', 'DONE']) {
+      for (final hasText in [true, false]) {
+        test(
+          'leading empty STOP preserves text=$hasText with $ending ending',
+          () async {
+            final server = await HttpServer.bind(
+              InternetAddress.loopbackIPv4,
+              0,
+            );
+            addTearDown(() => server.close(force: true));
+            var requestCount = 0;
+            server.listen((request) async {
+              requestCount++;
+              await utf8.decoder.bind(request).join();
+              request.response
+                ..statusCode = HttpStatus.ok
+                ..bufferOutput = false
+                ..headers.contentType = ContentType(
+                  'text',
+                  'event-stream',
+                  charset: 'utf-8',
+                );
+              request.response
+                ..write(_frame(finishReason: 'STOP'))
+                ..write(_frame(finishReason: 'STOP'));
+              if (hasText) {
+                for (final text in ['第一段正文。', '第二段正文。', '最后一段。']) {
+                  request.response.write(_frame(text: text));
+                }
+              }
+              if (ending == 'STOP') {
+                request.response
+                  ..write(_frame(finishReason: 'STOP'))
+                  ..write(_frame(finishReason: 'STOP'));
+              } else if (ending == 'DONE') {
+                request.response.write('data: [DONE]\n\n');
+              }
+              await request.response.close();
+            });
+
+            final chunks = await _streamFrom(
+              server,
+            ).toList().timeout(const Duration(seconds: 10));
+
+            expect(requestCount, 1);
+            expect(_joinedContent(chunks), hasText ? '第一段正文。第二段正文。最后一段。' : '');
+            expect(_isGenerationDone(chunks), isTrue);
+          },
+        );
+      }
+    }
+  });
+}


### PR DESCRIPTION
Closes #776.

## Summary

Ports upstream Kelivo commit [d35ee79](https://github.com/Chevey339/kelivo/commit/d35ee794d95ce7e76f207e2e4826e0656e95aac4) (`fix(google): ignore premature empty STOP frames`) to Cuplivo's inline Gemini SSE decoder.

## Root cause

Some Gemini-compatible proxies send empty frames (`content.parts: []`, only `finishReason: "STOP"`) at the head of the response. `_sendGoogleStream` treated any non-null `finishReason` as end-of-round and returned immediately, so every real content frame that arrived afterwards was dropped — empty or truncated replies.

## Fix

`lib/core/services/api/providers/google_common.dart`:

- Track `hasSeenPart` per HTTP round (set on any part).
- On a `STOP`, latch `stopAfterPart = hasSeenPart`.
- The early-finish guard now requires `finishReason != 'STOP' || stopAfterPart`, so a leading empty STOP cannot finish the stream and later parts cannot retroactively enable it. A new STOP after content still finishes normally.
- Non-STOP reasons (`MAX_TOKENS`, etc.) keep their existing behavior and truncation reporting.
- Existing `calls.isEmpty` / `expectImage` guards are unchanged; state resets per request round (per-response, matching upstream's per-response decoder).

## Tests

`test/gemini_premature_stop_test.dart` (new):

- Semantic guard: 2× leading empty STOP + text frames + held-open connection; asserts the stream is **not** done before a new STOP, then completes on that STOP with full content (`requestCount == 1`).
- Regression guard: an empty `MAX_TOKENS` frame still completes immediately with `truncationReason == 'max_tokens'`.
- Upstream-parity 2×3 E2E matrix: `STOP` / `EOF` / `[DONE]` × text / empty, asserting complete content, generation done, and a single request.

Mutation-checked: deleting either the `stopAfterPart` latch or the completion guard makes the semantic test fail, so the test is sensitive to the fix.

## Verification

- `flutter test test/gemini_premature_stop_test.dart` — 8/8 pass.
- Related suites (Google thinking config, thought signatures/parts, part ids, tool schema, parallel tool calls, SSE buffer flush) — 54/54 pass.
- `dart format` clean.
- `dart analyze --fatal-infos lib test` — no issues.

## Notes / residual risk

- After a leading empty STOP, completion now depends on a later STOP/EOF/socket close (the intended tradeoff; same as upstream).
- The guard keys on "any part", matching upstream. A proxy that puts a placeholder part (e.g. empty `text`) in the premature frame would not be covered; the tracking surface is `openai_common.dart`'s analogous finish branch, which is out of scope for this issue.
