### PR TITLE
chore(ci): OpenCodeReview 排除所有测试文件

### DIFF
--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -3,7 +3,8 @@
   "exclude": [
     "lib/l10n/app_localizations*.dart",
     "**/*.g.dart",
-    "**/*.freezed.dart"
+    "**/*.freezed.dart",
+    "**/*_test.dart"
   ],
   "rules": [
     {

--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -4,7 +4,14 @@
     "lib/l10n/app_localizations*.dart",
     "**/*.g.dart",
     "**/*.freezed.dart",
-    "**/*_test.dart"
+    "**/test/**",
+    "**/integration_test/**",
+    "**/androidtest/**",
+    "**/runnertests/**",
+    "**/*_test.*",
+    "**/*-test.*",
+    "**/*.test.*",
+    "**/*.spec.*"
   ],
   "rules": [
     {
@@ -38,10 +45,6 @@
     {
       "path": "lib/**/*.dart",
       "rule": "Repository-wide Dart rules for lib/**: (1) No user-visible string may be hardcoded in Dart UI code - page titles, button labels, SnackBar/Dialog/Tooltip content, semanticLabel, notification and tray text must all come from AppLocalizations. (2) Never hand-edit generated files (lib/l10n/app_localizations*.dart, lib/core/models/*.g.dart, lib/core/database/app_database.g.dart) - they come from flutter gen-l10n / build_runner. (3) No silent degradation - flag catch (_) {}, swallowed errors, hidden fallback paths, new error-swallowing logic and fake success branches; recoverable errors log context via debugPrint and continue, unrecoverable ones throw a specific exception. (4) The copyWith null-clear trap: on the sentinel pattern (lib/core/models/chat_message.dart, lib/core/providers/settings_provider.dart) copyWith(field: null) CLEARS the field, while on the plain ?? pattern (Conversation, Assistant, WorldBookEntry, AssistantRegex, QuickPhrase) it is a silent no-op - flag any copyWith(field: null) whose intent does not match the model's pattern, and flag mixing both patterns inside one model. (5) When a field is added to a model, check every consumer surface in the same change: copyWith, toJson/fromJson, clone/deep-copy, Drift table/column plus migration plus heal set plus repository read/write, backup/import/export round-trip, and equality when the field is identity-relevant. (6) Reuse the shared UI primitives (lib/shared/widgets/**, lib/shared/dialogs/**, lib/shared/responsive/**, lib/desktop/widgets/** - IosIconButton, IosCardPress, IosTileButton, IosSwitch, IosCheckbox, IosFormTextField, DesktopSelectDropdown, WindowTitleBar) - flag new page-private near-duplicates and Android ripple, Material default splash or default FAB emphasis, because the house style is custom iOS (color, opacity, subtle scale). (7) Navigation is Navigator 1.0 (Navigator.push(MaterialPageRoute(...))) with no go_router/auto_route, and desktop switches pages through the DesktopHomePage sidebar rather than the Navigator stack. (8) Keep it KISS/YAGNI - flag idle abstractions, empty config switches and unrelated refactors mixed into a bug fix; when a bug is fixed in one code path, look for parallel implementations of the same pattern and name the ones left unfixed."
-    },
-    {
-      "path": "test/**/*.dart",
-      "rule": "Test rules: flutter_test only - flag any new mockito/mocktail dependency, because hand-written Fake/Mock classes are the convention. Tests must be driven by the requirement, not by implementation details, and must cover the happy path, boundary inputs, failure paths and state transitions. A bug fix should come with a minimal failing case first; flag an after-the-fact weak-assertion test that would pass either way. Never widen a public API or expose private internals just to make a test possible. New user-visible behaviour needs a manual test plan (happy path plus edge cases) in the delivery notes."
     },
     {
       "path": "dependencies/**/*.dart",


### PR DESCRIPTION
## 背景

OpenCodeReview 当前会审核 PR 中的测试文件。OCR 内置默认只排除部分语言的测试命名，并没有完整覆盖 Cuplivo 的 Flutter、Web 和原生平台测试结构。

本 PR 改用 OCR 官方项目级 `user_exclude`，在文件进入 LLM 之前排除所有明确的测试路径和测试命名，减少审核噪声与 token 消耗。

官方文档：https://github.com/alibaba/open-code-review/blob/fbc11045bde7e37fee6268119cb9949a9a3474d1/pages/src/content/docs/en/review-rules.md

## 改动（1 文件，+9 / -5）

`.opencodereview/rule.json` 顶层 `exclude` 新增：

```json
"**/test/**",
"**/integration_test/**",
"**/androidtest/**",
"**/runnertests/**",
"**/*_test.*",
"**/*-test.*",
"**/*.test.*",
"**/*.spec.*"
```

OCR 的 glob 匹配不区分大小写，因此 `androidtest` / `runnertests` 分别覆盖 `androidTest` / `RunnerTests`。

同时删除 `test/**/*.dart` 审核规则：所有 `test/` 内容都已由高优先级 `exclude` 丢弃，继续保留该规则会成为永远不可达的死配置。

## 覆盖范围

- Flutter/Dart：`test/**`、`integration_test/**`、`*_test.*`
- 依赖包：`dependencies/**/test/**`
- Web：`test/**`、`*.test.*`、`*.spec.*`、`*-test.*`
- Android：`src/test/**`、`androidTest/**`
- iOS/macOS：`RunnerTests/**`
- 测试辅助文件、fixtures、golden 等只要位于明确的测试目录，也一起排除

## 防误伤边界

没有采用 `**/*test*/**` 或通用 `**/tests/**`：这类过宽 glob 会误伤生产代码，例如仓库现有：

```text
android/.../src/main/java/.../file/tests/FileUtilsTests.java
```

fixture 验证还确认 `src/main/java/com/example/tests/ProductionHelper.java` 继续进入审核。CI workflow 如 `.github/workflows/test.yml` 也是配置代码，不会因为文件名包含 `test` 而被排除。

## OCR v1.11.7 验证（与 CI pin 完全一致）

在临时 git 仓库构造 11 个文件：

```text
Will review (2):
  lib/keep.dart
  src/main/java/com/example/tests/ProductionHelper.java

Excluded from review (9):
  android/app/src/androidTest/Example.kt          (user_exclude)
  dependencies/pkg/test/helper.dart               (user_exclude)
  integration_test/app.dart                       (user_exclude)
  ios/RunnerTests/RunnerSpec.swift                 (user_exclude)
  misc/widget_test.dart                            (user_exclude)
  test/support/helper.dart                         (user_exclude)
  web/protocol.spec.js                             (user_exclude)
  web/protocol.test.mjs                            (user_exclude)
  website/scripts/e2e-test.ts                      (user_exclude)
```

## 生效边界

`pull_request_target` 会从 base/master 读取规则，因此本 PR 的自动审核仍使用 master 上的旧规则；本配置合并后才对之后的 OCR 运行生效。合并后可在 #811（含测试文件）评论 `/open-code-review` 做线上验收。

## 验证命令

- `python3 -m json.tool .opencodereview/rule.json`
- `git diff --check`
- `OCR_NO_UPDATE=1 npm exec --yes --package=@alibaba-group/open-code-review@1.11.7 -- ocr review --preview --repo <fixture> --commit HEAD`
- 未运行 Dart analyze/test：本改动仅影响 OCR 文件过滤，不改变应用代码或 CI 测试执行

## Pre-launch Checklist

- [x] 仅修改 `.opencodereview/rule.json`
- [x] 使用 OCR 官方 `exclude` / `user_exclude` 机制
- [x] 与 CI 相同的 OCR v1.11.7 验证
- [x] 所有测试样本均显示为 `user_exclude`
- [x] 普通源码及生产 `tests` 包未被误伤
- [x] 删除不可达的测试审核规则
- [x] 未提交密钥、生成文件或无关改动
