### PR TITLE
feat(desktop): enable process restart on desktop

### DIFF
--- a/lib/utils/platform_utils.dart
+++ b/lib/utils/platform_utils.dart
@@ -32,7 +32,7 @@ abstract final class PlatformUtils {
   static bool get isIOS => Platform.isIOS;
 
   static Future<void> restartApp() async {
-    if (Platform.isAndroid) {
+    if (defaultTargetPlatform == TargetPlatform.android || isDesktopTarget) {
       await Restart.restartApp();
     } else {
       exit(0);

--- a/test/utils/platform_utils_test.dart
+++ b/test/utils/platform_utils_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/utils/platform_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('restart');
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return <String, Object?>{'success': true, 'mode': 'process'};
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  for (final platform in const [
+    TargetPlatform.windows,
+    TargetPlatform.macOS,
+    TargetPlatform.linux,
+    TargetPlatform.android,
+  ]) {
+    test('restartApp routes $platform through the restart plugin', () async {
+      debugDefaultTargetPlatformOverride = platform;
+
+      await PlatformUtils.restartApp();
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'restartApp');
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Syncs upstream Kelivo commit [`1cadc143`](https://github.com/Chevey339/kelivo/commit/1cadc1434352f0782f2b538a32ff62fd58c12613) *feat: enable process restart on desktop*, adapted to the fork's current `restartApp()` body.

- `PlatformUtils.restartApp()` now routes `defaultTargetPlatform == android || isDesktopTarget` through `Restart.restartApp()`; only iOS keeps `exit(0)`.
- Desktop restore/import flows (`backup_pane`, LAN sync, restart-required dialog) now relaunch the app instead of merely quitting it.
- Android path untouched: the fork keeps `Restart.restartApp()` without `RestartMode.process` and without upstream's later result check, so no force-kill behavior change.

## Why it works

`restart_app` 1.9.1's Windows/macOS/Linux implementations accept `platformDefault` and treat it as `process`; the plugin is already registered in all three generated registrants.

## Tests

- New `test/utils/platform_utils_test.dart`: mocks `MethodChannel('restart')` and asserts windows/macOS/linux/android all invoke it.
- The iOS branch (`exit(0)`) cannot be unit-tested (it kills the test process); behavior is unchanged.
- Sanity check: with the old condition the new test process dies (all cases "did not complete").

## Verification

- `dart format` (no changes); `dart analyze --fatal-infos lib test` clean
- `flutter test test/utils/platform_utils_test.dart` -> 4/4 pass
- `flutter build windows --debug` -> built successfully

## Manual test plan

- Happy path: Windows app -> settings/backup -> restore a local backup -> "Restart Required" dialog -> OK -> the app should relaunch.
- Edge: if the native relaunch is rejected (e.g. MSIX/Store package cannot `CreateProcessW`), the app stays open (pre-existing behavior: the fork does not inspect the result).

## Not verified

- Actual relaunch on macOS/Linux (not available locally).
