### PR TITLE
fix(chat): 将消息中的裸链接渲染为可点击超链接（http/https/orpheus）

### DIFF
--- a/lib/shared/widgets/markdown_with_highlight.dart
+++ b/lib/shared/widgets/markdown_with_highlight.dart
@@ -361,6 +361,19 @@ class _MarkdownWithCodeHighlightState extends State<MarkdownWithCodeHighlight> {
       if (linkIdxInline != -1) {
         inlineComponents[linkIdxInline] = LineSafeLinkMd();
       }
+      // Auto-link bare URLs (https?:// and app deep-link schemes like
+      // orpheus://) so they are tappable; gpt_markdown leaves them as plain
+      // text (issue #314). Inserted right after the markdown-link component
+      // so explicit [text](url) links keep priority in the combined scan.
+      final bareUrlIdx = inlineComponents.indexWhere(
+        (c) => c is BareUrlAutolinkMd,
+      );
+      if (bareUrlIdx == -1) {
+        inlineComponents.insert(
+          linkIdxInline != -1 ? linkIdxInline + 1 : 0,
+          BareUrlAutolinkMd(),
+        );
+      }
       // Keep escaped punctuation out of block parsing so it cannot split
       // \( ... \) math containing \{...\}; inline math is registered ahead of it.
       inlineComponents.add(BackslashEscapeMd());
@@ -5965,6 +5978,61 @@ class EscapeAwareTableMd extends TableMd {
 }
 
 // Prevent link regex from spanning across lines (dotAll=true in engine).
+/// Auto-links bare URLs printed as plain text.
+///
+/// gpt_markdown only renders `[text](url)` markdown links and `<a>` HTML
+/// tags, so a URL written directly in prose stays plain and untappable
+/// (issue #314). This inline component recognizes explicitly-schemed URLs
+/// only — `http://`, `https://`, plus the `orpheus://` music deep-link
+/// scheme — keeping detection conservative. URLs inside markdown
+/// links/images are left to ATagMd/ImageMd via the `](` lookbehind, and
+/// trailing sentence punctuation is excluded from the link target.
+class BareUrlAutolinkMd extends InlineMd {
+  @override
+  RegExp get exp => RegExp(
+    r'''(?<!\]\()(?:https?|orpheus)://[^\s<>()\[\]{}“”‘’、。！，：；？《》「」『』〈〉]+''',
+  );
+
+  static final RegExp _trailingPunctuation = RegExp(
+    r'''[.,;:!?"\'…。，；：！？）】」』〉〗〕]+$''',
+  );
+
+  @override
+  InlineSpan span(BuildContext context, String text, GptMarkdownConfig config) {
+    final match = exp.firstMatch(text);
+    if (match == null) return TextSpan(text: text, style: config.style);
+
+    var url = match.group(0)!;
+    var suffix = '';
+    final punct = _trailingPunctuation.firstMatch(url);
+    if (punct != null && punct.start > 0) {
+      suffix = url.substring(punct.start);
+      url = url.substring(0, punct.start);
+    }
+    if (url.isEmpty) return TextSpan(text: text, style: config.style);
+
+    final cs = Theme.of(context).colorScheme;
+    final linkStyle = (config.style ?? const TextStyle()).copyWith(
+      color: cs.primary,
+      decoration: TextDecoration.none,
+    );
+
+    return TextSpan(
+      children: [
+        WidgetSpan(
+          baseline: TextBaseline.alphabetic,
+          alignment: PlaceholderAlignment.baseline,
+          child: GestureDetector(
+            onTap: () => config.onLinkTap?.call(url, url),
+            child: Text(url, style: linkStyle),
+          ),
+        ),
+        if (suffix.isNotEmpty) TextSpan(text: suffix, style: config.style),
+      ],
+    );
+  }
+}
+
 class LineSafeLinkMd extends ATagMd {
   @override
   RegExp get exp =>


### PR DESCRIPTION
## 关联 Issue

Fixes #314

## 问题

gpt_markdown 的 inline 组件只有 `[text](url)` 语法与 `<a>` HTML 标签，没有裸 URL 的 autolink 组件。AI 回复中直接输出的 URL（如 `https://github.com/...`）渲染为纯文本，无法点击，用户需要手动复制。同时音乐类 App deep-link（`orpheus://song/123`）也无法通过点击唤起对应应用。

## 修复

在 `markdown_with_highlight.dart` 中新增 `BareUrlAutolinkMd` inline 组件并注册：

**保守识别（按 #314 的处理建议）：**
- 只识别带明确协议的 URL：`http://`、`https://`，并顺带支持 `orpheus://`（网易云音乐 deep-link，点击直接唤起 App 播放）；
- 不识别裸域名（如 `github.com/foo`），避免误判。

**边界处理（按 #314 的处理建议）：**
- URL 结尾的中英文标点（`。，；：！？…` / `. , ; : ! ? ) ] ` 等）不并入链接目标；
- markdown 链接/图片内的 URL 通过 `](` lookbehind 保护，不会被二次包装，`ATagMd`/`ImageMd` 优先级不变。

**点击链路：**
- 复用现有 `onLinkTap` → `_handleLinkTap` → `launchUrl(mode: externalApplication)`，http/https 走浏览器，自定义 scheme 直接唤起对应 App，无新增权限与依赖。

## 改动范围

单文件：`lib/shared/widgets/markdown_with_highlight.dart`
- 新增 `BareUrlAutolinkMd` 类（约 55 行，带文档注释）；
- 注册一行（插入在 `LineSafeLinkMd` 之后，保证显式 markdown 链接优先）。

## 验证场景

- `https://github.com/cuplivo/cuplivo` → 渲染为可点击链接，跳浏览器；
- `orpheus://song/123` → 渲染为可点击链接，唤起网易云音乐；
- `[文本](https://a.b/c)` 与 `![alt](https://a.b/c.png)` → 渲染行为不变；
- `详见 https://a.b/c。` → 句尾中文句号不并入链接；
- 代码块内 URL → 不受影响（代码块在预处理阶段已被 mask）。