### PR TITLE
fix(ci): 修复 OCR 审查首跑崩溃（CLI 自更新竞争）并把 job 上限提到 60 分钟

### DIFF
--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -52,7 +52,10 @@ jobs:
   code-review:
     name: OpenCodeReview
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 60 分钟上限的依据：本机 75 个真实 OCR 会话实测中位 9.6 分钟、p90 17.6 分钟；
+    # 再用最近 22 个 PR 的 --preview 标定，中位 8.9 分钟、p90 21.1 分钟，
+    # 最大 49.6 分钟（上游同步类 PR、61 个可审文件）。30 分钟会把这类 PR 整个取消。
+    timeout-minutes: 60
     # PR 事件直接跑；评论触发必须是「人类 + 有写权限」，避免任意评论消耗 LLM 配额。
     if: |
       github.event_name == 'pull_request_target'

--- a/.github/workflows/ocr-review.yml
+++ b/.github/workflows/ocr-review.yml
@@ -52,6 +52,13 @@ jobs:
   code-review:
     name: OpenCodeReview
     runs-on: ubuntu-latest
+    # OCR CLI 启动器（bin/ocr.js）默认在后台 detached 自查更新，并执行
+    # npm i -g @alibaba-group/open-code-review@latest：它会替换 /usr/local/bin/ocr，
+    # 与同 job 里并发的 ocr 调用竞争（2026-09-10 首次运行即因此崩在 Configure OCR：
+    # Cannot find module '/usr/local/bin/ocr'），还会把 ocr_version 的 pin 换成 latest。
+    # 官方 action.yml 未设置该开关，必须自己关；runner 无 last-update-check，首跑必触发。
+    env:
+      OCR_NO_UPDATE: '1'
     # 60 分钟上限的依据：本机 75 个真实 OCR 会话实测中位 9.6 分钟、p90 17.6 分钟；
     # 再用最近 22 个 PR 的 --preview 标定，中位 8.9 分钟、p90 21.1 分钟，
     # 最大 49.6 分钟（上游同步类 PR、61 个可审文件）。30 分钟会把这类 PR 整个取消。


### PR DESCRIPTION
## 两个改动（同一文件，+11 / -1）

### 1. 修复首次真实运行的崩溃（`fix`）

2026-09-10 本 PR 打开后，新增的 `OpenCodeReview` check 第一次真跑就挂了（[run 34497517021](https://github.com/cuplivo/cuplivo/actions/runs/34497517021)，18 秒失败）：

```
Configure OCR: Error: Cannot find module '/usr/local/bin/ocr'
```

job 结束时的清理日志里还留着一个 `npm i @alibaba-` 进程。

**根因**（OCR CLI 的自更新机制，不是我们的配置错）：

| 证据 | 位置 |
|---|---|
| 未设 `OCR_NO_UPDATE` 时，启动器在后台 spawn 一个 **detached** 的更新脚本 | `bin/ocr.js:89` |
| 该脚本执行 `npm i -g @alibaba-group/open-code-review@<latest>` | `scripts/update.js:153` |
| 冷却判断依赖 `~/.opencodereview/last-update-check`，**全新 runner 没有这个文件** | `bin/ocr.js:92-99` |
| 官方 `action.yml` **没有**设置该开关（所以官方 action 同样暴露在这个竞争下） | 上游 `action.yml` |

它替换 `/usr/local/bin/ocr` 时，正好撞上同一 job 里连续十几次 `ocr config set` 调用 → `Cannot find module`。附带后果更严重：**它会把 `ocr_version: '1.11.7'` 的 pin 悄悄换成 latest**（本机安装就是这么从 1.11.7 被升到 1.11.8 的）。

**修复**：job 级 `env: OCR_NO_UPDATE: '1'`，让启动器跳过更新检查——消除竞争，同时让 `ocr_version` 的 pin 真正生效。

### 2. job 上限 30 → 60 分钟（`chore`）

30 分钟会**整段取消**超大 PR 的审查（取消时评论还没发布，等于白跑）。依据是实测而非拍脑袋：

- **本机 75 个真实 OCR 会话**：耗时中位 **9.6 分钟**、p90 **17.6 分钟**、最大 **29.9 分钟**；吞吐 **1.23 items/分钟**
- **最近 22 个 merge commit 用 `ocr review --preview`（免 token）标定**可审文件数后换算：中位 **8.9 分钟**、p90 **21.1 分钟**、最大 **49.6 分钟**（上游同步类 PR，61 个可审文件）

| PR 规模 | 可审文件 | 预测耗时 |
|---|---|---|
| 小修（#790/#749/#799） | 2 | ~1.6 分钟 |
| 常见（#747/#746/#753/#796/#752…） | 7–11 | 5.7–8.9 分钟 |
| 中等（#797 / #611） | 20–26 | 16.3 / 21.1 分钟 |
| 上游同步类（#640 等） | 58–61 | **47–50 分钟** ❌ 30 分钟必被取消 |

60 分钟让最坏情况（约 50 分钟）也能跑完并发布评论。

## 不改的部分

`review_task_timeout`（单任务 15 分钟）、`llm_timeout`（单请求 300 秒）、并发 8、`effort` 默认、`checkpoint_range`、`ocr_version: '1.11.7'` 全部不动。

## 验证

- `action-validator` + YAML 解析通过
- 本 PR 恢复后的运行用于验证修复：预期这次能走过 Configure OCR 并真正产出评论（上一版必崩）
- `Analyze / Test / L10n / Format` 覆盖（纯 YAML 改动）

## Pre-launch Checklist

- [x] 仅 CI 配置改动，无 Dart/ARB/生成文件
- [x] 改动经 schema 校验
- [x] 未提交任何密钥
- [x] 未改其他 workflow
