### PR TITLE
feat(presets): sync preset changes into existing conversations

### DIFF
--- a/lib/core/database/chat_database_repository.dart
+++ b/lib/core/database/chat_database_repository.dart
@@ -999,6 +999,24 @@ class ChatDatabaseRepository {
     await _compactMessageOrder(row.conversationId);
   }
 
+  /// Deletes all preset rows (`is_preset = 1`) of [conversationId] and
+  /// compacts the remaining `messageOrder` values once. Used by the preset
+  /// sync (issue #577); the caller owns trash / deletion-marker bookkeeping.
+  /// Returns the number of removed rows.
+  Future<int> deletePresetMessages(String conversationId) {
+    return _db.transaction(() async {
+      final deleted =
+          await (_db.delete(_db.messageRows)..where(
+                (t) =>
+                    t.conversationId.equals(conversationId) &
+                    t.isPreset.equals(true),
+              ))
+              .go();
+      await _compactMessageOrder(conversationId);
+      return deleted;
+    });
+  }
+
   Future<void> clearAllData() async {
     await _db.transaction(() async {
       await _db.delete(_db.geminiThoughtSignatureRows).go();

--- a/lib/core/services/chat/chat_service.dart
+++ b/lib/core/services/chat/chat_service.dart
@@ -55,6 +55,10 @@ class ChatService extends ChangeNotifier {
   final Set<String> _temporaryConversationIds = <String>{};
   final Map<String, Future<void>> _proactiveCareOperationTails =
       <String, Future<void>>{};
+  // Per-conversation preset-sync tails (issue #577): overlapping syncs for
+  // one conversation would otherwise interleave their delete/append passes
+  // and duplicate preset rows.
+  final Map<String, Future<void>> _presetSyncTails = <String, Future<void>>{};
   // Evicting these ids could reopen persistence races with background work.
   final Set<String> _discardedTemporaryConversationIds = <String>{};
   final Set<String> _discardedTemporaryMessageIds = <String>{};
@@ -879,6 +883,285 @@ class ChatService extends ChangeNotifier {
     return nonPreset == 0;
   }
 
+  /// Normalized preset payload (issue #577): role collapses to
+  /// 'assistant' | 'user' and empty-content entries are dropped. Shared by
+  /// the new-conversation injection and the existing-conversation sync so
+  /// both produce identical rows.
+  static List<({String role, String content})> normalizePresetPayload(
+    List<Map<String, String>> presets,
+  ) {
+    return <({String role, String content})>[
+      for (final pm in presets)
+        if ((pm['content'] ?? '').trim().isNotEmpty)
+          (
+            role: (pm['role'] ?? '') == 'assistant' ? 'assistant' : 'user',
+            content: (pm['content'] ?? '').trim(),
+          ),
+    ];
+  }
+
+  /// Stable fingerprint of a preset payload for cheap change detection.
+  static String presetPayloadFingerprint(List<Map<String, String>> presets) {
+    return jsonEncode(<List<String>>[
+      for (final pm in normalizePresetPayload(presets))
+        <String>[pm.role, pm.content],
+    ]);
+  }
+
+  /// Whether [conversationId] holds no real (non-preset) message rows — it is
+  /// empty or preset-only (issue #577). Decided via repo-level counts, never
+  /// through the ChatController load window (ADR-0050 rationale). Temporary
+  /// conversations keep their rows outside the repository; callers must skip
+  /// them before consulting this predicate.
+  Future<bool> hasNoRealMessages(String conversationId) async {
+    if (!initialized) return false;
+    return await _repo.getNonPresetMessageCount(conversationId) == 0;
+  }
+
+  /// Appends the normalized preset payload to [conversationId] through the
+  /// standard add path, which also promotes a draft. Shared by the
+  /// new-conversation injection (HomeViewModel.createNewConversation) and
+  /// the fresh branch of [syncPresetMessages] so both produce identical rows
+  /// (issue #577).
+  ///
+  /// Deliberately does NOT await [init]: callers are either post-startup
+  /// flows (chat service initialized by the startup gate) or test fakes that
+  /// override [addMessage]; opening the real database here would force a
+  /// synchronous init in contexts that cannot settle it.
+  Future<void> appendPresetMessages({
+    required String conversationId,
+    required List<Map<String, String>> presets,
+  }) async {
+    for (final pm in normalizePresetPayload(presets)) {
+      await addMessage(
+        conversationId: conversationId,
+        role: pm.role,
+        content: pm.content,
+        isPreset: true,
+      );
+    }
+  }
+
+  /// Replaces the preset message rows of [conversationId] with [presets]
+  /// (issue #577). [presets] uses the payload shape of
+  /// `AssistantProvider.getPresetMessagesForAssistant`.
+  ///
+  /// - Fresh conversations (no non-preset rows): stale preset rows are
+  ///   removed and the new list is appended — the same shape the
+  ///   new-conversation injection produces.
+  /// - Conversations with real messages: the new presets are inserted at the
+  ///   TOP; real rows keep their relative order, `messageOrder` is compacted
+  ///   and `truncateIndex` shifts by (added - removed) so the clear-context
+  ///   split keeps excluding the same real messages.
+  ///
+  /// Removed preset rows go through the standard deletion bookkeeping (trash
+  /// bundle + LAN-sync deletion marker) before the physical delete, mirroring
+  /// ADR-0050's "no bypass deletes" stance.
+  ///
+  /// Overlapping calls for the same conversation are serialized; a queued
+  /// call re-runs the fingerprint check and no-ops when the first one already
+  /// converged the rows.
+  ///
+  /// Returns true when rows were written. Temporary conversations, group
+  /// conversations and unknown conversation ids are never touched. Like
+  /// [isRecyclablePresetOnlyConversation], an uninitialized service no-ops
+  /// (logged) instead of opening the database mid-flight.
+  Future<bool> syncPresetMessages({
+    required String conversationId,
+    required List<Map<String, String>> presets,
+  }) {
+    return _enqueuePresetSync(
+      conversationId,
+      () => _syncPresetMessagesUnlocked(
+        conversationId: conversationId,
+        presets: presets,
+      ),
+    );
+  }
+
+  Future<bool> _syncPresetMessagesUnlocked({
+    required String conversationId,
+    required List<Map<String, String>> presets,
+  }) async {
+    if (!initialized) {
+      debugPrint('[PresetSync] skipped for $conversationId: not initialized');
+      return false;
+    }
+    final conversation = _conversationForMessages(conversationId);
+    if (conversation == null) return false;
+    if (conversation.isGroup) return false;
+    if (isTemporaryConversation(conversationId)) return false;
+
+    final normalized = normalizePresetPayload(presets);
+    final existing = getMessages(conversationId);
+    final existingPresets = existing
+        .where((m) => m.isPreset)
+        .toList(growable: false);
+    final realMessages = existing
+        .where((m) => !m.isPreset)
+        .toList(growable: false);
+
+    if (_presetRowsMatchPayload(existingPresets, normalized)) return false;
+
+    for (final preset in existingPresets) {
+      await _recordMessageDeletion(preset);
+      // Mirror ChatService.deleteMessage: assistant-role rows may carry tool
+      // events / Gemini thought signatures; presets normally have neither,
+      // but any that once did must not leave orphaned fidelity rows.
+      if (preset.role == 'assistant') {
+        try {
+          await _repo.deleteToolEvents(preset.id);
+          await _repo.deleteGeminiThoughtSignature(preset.id);
+        } catch (e) {
+          debugPrint(
+            '[PresetSync] fidelity cleanup failed for ${preset.id}: $e',
+          );
+        }
+      }
+    }
+    await _repo.deletePresetMessages(conversationId);
+
+    if (realMessages.isEmpty) {
+      // Fresh conversation: keep a clear-context split consistent. A split
+      // at 0 is a no-op marker and stays; any positive split excluded (some
+      // of) the old preset block, so the replacement keeps the context empty
+      // by excluding all new presets.
+      final shiftedTruncateIndex = conversation.truncateIndex <= 0
+          ? conversation.truncateIndex
+          : normalized.length;
+      if (shiftedTruncateIndex != conversation.truncateIndex) {
+        conversation.truncateIndex = shiftedTruncateIndex;
+        conversation.updatedAt = DateTime.now();
+        if (!_draftConversations.containsKey(conversationId)) {
+          await _saveConversation(conversation);
+        }
+      }
+      // Append the new list through the standard add path, which also
+      // promotes a draft exactly like the new-conversation injection does.
+      await appendPresetMessages(
+        conversationId: conversationId,
+        presets: presets,
+      );
+      await _refreshConversation(conversationId);
+      _messagesCache.remove(conversationId);
+      notifyListeners();
+      return true;
+    }
+
+    // Conversation with real messages: insert the new presets at the top.
+    // Provisional orders collide with the real rows' compacted orders; the
+    // reindex inside updateConversationMessages converges everything (the
+    // message_order index is not unique).
+    final presetIds = <String>[];
+    for (var i = 0; i < normalized.length; i++) {
+      final row = ChatMessage(
+        role: normalized[i].role,
+        content: normalized[i].content,
+        conversationId: conversationId,
+        isPreset: true,
+      );
+      presetIds.add(row.id);
+      await _repo.putMessage(row, messageOrder: i);
+    }
+
+    final orderedIds = <String>[...presetIds, ...realMessages.map((m) => m.id)];
+    conversation.truncateIndex = _shiftTruncateIndexForPresetReplacement(
+      conversation.truncateIndex,
+      removedPresets: existingPresets.length,
+      addedPresets: presetIds.length,
+    );
+    conversation.updatedAt = DateTime.now();
+    conversation.messageIds
+      ..clear()
+      ..addAll(orderedIds);
+    await _repo.updateConversationMessages(
+      conversation: conversation,
+      messageIds: orderedIds,
+    );
+    _messagesCache.remove(conversationId);
+    notifyListeners();
+    return true;
+  }
+
+  /// Applies the current preset payload to every persisted, non-group
+  /// conversation owned by [assistantId] (issue #577 "apply to all
+  /// conversations"). Returns the number of conversations whose rows
+  /// changed and the number whose rewrite failed. A per-conversation failure
+  /// is logged, counted and skipped so one bad conversation cannot abort the
+  /// batch.
+  Future<({int touched, int failed})> syncPresetMessagesForAssistant({
+    required String assistantId,
+    required List<Map<String, String>> presets,
+  }) async {
+    if (!initialized) {
+      debugPrint(
+        '[PresetSync] assistant-wide sync skipped for $assistantId: '
+        'not initialized',
+      );
+      return (touched: 0, failed: 0);
+    }
+    final targetIds = _conversationsCache.values
+        .where(
+          (c) =>
+              !c.isGroup &&
+              c.assistantId == assistantId &&
+              !isTemporaryConversation(c.id),
+        )
+        .map((c) => c.id)
+        .toList(growable: false);
+    var touched = 0;
+    var failed = 0;
+    for (final id in targetIds) {
+      try {
+        if (await syncPresetMessages(conversationId: id, presets: presets)) {
+          touched++;
+        }
+      } catch (e, st) {
+        failed++;
+        debugPrint('[PresetSync] assistant-wide sync failed for $id: $e\n$st');
+      }
+    }
+    if (touched > 0) notifyListeners();
+    return (touched: touched, failed: failed);
+  }
+
+  bool _presetRowsMatchPayload(
+    List<ChatMessage> rows,
+    List<({String role, String content})> payload,
+  ) {
+    if (rows.length != payload.length) return false;
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].role != payload[i].role) return false;
+      if (rows[i].content != payload[i].content) return false;
+    }
+    return true;
+  }
+
+  /// Shifts a clear-context split point across a preset replacement: the old
+  /// split excluded [removedPresets] preset rows that are gone and now has
+  /// [addedPresets] new ones at the top. A negative result means the old
+  /// split pointed inside the preset block; clamp to 0 (exclude nothing)
+  /// rather than dropping the marker entirely.
+  ///
+  /// `index <= 0` is a "no truncation" value (`0` excludes nothing) and is
+  /// preserved as-is — shifting it would silently exclude leading presets.
+  int _shiftTruncateIndexForPresetReplacement(
+    int index, {
+    required int removedPresets,
+    required int addedPresets,
+  }) {
+    if (index <= 0) return index;
+    final shifted = index - removedPresets + addedPresets;
+    if (shifted < 0) {
+      debugPrint(
+        '[PresetSync] truncateIndex $index clamped to 0 '
+        '(removed=$removedPresets added=$addedPresets)',
+      );
+      return 0;
+    }
+    return shifted;
+  }
+
   Future<bool> _deleteDraftConversation(String id) async {
     if (!_draftConversations.containsKey(id)) return false;
 
@@ -1495,6 +1778,33 @@ class ChatService extends ChangeNotifier {
     }
     notifyListeners();
     return message;
+  }
+
+  /// Serializes preset-sync rewrites for a single conversation (issue #577).
+  /// Failures are still reported to the originating caller, but never block a
+  /// later sync.
+  Future<T> _enqueuePresetSync<T>(
+    String conversationId,
+    Future<T> Function() operation,
+  ) {
+    final previous = _presetSyncTails[conversationId] ?? Future<void>.value();
+    final result = previous.then<T>(
+      (_) => operation(),
+      onError: (Object _, StackTrace __) => operation(),
+    );
+    final tail = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace __) {},
+    );
+    _presetSyncTails[conversationId] = tail;
+    unawaited(
+      tail.then<void>((_) {
+        if (identical(_presetSyncTails[conversationId], tail)) {
+          _presetSyncTails.remove(conversationId);
+        }
+      }),
+    );
+    return result;
   }
 
   /// Serializes proactive-care writes for a single conversation. Failures are

--- a/lib/features/home/controllers/home_page_controller.dart
+++ b/lib/features/home/controllers/home_page_controller.dart
@@ -163,6 +163,13 @@ class HomePageController extends ChangeNotifier {
 
   McpProvider? _mcpProvider;
   GenerationEngine? _generationEngine;
+  AssistantProvider? _assistantProvider;
+
+  // Preset message sync (issue #577): last-seen preset fingerprints per
+  // assistant id for cheap change detection, and the assistants whose preset
+  // changes are still pending a user decision on history conversations.
+  final Map<String, String> _assistantPresetFingerprints = <String, String>{};
+  final Set<String> _pendingPresetSyncAssistantIds = <String>{};
   String? _headlessChunkMessageId;
   bool _wasCurrentHeadlessActive = false;
   StreamSubscription<ChatAction>? _chatActionSub;
@@ -692,6 +699,169 @@ class HomePageController extends ChangeNotifier {
     } catch (e) {
       debugPrint('[GenerationEngine] listener FAILED: $e');
     }
+    try {
+      _assistantProvider = _context.read<AssistantProvider>();
+      _snapshotAssistantPresetFingerprints();
+      _assistantProvider!.addListener(_onAssistantsChanged);
+    } catch (e) {
+      debugPrint('[PresetSync] AssistantProvider listener failed: $e');
+    }
+  }
+
+  void _snapshotAssistantPresetFingerprints() {
+    final ap = _assistantProvider;
+    if (ap == null) return;
+    _assistantPresetFingerprints
+      ..clear()
+      ..addEntries(<MapEntry<String, String>>[
+        for (final a in ap.assistants)
+          MapEntry(
+            a.id,
+            ChatService.presetPayloadFingerprint(
+              ap.getPresetMessagesForAssistant(a.id),
+            ),
+          ),
+      ]);
+  }
+
+  void _onAssistantsChanged() {
+    if (_disposed) return;
+    unawaited(_handleAssistantsChangedForPresetSync());
+  }
+
+  /// Issue #577 change detection: diff each assistant's preset fingerprint.
+  /// A fresh current conversation self-syncs immediately; a conversation
+  /// with history raises the banner instead.
+  Future<void> _handleAssistantsChangedForPresetSync() async {
+    final ap = _assistantProvider;
+    if (ap == null) return;
+    final changedIds = <String>[];
+    final liveIds = <String>{};
+    for (final a in ap.assistants) {
+      liveIds.add(a.id);
+      final fingerprint = ChatService.presetPayloadFingerprint(
+        ap.getPresetMessagesForAssistant(a.id),
+      );
+      final previous = _assistantPresetFingerprints[a.id];
+      if (previous == null) {
+        // First observation (the cold-start DB load notifies after this
+        // listener attaches, and newly added assistants arrive the same way):
+        // record the baseline without treating it as a preset change — a
+        // null previous fingerprint is not an edit.
+        _assistantPresetFingerprints[a.id] = fingerprint;
+        continue;
+      }
+      if (previous != fingerprint) {
+        _assistantPresetFingerprints[a.id] = fingerprint;
+        changedIds.add(a.id);
+      }
+    }
+    for (final id in _assistantPresetFingerprints.keys.toSet()) {
+      if (!liveIds.contains(id)) {
+        _assistantPresetFingerprints.remove(id);
+        _pendingPresetSyncAssistantIds.remove(id);
+      }
+    }
+    if (changedIds.isEmpty || _disposed) return;
+    if (!_chatService.initialized) return;
+    final convo = currentConversation;
+    final assistantId = convo?.assistantId;
+
+    // Edits made while chatting with another assistant (issue #577
+    // follow-up): keep a pending marker for any changed assistant that owns
+    // persisted conversations, so the banner surfaces when the user later
+    // opens one of its history conversations. No banner now — banner
+    // visibility is scoped to the current conversation's assistant.
+    for (final id in changedIds) {
+      if (id == assistantId) continue;
+      final ownsConversations = _chatService.getAllConversations().any(
+        (c) => c.assistantId == id,
+      );
+      if (ownsConversations) _pendingPresetSyncAssistantIds.add(id);
+    }
+
+    if (convo == null ||
+        assistantId == null ||
+        !changedIds.contains(assistantId)) {
+      return;
+    }
+    if (_chatService.isTemporaryConversation(convo.id)) return;
+    try {
+      final fresh = await _chatService.hasNoRealMessages(convo.id);
+      if (_disposed) return;
+      if (fresh) {
+        await _viewModel.syncFreshPresets(convo);
+      } else {
+        _pendingPresetSyncAssistantIds.add(assistantId);
+        notifyListeners();
+      }
+    } catch (e) {
+      debugPrint('[PresetSync] change handling failed for $assistantId: $e');
+    }
+  }
+
+  /// Whether the current conversation should show the "preset messages
+  /// changed" banner (issue #577): its owning assistant has a pending preset
+  /// change and the conversation holds real messages (fresh ones self-sync).
+  bool get showPresetSyncBanner {
+    final convo = currentConversation;
+    final assistantId = convo?.assistantId;
+    if (convo == null || assistantId == null) return false;
+    if (!_pendingPresetSyncAssistantIds.contains(assistantId)) return false;
+    if (_chatService.isTemporaryConversation(convo.id)) return false;
+    return _chatController.messages.any((m) => !m.isPreset);
+  }
+
+  Future<void> applyPresetsToCurrentConversation() async {
+    final convo = currentConversation;
+    final assistantId = convo?.assistantId;
+    if (convo == null || assistantId == null) return;
+    _pendingPresetSyncAssistantIds.remove(assistantId);
+    notifyListeners();
+    try {
+      await _viewModel.syncPresetsToConversation(convo);
+    } catch (e) {
+      debugPrint('[PresetSync] apply-to-current failed: $e');
+      if (_disposed) return;
+      // The rewrite failed: restore the banner instead of reporting success.
+      _pendingPresetSyncAssistantIds.add(assistantId);
+      notifyListeners();
+      _showPresetSyncFailed();
+    }
+  }
+
+  /// Returns the per-conversation outcome; the caller surfaces the result.
+  Future<({int touched, int failed})> applyPresetsToAllConversations() async {
+    final convo = currentConversation;
+    final assistantId = convo?.assistantId;
+    if (convo == null || assistantId == null) return (touched: 0, failed: 0);
+    _pendingPresetSyncAssistantIds.remove(assistantId);
+    notifyListeners();
+    final result = await _viewModel.syncPresetsAcrossConversations(assistantId);
+    if (result.failed > 0 && !_disposed) {
+      // Partial failure: keep the banner so the user can retry.
+      _pendingPresetSyncAssistantIds.add(assistantId);
+      notifyListeners();
+    }
+    return result;
+  }
+
+  void _showPresetSyncFailed() {
+    final l10n = AppLocalizations.of(_context);
+    if (l10n == null) return;
+    showAppSnackBar(
+      _context,
+      message: l10n.homePagePresetSyncFailed,
+      type: NotificationType.error,
+    );
+  }
+
+  void dismissPresetSyncBanner() {
+    final assistantId = currentConversation?.assistantId;
+    if (assistantId == null) return;
+    if (_pendingPresetSyncAssistantIds.remove(assistantId)) {
+      notifyListeners();
+    }
   }
 
   void _setupKeyboardListeners() {}
@@ -942,6 +1112,9 @@ class HomePageController extends ChangeNotifier {
         _chatController.setCurrentConversation(startup);
         _streamController.clearGeminiThoughtSigs();
         _restoreMessageUiState();
+        // Issue #577: a fresh startup conversation reflects the owning
+        // assistant's current preset list.
+        unawaited(_viewModel.syncFreshPresets(startup));
         notifyListeners();
         _scrollToBottomSoon(animate: false);
       } else {
@@ -3289,6 +3462,7 @@ class HomePageController extends ChangeNotifier {
     _convoFadeController.dispose();
     _mcpProvider?.removeListener(_onMcpChanged);
     _generationEngine?.removeListener(_onHeadlessGenChanged);
+    _assistantProvider?.removeListener(_onAssistantsChanged);
     _cancelHeadlessChunkSub();
     _scrollCtrl.dispose();
     try {

--- a/lib/features/home/controllers/home_view_model.dart
+++ b/lib/features/home/controllers/home_view_model.dart
@@ -1087,6 +1087,10 @@ class HomeViewModel extends ChangeNotifier {
       notifyListeners();
       onConversationSwitched?.call();
       unawaited(_drainQueuedInputIfReady(id));
+      // Issue #577: a fresh conversation always reflects the owning
+      // assistant's current preset list. Conversations with history are
+      // handled by the explicit banner actions instead.
+      unawaited(syncFreshPresets(convo));
       // Recycle only after the switch really happened; a failed target
       // (convo == null) leaves the old conversation visible, and deleting it
       // here would yank the user's current view.
@@ -1138,6 +1142,89 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  // ============================================================================
+  // Preset Message Sync (issue #577)
+  // ============================================================================
+
+  /// Guards shared by the preset sync entry points: the conversation must be
+  /// a persisted (non-temporary) single-chat conversation owned by a live
+  /// assistant.
+  bool _canSyncPresetsFor(Conversation convo) {
+    if (_chatService.isTemporaryConversation(convo.id)) return false;
+    final assistantId = convo.assistantId;
+    if (assistantId == null || assistantId.isEmpty) return false;
+    return _contextProvider.read<AssistantProvider>().getById(assistantId) !=
+        null;
+  }
+
+  /// Auto-sync for the #577 flow: when [convo] holds no real (non-preset)
+  /// messages, replace its preset rows with the owning assistant's current
+  /// list. Conversations with history are never touched here — they go
+  /// through the explicit banner actions instead. Returns true when rows
+  /// were written.
+  Future<bool> syncFreshPresets(Conversation convo) async {
+    if (!_canSyncPresetsFor(convo)) return false;
+    try {
+      if (!await _chatService.hasNoRealMessages(convo.id)) return false;
+      return await _syncPresetsAndReload(convo);
+    } catch (e) {
+      debugPrint('[PresetSync] fresh preset sync failed for ${convo.id}: $e');
+      return false;
+    }
+  }
+
+  /// Explicit "apply to this conversation" (banner action): replaces the
+  /// preset rows regardless of history; real rows keep their order and shift
+  /// below the new presets. Returns true when rows were written.
+  ///
+  /// Unlike [syncFreshPresets], failures are rethrown after logging so the
+  /// banner flow can restore its pending marker and surface the error
+  /// instead of reporting a silent success.
+  Future<bool> syncPresetsToConversation(Conversation convo) async {
+    if (!_canSyncPresetsFor(convo)) return false;
+    try {
+      return await _syncPresetsAndReload(convo);
+    } catch (e) {
+      debugPrint('[PresetSync] preset sync failed for ${convo.id}: $e');
+      rethrow;
+    }
+  }
+
+  Future<bool> _syncPresetsAndReload(Conversation convo) async {
+    final ap = _contextProvider.read<AssistantProvider>();
+    final changed = await _chatService.syncPresetMessages(
+      conversationId: convo.id,
+      presets: ap.getPresetMessagesForAssistant(convo.assistantId),
+    );
+    if (changed && currentConversation?.id == convo.id) {
+      _chatController.reloadMessages();
+      notifyListeners();
+    }
+    return changed;
+  }
+
+  /// "Apply to all conversations" (banner action): applies the assistant's
+  /// current preset list to every persisted conversation it owns. Returns the
+  /// per-conversation outcome; the caller surfaces failures.
+  Future<({int touched, int failed})> syncPresetsAcrossConversations(
+    String assistantId,
+  ) async {
+    final ap = _contextProvider.read<AssistantProvider>();
+    if (ap.getById(assistantId) == null) return (touched: 0, failed: 0);
+    final result = await _chatService.syncPresetMessagesForAssistant(
+      assistantId: assistantId,
+      presets: ap.getPresetMessagesForAssistant(assistantId),
+    );
+    final convo = currentConversation;
+    if (result.touched > 0 &&
+        convo != null &&
+        convo.assistantId == assistantId) {
+      _chatController.reloadMessages();
+      notifyListeners();
+    }
+    return result;
+  }
+
   /// Create a new conversation.
   Future<void> createNewConversation() async {
     // Flush current conversation progress before creating new
@@ -1160,25 +1247,22 @@ class HomeViewModel extends ChangeNotifier {
     _streamController.clearAllState();
     notifyListeners();
 
-    // Inject assistant preset messages into new conversation (ordered)
+    // Inject assistant preset messages into new conversation (ordered).
+    // Shares the #577 row shape with the existing-conversation sync via
+    // ChatService.appendPresetMessages.
     try {
       final presets = ap.getPresetMessagesForAssistant(a?.id);
       if (presets.isNotEmpty && currentConversation != null) {
-        for (final pm in presets) {
-          final role = (pm['role'] == 'assistant') ? 'assistant' : 'user';
-          final content = (pm['content'] ?? '').trim();
-          if (content.isEmpty) continue;
-          await _chatService.addMessage(
-            conversationId: currentConversation!.id,
-            role: role,
-            content: content,
-            isPreset: true,
-          );
-        }
+        await _chatService.appendPresetMessages(
+          conversationId: currentConversation!.id,
+          presets: presets,
+        );
         _chatController.reloadMessages();
         notifyListeners();
       }
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('[HomeViewModel] preset injection failed: $e');
+    }
 
     onScrollToBottom?.call();
   }

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -1481,6 +1481,132 @@ class _HomePageState extends State<HomePage>
     );
   }
 
+  /// Issue #577: shown below the preset toggle bar when the owning
+  /// assistant's preset messages changed and this conversation holds real
+  /// messages (fresh conversations self-sync instead).
+  Widget _buildPresetSyncBanner(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    final busy = _controller.isCurrentConversationLoading;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(10, 4, 10, 2),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(12, 6, 2, 6),
+        decoration: BoxDecoration(
+          color: context.appColors.surfaceFill,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                l10n.homePagePresetSyncBannerText,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: cs.onSurface.withValues(alpha: 0.8),
+                ),
+              ),
+            ),
+            _buildPresetSyncBannerAction(
+              context,
+              label: l10n.homePagePresetSyncApplyCurrent,
+              enabled: !busy,
+              onTap: () =>
+                  unawaited(_controller.applyPresetsToCurrentConversation()),
+            ),
+            const SizedBox(width: 4),
+            _buildPresetSyncBannerAction(
+              context,
+              label: l10n.homePagePresetSyncApplyAll,
+              enabled: !busy,
+              onTap: () => unawaited(_applyPresetsToAllConversations()),
+            ),
+            IosIconButton(
+              icon: Lucide.X,
+              size: 14,
+              padding: const EdgeInsets.all(6),
+              semanticLabel: l10n.homePagePresetSyncDismiss,
+              onTap: _controller.dismissPresetSyncBanner,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPresetSyncBannerAction(
+    BuildContext context, {
+    required String label,
+    required bool enabled,
+    required VoidCallback onTap,
+  }) {
+    final cs = Theme.of(context).colorScheme;
+    return IosCardPress(
+      onTap: enabled ? onTap : null,
+      borderRadius: BorderRadius.circular(8),
+      baseColor: Colors.transparent,
+      pressedBlendStrength: 0.06,
+      haptics: false,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: AppFontWeights.medium,
+          color: enabled ? cs.primary : cs.onSurface.withValues(alpha: 0.4),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _applyPresetsToAllConversations() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(
+          AppLocalizations.of(
+            dialogContext,
+          )!.homePagePresetSyncApplyAllConfirmTitle,
+        ),
+        content: Text(
+          AppLocalizations.of(
+            dialogContext,
+          )!.homePagePresetSyncApplyAllConfirmBody,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(AppLocalizations.of(dialogContext)!.homePageCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(
+              AppLocalizations.of(dialogContext)!.homePagePresetSyncConfirm,
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final result = await _controller.applyPresetsToAllConversations();
+    if (!mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+    if (result.failed > 0) {
+      showAppSnackBar(
+        context,
+        message: l10n.homePagePresetSyncFailed,
+        type: NotificationType.error,
+      );
+      return;
+    }
+    if (result.touched <= 0) return;
+    showAppSnackBar(
+      context,
+      message: l10n.homePagePresetSyncAllDone(result.touched),
+      type: NotificationType.success,
+    );
+  }
+
   Widget _buildMessageListView(
     BuildContext context, {
     required double topContentPadding,
@@ -1517,12 +1643,21 @@ class _HomePageState extends State<HomePage>
         : allMessages;
 
     Widget? presetHeaderWidget;
-    if (showPresetToggle) {
-      presetHeaderWidget = _buildPresetToggleBar(
-        context,
-        presetCount: presetCount,
-        isExpanded: _presetsExpanded,
-        onToggle: () => setState(() => _presetsExpanded = !_presetsExpanded),
+    final showPresetSyncBanner = _controller.showPresetSyncBanner;
+    if (showPresetToggle || showPresetSyncBanner) {
+      presetHeaderWidget = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showPresetToggle)
+            _buildPresetToggleBar(
+              context,
+              presetCount: presetCount,
+              isExpanded: _presetsExpanded,
+              onToggle: () =>
+                  setState(() => _presetsExpanded = !_presetsExpanded),
+            ),
+          if (showPresetSyncBanner) _buildPresetSyncBanner(context),
+        ],
       );
     }
 
@@ -1545,6 +1680,12 @@ class _HomePageState extends State<HomePage>
     if (useWebViewport && afterMessageWidgets.isNotEmpty) {
       useWebViewport = false;
       _scheduleMultiAIFallbackPrompt(conversationId);
+    }
+
+    // Issue #577: the preset sync banner is a Flutter list header; while a
+    // pending change exists, fall back so its apply actions stay reachable.
+    if (useWebViewport && showPresetSyncBanner) {
+      useWebViewport = false;
     }
 
     final truncIndex = HomeViewModel.adjustTruncIndexForPresetFolding(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -506,6 +506,22 @@
     }
   },
   "homePagePresetConversationBlocked": "Send a message first before creating a new conversation",
+  "homePagePresetSyncBannerText": "Preset messages changed",
+  "homePagePresetSyncApplyCurrent": "Apply here",
+  "homePagePresetSyncApplyAll": "Apply to all",
+  "homePagePresetSyncApplyAllConfirmTitle": "Apply to all conversations?",
+  "homePagePresetSyncApplyAllConfirmBody": "The current preset messages will be applied to every conversation of this assistant. Conversations with chat history will have their context updated.",
+  "homePagePresetSyncConfirm": "Apply",
+  "homePagePresetSyncAllDone": "Applied to {count, plural, one{{count} conversation} other{{count} conversations}}",
+  "@homePagePresetSyncAllDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetSyncDismiss": "Dismiss",
+  "homePagePresetSyncFailed": "Preset messages could not be applied",
   "assistantEditPageTitle": "Assistant",
   "assistantEditPageNotFound": "Assistant not found",
   "assistantEditPageBasicTab": "Basic",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2176,6 +2176,60 @@ abstract class AppLocalizations {
   /// **'Send a message first before creating a new conversation'**
   String get homePagePresetConversationBlocked;
 
+  /// No description provided for @homePagePresetSyncBannerText.
+  ///
+  /// In en, this message translates to:
+  /// **'Preset messages changed'**
+  String get homePagePresetSyncBannerText;
+
+  /// No description provided for @homePagePresetSyncApplyCurrent.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply here'**
+  String get homePagePresetSyncApplyCurrent;
+
+  /// No description provided for @homePagePresetSyncApplyAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply to all'**
+  String get homePagePresetSyncApplyAll;
+
+  /// No description provided for @homePagePresetSyncApplyAllConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply to all conversations?'**
+  String get homePagePresetSyncApplyAllConfirmTitle;
+
+  /// No description provided for @homePagePresetSyncApplyAllConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'The current preset messages will be applied to every conversation of this assistant. Conversations with chat history will have their context updated.'**
+  String get homePagePresetSyncApplyAllConfirmBody;
+
+  /// No description provided for @homePagePresetSyncConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get homePagePresetSyncConfirm;
+
+  /// No description provided for @homePagePresetSyncAllDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Applied to {count, plural, one{{count} conversation} other{{count} conversations}}'**
+  String homePagePresetSyncAllDone(int count);
+
+  /// No description provided for @homePagePresetSyncDismiss.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get homePagePresetSyncDismiss;
+
+  /// No description provided for @homePagePresetSyncFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Preset messages could not be applied'**
+  String get homePagePresetSyncFailed;
+
   /// No description provided for @assistantEditPageTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1194,6 +1194,43 @@ class AppLocalizationsEn extends AppLocalizations {
       'Send a message first before creating a new conversation';
 
   @override
+  String get homePagePresetSyncBannerText => 'Preset messages changed';
+
+  @override
+  String get homePagePresetSyncApplyCurrent => 'Apply here';
+
+  @override
+  String get homePagePresetSyncApplyAll => 'Apply to all';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmTitle =>
+      'Apply to all conversations?';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmBody =>
+      'The current preset messages will be applied to every conversation of this assistant. Conversations with chat history will have their context updated.';
+
+  @override
+  String get homePagePresetSyncConfirm => 'Apply';
+
+  @override
+  String homePagePresetSyncAllDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count conversations',
+      one: '$count conversation',
+    );
+    return 'Applied to $_temp0';
+  }
+
+  @override
+  String get homePagePresetSyncDismiss => 'Dismiss';
+
+  @override
+  String get homePagePresetSyncFailed => 'Preset messages could not be applied';
+
+  @override
   String get assistantEditPageTitle => 'Assistant';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1158,6 +1158,41 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homePagePresetConversationBlocked => '请先发送消息后再创建新对话';
 
   @override
+  String get homePagePresetSyncBannerText => '预设消息已更新';
+
+  @override
+  String get homePagePresetSyncApplyCurrent => '应用到当前会话';
+
+  @override
+  String get homePagePresetSyncApplyAll => '应用到所有会话';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmTitle => '应用到所有会话？';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmBody =>
+      '当前预设消息将应用到该助手的所有会话；包含历史消息的会话，其上下文将被更新。';
+
+  @override
+  String get homePagePresetSyncConfirm => '应用';
+
+  @override
+  String homePagePresetSyncAllDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已应用到 $count 个会话',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get homePagePresetSyncDismiss => '关闭';
+
+  @override
+  String get homePagePresetSyncFailed => '预设消息应用失败';
+
+  @override
   String get assistantEditPageTitle => '助手';
 
   @override
@@ -11067,6 +11102,41 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get homePagePresetConversationBlocked => '请先发送消息后再创建新对话';
+
+  @override
+  String get homePagePresetSyncBannerText => '预设消息已更新';
+
+  @override
+  String get homePagePresetSyncApplyCurrent => '应用到当前会话';
+
+  @override
+  String get homePagePresetSyncApplyAll => '应用到所有会话';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmTitle => '应用到所有会话？';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmBody =>
+      '当前预设消息将应用到该助手的所有会话；包含历史消息的会话，其上下文将被更新。';
+
+  @override
+  String get homePagePresetSyncConfirm => '应用';
+
+  @override
+  String homePagePresetSyncAllDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已应用到 $count 个会话',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get homePagePresetSyncDismiss => '关闭';
+
+  @override
+  String get homePagePresetSyncFailed => '预设消息应用失败';
 
   @override
   String get assistantEditPageTitle => '助手';
@@ -20979,6 +21049,41 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get homePagePresetConversationBlocked => '請先傳送訊息後再建立新對話';
+
+  @override
+  String get homePagePresetSyncBannerText => '預設訊息已更新';
+
+  @override
+  String get homePagePresetSyncApplyCurrent => '套用到目前會話';
+
+  @override
+  String get homePagePresetSyncApplyAll => '套用到所有會話';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmTitle => '套用到所有會話？';
+
+  @override
+  String get homePagePresetSyncApplyAllConfirmBody =>
+      '目前預設訊息將套用到該助手的所有會話；包含歷史訊息的會話，其上下文將被更新。';
+
+  @override
+  String get homePagePresetSyncConfirm => '套用';
+
+  @override
+  String homePagePresetSyncAllDone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '已套用到 $count 個會話',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get homePagePresetSyncDismiss => '關閉';
+
+  @override
+  String get homePagePresetSyncFailed => '預設訊息套用失敗';
 
   @override
   String get assistantEditPageTitle => '助理';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1018,6 +1018,22 @@
     }
   },
   "homePagePresetConversationBlocked": "请先发送消息后再创建新对话",
+  "homePagePresetSyncBannerText": "预设消息已更新",
+  "homePagePresetSyncApplyCurrent": "应用到当前会话",
+  "homePagePresetSyncApplyAll": "应用到所有会话",
+  "homePagePresetSyncApplyAllConfirmTitle": "应用到所有会话？",
+  "homePagePresetSyncApplyAllConfirmBody": "当前预设消息将应用到该助手的所有会话；包含历史消息的会话，其上下文将被更新。",
+  "homePagePresetSyncConfirm": "应用",
+  "homePagePresetSyncAllDone": "{count, plural, other{已应用到 {count} 个会话}}",
+  "@homePagePresetSyncAllDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetSyncDismiss": "关闭",
+  "homePagePresetSyncFailed": "预设消息应用失败",
   "chatHistoryPageTitle": "聊天历史",
   "chatHistoryPageSearchTooltip": "搜索",
   "chatHistoryPageDeleteAllTooltip": "删除未置顶",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1063,6 +1063,22 @@
     }
   },
   "homePagePresetConversationBlocked": "请先发送消息后再创建新对话",
+  "homePagePresetSyncBannerText": "预设消息已更新",
+  "homePagePresetSyncApplyCurrent": "应用到当前会话",
+  "homePagePresetSyncApplyAll": "应用到所有会话",
+  "homePagePresetSyncApplyAllConfirmTitle": "应用到所有会话？",
+  "homePagePresetSyncApplyAllConfirmBody": "当前预设消息将应用到该助手的所有会话；包含历史消息的会话，其上下文将被更新。",
+  "homePagePresetSyncConfirm": "应用",
+  "homePagePresetSyncAllDone": "{count, plural, other{已应用到 {count} 个会话}}",
+  "@homePagePresetSyncAllDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetSyncDismiss": "关闭",
+  "homePagePresetSyncFailed": "预设消息应用失败",
   "chatHistoryPageTitle": "聊天历史",
   "chatHistoryPageSearchTooltip": "搜索",
   "chatHistoryPageDeleteAllTooltip": "删除未置顶",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1018,6 +1018,22 @@
     }
   },
   "homePagePresetConversationBlocked": "請先傳送訊息後再建立新對話",
+  "homePagePresetSyncBannerText": "預設訊息已更新",
+  "homePagePresetSyncApplyCurrent": "套用到目前會話",
+  "homePagePresetSyncApplyAll": "套用到所有會話",
+  "homePagePresetSyncApplyAllConfirmTitle": "套用到所有會話？",
+  "homePagePresetSyncApplyAllConfirmBody": "目前預設訊息將套用到該助手的所有會話；包含歷史訊息的會話，其上下文將被更新。",
+  "homePagePresetSyncConfirm": "套用",
+  "homePagePresetSyncAllDone": "{count, plural, other{已套用到 {count} 個會話}}",
+  "@homePagePresetSyncAllDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "homePagePresetSyncDismiss": "關閉",
+  "homePagePresetSyncFailed": "預設訊息套用失敗",
   "chatHistoryPageTitle": "聊天歷史",
   "chatHistoryPageSearchTooltip": "搜尋",
   "chatHistoryPageDeleteAllTooltip": "刪除未置頂",

--- a/test/core/services/chat/chat_service_preset_sync_test.dart
+++ b/test/core/services/chat/chat_service_preset_sync_test.dart
@@ -1,0 +1,568 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:Cuplivo/core/models/conversation.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$path/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$path/tmp';
+}
+
+Map<String, String> _preset(String role, String content) => <String, String>{
+  'role': role,
+  'content': content,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late ChatService service;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('preset_sync_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    service = ChatService();
+    await service.init();
+  });
+
+  tearDown(() async {
+    await service.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<Conversation> newConversation(String id, {String? assistantId}) async {
+    return service.createConversation(title: id, assistantId: assistantId);
+  }
+
+  group('ChatService.syncPresetMessages', () {
+    test(
+      'inserts presets into an empty conversation, normalizing roles',
+      () async {
+        final convo = await newConversation('empty', assistantId: 'a1');
+        final changed = await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [
+            _preset('user', '  hello  '),
+            _preset('weird-role', 'normalized'),
+            _preset('assistant', '   '),
+            _preset('assistant', 'greeting reply'),
+          ],
+        );
+        expect(changed, isTrue);
+
+        final messages = service.getMessages(convo.id);
+        expect(messages.map((m) => (m.role, m.content)), [
+          ('user', 'hello'),
+          ('user', 'normalized'),
+          ('assistant', 'greeting reply'),
+        ]);
+        expect(messages.every((m) => m.isPreset), isTrue);
+        expect(await service.hasNoRealMessages(convo.id), isTrue);
+      },
+    );
+
+    test('replaces the preset list of a preset-only conversation', () async {
+      final convo = await newConversation('preset-only', assistantId: 'a1');
+      final oldFirst = await service.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'old v1',
+        isPreset: true,
+      );
+      await service.addMessage(
+        conversationId: convo.id,
+        role: 'assistant',
+        content: 'old v2',
+        isPreset: true,
+      );
+
+      final changed = await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'new v1'), _preset('user', 'new v2')],
+      );
+      expect(changed, isTrue);
+
+      final messages = service.getMessages(convo.id);
+      expect(messages.map((m) => m.content), ['new v1', 'new v2']);
+      expect(
+        messages.any((m) => m.id == oldFirst.id),
+        isFalse,
+        reason: 'stale preset rows must be removed, not reused',
+      );
+      expect(
+        await service.isRecyclablePresetOnlyConversation(convo.id),
+        isTrue,
+        reason: 'a synced preset-only conversation stays preset-only',
+      );
+
+      // A second identical sync is a no-op.
+      final again = await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'new v1'), _preset('user', 'new v2')],
+      );
+      expect(again, isFalse);
+    });
+
+    test(
+      'inserts new presets at the top of a conversation with history',
+      () async {
+        final convo = await newConversation('history', assistantId: 'a1');
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'old preset',
+          isPreset: true,
+        );
+        final r1 = await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'real 1',
+        );
+        final r2 = await service.addMessage(
+          conversationId: convo.id,
+          role: 'assistant',
+          content: 'real 2',
+        );
+
+        final changed = await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [
+            _preset('user', 'q1'),
+            _preset('assistant', 'q2'),
+            _preset('user', 'q3'),
+          ],
+        );
+        expect(changed, isTrue);
+
+        final messages = service.getMessages(convo.id);
+        expect(messages.map((m) => m.content), [
+          'q1',
+          'q2',
+          'q3',
+          'real 1',
+          'real 2',
+        ]);
+        expect(messages.map((m) => m.isPreset), [
+          true,
+          true,
+          true,
+          false,
+          false,
+        ]);
+        expect(
+          messages.map((m) => m.id),
+          containsAllInOrder(<String>[r1.id, r2.id]),
+        );
+        // messageOrder stays contiguous after the replacement.
+        for (var i = 0; i < messages.length; i++) {
+          expect(
+            await service.repo.getMessageIndex(convo.id, messages[i].id),
+            i,
+          );
+        }
+        expect(await service.hasNoRealMessages(convo.id), isFalse);
+      },
+    );
+
+    test(
+      'shifts truncateIndex by (added - removed) on history conversations',
+      () async {
+        final convo = await newConversation('trunc', assistantId: 'a1');
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'old preset',
+          isPreset: true,
+        );
+        for (var i = 1; i <= 4; i++) {
+          await service.addMessage(
+            conversationId: convo.id,
+            role: 'user',
+            content: 'real $i',
+          );
+        }
+        // [P1, R1..R4]: split at 4 keeps only R4 in context.
+        final cached = service.getConversation(convo.id)!;
+        cached.truncateIndex = 4;
+        await service.repo.putConversation(cached);
+
+        // removed=1, added=3 → 4 - 1 + 3 = 6; [Q1..Q3, R1..R4] keeps only R4.
+        await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [
+            _preset('user', 'q1'),
+            _preset('assistant', 'q2'),
+            _preset('user', 'q3'),
+          ],
+        );
+
+        final messages = service.getMessages(convo.id);
+        expect(messages, hasLength(7));
+        expect(service.getConversation(convo.id)!.truncateIndex, 6);
+        // The same real message stays inside the truncated context.
+        expect(messages.sublist(6).single.content, 'real 4');
+      },
+    );
+
+    test('keeps truncateIndex when preset count is unchanged', () async {
+      final convo = await newConversation('trunc-same', assistantId: 'a1');
+      await service.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'p1',
+        isPreset: true,
+      );
+      await service.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'real 1',
+      );
+      final cached = service.getConversation(convo.id)!;
+      cached.truncateIndex = 1;
+      await service.repo.putConversation(cached);
+
+      await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'p1-replaced')],
+      );
+
+      // removed=1, added=1 → index stays at the first real row.
+      expect(service.getConversation(convo.id)!.truncateIndex, 1);
+      final messages = service.getMessages(convo.id);
+      expect(messages.map((m) => m.content), ['p1-replaced', 'real 1']);
+    });
+
+    test(
+      'keeps a cleared context when a preset-only conversation is resynced',
+      () async {
+        final convo = await newConversation('fresh-trunc', assistantId: 'a1');
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'p1',
+          isPreset: true,
+        );
+        // Simulate "clear context" at the tail of a preset-only conversation:
+        // toggleTruncateAtTail sets the index to the full message count.
+        final cached = service.getConversation(convo.id)!;
+        cached.truncateIndex = 1;
+        await service.repo.putConversation(cached);
+
+        await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [
+            _preset('user', 'q1'),
+            _preset('assistant', 'q2'),
+            _preset('user', 'q3'),
+          ],
+        );
+
+        // The replacement excludes all new presets, so the context stays empty.
+        expect(service.getConversation(convo.id)!.truncateIndex, 3);
+        final messages = service.getMessages(convo.id);
+        expect(messages.map((m) => m.content), ['q1', 'q2', 'q3']);
+        expect(messages.sublist(3), isEmpty);
+      },
+    );
+
+    test(
+      'preserves a no-op truncate marker on an empty conversation',
+      () async {
+        final convo = await newConversation('fresh-zero', assistantId: 'a1');
+        final cached = service.getConversation(convo.id)!;
+        cached.truncateIndex = 0;
+        await service.repo.putConversation(cached);
+
+        await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [_preset('user', 'q1')],
+        );
+
+        expect(service.getConversation(convo.id)!.truncateIndex, 0);
+        expect(service.getMessages(convo.id).map((m) => m.content), ['q1']);
+      },
+    );
+
+    test(
+      'does not shift a no-op truncate marker on a history conversation',
+      () async {
+        final convo = await newConversation('trunc-zero', assistantId: 'a1');
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'p1',
+          isPreset: true,
+        );
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'real 1',
+        );
+        final cached = service.getConversation(convo.id)!;
+        cached.truncateIndex = 0; // excludes nothing
+        await service.repo.putConversation(cached);
+
+        await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [
+            _preset('user', 'q1'),
+            _preset('assistant', 'q2'),
+            _preset('user', 'q3'),
+          ],
+        );
+
+        expect(service.getConversation(convo.id)!.truncateIndex, 0);
+        final messages = service.getMessages(convo.id);
+        expect(messages.map((m) => m.content), ['q1', 'q2', 'q3', 'real 1']);
+      },
+    );
+
+    test(
+      'clearing the preset list removes preset rows and preserves history',
+      () async {
+        final convo = await newConversation('clear-presets', assistantId: 'a1');
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'p1',
+          isPreset: true,
+        );
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'assistant',
+          content: 'p2',
+          isPreset: true,
+        );
+        await service.addMessage(
+          conversationId: convo.id,
+          role: 'user',
+          content: 'real 1',
+        );
+        final cached = service.getConversation(convo.id)!;
+        cached.truncateIndex = 3; // excludes p1, p2 and real 1
+        await service.repo.putConversation(cached);
+
+        final changed = await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: const [],
+        );
+
+        expect(changed, isTrue);
+        final messages = service.getMessages(convo.id);
+        expect(messages.map((m) => m.content), ['real 1']);
+        expect(messages.single.isPreset, isFalse);
+        // removed=2, added=0 → index shifts from 3 to 1 (context stays empty).
+        expect(service.getConversation(convo.id)!.truncateIndex, 1);
+        expect(await service.hasNoRealMessages(convo.id), isFalse);
+      },
+    );
+
+    test(
+      'overlapping syncs for one conversation do not duplicate rows',
+      () async {
+        final convo = await newConversation('overlap', assistantId: 'a1');
+        final results = await Future.wait([
+          service.syncPresetMessages(
+            conversationId: convo.id,
+            presets: [_preset('user', 'q1'), _preset('assistant', 'q2')],
+          ),
+          service.syncPresetMessages(
+            conversationId: convo.id,
+            presets: [_preset('user', 'q1'), _preset('assistant', 'q2')],
+          ),
+        ]);
+
+        // The first call writes; the queued second one re-checks and no-ops.
+        expect(results, [true, false]);
+        expect(service.getMessages(convo.id).map((m) => m.content), [
+          'q1',
+          'q2',
+        ]);
+      },
+    );
+
+    test('skips temporary conversations', () async {
+      final convo = await service.createDraftConversation(
+        title: 'Temporary',
+        assistantId: 'a1',
+        temporary: true,
+      );
+      await service.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'real 1',
+      );
+
+      final changed = await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'q1')],
+      );
+
+      expect(changed, isFalse);
+      expect(service.getMessages(convo.id).map((m) => m.content), ['real 1']);
+    });
+
+    test('skips group conversations', () async {
+      final convo = await newConversation('group-conv', assistantId: 'a1');
+      final cached = service.getConversation(convo.id)!;
+      cached.conversationKind = Conversation.kindGroup;
+      await service.repo.putConversation(cached);
+
+      final changed = await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'q1')],
+      );
+
+      expect(changed, isFalse);
+    });
+
+    test('returns false for unknown conversation ids', () async {
+      final changed = await service.syncPresetMessages(
+        conversationId: 'does-not-exist',
+        presets: [_preset('user', 'q1')],
+      );
+      expect(changed, isFalse);
+    });
+
+    test('records removed preset rows in the trash store', () async {
+      final convo = await newConversation('trash', assistantId: 'a1');
+      final oldPreset = await service.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'old preset',
+        isPreset: true,
+      );
+
+      await service.syncPresetMessages(
+        conversationId: convo.id,
+        presets: [_preset('user', 'new preset')],
+      );
+
+      final records = await service.deletedRecordsStore!.listDeletedRecords();
+      expect(records.map((r) => r.id), contains(oldPreset.id));
+    });
+
+    test(
+      'removes tool events and gemini signatures of replaced presets',
+      () async {
+        final convo = await newConversation('fidelity', assistantId: 'a1');
+        final oldPreset = await service.addMessage(
+          conversationId: convo.id,
+          role: 'assistant',
+          content: 'old preset',
+          isPreset: true,
+        );
+        await service.repo.setToolEvents(oldPreset.id, [
+          <String, dynamic>{
+            'name': 'test_tool',
+            'arguments': const <String, dynamic>{},
+            'content': 'ok',
+          },
+        ]);
+        await service.repo.setGeminiThoughtSignature(oldPreset.id, 'sig-1');
+
+        await service.syncPresetMessages(
+          conversationId: convo.id,
+          presets: [_preset('assistant', 'new preset')],
+        );
+
+        expect(await service.repo.getToolEvents(oldPreset.id), isEmpty);
+        expect(service.getGeminiThoughtSignature(oldPreset.id), isNull);
+      },
+    );
+  });
+
+  group('ChatService.syncPresetMessagesForAssistant', () {
+    test('syncs only conversations owned by the assistant', () async {
+      final ownedFresh = await newConversation('a1-fresh', assistantId: 'a1');
+      final ownedHistory = await newConversation(
+        'a1-history',
+        assistantId: 'a1',
+      );
+      await service.addMessage(
+        conversationId: ownedHistory.id,
+        role: 'user',
+        content: 'real 1',
+      );
+      final foreign = await newConversation('a2-fresh', assistantId: 'a2');
+      final unowned = await newConversation('unowned');
+
+      final result = await service.syncPresetMessagesForAssistant(
+        assistantId: 'a1',
+        presets: [_preset('user', 'q1')],
+      );
+
+      expect(result.touched, 2);
+      expect(result.failed, 0);
+      expect(service.getMessages(ownedFresh.id).map((m) => m.content), ['q1']);
+      expect(service.getMessages(ownedHistory.id).map((m) => m.content), [
+        'q1',
+        'real 1',
+      ]);
+      expect(service.getMessages(foreign.id), isEmpty);
+      expect(service.getMessages(unowned.id), isEmpty);
+    });
+
+    test('returns 0 for an assistant without conversations', () async {
+      final result = await service.syncPresetMessagesForAssistant(
+        assistantId: 'nobody',
+        presets: [_preset('user', 'q1')],
+      );
+      expect(result.touched, 0);
+      expect(result.failed, 0);
+    });
+  });
+
+  group('ChatService.presetPayloadFingerprint', () {
+    test('is stable across equal payloads and distinct across changes', () {
+      final a = ChatService.presetPayloadFingerprint([
+        _preset('user', 'hi'),
+        _preset('assistant', 'yo'),
+      ]);
+      final b = ChatService.presetPayloadFingerprint([
+        _preset('user', 'hi'),
+        _preset('assistant', 'yo'),
+      ]);
+      final c = ChatService.presetPayloadFingerprint([
+        _preset('assistant', 'yo'),
+        _preset('user', 'hi'),
+      ]);
+      final d = ChatService.presetPayloadFingerprint([
+        _preset('user', 'hi '),
+        _preset('assistant', 'yo'),
+      ]);
+      final empty = ChatService.presetPayloadFingerprint(const []);
+      final emptyWithNoise = ChatService.presetPayloadFingerprint([
+        _preset('user', '   '),
+      ]);
+      expect(a, b);
+      expect(a, isNot(c));
+      expect(a, d, reason: 'payload normalization trims content');
+      expect(
+        empty,
+        emptyWithNoise,
+        reason: 'blank-only entries are dropped before fingerprinting',
+      );
+    });
+  });
+}

--- a/test/features/home/controllers/home_page_controller_preset_sync_test.dart
+++ b/test/features/home/controllers/home_page_controller_preset_sync_test.dart
@@ -1,0 +1,715 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/models/assistant.dart';
+import 'package:Cuplivo/core/models/preset_message.dart';
+import 'package:Cuplivo/core/providers/assistant_provider.dart';
+import 'package:Cuplivo/core/providers/group_chat_provider.dart';
+import 'package:Cuplivo/core/providers/mcp_provider.dart';
+import 'package:Cuplivo/core/providers/quick_instruction_provider.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/chat/chat_service.dart';
+import 'package:Cuplivo/core/services/generation_engine.dart';
+import 'package:Cuplivo/features/home/controllers/home_page_controller.dart';
+import 'package:Cuplivo/features/home/widgets/chat_input_bar.dart';
+import 'package:Cuplivo/features/home/widgets/quick_instruction_editing_controller.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.path);
+
+  final String path;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => path;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => path;
+
+  @override
+  Future<String?> getApplicationCachePath() async => '$path/cache';
+
+  @override
+  Future<String?> getTemporaryPath() async => '$path/tmp';
+}
+
+/// Lets a test force the next preset rewrite to throw, exercising the
+/// banner's failure-restore path.
+class _FailingPresetSyncService extends ChatService {
+  bool failPresetSync = false;
+
+  @override
+  Future<bool> syncPresetMessages({
+    required String conversationId,
+    required List<Map<String, String>> presets,
+  }) {
+    if (failPresetSync) {
+      throw StateError('preset sync failure (test)');
+    }
+    return super.syncPresetMessages(
+      conversationId: conversationId,
+      presets: presets,
+    );
+  }
+}
+
+class _ControllerHost extends StatefulWidget {
+  const _ControllerHost({required this.onReady});
+
+  final ValueChanged<HomePageController> onReady;
+
+  @override
+  State<_ControllerHost> createState() => _ControllerHostState();
+}
+
+class _ControllerHostState extends State<_ControllerHost>
+    with SingleTickerProviderStateMixin {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  final GlobalKey _inputBarKey = GlobalKey();
+  final FocusNode _inputFocus = FocusNode();
+  final QuickInstructionEditingController _inputController =
+      QuickInstructionEditingController();
+  final ChatInputBarController _mediaController = ChatInputBarController();
+  final ScrollController _scrollController = ScrollController();
+  late final HomePageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = HomePageController(
+      context: context,
+      vsync: this,
+      scaffoldKey: _scaffoldKey,
+      inputBarKey: _inputBarKey,
+      inputFocus: _inputFocus,
+      inputController: _inputController,
+      mediaController: _mediaController,
+      scrollController: _scrollController,
+    );
+    widget.onReady(_controller);
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(key: _scaffoldKey);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _inputFocus.dispose();
+    _inputController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+}
+
+class _Harness {
+  _Harness({
+    required this.controller,
+    required this.chatService,
+    required this.settings,
+    required this.assistants,
+    required this.quickInstructions,
+    required this.mcp,
+    required this.engine,
+    required this.groupChats,
+    required this.tempDir,
+  });
+
+  final HomePageController controller;
+  final ChatService chatService;
+  final SettingsProvider settings;
+  final AssistantProvider assistants;
+  final QuickInstructionProvider quickInstructions;
+  final McpProvider mcp;
+  final GenerationEngine engine;
+  final GroupChatProvider groupChats;
+  final Directory tempDir;
+
+  /// The chat service is backed by a real file database whose queries do not
+  /// settle inside testWidgets' fake-async zone, so every scenario body that
+  /// touches it must run through [WidgetTester.runAsync] (see main()).
+  Future<void> dispose(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await chatService.close();
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.pumpWidget(const SizedBox.shrink());
+    engine.dispose();
+    mcp.dispose();
+    quickInstructions.dispose();
+    assistants.dispose();
+    settings.dispose();
+    groupChats.dispose();
+  }
+
+  /// Real-time condition poll so the controller's unawaited
+  /// AssistantProvider listener (repo I/O included) settles before
+  /// assertions. Only valid inside a `tester.runAsync` body.
+  Future<void> settleFor(
+    bool Function() condition, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      if (condition()) return;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+    fail('condition not met within ${timeout.inMilliseconds}ms');
+  }
+}
+
+Future<_Harness> _pumpHarness(
+  WidgetTester tester, {
+  ChatService Function()? createService,
+}) async {
+  SharedPreferences.setMockInitialValues(const <String, Object>{});
+  final preferences = BusinessPreferences.memoryForTests();
+
+  late final Directory tempDir;
+  late final ChatService chatService;
+  late final SettingsProvider settings;
+  late final QuickInstructionProvider quickInstructions;
+  late final GroupChatProvider groupChats;
+  await tester.runAsync(() async {
+    tempDir = await Directory.systemTemp.createTemp('preset_sync_ctrl_');
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    chatService = (createService ?? ChatService.new)();
+    await chatService.init();
+    settings = SettingsProvider(preferences: preferences);
+    await settings.loaded;
+    quickInstructions = QuickInstructionProvider(preferences: preferences);
+    await quickInstructions.initialize();
+    groupChats = GroupChatProvider(chatService: chatService);
+    await groupChats.load();
+  });
+
+  // chatService is wired so the cold-start load path (`ensureLoaded` →
+  // `notifyListeners`) exercises the preset-change listener like production.
+  final assistants = AssistantProvider(
+    preferences: preferences,
+    chatService: chatService,
+  );
+
+  late BuildContext providerContext;
+  final mcp = McpProvider(
+    preferences: preferences,
+    contextProvider: () => providerContext,
+  );
+  final engine = GenerationEngine(chatService: chatService);
+
+  HomePageController? controller;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: MultiProvider(
+        providers: [
+          Provider<BusinessPreferences>.value(value: preferences),
+          ChangeNotifierProvider<ChatService>.value(value: chatService),
+          ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+          ChangeNotifierProvider<AssistantProvider>.value(value: assistants),
+          ChangeNotifierProvider<QuickInstructionProvider>.value(
+            value: quickInstructions,
+          ),
+          ChangeNotifierProvider<McpProvider>.value(value: mcp),
+          ChangeNotifierProvider<GenerationEngine>.value(value: engine),
+          ChangeNotifierProvider<GroupChatProvider>.value(value: groupChats),
+        ],
+        child: Builder(
+          builder: (context) {
+            providerContext = context;
+            return _ControllerHost(onReady: (value) => controller = value);
+          },
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  return _Harness(
+    controller: controller!,
+    chatService: chatService,
+    settings: settings,
+    assistants: assistants,
+    quickInstructions: quickInstructions,
+    mcp: mcp,
+    engine: engine,
+    groupChats: groupChats,
+    tempDir: tempDir,
+  );
+}
+
+Future<String> _addAssistant(
+  _Harness harness,
+  String name,
+  List<PresetMessage> presets,
+) async {
+  final id = await harness.assistants.addAssistant(name: name);
+  final assistant = harness.assistants.getById(id)!;
+  await harness.assistants.updateAssistant(
+    assistant.copyWith(presetMessages: presets),
+  );
+  return id;
+}
+
+Future<String> _newConversation(
+  _Harness harness,
+  String title,
+  String assistantId, {
+  String? presetContent,
+  String? realContent,
+}) async {
+  final convo = await harness.chatService.createConversation(
+    title: title,
+    assistantId: assistantId,
+  );
+  if (presetContent != null) {
+    await harness.chatService.addMessage(
+      conversationId: convo.id,
+      role: 'user',
+      content: presetContent,
+      isPreset: true,
+    );
+  }
+  if (realContent != null) {
+    await harness.chatService.addMessage(
+      conversationId: convo.id,
+      role: 'user',
+      content: realContent,
+    );
+  }
+  return convo.id;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('preset change on a fresh current conversation self-syncs', (
+    tester,
+  ) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final convoId = await _newConversation(harness, 'Fresh', a1);
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(convoId),
+      );
+      await harness.settleFor(
+        () =>
+            harness.chatService.getMessages(convoId).isEmpty &&
+            harness.controller.currentConversation?.id == convoId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(
+        () => harness.chatService
+            .getMessages(convoId)
+            .any((m) => m.content == 'v2'),
+      );
+
+      expect(harness.chatService.getMessages(convoId).map((m) => m.content), [
+        'v2',
+      ]);
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+    });
+  });
+
+  testWidgets('preset change on a conversation with history raises the banner; '
+      'apply-here rewrites presets at the top', (tester) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final convoId = await _newConversation(
+        harness,
+        'History',
+        a1,
+        presetContent: 'old preset',
+        realContent: 'hello',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(convoId),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == convoId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+
+      expect(harness.controller.showPresetSyncBanner, isTrue);
+      // Nothing written until the user acts.
+      expect(harness.chatService.getMessages(convoId).map((m) => m.content), [
+        'old preset',
+        'hello',
+      ]);
+
+      await harness.controller.applyPresetsToCurrentConversation();
+      await harness.settleFor(
+        () =>
+            harness.chatService
+                .getMessages(convoId)
+                .map((m) => m.content)
+                .toString() ==
+            '(v2, hello)',
+      );
+
+      final messages = harness.chatService.getMessages(convoId);
+      expect(messages.map((m) => m.content), ['v2', 'hello']);
+      expect(messages.first.isPreset, isTrue);
+      expect(messages.last.isPreset, isFalse);
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+    });
+  });
+
+  testWidgets('apply-to-all rewrites every conversation of the assistant', (
+    tester,
+  ) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final a2 = await _addAssistant(harness, 'A2', const <PresetMessage>[]);
+      final historyId = await _newConversation(
+        harness,
+        'History',
+        a1,
+        presetContent: 'old preset',
+        realContent: 'hello',
+      );
+      final freshId = await _newConversation(harness, 'Fresh', a1);
+      final foreignId = await _newConversation(
+        harness,
+        'Foreign',
+        a2,
+        realContent: 'do not touch',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(historyId),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == historyId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+      expect(harness.controller.showPresetSyncBanner, isTrue);
+
+      final result = await harness.controller.applyPresetsToAllConversations();
+      await harness.settleFor(
+        () =>
+            harness.chatService
+                .getMessages(historyId)
+                .map((m) => m.content)
+                .toString() ==
+            '(v2, hello)',
+      );
+
+      expect(result.touched, 2);
+      expect(result.failed, 0);
+      expect(harness.chatService.getMessages(historyId).map((m) => m.content), [
+        'v2',
+        'hello',
+      ]);
+      expect(harness.chatService.getMessages(freshId).map((m) => m.content), [
+        'v2',
+      ]);
+      expect(harness.chatService.getMessages(foreignId).map((m) => m.content), [
+        'do not touch',
+      ]);
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+    });
+  });
+
+  testWidgets('dismiss clears the banner without writing anything', (
+    tester,
+  ) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final convoId = await _newConversation(
+        harness,
+        'History',
+        a1,
+        presetContent: 'old preset',
+        realContent: 'hello',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(convoId),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == convoId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+      expect(harness.controller.showPresetSyncBanner, isTrue);
+
+      harness.controller.dismissPresetSyncBanner();
+      await harness.settleFor(() => !harness.controller.showPresetSyncBanner);
+
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+      expect(harness.chatService.getMessages(convoId).map((m) => m.content), [
+        'old preset',
+        'hello',
+      ]);
+    });
+  });
+
+  testWidgets('banner never shows on temporary conversations', (tester) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final historyId = await _newConversation(
+        harness,
+        'History',
+        a1,
+        presetContent: 'old preset',
+        realContent: 'hello',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(historyId),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == historyId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+
+      // Move to a temporary conversation of the same assistant that holds a
+      // real message: the assistant-scoped pending marker must not leak in.
+      final temp = await harness.chatService.createDraftConversation(
+        title: 'Temporary',
+        assistantId: a1,
+        temporary: true,
+      );
+      await harness.chatService.addMessage(
+        conversationId: temp.id,
+        role: 'user',
+        content: 'temp hello',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(temp.id),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == temp.id,
+      );
+
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+    });
+  });
+
+  testWidgets(
+    'edits to a non-current assistant surface the banner on a later visit',
+    (tester) async {
+      final harness = await _pumpHarness(tester);
+      addTearDown(() => harness.dispose(tester));
+
+      await tester.runAsync(() async {
+        final a1 = await _addAssistant(harness, 'A1', [
+          PresetMessage(role: 'user', content: 'a v1'),
+        ]);
+        final a2 = await _addAssistant(harness, 'A2', [
+          PresetMessage(role: 'user', content: 'b v1'),
+        ]);
+        final a1History = await _newConversation(
+          harness,
+          'A1 History',
+          a1,
+          presetContent: 'a old preset',
+          realContent: 'a hello',
+        );
+        final a2History = await _newConversation(
+          harness,
+          'A2 History',
+          a2,
+          presetContent: 'b old preset',
+          realContent: 'b hello',
+        );
+
+        // Chat with A1 while editing A2's presets.
+        harness.controller.chatController.setCurrentConversation(
+          harness.chatService.getConversation(a1History),
+        );
+        await harness.settleFor(
+          () => harness.controller.currentConversation?.id == a1History,
+        );
+        final a2Assistant = harness.assistants.getById(a2)!;
+        await harness.assistants.updateAssistant(
+          a2Assistant.copyWith(
+            presetMessages: [PresetMessage(role: 'user', content: 'b v2')],
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // No banner in A1's conversation, and nothing written yet.
+        expect(harness.controller.showPresetSyncBanner, isFalse);
+        expect(
+          harness.chatService.getMessages(a2History).map((m) => m.content),
+          ['b old preset', 'b hello'],
+        );
+
+        // Visiting A2's history conversation surfaces the pending change.
+        harness.controller.chatController.setCurrentConversation(
+          harness.chatService.getConversation(a2History),
+        );
+        await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+        expect(harness.controller.showPresetSyncBanner, isTrue);
+        expect(
+          harness.chatService.getMessages(a2History).map((m) => m.content),
+          ['b old preset', 'b hello'],
+        );
+      });
+    },
+  );
+
+  testWidgets('cold-start assistant load does not raise the preset banner', (
+    tester,
+  ) async {
+    final harness = await _pumpHarness(tester);
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      // Seed the assistant + a history conversation in the repository
+      // BEFORE the provider loads, mirroring production: the controller
+      // attaches its listener to an empty AssistantProvider, then the DB
+      // load notifies. A null previous fingerprint is not an edit.
+      final seeded = Assistant(
+        id: 'seeded-a1',
+        name: 'Seeded',
+        presetMessages: [PresetMessage(role: 'user', content: 's v1')],
+      );
+      await harness.chatService.repo.putAssistant(seeded);
+      final convo = await harness.chatService.createConversation(
+        title: 'Seeded History',
+        assistantId: seeded.id,
+      );
+      await harness.chatService.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'old preset',
+        isPreset: true,
+      );
+      await harness.chatService.addMessage(
+        conversationId: convo.id,
+        role: 'user',
+        content: 'hello',
+      );
+
+      await harness.assistants.ensureLoaded();
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(convo.id),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == convo.id,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(harness.controller.showPresetSyncBanner, isFalse);
+      expect(harness.chatService.getMessages(convo.id).map((m) => m.content), [
+        'old preset',
+        'hello',
+      ]);
+    });
+  });
+
+  testWidgets('a failed apply restores the banner and reports the error', (
+    tester,
+  ) async {
+    final harness = await _pumpHarness(
+      tester,
+      createService: _FailingPresetSyncService.new,
+    );
+    addTearDown(() => harness.dispose(tester));
+
+    await tester.runAsync(() async {
+      final failing = harness.chatService as _FailingPresetSyncService;
+      final a1 = await _addAssistant(harness, 'A1', [
+        PresetMessage(role: 'user', content: 'v1'),
+      ]);
+      final convoId = await _newConversation(
+        harness,
+        'History',
+        a1,
+        presetContent: 'old preset',
+        realContent: 'hello',
+      );
+      harness.controller.chatController.setCurrentConversation(
+        harness.chatService.getConversation(convoId),
+      );
+      await harness.settleFor(
+        () => harness.controller.currentConversation?.id == convoId,
+      );
+
+      final assistant = harness.assistants.getById(a1)!;
+      await harness.assistants.updateAssistant(
+        assistant.copyWith(
+          presetMessages: [PresetMessage(role: 'user', content: 'v2')],
+        ),
+      );
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+
+      failing.failPresetSync = true;
+      await harness.controller.applyPresetsToCurrentConversation();
+      await harness.settleFor(() => harness.controller.showPresetSyncBanner);
+
+      // The banner is restored and nothing was written.
+      expect(harness.controller.showPresetSyncBanner, isTrue);
+      expect(harness.chatService.getMessages(convoId).map((m) => m.content), [
+        'old preset',
+        'hello',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #577. Preset messages were only materialized as `isPreset` rows when a conversation was created, so adding/editing presets on an assistant never reached its existing conversations. This PR adds a sync path plus an explicit user-facing apply flow.

## Behavior

- **Fresh conversations** (no real messages): always auto-sync — on switch, on startup, on preset change, and on new-conversation creation.
- **Conversations with history**: preset changes raise an inline banner under the preset toggle bar with:
  - **Apply here** — replace this conversation's preset rows (new presets go to the top, history keeps its order).
  - **Apply to all** — replace across every conversation of the assistant, behind a confirmation dialog and followed by a result snackbar.
  - **Dismiss** — clear the pending marker until the next preset change.
- Edits made while chatting with another assistant set a pending marker that surfaces when that assistant's history conversation is opened.
- Temporary conversations never show the banner; group conversations and unowned conversations are never touched.

## Implementation notes

- `ChatService.syncPresetMessages` is the single write path (also used by `createNewConversation` via `appendPresetMessages`): delete stale preset rows (standard trash + LAN deletion-marker bookkeeping), re-index `messageOrder`, and shift `truncateIndex` so the clear-context split keeps excluding the same messages. `truncateIndex <= 0` is preserved as a no-op marker.
- Per-conversation serialization (`_presetSyncTails`) keeps overlapping syncs from interleaving delete/append passes.
- Fresh detection uses repo-level `is_preset = 0` counts, not the load window (ADR-0050 rationale).
- Change detection diffs assistant preset fingerprints; a first-seen assistant (cold-start load, newly added) only records a baseline, never raises the banner.
- Apply failures restore the banner and surface `homePagePresetSyncFailed` instead of reporting success.
- While a pending banner exists, the experimental web viewport falls back to the Flutter list so the banner actions stay reachable.

## Verification

- `flutter gen-l10n` — generated files current; `desiredFileName.txt` = `{}` (no untranslated entries).
- `dart format` on all changed Dart paths.
- `dart analyze --fatal-infos lib test` — no issues.
- `flutter test test/core/services/chat test/features/home/controllers` — 209 passed:
  - new `chat_service_preset_sync_test.dart` (18): fresh replace, history top-insert, truncate shifts (including `0`), empty payload, trash record, fidelity cleanup, concurrency, assistant scoping, skipped types.
  - new `home_page_controller_preset_sync_test.dart` (8): fresh self-sync, banner + apply-here, apply-to-all, dismiss, temporary guard, cross-assistant pending, cold-start regression, failure restore.
  - existing preset-recycle (#578/ADR-0050) and controller suites remain green.

## Risks / notes

- Replaced preset rows write trash entries + sync deletion markers (consistent with ADR-0050's "no bypass deletes"); "apply to all" on many conversations can add several small trash entries (capped by the existing 10 MB FIFO).
- Cross-assistant pending uses an "assistant owns persisted conversations" heuristic; a narrow race can raise one dismissible banner for an already-synced conversation (no row writes, because the service re-checks fingerprints).
- LAN merge is append-only for messages: preset content updates do not propagate to a peer's existing rows; removed rows surface as deletion markers.
- Manual UI verification on Windows desktop (banner layout, confirm dialog, snackbars, web-viewport fallback) is still pending.

## Checklist

- [x] New user-visible text uses `AppLocalizations` (4 ARBs in sync; `gen-l10n` run)
- [x] `dart format` executed
- [x] `dart analyze --fatal-infos lib test` clean
- [x] Related test subset executed (209 passed)
- [x] No new database schema changes
- [x] Shared UI / theme tokens reused (no new near-duplicate widgets, no Material ripple)
- [x] Manual desktop UI pass (pending)
