### PR TITLE
ci: 接入 OpenCodeReview 自动 PR 审查

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -1,0 +1,109 @@
+name: PR Review
+
+# 自动 PR 审查（Alibaba Open Code Review）。
+#
+# 唯一需要人工配置项：
+#   Settings -> Secrets and variables -> Actions -> New repository secret
+#   OCR_LLM_AUTH_TOKEN = Token Plan CN 的 API key
+#
+# 端点 / 模型 / 语言 / 思考开关都写在本文件内，改动走 PR 评审。
+# 升级 action 时，把下面的 pin SHA 与 ocr_version 一起改，并回归验证 .arb 仍被审。
+# Releases: https://github.com/alibaba/open-code-review/releases
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# 匹配事件按 PR 分组，新推送可取消同 PR 上仍在跑的旧审查；
+# 无关评论落到唯一的 noop-<run_id> 组，瞬间跳过且不会打断正在跑的审查。
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event_name == 'pull_request_target'
+        || (
+          github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && github.event.comment.user.type != 'Bot'
+          && (
+            github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'COLLABORATOR'
+          )
+          && (
+            startsWith(github.event.comment.body, '/open-code-review')
+            || startsWith(github.event.comment.body, '@open-code-review')
+          )
+        )
+      )
+      && format('ocr-{0}', github.event.pull_request.number || github.event.issue.number)
+      || format('noop-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  code-review:
+    name: OpenCodeReview
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # PR 事件直接跑；评论触发必须是「人类 + 有写权限」，避免任意评论消耗 LLM 配额。
+    if: |
+      github.event_name == 'pull_request_target'
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && (
+          github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+        && (
+          startsWith(github.event.comment.body, '/open-code-review')
+          || startsWith(github.event.comment.body, '@open-code-review')
+        )
+      )
+    steps:
+      # 评论事件没有 PR payload，需要补 base/head/title。
+      - name: Get PR context
+        id: pr-context
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+            core.setOutput('title', pullRequest.title);
+
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@810aeb5dc2e2b9485f5a1981485e65b25250f609 # v1.11.7
+        with:
+          llm_url: 'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions'
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_model: 'qwen3.8-flash'
+          llm_use_anthropic: 'false'
+          # Qwen 系用顶层 enable_thinking；覆盖 action 默认的 Claude 形状 extra_body。
+          llm_extra_body: '{"enable_thinking": false}'
+          language: 'English'
+          # action 与 CLI 双钉，保证审查行为可复现。
+          ocr_version: '1.11.7'
+          sticky_summary: 'true'
+          # 只审上一次 checkpoint 之后的增量，避免每个 push 重审整条 PR。
+          checkpoint_range: 'true'
+          # PR 标题作为背景上下文；PR 可控文本只经 with/env 传入，绝不拼进 run:。
+          background: ${{ steps.pr-context.outputs.title || github.event.pull_request.title }}
+          base_ref: ${{ steps.pr-context.outputs.base_ref }}
+          head_sha: ${{ steps.pr-context.outputs.head_sha }}

--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -1,0 +1,54 @@
+{
+  "include": ["**/*.arb"],
+  "exclude": [
+    "lib/l10n/app_localizations*.dart",
+    "**/*.g.dart",
+    "**/*.freezed.dart"
+  ],
+  "rules": [
+    {
+      "path": ".github/workflows/*.{yml,yaml}",
+      "rule": "Cuplivo keeps several similar workflow files that must stay in sync (.github/workflows/pr-check.yml, web-ci.yml, build-stable-44.yml, ocr-review.yml). When build, version-bump, secret-injection or dependency-install logic changes in one, check whether the SAME change is required in the others and flag any workflow that was missed. Also enforce: least-privilege permissions:; secrets passed only to the steps that need them; never interpolate PR-controlled values (PR title, branch name, commit message) directly into run: - pass them through env: and quote them; in a pull_request_target workflow never check out, source or execute code or scripts from the PR branch; never commit real credentials (SILICONFLOW_KEY and keystore/alias/password values are injected from repository secrets at build time, and lib/secrets/fallback.dart must keep placeholders only)."
+    },
+    {
+      "path": "**/*.arb",
+      "rule": "Cuplivo localization contract: lib/l10n/app_en.arb, app_zh.arb, app_zh_Hans.arb and app_zh_Hant.arb must be updated in the SAME change. Flag as a bug: a new key added to only some of the four files; @key metadata, placeholders, plurals or select forms that disagree across the four; a key added without a translation in every language (desiredFileName.txt must not gain untranslated entries); keys that are not camelCase with a feature prefix, or that collide with an existing key; an edited message that leaves the other three languages stale. Never hand-edit the generated lib/l10n/app_localizations*.dart (flutter gen-l10n output)."
+    },
+    {
+      "path": "lib/core/database/**/*.dart",
+      "rule": "Drift/SQLite rules (app_database.dart, schema v21 with a migration strategy plus a self-heal pass). A new column or table requires all three in the same change: (a) the schema bump plus migration, (b) the matching entry in AppDatabase._healSchemaIfNeeded()'s heal set, (c) the regression test in test/core/database/schema_heal_discoverable_test.dart - flag whichever is missing. Never add director_message_rows back to the heal set (v14 deliberately dropped it). Group-conversation tables and columns must be wired into clearAllData (child-before-parent FK delete order), _exportChatsToFile and _restoreFromBackupFile together. Business preferences (settings, providers, MCP, worldbooks, memories, tags, TTS/ASR/search services, injection prompts) live in the preference_rows KV table and are reachable only through the BusinessPreferences facade - flag any new shared_preferences use outside BusinessKeyRegistry.localOnlyKeys. Writing Assistant data back to SharedPreferences is a data-loss bug and must be rejected: assistants persist in SQLite, and only the backup settings.json merge may carry them to disk. The two assistant row mappers ChatDatabaseRepository._assistantFromRow and ProactiveCareMessageFlow._assistantFromRow mirror each other over the same columns - flag a field added to one without the other."
+    },
+    {
+      "path": "lib/core/providers/**/*.dart",
+      "rule": "State management is Provider + ChangeNotifier only - flag Riverpod/Bloc/GetX/get_it or any new DI container. A new provider or service must be registered in the MultiProvider tree in lib/main.dart; a provider that is constructed but unregistered is invisible to the widget tree. Read state with context.watch<T>(), trigger actions with context.read<T>(). Business preferences go through the BusinessPreferences facade (SQLite KV), never shared_preferences; shared_preferences is only for device-local state (window geometry, hotkeys, OAuth tokens, chat input draft, workspaces_dir_v1, flutter_log_enabled_v1). Preference keys that arrive by upstream port or rebase must be re-homed to SQLite in the same change - a new key whose read side uses BusinessPreferences while its write side stays raw SharedPreferences silently breaks persistence."
+    },
+    {
+      "path": "lib/core/services/api/**/*.dart",
+      "rule": "These provider implementations are parallel surfaces that share bug patterns and feature gaps: openai_common.dart, claude_official.dart, google_common.dart, google_vertex.dart, google_gemini.dart, openai_responses.dart, openai_images.dart. When a fix or feature lands in one, check whether the same fix is required in the others and name the ones that were missed. All HTTP must go through DioHttpClient (lib/core/services/network/dio_http_client.dart) so SOCKS5 proxy, CancelToken and request logging keep working - flag new raw http.get, bare dio.Dio or ad-hoc client calls. Also flag unvalidated user input reaching a request URL or header, and any API key or token written into logs."
+    },
+    {
+      "path": "lib/desktop/**/*.dart",
+      "rule": "lib/desktop/** is the desktop app shell (nav rail, window title bar, hotkeys, tray, desktop settings), NOT a stretched mobile layout; shared chat content lives in lib/features/home/**. Flag desktop-only control flow added to mobile branches (home_mobile_layout.dart) and mobile-only assumptions leaking into desktop code. HARD CRASH CONSTRAINT: never use Material Slider on Windows paths - it creates an OverlayPortal that corrupts the Windows accessibility tree and crashes the app (issue #119); sliders must use the shared SfSliderTile (lib/shared/widgets/sf_slider_tile.dart) or a custom slider with no OverlayPortal. Desktop interactions need hover, right-click and keyboard paths, not only touch. All user-visible text (labels, tooltips, tray menus) must come from AppLocalizations."
+    },
+    {
+      "path": "lib/theme/**/*.dart",
+      "rule": "lib/theme/** is the single source of truth for theming. The 9 presets in ThemePalettes.all are the only preset source and are never generated at runtime; a custom theme stores ARGB ints and its full M3 ColorScheme is generated at runtime via HCT TONAL_SPOT - never hand-write a ColorScheme. AppSemanticColors is the ThemeExtension for tokens ColorScheme lacks (surfaceFill, surfaceCard, success/warning and their containers, searchHighlight, chartSeries) and is read through context.appColors. Flag raw color literals in UI code: new colors must use scheme roles, AppSemanticColors or theme constants, and a deliberately fixed color must carry a color-gate: ignore marker. Android dynamic color and Custom Theme stay mutually exclusive, with the active Custom Theme winning."
+    },
+    {
+      "path": "lib/**/*.dart",
+      "rule": "Repository-wide Dart rules for lib/**: (1) No user-visible string may be hardcoded in Dart UI code - page titles, button labels, SnackBar/Dialog/Tooltip content, semanticLabel, notification and tray text must all come from AppLocalizations. (2) Never hand-edit generated files (lib/l10n/app_localizations*.dart, lib/core/models/*.g.dart, lib/core/database/app_database.g.dart) - they come from flutter gen-l10n / build_runner. (3) No silent degradation - flag catch (_) {}, swallowed errors, hidden fallback paths, new error-swallowing logic and fake success branches; recoverable errors log context via debugPrint and continue, unrecoverable ones throw a specific exception. (4) The copyWith null-clear trap: on the sentinel pattern (lib/core/models/chat_message.dart, lib/core/providers/settings_provider.dart) copyWith(field: null) CLEARS the field, while on the plain ?? pattern (Conversation, Assistant, WorldBookEntry, AssistantRegex, QuickPhrase) it is a silent no-op - flag any copyWith(field: null) whose intent does not match the model's pattern, and flag mixing both patterns inside one model. (5) When a field is added to a model, check every consumer surface in the same change: copyWith, toJson/fromJson, clone/deep-copy, Drift table/column plus migration plus heal set plus repository read/write, backup/import/export round-trip, and equality when the field is identity-relevant. (6) Reuse the shared UI primitives (lib/shared/widgets/**, lib/shared/dialogs/**, lib/shared/responsive/**, lib/desktop/widgets/** - IosIconButton, IosCardPress, IosTileButton, IosSwitch, IosCheckbox, IosFormTextField, DesktopSelectDropdown, WindowTitleBar) - flag new page-private near-duplicates and Android ripple, Material default splash or default FAB emphasis, because the house style is custom iOS (color, opacity, subtle scale). (7) Navigation is Navigator 1.0 (Navigator.push(MaterialPageRoute(...))) with no go_router/auto_route, and desktop switches pages through the DesktopHomePage sidebar rather than the Navigator stack. (8) Keep it KISS/YAGNI - flag idle abstractions, empty config switches and unrelated refactors mixed into a bug fix; when a bug is fixed in one code path, look for parallel implementations of the same pattern and name the ones left unfixed."
+    },
+    {
+      "path": "test/**/*.dart",
+      "rule": "Test rules: flutter_test only - flag any new mockito/mocktail dependency, because hand-written Fake/Mock classes are the convention. Tests must be driven by the requirement, not by implementation details, and must cover the happy path, boundary inputs, failure paths and state transitions. A bug fix should come with a minimal failing case first; flag an after-the-fact weak-assertion test that would pass either way. Never widen a public API or expose private internals just to make a test possible. New user-visible behaviour needs a manual test plan (happy path plus edge cases) in the delivery notes."
+    },
+    {
+      "path": "dependencies/**/*.dart",
+      "rule": "dependencies/** holds vendored path dependencies treated as independent modules (mcp_client, tray_manager/packages/tray_manager, flutter_tts, flutter-permission-handler/permission_handler_windows). A fix or feature must land in the dependency's own source, not only be patched at the root repo surface - flag root-level workarounds that leave the dependency itself inconsistent. Flag changes that diverge from upstream without a stated reason, and check that the root package still compiles against the changed API. Do not raise style-only findings here: prefer regressions the change introduces."
+    },
+    {
+      "path": "**/*.dart",
+      "rule": "Apply the repository rules in AGENTS.md: localize every user-visible string, never hand-edit generated files, add no silent fallbacks or swallowed errors, keep the change to the minimum closed loop needed for the task, and do not mix unrelated refactoring into it."
+    }
+  ]
+}


### PR DESCRIPTION
## 目的

给 Cuplivo 加上**自动 PR 审查**：PR 打开/更新/重开时自动跑 [Alibaba Open Code Review (OCR)](https://open-codereview.ai/docs)，把发现以 **inline review comment + sticky 汇总评论**的形式发到 PR 上；协作成员评论 `/open-code-review` 可手动重跑。

**只发评论，不做 required check，不阻塞合并。**

## 改动（2 个新文件，163 行，不含任何 Dart/ARB 改动）

### 1. `.github/workflows/ocr-review.yml`
- 触发：`pull_request_target`（target `master`，opened / synchronize / reopened）+ `issue_comment`（限 MEMBER / OWNER / COLLABORATOR 且排除 Bot，避免任意评论消耗 LLM 配额）
- action 与 CLI **双钉 v1.11.7**：`alibaba/open-code-review@810aeb5dc2…f609` + `ocr_version: '1.11.7'`，保证审查行为可复现
- LLM：Token Plan CN 端点 + `qwen3.8-flash`，`llm_extra_body: '{"enable_thinking": false}'`（Qwen 系用顶层 `enable_thinking`，覆盖 action 默认的 Claude 形状 body）
- `checkpoint_range: true`：每个 push 只审上一次 checkpoint 之后的增量（fail-closed，base 变动/强制推送时自动退回全量）
- 安全：`permissions` 仅 `contents: read` + `pull-requests: write`；workflow 内不 checkout、不执行 PR 代码；规则文件取自 default branch 检出（PR 无法放宽自己的审查规则）；PR 可控文本只经 `with:`/`env:` 传入，绝不拼进 `run:`

### 2. `.opencodereview/rule.json`
OCR 内置规则**没有 Dart 层**（`.dart` 落到 `default.md`），且 `.arb` 不在其支持文件类型白名单内。这个文件把 AGENTS.md 的硬约束变成审查提示词，按作用域分派：

`.github/workflows/*` → 同类 workflow 同步纪律、secrets/注入安全 ｜ `**/*.arb` → 4 个 ARB 必须同步、`@key`/占位符一致、不许手改生成的 `app_localizations*.dart` ｜ `lib/core/database/**` → schema 迁移 + heal set + `schema_heal_discoverable_test.dart` 三件套、BusinessPreferences、assistant 存储禁令、两个 `_assistantFromRow` 镜像 ｜ `lib/core/providers/**` → Provider+ChangeNotifier、必须在 `main.dart` 注册 ｜ `lib/core/services/api/**` → 7 个 provider 并行面、必须走 DioHttpClient ｜ `lib/desktop/**` → Windows 禁用 Material Slider（#119）、桌面/移动入口边界 ｜ `lib/theme/**` → 主题 token、禁止硬编码颜色 ｜ `lib/**` → 本地化、禁止手改生成文件、禁止静默降级、copyWith null 陷阱、更新面完整性、组件复用、Navigator 1.0 ｜ `test/**` → flutter_test only、不用 mockito/mocktail ｜ `dependencies/**` → path 依赖作为独立模块

其中 `include: ["**/*.arb"]` 是让 ARB 文件进入审查的唯一手段；`exclude` 挡住约 74k 行的生成物。

## ⚠️ 合并前必须做的一件事：填 API key

**Settings → Secrets and variables → Actions → New repository secret**

| Name | Value |
|---|---|
| `OCR_LLM_AUTH_TOKEN` | Token Plan CN 的 API key（`sk-…`） |

只需这一个 secret，不需要新增 variable，也不用改分支保护。**在填之前 workflow 会在 PR 上红叉（认证失败），但不阻塞合并。**

## 验证记录

| 验证 | 结果 |
|---|---|
| `ocr rules check` × 13 个代表路径 | 全部命中预期规则；`lib/main.dart` → `lib/**/*.dart` 证明 `/**/` 匹配零级目录 |
| `ocr review --preview` 对 commit `765d95c0`（同时改了 4 个 `.arb` + 3 个生成的 `app_localizations*.dart`） | 4 个 `.arb` **全部进入审查**，3 个生成文件 `user_exclude` 排除 |
| `ocr review --preview` 对改 `app_database.g.dart` 的 commit | `.g.dart` 被 `user_exclude` 排除 |
| `action-validator` 校验全部 4 个 workflow | 4/4 通过（GitHub Actions schema） |
| 拉取 pin SHA 的 `action.yml` 逐项比对 `with:` | 12 个键全部存在、4 个必填项齐全、无拼写错误 |
| `ocr version` | 报 `v1.11.7 (810aeb5dc2)`，与 pin SHA 一致 |

**未跑 / 跳过：**
- `dart analyze --fatal-infos lib test`：本机 Flutter 为 3.44.8，而 repo 要求 `>=3.44.9`（CI 钉 3.44.9），`flutter pub get` 版本求解失败 → 无 `package_config.json` → analyzer 输出 112,687 条假错误（AGENTS.md §3.4 记录的陷阱），无回归意义。本 PR **不含任何 Dart/ARB 改动**，CI 的 `Analyze / Test / L10n / Format` 会正常覆盖。
- `dart format`：不适用（仅 YAML/JSON）。
- 真实 LLM 审查未在本地跑（会消耗配额），改由合并后的端到端验收覆盖。

## 合并后必做的验收

`pull_request_target` 自 2025-12 起强制以 default branch 作为 workflow 来源，**所以本 PR 自己不会触发审查**（预期行为），需合并到 master 后再验证：

1. 开一个临时 PR，故意只改 `lib/l10n/app_en.arb` 制造 4 文件不同步 → 应出现 `OpenCodeReview` check + inline 评论指出该违规
2. 再 push 一个 commit → `range_summary` 应显示 `checkpoint (ok)`（只审增量）
3. 在该 PR 评论 `/open-code-review` → 应能手动重跑
4. 关闭临时 PR

## 风险 / 回滚

- 首跑若认证失败 → 检查 `OCR_LLM_AUTH_TOKEN`
- `qwen3.8-flash` 在该端点若对 `enable_thinking` 报 400 → 把 `llm_extra_body` 换成 action 默认值或删掉该行
- 想升级为卡合并的必需检查：Settings → Branches → master → Require status checks 勾 `OpenCodeReview`（不在本 PR 范围）
- 回滚：删除这两个文件即可，无数据/配置残留

## Pre-launch Checklist

- [x] 改动仅限 CI 配置，不含 Dart/ARB/生成文件
- [x] workflow 通过 GitHub Actions schema 校验，action 输入与 pin 的 `action.yml` 逐项比对一致
- [x] `permissions` 最小化；未在 `pull_request_target` 中执行 PR 代码
- [x] 未提交任何真实密钥（key 由仓库 secret 注入）
- [ ] 未跑 `dart analyze`（原因见上：本机 SDK 版本不足，且本 PR 无 Dart 改动）
- [ ] 未做平台目标验证（未改 `android/ ios/ macos/ linux/ windows/`）
