### PR TITLE
fix(group-chat): keep queued sends across page leave (issue #680)

### DIFF
--- a/lib/core/providers/group_chat_provider.dart
+++ b/lib/core/providers/group_chat_provider.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
+import '../models/chat_input_data.dart';
 import '../models/conversation.dart';
 import '../models/group_chat.dart';
 import '../models/group_chat_member.dart';
@@ -28,6 +29,14 @@ class GroupChatProvider extends ChangeNotifier {
   final Map<String, List<GroupChatMember>> _membersByGroup = {};
   final Map<String, List<GroupChatDirectorRuntimeLog>> _runtimeDirectorLogs =
       {};
+
+  /// Session-level stash for a queued send that outlives its page:
+  /// GroupChatView stashes its one-slot pending send on dispose (mobile
+  /// route pop) so the queued text is not silently lost; a freshly mounted
+  /// view for the same group takes it back and auto-drains (mirrors the
+  /// single-chat per-conversation queue drain). In-memory only — process
+  /// death loses it, same as the single-chat queue. Cleared with the group.
+  final Map<String, ChatInputData> _pendingQueuedInput = {};
   bool _loaded = false;
 
   bool get loaded => _loaded;
@@ -43,6 +52,7 @@ class GroupChatProvider extends ChangeNotifier {
       ..addAll(list);
     _membersByGroup.clear();
     _runtimeDirectorLogs.clear();
+    _pendingQueuedInput.clear();
     for (final g in list) {
       _membersByGroup[g.id] = await _chatService.repo.getGroupMembers(g.id);
     }
@@ -84,6 +94,28 @@ class GroupChatProvider extends ChangeNotifier {
       logs.removeRange(0, logs.length - maxRuntimeDirectorLogsPerGroup);
     }
     notifyListeners();
+  }
+
+  /// Stashes a queued send for [groupChatId] so it survives the page being
+  /// disposed (mobile route pop). Callers must not stash for a group that no
+  /// longer exists. Notifies listeners: a view of the same group that mounted
+  /// before this stash landed (the disposing route can outlive the new one's
+  /// first frame during the pop animation) picks it up from the notification.
+  void stashQueuedInput(String groupChatId, ChatInputData input) {
+    _pendingQueuedInput[groupChatId] = input;
+    notifyListeners();
+  }
+
+  /// Takes (and removes) the stashed queued send for [groupChatId], if any.
+  ChatInputData? takeQueuedInput(String groupChatId) {
+    return _pendingQueuedInput.remove(groupChatId);
+  }
+
+  /// Whether a stash exists for [groupChatId], without consuming it. Lets a
+  /// mounted view cheaply decide whether a provider notification is a stash
+  /// handoff worth a post-frame drain check.
+  bool hasQueuedInput(String groupChatId) {
+    return _pendingQueuedInput.containsKey(groupChatId);
   }
 
   /// Latest public message preview for list subtitle.
@@ -312,6 +344,9 @@ class GroupChatProvider extends ChangeNotifier {
     _groups.removeWhere((g) => g.id == groupChatId);
     _membersByGroup.remove(groupChatId);
     _runtimeDirectorLogs.remove(groupChatId);
+    // A queued send of a deleted group must never resurrect as a send into
+    // a fresh view (or leak in memory).
+    _pendingQueuedInput.remove(groupChatId);
     notifyListeners();
   }
 }

--- a/lib/features/group_chat/widgets/group_chat_view.dart
+++ b/lib/features/group_chat/widgets/group_chat_view.dart
@@ -91,6 +91,7 @@ class _GroupChatViewState extends State<GroupChatView> {
   late GroupChatOrchestrator _orchestrator;
   late FileUploadService _fileUploadService;
   late OcrService _ocrService;
+  late GroupChatProvider _groupChatProvider;
 
   bool _loading = false;
   bool _initialized = false;
@@ -99,6 +100,9 @@ class _GroupChatViewState extends State<GroupChatView> {
   /// per-conversation queue semantics — see queueIfCurrentConversationBusy).
   /// Drained by [_maybeDrainQueue] when the round ends.
   ChatInputData? _queuedInput;
+
+  /// Coalesces provider notifications into one post-frame stash pickup.
+  bool _stashPickupScheduled = false;
 
   bool get _isDesktop =>
       defaultTargetPlatform == TargetPlatform.macOS ||
@@ -118,6 +122,7 @@ class _GroupChatViewState extends State<GroupChatView> {
     super.didChangeDependencies();
     if (_initialized) return;
     _initialized = true;
+    _groupChatProvider = context.read<GroupChatProvider>();
     _listController = ListController();
     _chatService = context.read<ChatService>();
     _ocrService = OcrService(chatService: _chatService);
@@ -210,6 +215,8 @@ class _GroupChatViewState extends State<GroupChatView> {
       },
     );
     _bindConversation();
+    _takeStashedQueuedInput();
+    _groupChatProvider.addListener(_onGroupChatProviderChanged);
   }
 
   void _onChatControllerChanged() {
@@ -285,6 +292,18 @@ class _GroupChatViewState extends State<GroupChatView> {
 
   @override
   void dispose() {
+    // Session-level queue handoff: a queued send must not die with the page.
+    // Stash it for the next GroupChatView instance of this group (mobile
+    // route pop; a mounted successor picks it up via the provider
+    // notification). The getById guard is the actual protection: desktop
+    // keep-alive views dispose only when their group is deleted, and by then
+    // getById is null, so nothing is re-stashed for a dead group.
+    // (deleteGroup only clears entries stashed before the deletion.)
+    _groupChatProvider.removeListener(_onGroupChatProviderChanged);
+    if (_queuedInput != null &&
+        _groupChatProvider.getById(widget.groupChatId) != null) {
+      _groupChatProvider.stashQueuedInput(widget.groupChatId, _queuedInput!);
+    }
     _orchestrator.requestStop();
     _streamController.dispose();
     _chatController.removeListener(_onChatControllerChanged);
@@ -338,12 +357,37 @@ class _GroupChatViewState extends State<GroupChatView> {
   /// double-drain.
   void _maybeDrainQueue() {
     if (!mounted) return;
-    if (_queuedInput == null) return;
     if (_loading || _orchestrator.isBusy) return;
-    final q = _queuedInput!;
+    final q = _queuedInput;
+    if (q == null) {
+      // Idle with an empty local slot: a session-level stash may have
+      // arrived after mount (the previous view's dispose can land after
+      // this one mounted during the pop animation) — pick it up. Called
+      // from a post-frame phase or an async continuation, so draining
+      // directly is safe.
+      _takeStashedQueuedInput(deferSend: false);
+      return;
+    }
     _queuedInput = null;
     setState(() {});
     unawaited(_send(q));
+  }
+
+  /// Picks up a session-level stash that lands after this view mounted (see
+  /// [GroupChatProvider.stashQueuedInput]). One post-frame check per
+  /// notification burst, deferred because the notification can fire inside
+  /// another widget's unmount/build; the frame is requested explicitly
+  /// because a provider notification alone does not schedule one.
+  void _onGroupChatProviderChanged() {
+    if (_stashPickupScheduled) return;
+    if (!_groupChatProvider.hasQueuedInput(widget.groupChatId)) return;
+    _stashPickupScheduled = true;
+    WidgetsBinding.instance.scheduleFrame();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _stashPickupScheduled = false;
+      if (!mounted) return;
+      _maybeDrainQueue();
+    });
   }
 
   /// Restores a cancelled queued send back into the composer (text + media),
@@ -362,6 +406,42 @@ class _GroupChatViewState extends State<GroupChatView> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _inputFocus.requestFocus();
     });
+  }
+
+  /// Session-level queue handoff: pops the stash a previous GroupChatView
+  /// instance of this group left on dispose (mobile route pop while a round
+  /// was busy) and auto-drains it, mirroring the single-chat queue that
+  /// drains when the conversation becomes current and free. The round was
+  /// stopped by the old page's dispose, so a fresh mount is normally idle;
+  /// if it is somehow busy, the stashed send falls back into the one-slot
+  /// pending input and drains via [_maybeDrainQueue]. A local slot always
+  /// wins (it is newer); the stash stays for the next drain check.
+  ///
+  /// [deferSend] is for the mount path: it runs inside
+  /// `didChangeDependencies` (build phase), where starting the send would
+  /// `setState` illegally, so it defers to the end of the frame. Callers
+  /// running after the build phase (post-frame, async continuations) pass
+  /// `false` and drain immediately.
+  void _takeStashedQueuedInput({bool deferSend = true}) {
+    if (_queuedInput != null) return;
+    final stashed = _groupChatProvider.takeQueuedInput(widget.groupChatId);
+    if (stashed == null) return;
+
+    void drain() {
+      if (!mounted) return;
+      if (_loading || _orchestrator.isBusy) {
+        _queuedInput = stashed;
+        setState(() {});
+        return;
+      }
+      unawaited(_send(stashed));
+    }
+
+    if (deferSend) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => drain());
+    } else {
+      drain();
+    }
   }
 
   Future<void> _showQuickInstructionMenu() async {

--- a/test/features/group_chat/group_chat_queued_input_session_test.dart
+++ b/test/features/group_chat/group_chat_queued_input_session_test.dart
@@ -1,0 +1,431 @@
+import 'dart:async';
+
+import 'package:Cuplivo/core/database/app_database.dart';
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/database/chat_database_repository.dart';
+import 'package:Cuplivo/core/models/chat_input_data.dart';
+import 'package:Cuplivo/core/models/chat_message.dart';
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/models/group_chat.dart';
+import 'package:Cuplivo/core/providers/asr_provider.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/group_chat_provider.dart';
+import 'package:Cuplivo/core/providers/input_status_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/providers/user_provider.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/services/generation_engine.dart';
+import 'package:Cuplivo/features/group_chat/widgets/group_chat_view.dart';
+import 'package:Cuplivo/features/home/services/ask_user_interaction_service.dart';
+import 'package:Cuplivo/features/home/services/input_draft_persistence.dart';
+import 'package:Cuplivo/features/home/services/tool_approval_service.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+/// An initialized [ChatService] backed by an in-memory database.
+///
+/// The base [ChatService] methods read the private `_repo` field directly
+/// (virtual dispatch does not apply), so the methods the flows under test
+/// touch are overridden to write through the repository, mirroring the
+/// desktop group-creation regression test. Conversations are also kept in a
+/// memory map because the repository's sync connection (`getConversationSync`)
+/// is unavailable for `NativeDatabase.memory()`; the map keeps
+/// `getConversation`/`getCompleteConversation` faithful so the group
+/// short-circuits (e.g. quick-instruction freeze) are exercised.
+/// [gateQueue] deterministically holds `addMessage` calls (the user-message
+/// persist of a send) so a test can stage the busy state; an empty queue
+/// passes through immediately.
+class _InMemoryChatService extends ChatService {
+  late final AppDatabase db = AppDatabase(NativeDatabase.memory());
+  late final ChatDatabaseRepository _testRepo = ChatDatabaseRepository(db);
+
+  /// Conversations created through [createConversation]. The sync repo
+  /// connection is null for in-memory databases, so these reads are served
+  /// from the map instead.
+  final Map<String, Conversation> _conversations = <String, Conversation>{};
+
+  /// Consumed FIFO by [addMessage]. Enqueue a completer to hold the next
+  /// user-message persist (a send reaches busy while it is pending).
+  final List<Completer<void>> gateQueue = <Completer<void>>[];
+
+  @override
+  bool get initialized => true;
+
+  @override
+  ChatDatabaseRepository get repo => _testRepo;
+
+  @override
+  Future<Conversation> createConversation({
+    String? title,
+    String? assistantId,
+    List<String>? mcpServerIds,
+    String? parentConversationId,
+    String conversationKind = Conversation.kindNormal,
+    bool setAsCurrent = true,
+    List<String>? persistentQuickInstructionIds,
+  }) async {
+    final conversation = Conversation(
+      title: title ?? 'New Chat',
+      assistantId: assistantId,
+      mcpServerIds: mcpServerIds,
+      parentConversationId: parentConversationId,
+      conversationKind: conversationKind,
+      persistentQuickInstructionIds: persistentQuickInstructionIds,
+    );
+    await _testRepo.putConversation(conversation);
+    _conversations[conversation.id] = conversation;
+    return conversation;
+  }
+
+  @override
+  Conversation? getConversation(String id) {
+    if (id.isEmpty) return null;
+    return _conversations[id];
+  }
+
+  @override
+  Conversation? getCompleteConversation(String id) {
+    return _conversations[id];
+  }
+
+  @override
+  Future<ChatMessage> addMessage({
+    required String conversationId,
+    required String role,
+    required String content,
+    String? modelId,
+    String? providerId,
+    int? totalTokens,
+    bool isStreaming = false,
+    String? reasoningText,
+    DateTime? reasoningStartAt,
+    DateTime? reasoningFinishedAt,
+    String? groupId,
+    String? subgroupId,
+    int? version,
+    bool isPreset = false,
+    String? speakerAssistantId,
+    String? quoteJson,
+    String? quickInstructionInvocationsJson,
+  }) async {
+    if (gateQueue.isNotEmpty) {
+      await gateQueue.removeAt(0).future;
+    }
+    final message = ChatMessage(
+      role: role,
+      content: content,
+      conversationId: conversationId,
+      modelId: modelId,
+      providerId: providerId,
+      totalTokens: totalTokens,
+      isStreaming: isStreaming,
+      reasoningText: reasoningText,
+      reasoningStartAt: reasoningStartAt,
+      reasoningFinishedAt: reasoningFinishedAt,
+      groupId: groupId,
+      subgroupId: subgroupId,
+      version: version,
+      isPreset: isPreset,
+      speakerAssistantId: speakerAssistantId,
+      quoteJson: quoteJson,
+      quickInstructionInvocationsJson: quickInstructionInvocationsJson,
+    );
+    await _testRepo.putMessage(
+      message,
+      messageOrder: await _testRepo.getMessageCount(conversationId),
+    );
+    return message;
+  }
+
+  @override
+  Future<void> updateMessage(
+    String messageId, {
+    String? content,
+    int? totalTokens,
+    int? contextTokens,
+    bool? isStreaming,
+    String? reasoningText,
+    DateTime? reasoningStartAt,
+    DateTime? reasoningFinishedAt,
+    Object? translation = ChatMessage.sentinel,
+    String? reasoningSegmentsJson,
+    int? promptTokens,
+    int? completionTokens,
+    int? cachedTokens,
+    int? durationMs,
+    Object? groupId = ChatMessage.sentinel,
+    Object? subgroupId = ChatMessage.sentinel,
+    Object? version = ChatMessage.sentinel,
+    Object? requestAllowImagesApiRouting = ChatMessage.sentinel,
+    Object? requestExtraBody = ChatMessage.sentinel,
+    Object? quickInstructionInvocationsJson = ChatMessage.sentinel,
+  }) async {
+    // Routing metadata only; irrelevant to the assertions here.
+  }
+
+  @override
+  Future<void> bumpConversationUpdatedAt(String conversationId) async {}
+
+  @override
+  Future<void> deleteConversation(String id, {bool allowGroup = false}) async {
+    await _testRepo.deleteConversation(id);
+  }
+
+  Future<void> closeDb() async {
+    await _testRepo.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GroupChatProvider pending queued input stash', () {
+    test('stash and take round-trip per group', () {
+      final provider = GroupChatProvider(chatService: ChatService());
+      const input = ChatInputData(text: 'hello');
+      const other = ChatInputData(text: 'other');
+
+      provider.stashQueuedInput('group-1', input);
+      provider.stashQueuedInput('group-2', other);
+
+      expect(provider.takeQueuedInput('group-1')?.text, 'hello');
+      // Take removes: a second take drains nothing.
+      expect(provider.takeQueuedInput('group-1'), isNull);
+      // Other groups are untouched.
+      expect(provider.takeQueuedInput('group-2')?.text, 'other');
+      expect(provider.takeQueuedInput('unknown'), isNull);
+    });
+
+    test('load() clears the in-memory stash', () async {
+      final service = _InMemoryChatService();
+      addTearDown(service.closeDb);
+      final provider = GroupChatProvider(chatService: service);
+      provider.stashQueuedInput('group-1', const ChatInputData(text: 'x'));
+
+      await provider.load();
+
+      expect(provider.takeQueuedInput('group-1'), isNull);
+    });
+
+    test('deleteGroup clears the stash of the deleted group', () async {
+      final service = _InMemoryChatService();
+      addTearDown(service.closeDb);
+      final provider = GroupChatProvider(chatService: service);
+      await provider.load();
+      final group = await provider.createGroup(name: 'G');
+      provider.stashQueuedInput(group.id, const ChatInputData(text: 'lost'));
+
+      await provider.deleteGroup(group.id);
+
+      expect(provider.takeQueuedInput(group.id), isNull);
+    });
+  });
+
+  group('GroupChatView queued input session lifecycle', () {
+    late _InMemoryChatService chatService;
+    late GroupChatProvider provider;
+    late GroupChat group;
+
+    setUp(() async {
+      chatService = _InMemoryChatService();
+      addTearDown(chatService.closeDb);
+      provider = GroupChatProvider(chatService: chatService);
+      await provider.load();
+      group = await provider.createGroup(name: 'G');
+      // No assistants: a drained send reaches the round and ends with the
+      // groupChatNoAssistants feedback - a deterministic, brief "round".
+    });
+
+    Future<void> imeSend(WidgetTester tester, String text) async {
+      await tester.enterText(find.byType(TextField), text);
+      await tester.testTextInput.receiveAction(TextInputAction.send);
+      await tester.pump();
+      await tester.pump();
+    }
+
+    Future<void> pumpGroupView(WidgetTester tester) async {
+      final businessPrefs = BusinessPreferences.memoryForTests();
+      final settings = SettingsProvider(preferences: businessPrefs);
+      await tester.runAsync(waitForSettingsLoad);
+      addTearDown(settings.dispose);
+      // Force the IME return key to submit (mobile default is newline) so
+      // the busy-queue entry path (keyboard send while a round runs) is
+      // drivable in the test.
+      await tester.runAsync(() => settings.setEnterToSendOnMobile(true));
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider<BusinessPreferences>.value(value: businessPrefs),
+            ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+            ChangeNotifierProvider<AssistantProvider>(
+              create: (_) => AssistantProvider(preferences: businessPrefs),
+            ),
+            ChangeNotifierProvider<UserProvider>(
+              create: (_) => UserProvider(preferences: businessPrefs),
+            ),
+            ChangeNotifierProvider<GroupChatProvider>.value(value: provider),
+            ChangeNotifierProvider<ChatService>.value(value: chatService),
+            ChangeNotifierProvider<GenerationEngine>(
+              create: (_) => GenerationEngine(chatService: chatService),
+            ),
+            ChangeNotifierProvider<ToolApprovalService>(
+              create: (_) => ToolApprovalService(),
+            ),
+            ChangeNotifierProvider<AskUserInteractionService>(
+              create: (_) => AskUserInteractionService(),
+            ),
+            ChangeNotifierProvider<AsrProvider>(
+              create: (_) => AsrProvider(settingsProvider: settings),
+            ),
+            ChangeNotifierProvider<InputStatusProvider>(
+              create: (_) => InputStatusProvider(),
+            ),
+            Provider<InputDraftPersistence>(
+              create: (_) => InputDraftPersistence(null),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: GroupChatView(groupChatId: group.id)),
+          ),
+        ),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('a stashed send drains automatically on remount '
+        '(issue #680 happy path)', (tester) async {
+      await pumpGroupView(tester);
+
+      // Leave (dispose the view, no queued input → no stash) and then stash
+      // while no view is mounted: the fresh mount takes the stash and
+      // auto-sends it.
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            Provider<BusinessPreferences>.value(
+              value: BusinessPreferences.memoryForTests(),
+            ),
+          ],
+          child: const MaterialApp(home: Scaffold(body: SizedBox())),
+        ),
+      );
+      await tester.pump();
+      provider.stashQueuedInput(group.id, const ChatInputData(text: 'B'));
+      await pumpGroupView(tester);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(provider.takeQueuedInput(group.id), isNull);
+      final messages = await chatService.repo.getMessagesRange(
+        group.conversationId,
+        start: 0,
+        limit: 100,
+      );
+      expect(
+        messages.any((m) => m.role == 'user' && m.content == 'B'),
+        isTrue,
+        reason: 'the stashed queued send must be sent after remount',
+      );
+      // The drained round ends with the groupChatNoAssistants feedback
+      // snackbar; advance fake time past its timer and exit animation so
+      // nothing is pending when the test tears the tree down.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('a late stash from the disposing view is picked up while '
+        'mounted (pop-animation race)', (tester) async {
+      await pumpGroupView(tester);
+
+      // The disposing route can outlive the new route's first frame during
+      // the pop animation: the new view mounted first (mount-time take found
+      // nothing) and the stash lands afterwards. The provider notification
+      // must trigger a pickup in the already-mounted view.
+      provider.stashQueuedInput(group.id, const ChatInputData(text: 'D'));
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(provider.takeQueuedInput(group.id), isNull);
+      final messages = await chatService.repo.getMessagesRange(
+        group.conversationId,
+        start: 0,
+        limit: 100,
+      );
+      expect(
+        messages.any((m) => m.role == 'user' && m.content == 'D'),
+        isTrue,
+        reason: 'a stash that lands after mount must still drain',
+      );
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('a queued send is stashed on dispose instead of being '
+        'silently dropped (issue #680)', (tester) async {
+      await pumpGroupView(tester);
+
+      // Gate the first send's user-message persist so the view stays busy.
+      final gateA = Completer<void>();
+      chatService.gateQueue.add(gateA);
+      await imeSend(tester, 'A');
+      expect(
+        chatService.gateQueue,
+        isEmpty,
+        reason: 'A consumed the gate and is held',
+      );
+
+      // While busy, a second keyboard send enters the page-level slot.
+      await imeSend(tester, 'B');
+
+      // Release the gate while still mounted: A finishes, the drain hook
+      // fires _send(B) which is held by the next gate. A's user message is
+      // now persisted; B is in flight.
+      final gateB = Completer<void>();
+      chatService.gateQueue.add(gateB);
+      gateA.complete();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final messagesA = await chatService.repo.getMessagesRange(
+        group.conversationId,
+        start: 0,
+        limit: 100,
+      );
+      expect(
+        messagesA.any((m) => m.role == 'user' && m.content == 'A'),
+        isTrue,
+      );
+      // A's round ended with the groupChatNoAssistants feedback snackbar;
+      // advance fake time past its timer and exit animation before
+      // queueing further sends.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pump(const Duration(seconds: 1));
+
+      // Leave the page (route pop → dispose) while B runs and C is queued:
+      // C must be stashed at session level instead of silently dropped.
+      await imeSend(tester, 'C');
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(
+        provider.takeQueuedInput(group.id)?.text,
+        'C',
+        reason: 'dispose must stash the queued send',
+      );
+    });
+  });
+}
+
+Future<void> waitForSettingsLoad() async {
+  for (var i = 0; i < 25; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}


### PR DESCRIPTION
## Summary

Mobile group chat implemented queued sends as page-level state in `GroupChatView` (`_queuedInput`). Popping the route (`requestStop` in `dispose`) silently dropped the queued text: the composer was already cleared at queue time, and the queue slot died with the page. Desktop does not have this problem (keep-alive views).

This implements **option B** from #680: the queued send is kept at session level and auto-drains when the group is re-opened, mirroring the single-chat per-conversation queue semantics. Round lifecycle on leave is unchanged (the round still stops on page dispose, as accepted in the issue).

Closes #680.

## Behavior

- Queue a send while a round runs, then leave the group (mobile route pop): the queued message is kept in memory at session level instead of being silently dropped.
- Re-opening that group auto-sends the queued message (the round was stopped on leave, so the fresh view is idle).
- A stash that lands after the successor view already mounted (the disposing route can outlive the new route's first frame during the pop animation) is picked up via the provider notification.
- Deleting the group clears its stash (no resurrection, no leak). Desktop keep-alive behavior is unchanged: views dispose only on group deletion and never re-stash for a dead group (group-exists guard).
- In-memory only: a process kill loses the stash, same as the single-chat queue.

## Changes

- **`GroupChatProvider`** (`lib/core/providers/group_chat_provider.dart`): per-group in-memory stash (`stashQueuedInput` / `takeQueuedInput` / `hasQueuedInput`), cleared in `load()` and `deleteGroup`; `stashQueuedInput` notifies so an already-mounted successor view can pick it up.
- **`GroupChatView`** (`lib/features/group_chat/widgets/group_chat_view.dart`): `dispose` stashes the pending send (guarded by `getById != null` for the desktop delete ordering); mount takes the stash and auto-sends when idle; `_onGroupChatProviderChanged` picks up a stash that lands after mount via one post-frame hop + explicit `scheduleFrame()`; busy fallback into the local one-slot input; the nested post-frame hop was removed because `addPostFrameCallback` does not schedule a frame.
- **Tests** (`test/features/group_chat/group_chat_queued_input_session_test.dart`, new): stash/take semantics, `load()` / `deleteGroup` clearing, drain-on-remount, late-stash pickup, stash-on-dispose, driven end-to-end against an in-memory Drift DB with a gated `addMessage` fake (stages the busy state deterministically).
- No l10n changes (no user-visible text); no persisted schema/format changes.

## Test plan

- `dart format` clean on changed paths.
- `dart analyze --fatal-infos lib test` — clean.
- `flutter test test/features/group_chat/` — 53 tests pass (6 new, 47 existing, zero regressions).
- Not machine-verified: mobile device walkthrough (the mobile route is only reachable on mobile layouts; Windows-only environment). The widget tests run the same mobile-platform path (tests are forced to Android), so the uncovered risk is the real-device route animation/gesture layer only.
