### PR TITLE
feat(chat): support OAuth Responses reasoning previews (port of Chevey339/kelivo#1010)

### DIFF
--- a/assets/web_chat/app.mjs
+++ b/assets/web_chat/app.mjs
@@ -24,6 +24,7 @@ import {
   messageIndexAtOffset,
   normalizeMeasuredHeight,
   normalizeContentInset,
+  latestReasoningPreview,
   partitionThinkingSteps,
   receiveTransferChunk,
   reduceEnvelope,
@@ -727,6 +728,7 @@ function disclosure({
   className,
   icon = null,
   detailNode = null,
+  previewNode = null,
   onToggle,
 }) {
   const root = document.createElement('section');
@@ -775,7 +777,7 @@ function disclosure({
   const leading = icon ? iconNode(icon, 'disclosure-icon') : null;
   const chevron = iconNode('next', 'disclosure-chevron');
   header.replaceChildren(...[leading, title, detailNode, chevron].filter(Boolean));
-  root.append(header, body);
+  root.append(header, ...[previewNode, body].filter(Boolean));
   updateDisclosure(root, header, body, Boolean(expanded));
   return root;
 }
@@ -1330,6 +1332,20 @@ function ensureReasoningElapsedTimer() {
   }
 }
 
+// Collapsed reasoning cards show the newest fragment while the model is
+// still thinking, mirroring the Flutter `_AnimatedReasoningPreview`.
+function createReasoningPreviewNode(segment, expanded) {
+  if (expanded || !segment.loading) return null;
+  if (state.display?.showCollapsedReasoningPreview === false) return null;
+  const preview = latestReasoningPreview(segment.text ?? '');
+  if (preview.length === 0) return null;
+  const node = document.createElement('div');
+  node.className = 'thinking-preview';
+  node.dataset.reasoningPreview = 'true';
+  node.textContent = preview;
+  return node;
+}
+
 function renderReasoningSegment(message, segment, index, parent) {
   const kind = segment.kind ?? 'legacy';
   const segmentIndex = Number.isInteger(segment.index) ? segment.index : index;
@@ -1355,6 +1371,7 @@ function renderReasoningSegment(message, segment, index, parent) {
     className: 'thinking',
     icon: 'reasoning',
     detailNode: createReasoningElapsedNode(segment),
+    previewNode: createReasoningPreviewNode(segment, expanded),
     onToggle: (next) => {
       if (kind === 'legacy') {
         localExpansions.set(key, next);

--- a/assets/web_chat/protocol.mjs
+++ b/assets/web_chat/protocol.mjs
@@ -1,5 +1,5 @@
 export const PROTOCOL_VERSION = 5;
-export const ASSET_VERSION = 'web-chat-v22';
+export const ASSET_VERSION = 'web-chat-v23';
 
 const transfers = new Map();
 
@@ -702,6 +702,40 @@ export function formatReasoningElapsed(startAt, finishedAt, loading, now = Date.
       : start;
   if (!Number.isFinite(end)) return '';
   return `(${(Math.max(0, end - start) / 1000).toFixed(1)}s)`;
+}
+
+// Mirrors the Flutter `latestReasoningPreview`: providers often stream one
+// cumulative summary string, so a collapsed card should show the newest
+// fragment rather than the whole accumulated text.
+export function latestReasoningPreview(raw, maxCharacters = 96) {
+  let value = String(raw ?? '').replaceAll('\r', '').trim();
+  if (value.length === 0) return '';
+
+  const lines = value.split('\n').map((line) => line.trim()).filter(Boolean);
+  if (lines.length > 0) value = lines[lines.length - 1];
+
+  const fragments = value.split('**').map((f) => f.trim()).filter(Boolean);
+  if (fragments.length > 1) value = fragments[fragments.length - 1];
+
+  const sentences = value
+    .split(/[.!?\u3002\uff01\uff1f\uff1b;]+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+  if (sentences.length > 1) value = sentences[sentences.length - 1];
+
+  value = value
+    .replace(/^[\s>*_`~-]+/, '')
+    .replace(/[\s>*_`~]+$/, '')
+    .trim();
+  if (value.length === 0) return '';
+  if (value.length <= maxCharacters) return value;
+
+  let tail = value.slice(value.length - maxCharacters);
+  const firstWhitespace = /\s/.exec(tail);
+  if (firstWhitespace && firstWhitespace.index < tail.length - 12) {
+    tail = tail.slice(firstWhitespace.index + 1);
+  }
+  return `\u2026${tail.trim()}`;
 }
 
 function parseTimestamp(value) {

--- a/assets/web_chat/styles.css
+++ b/assets/web_chat/styles.css
@@ -680,6 +680,19 @@ body[data-background-style="defaultStyle"] .html-preview {
 }
 .thinking-body, .tool-body { font-size: calc(12.5px * var(--cuplivo-font-scale)); line-height: 1.32; }
 .thinking-body[hidden], .tool-body[hidden], .markdown[hidden], .html-preview-body[hidden] { display: none; }
+.thinking-preview {
+  position: relative;
+  z-index: 1;
+  margin: 0 4px 6px 39px;
+  font-size: calc(12.5px * var(--cuplivo-font-scale));
+  line-height: 1.32;
+  color: var(--cuplivo-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.thinking.is-expanded > .thinking-preview { display: none; }
 .tool-body > pre {
   max-width: 100%;
   overflow: auto;

--- a/assets/web_chat/styles.css
+++ b/assets/web_chat/styles.css
@@ -26,6 +26,8 @@
   --cuplivo-user-avatar-background: Canvas;
   --cuplivo-assistant-avatar-background: Canvas;
   --cuplivo-font-scale: 1;
+  /* Shared left inset for disclosure bodies and their collapsed preview. */
+  --cuplivo-disclosure-indent: 39px;
   --cuplivo-default-app-font: system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
   --cuplivo-default-code-font: ui-monospace, SFMono-Regular, Menlo, Monaco,
@@ -675,7 +677,7 @@ body[data-background-style="defaultStyle"] .html-preview {
   position: relative;
   z-index: 1;
   border-top: 1px solid var(--cuplivo-outline-soft);
-  padding: 8px 4px 10px 39px;
+  padding: 8px 4px 10px var(--cuplivo-disclosure-indent);
   white-space: pre-wrap;
 }
 .thinking-body, .tool-body { font-size: calc(12.5px * var(--cuplivo-font-scale)); line-height: 1.32; }
@@ -683,16 +685,18 @@ body[data-background-style="defaultStyle"] .html-preview {
 .thinking-preview {
   position: relative;
   z-index: 1;
-  margin: 0 4px 6px 39px;
+  margin: 0 4px 6px var(--cuplivo-disclosure-indent);
   font-size: calc(12.5px * var(--cuplivo-font-scale));
   line-height: 1.32;
   color: var(--cuplivo-muted);
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: anywhere;
 }
-.thinking.is-expanded > .thinking-preview { display: none; }
+.disclosure.is-expanded > .thinking-preview { display: none; }
 .tool-body > pre {
   max-width: 100%;
   overflow: auto;

--- a/assets/web_chat/test/protocol.test.mjs
+++ b/assets/web_chat/test/protocol.test.mjs
@@ -105,14 +105,14 @@ test('transfer chunks reassemble UTF-8 snapshots', () => {
 });
 
 test('snapshot reducer rejects an older revision in the same session', () => {
-  const current = { type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v22', renderSessionId: 's', renderRevision: 4, messages: [] };
+  const current = { type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v23', renderSessionId: 's', renderRevision: 4, messages: [] };
   const older = { ...current, renderRevision: 3, messages: [{ id: 'old' }] };
   assert.equal(reduceEnvelope(current, older), current);
 });
 
 test('new snapshots retain resolved opaque media only in the same session', () => {
   const current = {
-    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v22',
+    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v23',
     renderSessionId: 's', renderRevision: 4, messages: [],
     media: { 'asset:icon': 'data:image/svg+xml;base64,PHN2Zy8+' },
   };
@@ -495,7 +495,7 @@ test('typed appearance maps only the three supported surfaces and clears default
 
 test('same-session streaming snapshots preserve a newer live patch', () => {
   const state = {
-    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v22',
+    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v23',
     renderSessionId: 's', conversationId: 'c', renderRevision: 2,
     messages: [{ id: 'm', content: 'new', isStreaming: true, streamRevision: 7 }],
   };
@@ -510,7 +510,7 @@ test('same-session streaming snapshots preserve a newer live patch', () => {
 
 test('live translation survives unrelated snapshots until it is finalized', () => {
   const state = {
-    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v22',
+    type: 'snapshot', protocolVersion: 5, assetVersion: 'web-chat-v23',
     renderSessionId: 's', conversationId: 'c', renderRevision: 2,
     messages: [{
       id: 'm', content: 'answer', isStreaming: false,

--- a/assets/web_chat/test/reasoning_preview.test.mjs
+++ b/assets/web_chat/test/reasoning_preview.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { latestReasoningPreview } from '../protocol.mjs';
+
+test('uses the newest fragment from concatenated summary updates', () => {
+  assert.equal(
+    latestReasoningPreview('**Planning**Checking constraints**'),
+    'Checking constraints',
+  );
+});
+
+test('uses the last non-empty line or sentence', () => {
+  assert.equal(latestReasoningPreview('first step\nsecond step'), 'second step');
+  assert.equal(latestReasoningPreview('first step. second step.'), 'second step');
+});
+
+test('trims a long preview from the current tail', () => {
+  const preview = latestReasoningPreview(
+    'A very long accumulated reasoning summary that keeps growing',
+    24,
+  );
+  assert.ok(preview.startsWith('\u2026'));
+  assert.ok(preview.endsWith('keeps growing'));
+});
+
+test('returns an empty preview for blank input', () => {
+  assert.equal(latestReasoningPreview('   \n  '), '');
+  assert.equal(latestReasoningPreview(null), '');
+});

--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -155,6 +155,8 @@ class SettingsProvider extends ChangeNotifier {
       'display_show_user_message_actions_v1';
   static const String _displayAutoCollapseThinkingKey =
       'display_auto_collapse_thinking_v1';
+  static const String _displayShowCollapsedReasoningPreviewKey =
+      'display_show_collapsed_reasoning_preview_v1';
   static const String _displayCollapseThinkingStepsKey =
       'display_collapse_thinking_steps_v1';
   static const String _displayShowToolResultSummaryKey =
@@ -1305,6 +1307,8 @@ class SettingsProvider extends ChangeNotifier {
         prefs.getBool(_displayShowUserMessageActionsKey) ?? true;
     _autoCollapseThinking =
         prefs.getBool(_displayAutoCollapseThinkingKey) ?? true;
+    _showCollapsedReasoningPreview =
+        prefs.getBool(_displayShowCollapsedReasoningPreviewKey) ?? true;
     _collapseThinkingSteps =
         prefs.getBool(_displayCollapseThinkingStepsKey) ?? false;
     _showToolResultSummary =
@@ -4557,6 +4561,17 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     await prefs.setBool(_displayAutoCollapseThinkingKey, v);
   }
 
+  // Display: show the latest reasoning fragment in collapsed thinking cards.
+  bool _showCollapsedReasoningPreview = true;
+  bool get showCollapsedReasoningPreview => _showCollapsedReasoningPreview;
+  Future<void> setShowCollapsedReasoningPreview(bool v) async {
+    if (_showCollapsedReasoningPreview == v) return;
+    _showCollapsedReasoningPreview = v;
+    notifyListeners();
+    final prefs = _preferences;
+    await prefs.setBool(_displayShowCollapsedReasoningPreviewKey, v);
+  }
+
   bool _collapseThinkingSteps = false;
   bool get collapseThinkingSteps => _collapseThinkingSteps;
   Future<void> setCollapseThinkingSteps(bool v) async {
@@ -5662,6 +5677,7 @@ DO NOT GIVE ANSWERS OR DO HOMEWORK FOR THE USER. If the user asks a math or logi
     copy._showModelName = _showModelName;
     copy._showModelTimestamp = _showModelTimestamp;
     copy._autoCollapseThinking = _autoCollapseThinking;
+    copy._showCollapsedReasoningPreview = _showCollapsedReasoningPreview;
     copy._collapseThinkingSteps = _collapseThinkingSteps;
     copy._showToolResultSummary = _showToolResultSummary;
     copy._regenerateDeleteTrailingMessages = _regenerateDeleteTrailingMessages;

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -593,22 +593,46 @@ String _responsesReasoningText(dynamic rawOutput) {
   final buffer = StringBuffer();
   for (final item in rawOutput) {
     if (item is! Map || item['type'] != 'reasoning') continue;
-    final content = item['content'];
-    if (content is String) {
-      buffer.write(content);
-      continue;
+    // OpenAI-compatible gateways commonly put visible reasoning in `summary`,
+    // while the full reasoning item only contains encrypted content. Prefer
+    // content when it is available, and fall back to the summary array used by
+    // OAuth/Codex-style Responses implementations.
+    final content = _responsesReasoningValue(item['content']);
+    final summary = _responsesReasoningValue(item['summary']);
+    buffer.write(content.isNotEmpty ? content : summary);
+  }
+  return buffer.toString();
+}
+
+String _responsesReasoningValue(dynamic raw) {
+  if (raw is String) return raw;
+  if (raw is List) {
+    final buffer = StringBuffer();
+    for (final item in raw) {
+      buffer.write(_responsesReasoningValue(item));
     }
-    if (content is! List) continue;
-    for (final part in content) {
-      if (part is String) {
-        buffer.write(part);
-      } else if (part is Map &&
-          (part['type'] == 'reasoning_text' || part['type'] == 'text')) {
-        buffer.write((part['text'] ?? part['content'] ?? '').toString());
+    return buffer.toString();
+  }
+  if (raw is Map) {
+    for (final key in const <String>['text', 'summary', 'content']) {
+      final value = raw[key];
+      if (value is String) return value;
+      if (value is List) {
+        final nested = _responsesReasoningValue(value);
+        if (nested.isNotEmpty) return nested;
       }
     }
   }
-  return buffer.toString();
+  return '';
+}
+
+String _responsesReasoningKey(dynamic rawObj, {required bool isSummary}) {
+  final obj = rawObj is Map ? rawObj : const <String, dynamic>{};
+  final itemId = (obj['item_id'] ?? '').toString();
+  final outputIndex = (obj['output_index'] ?? '').toString();
+  final summaryIndex = (obj['summary_index'] ?? '').toString();
+  final prefix = isSummary ? 'summary' : 'reasoning';
+  return '$prefix:$itemId:$outputIndex:$summaryIndex';
 }
 
 String _stripDataUrlPrefix(String dataUrl) {
@@ -2305,6 +2329,68 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       <int, _ResponsesImageGenerationResult>{};
   List<Map<String, dynamic>> lastResponseOutputItems =
       const <Map<String, dynamic>>[];
+  // Responses API: remember streamed output items and reasoning text so
+  // terminal events can replay fragments that never arrived as deltas.
+  final Map<int, Map<String, dynamic>> respOutputItemsByIndex =
+      <int, Map<String, dynamic>>{};
+  final Map<String, int> respOutputItemIndexesById = <String, int>{};
+  final Map<String, String> respReasoningTextByKey = <String, String>{};
+
+  void rememberResponsesOutputItem(int index, Map item) {
+    final copied = Map<String, dynamic>.from(item);
+    respOutputItemsByIndex[index] = copied;
+    final itemId = (copied['id'] ?? '').toString();
+    if (itemId.isNotEmpty) respOutputItemIndexesById[itemId] = index;
+  }
+
+  List<Map<String, dynamic>> capturedResponsesOutputItems() {
+    final indexes = respOutputItemsByIndex.keys.toList()..sort();
+    return [for (final index in indexes) respOutputItemsByIndex[index]!];
+  }
+
+  /// Accumulates reasoning text per stream key and returns only the fragment
+  /// that has not been emitted yet. Final (`*.done` / item) payloads repeat
+  /// the whole text, so emit the missing suffix instead of duplicating it.
+  String? emitResponsesReasoning(
+    dynamic rawObj,
+    String text, {
+    required bool isSummary,
+    bool isFinal = false,
+  }) {
+    final key = _responsesReasoningKey(rawObj, isSummary: isSummary);
+    final previous = respReasoningTextByKey[key] ?? '';
+    var delta = text;
+    if (isFinal) {
+      if (text == previous || previous.startsWith(text)) return null;
+      if (text.startsWith(previous)) {
+        delta = text.substring(previous.length);
+      }
+    }
+    if (delta.isEmpty) return null;
+    respReasoningTextByKey[key] = '$previous$delta';
+    return delta;
+  }
+
+  String? emitResponsesReasoningItem(Map item) {
+    final content = _responsesReasoningValue(item['content']);
+    final summary = _responsesReasoningValue(item['summary']);
+    final text = content.isNotEmpty ? content : summary;
+    if (text.isEmpty) return null;
+    final isSummary = item['summary'] is List;
+    final itemId = (item['id'] ?? '').toString();
+    return emitResponsesReasoning(
+      <String, dynamic>{
+        'item_id': item['id'],
+        if (respOutputItemIndexesById[itemId] != null)
+          'output_index': respOutputItemIndexesById[itemId],
+        'summary_index': 0,
+      },
+      text,
+      isSummary: isSummary,
+      isFinal: true,
+    );
+  }
+
   String? finishReason;
   String?
   incompleteReason; // Responses API: json['response']['incomplete_details']['reason']
@@ -2874,25 +2960,47 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
           } else if (type == 'response.reasoning_summary_text.delta' ||
               type == 'response.reasoning_text.delta') {
             final delta = json['delta'];
-            if (delta is String) reasoning = delta;
+            if (delta is String && delta.isNotEmpty) {
+              reasoning = emitResponsesReasoning(
+                json,
+                delta,
+                isSummary: type == 'response.reasoning_summary_text.delta',
+              );
+            }
+          } else if (type == 'response.reasoning_summary_text.done' ||
+              type == 'response.reasoning_text.done') {
+            final doneText = json['text'];
+            if (doneText is String && doneText.isNotEmpty) {
+              reasoning = emitResponsesReasoning(
+                json,
+                doneText,
+                isSummary: type == 'response.reasoning_summary_text.done',
+                isFinal: true,
+              );
+            }
           } else if (type == 'response.output_item.added') {
             try {
               final item = json['item'];
               final idx = (json['output_index'] ?? 0) as int? ?? 0;
-              if (item is Map && (item['type'] ?? '') == 'function_call') {
-                final name = (item['name'] ?? '').toString();
-                final callId = (item['call_id'] ?? '').toString();
-                respToolCallsByIndex[idx] = {
-                  'call_id': callId,
-                  'name': name,
-                  'args': '',
-                };
-              } else if (item is Map &&
-                  _isResponsesImageGenerationType(item['type'])) {
-                responsesImagesByIndex.putIfAbsent(
-                  idx,
-                  () => const _ResponsesImageGenerationResult(),
-                );
+              if (item is Map) {
+                rememberResponsesOutputItem(idx, item);
+                final itemType = (item['type'] ?? '').toString();
+                if (itemType == 'reasoning') {
+                  reasoning = emitResponsesReasoningItem(item);
+                } else if (itemType == 'function_call') {
+                  final name = (item['name'] ?? '').toString();
+                  final callId = (item['call_id'] ?? '').toString();
+                  respToolCallsByIndex[idx] = {
+                    'call_id': callId,
+                    'name': name,
+                    'args': '',
+                  };
+                } else if (_isResponsesImageGenerationType(itemType)) {
+                  responsesImagesByIndex.putIfAbsent(
+                    idx,
+                    () => const _ResponsesImageGenerationResult(),
+                  );
+                }
               }
             } catch (_) {}
           } else if (type == 'response.image_generation_call.partial_image') {
@@ -2922,25 +3030,32 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
             try {
               final item = json['item'];
               final idx = (json['output_index'] ?? 0) as int? ?? 0;
-              if (item is Map && (item['type'] ?? '') == 'function_call') {
-                final args = (item['arguments'] ?? '').toString();
-                final entry = respToolCallsByIndex.putIfAbsent(
-                  idx,
-                  () => {
-                    'call_id': (item['call_id'] ?? '').toString(),
-                    'name': (item['name'] ?? '').toString(),
-                    'args': '',
-                  },
-                );
-                if (args.isNotEmpty) entry['args'] = args;
-              } else if (item is Map &&
-                  _isResponsesImageGenerationType(item['type'])) {
-                final b64 = (item['result'] ?? '').toString();
-                if (b64.isNotEmpty) {
-                  responsesImagesByIndex[idx] = _ResponsesImageGenerationResult(
-                    base64: b64,
-                    outputFormat: (item['output_format'] ?? '').toString(),
+              if (item is Map) {
+                rememberResponsesOutputItem(idx, item);
+                final itemType = (item['type'] ?? '').toString();
+                if (itemType == 'reasoning') {
+                  reasoning = emitResponsesReasoningItem(item);
+                } else if (itemType == 'function_call') {
+                  final args = (item['arguments'] ?? '').toString();
+                  final entry = respToolCallsByIndex.putIfAbsent(
+                    idx,
+                    () => {
+                      'call_id': (item['call_id'] ?? '').toString(),
+                      'name': (item['name'] ?? '').toString(),
+                      'args': '',
+                    },
                   );
+                  if (args.isNotEmpty) entry['args'] = args;
+                } else if (_isResponsesImageGenerationType(itemType)) {
+                  final b64 = (item['result'] ?? '').toString();
+                  if (b64.isNotEmpty) {
+                    responsesImagesByIndex[idx] =
+                        _ResponsesImageGenerationResult(
+                          base64: b64,
+                          outputFormat: (item['output_format'] ?? '')
+                              .toString(),
+                        );
+                  }
                 }
               }
             } catch (_) {}
@@ -2989,13 +3104,34 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               final output = json['response']?['output'];
               final items = <Map<String, dynamic>>[];
               final completedImageIndexes = <int>{};
-              // Save output items for potential follow-up call input
-              lastResponseOutputItems = const <Map<String, dynamic>>[];
+              // Save output items for potential follow-up call input. When the
+              // terminal payload omits them, fall back to items captured from
+              // streaming events so reasoning is not lost.
+              final terminalItems = <Map<String, dynamic>>[];
               if (output is List) {
-                lastResponseOutputItems = [
-                  for (final it in output)
-                    if (it is Map) (it.cast<String, dynamic>()),
-                ];
+                for (var index = 0; index < output.length; index++) {
+                  final rawItem = output[index];
+                  if (rawItem is! Map) continue;
+                  final item = Map<String, dynamic>.from(rawItem);
+                  rememberResponsesOutputItem(index, item);
+                  terminalItems.add(item);
+                }
+              }
+              lastResponseOutputItems = terminalItems.isNotEmpty
+                  ? terminalItems
+                  : capturedResponsesOutputItems();
+              for (final item in lastResponseOutputItems) {
+                if (item['type'] != 'reasoning') continue;
+                final reasoningItemText = emitResponsesReasoningItem(item);
+                if (reasoningItemText != null && reasoningItemText.isNotEmpty) {
+                  yield ChatStreamChunk(
+                    content: '',
+                    reasoning: reasoningItemText,
+                    isDone: false,
+                    totalTokens: totalTokens,
+                    usage: usage,
+                  );
+                }
               }
               if (output is List) {
                 int idx = 1;

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -2335,6 +2335,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       <int, Map<String, dynamic>>{};
   final Map<String, int> respOutputItemIndexesById = <String, int>{};
   final Map<String, String> respReasoningTextByKey = <String, String>{};
+  // Which namespace the delta stream used for an item (`summary:` vs
+  // `reasoning:`), keyed by item id. Terminal items can carry the same text
+  // under a different field than the deltas did, and the dedup lookup has to
+  // follow the stream, not the field.
+  final Map<String, bool> respReasoningIsSummaryByItemId = <String, bool>{};
 
   void rememberResponsesOutputItem(int index, Map item) {
     final copied = Map<String, dynamic>.from(item);
@@ -2368,6 +2373,12 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     }
     if (delta.isEmpty) return null;
     respReasoningTextByKey[key] = '$previous$delta';
+    if (!isFinal) {
+      final itemId = rawObj is Map ? (rawObj['item_id'] ?? '').toString() : '';
+      if (itemId.isNotEmpty) {
+        respReasoningIsSummaryByItemId[itemId] = isSummary;
+      }
+    }
     return delta;
   }
 
@@ -2376,10 +2387,14 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     final summary = _responsesReasoningValue(item['summary']);
     final text = content.isNotEmpty ? content : summary;
     if (text.isEmpty) return null;
-    // Derive the dedup namespace from the field that produced the text so the
-    // terminal item is compared against the delta stream that carried it.
-    final isSummary = content.isEmpty;
     final itemId = (item['id'] ?? '').toString();
+    // Follow the namespace the deltas used for this item; only fall back to
+    // the field that produced the text when no delta was ever seen. Some
+    // gateways stream `reasoning_text.delta` but expose the terminal text
+    // under `summary` (and vice versa), which would otherwise miss the
+    // accumulated entry and re-emit the whole block.
+    final isSummary =
+        respReasoningIsSummaryByItemId[itemId] ?? content.isEmpty;
     return emitResponsesReasoning(
       <String, dynamic>{
         'item_id': item['id'],
@@ -3135,13 +3150,18 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   );
                 }
               }
-              // Round-scoped bookkeeping: a tool follow-up round reuses this
-              // generator, so the capture and dedup maps must not leak into
-              // the next request (unlike `lastResponseOutputItems`, which is
-              // the payload handed to the next round on purpose).
+              // Round-scoped bookkeeping captured from streaming events. It
+              // has served its purpose once the terminal payload arrived, so
+              // release it here rather than holding reasoning text and output
+              // items for the rest of the generator's lifetime. Rounds after
+              // the first one are parsed by the follow-up loop with its own
+              // per-round state, so nothing re-reads these maps; the tool-call
+              // accumulators (`respToolCallsByIndex`, `toolAccResp`) are read
+              // in this same iteration and therefore stay untouched.
               respOutputItemsByIndex.clear();
               respOutputItemIndexesById.clear();
               respReasoningTextByKey.clear();
+              respReasoningIsSummaryByItemId.clear();
               if (output is List) {
                 int idx = 1;
                 final seen = <String>{};

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -2376,7 +2376,9 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     final summary = _responsesReasoningValue(item['summary']);
     final text = content.isNotEmpty ? content : summary;
     if (text.isEmpty) return null;
-    final isSummary = item['summary'] is List;
+    // Derive the dedup namespace from the field that produced the text so the
+    // terminal item is compared against the delta stream that carried it.
+    final isSummary = content.isEmpty;
     final itemId = (item['id'] ?? '').toString();
     return emitResponsesReasoning(
       <String, dynamic>{
@@ -3133,6 +3135,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                   );
                 }
               }
+              // Round-scoped bookkeeping: a tool follow-up round reuses this
+              // generator, so the capture and dedup maps must not leak into
+              // the next request (unlike `lastResponseOutputItems`, which is
+              // the payload handed to the next round on purpose).
+              respOutputItemsByIndex.clear();
+              respOutputItemIndexesById.clear();
+              respReasoningTextByKey.clear();
               if (output is List) {
                 int idx = 1;
                 final seen = <String>{};

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -635,6 +635,80 @@ String _responsesReasoningKey(dynamic rawObj, {required bool isSummary}) {
   return '$prefix:$itemId:$outputIndex:$summaryIndex';
 }
 
+/// Accumulates reasoning text per stream key and returns only the fragment
+/// that has not been emitted yet. Final (`*.done`) payloads repeat the whole
+/// text, so emit the missing suffix instead of duplicating it.
+///
+/// [textByKey] tracks the per-key stream state; [streamedByItemId] tracks
+/// everything emitted for an item across keys, which is what a terminal item
+/// is eventually compared against.
+String? _emitResponsesReasoningDelta(
+  Map<String, String> textByKey,
+  Map<String, String> streamedByItemId,
+  dynamic rawObj,
+  String text, {
+  required bool isSummary,
+  bool isFinal = false,
+}) {
+  final key = _responsesReasoningKey(rawObj, isSummary: isSummary);
+  final previous = textByKey[key] ?? '';
+  var delta = text;
+  if (isFinal) {
+    if (text == previous || previous.startsWith(text)) return null;
+    if (text.startsWith(previous)) {
+      delta = text.substring(previous.length);
+    }
+  }
+  if (delta.isEmpty) return null;
+  textByKey[key] = '$previous$delta';
+  if (!isFinal) {
+    final itemId = rawObj is Map ? (rawObj['item_id'] ?? '').toString() : '';
+    if (itemId.isNotEmpty) {
+      streamedByItemId[itemId] = '${streamedByItemId[itemId] ?? ''}$delta';
+    }
+  }
+  return delta;
+}
+
+/// Emits the reasoning carried by a `reasoning` output item. The item repeats
+/// what was streamed for it, possibly under a different field or concatenated
+/// from several summary parts, so compare against the per-item aggregate and
+/// only emit what is still missing.
+String? _emitResponsesReasoningItemText(
+  Map<String, String> textByKey,
+  Map<String, String> streamedByItemId,
+  Map item, {
+  int? outputIndex,
+}) {
+  final content = _responsesReasoningValue(item['content']);
+  final summary = _responsesReasoningValue(item['summary']);
+  final text = content.isNotEmpty ? content : summary;
+  if (text.isEmpty) return null;
+  final itemId = (item['id'] ?? '').toString();
+  final streamed = streamedByItemId[itemId] ?? '';
+  if (streamed.isNotEmpty) {
+    if (text == streamed || streamed.startsWith(text)) return null;
+    final delta = text.startsWith(streamed)
+        ? text.substring(streamed.length)
+        : text;
+    if (delta.isEmpty) return null;
+    streamedByItemId[itemId] = text;
+    return delta;
+  }
+  return _emitResponsesReasoningDelta(
+    textByKey,
+    streamedByItemId,
+    <String, dynamic>{
+      'item_id': item['id'],
+      if (outputIndex != null) 'output_index': outputIndex,
+      'summary_index': 0,
+    },
+    text,
+    isSummary: content.isEmpty,
+    isFinal: true,
+  );
+}
+
 String _stripDataUrlPrefix(String dataUrl) {
   final commaIndex = dataUrl.indexOf(',');
   if (commaIndex >= 0 && commaIndex + 1 < dataUrl.length) {
@@ -2335,11 +2409,11 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
       <int, Map<String, dynamic>>{};
   final Map<String, int> respOutputItemIndexesById = <String, int>{};
   final Map<String, String> respReasoningTextByKey = <String, String>{};
-  // Which namespace the delta stream used for an item (`summary:` vs
-  // `reasoning:`), keyed by item id. Terminal items can carry the same text
-  // under a different field than the deltas did, and the dedup lookup has to
-  // follow the stream, not the field.
-  final Map<String, bool> respReasoningIsSummaryByItemId = <String, bool>{};
+  // Everything already streamed for a reasoning item — across namespaces and
+  // summary parts. A terminal item repeats that text (possibly under another
+  // field or concatenated from several summary parts), so the final dedup
+  // compares against this aggregate rather than a single key.
+  final Map<String, String> respReasoningStreamedByItemId = <String, String>{};
 
   void rememberResponsesOutputItem(int index, Map item) {
     final copied = Map<String, dynamic>.from(item);
@@ -2353,58 +2427,29 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     return [for (final index in indexes) respOutputItemsByIndex[index]!];
   }
 
-  /// Accumulates reasoning text per stream key and returns only the fragment
-  /// that has not been emitted yet. Final (`*.done` / item) payloads repeat
-  /// the whole text, so emit the missing suffix instead of duplicating it.
   String? emitResponsesReasoning(
     dynamic rawObj,
     String text, {
     required bool isSummary,
     bool isFinal = false,
   }) {
-    final key = _responsesReasoningKey(rawObj, isSummary: isSummary);
-    final previous = respReasoningTextByKey[key] ?? '';
-    var delta = text;
-    if (isFinal) {
-      if (text == previous || previous.startsWith(text)) return null;
-      if (text.startsWith(previous)) {
-        delta = text.substring(previous.length);
-      }
-    }
-    if (delta.isEmpty) return null;
-    respReasoningTextByKey[key] = '$previous$delta';
-    if (!isFinal) {
-      final itemId = rawObj is Map ? (rawObj['item_id'] ?? '').toString() : '';
-      if (itemId.isNotEmpty) {
-        respReasoningIsSummaryByItemId[itemId] = isSummary;
-      }
-    }
-    return delta;
+    return _emitResponsesReasoningDelta(
+      respReasoningTextByKey,
+      respReasoningStreamedByItemId,
+      rawObj,
+      text,
+      isSummary: isSummary,
+      isFinal: isFinal,
+    );
   }
 
   String? emitResponsesReasoningItem(Map item) {
-    final content = _responsesReasoningValue(item['content']);
-    final summary = _responsesReasoningValue(item['summary']);
-    final text = content.isNotEmpty ? content : summary;
-    if (text.isEmpty) return null;
     final itemId = (item['id'] ?? '').toString();
-    // Follow the namespace the deltas used for this item; only fall back to
-    // the field that produced the text when no delta was ever seen. Some
-    // gateways stream `reasoning_text.delta` but expose the terminal text
-    // under `summary` (and vice versa), which would otherwise miss the
-    // accumulated entry and re-emit the whole block.
-    final isSummary =
-        respReasoningIsSummaryByItemId[itemId] ?? content.isEmpty;
-    return emitResponsesReasoning(
-      <String, dynamic>{
-        'item_id': item['id'],
-        if (respOutputItemIndexesById[itemId] != null)
-          'output_index': respOutputItemIndexesById[itemId],
-        'summary_index': 0,
-      },
-      text,
-      isSummary: isSummary,
-      isFinal: true,
+    return _emitResponsesReasoningItemText(
+      respReasoningTextByKey,
+      respReasoningStreamedByItemId,
+      item,
+      outputIndex: respOutputItemIndexesById[itemId],
     );
   }
 
@@ -3161,7 +3206,7 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               respOutputItemsByIndex.clear();
               respOutputItemIndexesById.clear();
               respReasoningTextByKey.clear();
-              respReasoningIsSummaryByItemId.clear();
+              respReasoningStreamedByItemId.clear();
               if (output is List) {
                 int idx = 1;
                 final seen = <String>{};
@@ -3472,6 +3517,12 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     <int, Map<String, String>>{};
                 List<Map<String, dynamic>> outItems2 =
                     const <Map<String, dynamic>>[];
+                // Reasoning stream state for this follow-up round only; the
+                // round-scoped maps of the outer stream are not reused here.
+                final Map<String, String> reasoning2TextByKey =
+                    <String, String>{};
+                final Map<String, String> reasoning2StreamedByItemId =
+                    <String, String>{};
                 await for (final ch in _ensureTrailingNewline(s2)) {
                   buf2 += ch;
                   final lines2 = buf2.split('\n');
@@ -3496,10 +3547,85 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                           );
                         }
                       } else if (o is Map &&
+                          ((o['type'] ?? '') ==
+                                  'response.reasoning_summary_text.delta' ||
+                              (o['type'] ?? '') ==
+                                  'response.reasoning_text.delta')) {
+                        final isSummary =
+                            (o['type'] ?? '') ==
+                            'response.reasoning_summary_text.delta';
+                        final delta = (o['delta'] ?? '').toString();
+                        if (delta.isNotEmpty) {
+                          final reasoningDelta = _emitResponsesReasoningDelta(
+                            reasoning2TextByKey,
+                            reasoning2StreamedByItemId,
+                            o,
+                            delta,
+                            isSummary: isSummary,
+                          );
+                          if (reasoningDelta != null &&
+                              reasoningDelta.isNotEmpty) {
+                            yield ChatStreamChunk(
+                              content: '',
+                              reasoning: reasoningDelta,
+                              isDone: false,
+                              totalTokens: 0,
+                              usage: usage,
+                            );
+                          }
+                        }
+                      } else if (o is Map &&
+                          ((o['type'] ?? '') ==
+                                  'response.reasoning_summary_text.done' ||
+                              (o['type'] ?? '') ==
+                                  'response.reasoning_text.done')) {
+                        final isSummary =
+                            (o['type'] ?? '') ==
+                            'response.reasoning_summary_text.done';
+                        final doneText = (o['text'] ?? '').toString();
+                        if (doneText.isNotEmpty) {
+                          final reasoningDelta = _emitResponsesReasoningDelta(
+                            reasoning2TextByKey,
+                            reasoning2StreamedByItemId,
+                            o,
+                            doneText,
+                            isSummary: isSummary,
+                            isFinal: true,
+                          );
+                          if (reasoningDelta != null &&
+                              reasoningDelta.isNotEmpty) {
+                            yield ChatStreamChunk(
+                              content: '',
+                              reasoning: reasoningDelta,
+                              isDone: false,
+                              totalTokens: 0,
+                              usage: usage,
+                            );
+                          }
+                        }
+                      } else if (o is Map &&
                           (o['type'] ?? '') == 'response.output_item.added') {
                         final item = o['item'];
                         final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
                         if (item is Map &&
+                            (item['type'] ?? '') == 'reasoning') {
+                          final reasoningDelta = _emitResponsesReasoningItemText(
+                            reasoning2TextByKey,
+                            reasoning2StreamedByItemId,
+                            item,
+                            outputIndex: idx2,
+                          );
+                          if (reasoningDelta != null &&
+                              reasoningDelta.isNotEmpty) {
+                            yield ChatStreamChunk(
+                              content: '',
+                              reasoning: reasoningDelta,
+                              isDone: false,
+                              totalTokens: 0,
+                              usage: usage,
+                            );
+                          }
+                        } else if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           respCalls2[idx2] = {
                             'call_id': (item['call_id'] ?? '').toString(),
@@ -3524,6 +3650,24 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                         final item = o['item'];
                         final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
                         if (item is Map &&
+                            (item['type'] ?? '') == 'reasoning') {
+                          final reasoningDelta = _emitResponsesReasoningItemText(
+                            reasoning2TextByKey,
+                            reasoning2StreamedByItemId,
+                            item,
+                            outputIndex: idx2,
+                          );
+                          if (reasoningDelta != null &&
+                              reasoningDelta.isNotEmpty) {
+                            yield ChatStreamChunk(
+                              content: '',
+                              reasoning: reasoningDelta,
+                              isDone: false,
+                              totalTokens: 0,
+                              usage: usage,
+                            );
+                          }
+                        } else if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           final args = (item['arguments'] ?? '').toString();
                           final entry = respCalls2.putIfAbsent(
@@ -3551,6 +3695,27 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                             for (final it in out2)
                               if (it is Map) (it.cast<String, dynamic>()),
                           ];
+                          // A terminal item may be the only carrier of the
+                          // round's reasoning; emit what was not streamed.
+                          for (final it in outItems2) {
+                            if (it['type'] != 'reasoning') continue;
+                            final reasoningDelta =
+                                _emitResponsesReasoningItemText(
+                                  reasoning2TextByKey,
+                                  reasoning2StreamedByItemId,
+                                  it,
+                                );
+                            if (reasoningDelta != null &&
+                                reasoningDelta.isNotEmpty) {
+                              yield ChatStreamChunk(
+                                content: '',
+                                reasoning: reasoningDelta,
+                                isDone: false,
+                                totalTokens: 0,
+                                usage: usage,
+                              );
+                            }
+                          }
                         }
                       }
                     } catch (_) {}

--- a/lib/core/services/api/providers/openai_common.dart
+++ b/lib/core/services/api/providers/openai_common.dart
@@ -639,9 +639,11 @@ String _responsesReasoningKey(dynamic rawObj, {required bool isSummary}) {
 /// that has not been emitted yet. Final (`*.done`) payloads repeat the whole
 /// text, so emit the missing suffix instead of duplicating it.
 ///
-/// [textByKey] tracks the per-key stream state; [streamedByItemId] tracks
-/// everything emitted for an item across keys, which is what a terminal item
-/// is eventually compared against.
+/// [textByKey] tracks the per-key stream state. [streamedByItemId] tracks
+/// everything already shown for an item, across keys and summary parts; every
+/// emitted fragment is appended there — including fragments that came from a
+/// `*.done` payload — so a terminal item can be compared against the complete
+/// text no matter which namespace carried it.
 String? _emitResponsesReasoningDelta(
   Map<String, String> textByKey,
   Map<String, String> streamedByItemId,
@@ -661,11 +663,9 @@ String? _emitResponsesReasoningDelta(
   }
   if (delta.isEmpty) return null;
   textByKey[key] = '$previous$delta';
-  if (!isFinal) {
-    final itemId = rawObj is Map ? (rawObj['item_id'] ?? '').toString() : '';
-    if (itemId.isNotEmpty) {
-      streamedByItemId[itemId] = '${streamedByItemId[itemId] ?? ''}$delta';
-    }
+  final itemId = rawObj is Map ? (rawObj['item_id'] ?? '').toString() : '';
+  if (itemId.isNotEmpty) {
+    streamedByItemId[itemId] = '${streamedByItemId[itemId] ?? ''}$delta';
   }
   return delta;
 }
@@ -684,7 +684,11 @@ String? _emitResponsesReasoningItemText(
   final summary = _responsesReasoningValue(item['summary']);
   final text = content.isNotEmpty ? content : summary;
   if (text.isEmpty) return null;
-  final itemId = (item['id'] ?? '').toString();
+  final rawItemId = (item['id'] ?? '').toString();
+  // Items without an id would otherwise share one bucket and dedupe against
+  // each other's text, silently dropping valid reasoning; fall back to the
+  // output index so each item keeps its own aggregate.
+  final itemId = rawItemId.isNotEmpty ? rawItemId : 'idx:${outputIndex ?? -1}';
   final streamed = streamedByItemId[itemId] ?? '';
   if (streamed.isNotEmpty) {
     if (text == streamed || streamed.startsWith(text)) return null;
@@ -699,7 +703,7 @@ String? _emitResponsesReasoningItemText(
     textByKey,
     streamedByItemId,
     <String, dynamic>{
-      'item_id': item['id'],
+      'item_id': itemId,
       if (outputIndex != null) 'output_index': outputIndex,
       'summary_index': 0,
     },
@@ -2443,13 +2447,13 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
     );
   }
 
-  String? emitResponsesReasoningItem(Map item) {
+  String? emitResponsesReasoningItem(Map item, {int? outputIndex}) {
     final itemId = (item['id'] ?? '').toString();
     return _emitResponsesReasoningItemText(
       respReasoningTextByKey,
       respReasoningStreamedByItemId,
       item,
-      outputIndex: respOutputItemIndexesById[itemId],
+      outputIndex: outputIndex ?? respOutputItemIndexesById[itemId],
     );
   }
 
@@ -3182,9 +3186,17 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
               lastResponseOutputItems = terminalItems.isNotEmpty
                   ? terminalItems
                   : capturedResponsesOutputItems();
-              for (final item in lastResponseOutputItems) {
+              for (
+                var index = 0;
+                index < lastResponseOutputItems.length;
+                index++
+              ) {
+                final item = lastResponseOutputItems[index];
                 if (item['type'] != 'reasoning') continue;
-                final reasoningItemText = emitResponsesReasoningItem(item);
+                final reasoningItemText = emitResponsesReasoningItem(
+                  item,
+                  outputIndex: index,
+                );
                 if (reasoningItemText != null && reasoningItemText.isNotEmpty) {
                   yield ChatStreamChunk(
                     content: '',
@@ -3523,6 +3535,23 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                     <String, String>{};
                 final Map<String, String> reasoning2StreamedByItemId =
                     <String, String>{};
+                // Output items seen while streaming this round, so a terminal
+                // payload that omits `output` can still replay them.
+                final Map<int, Map<String, dynamic>> roundItemsByIndex =
+                    <int, Map<String, dynamic>>{};
+
+                ChatStreamChunk? reasoningChunk(String? delta) {
+                  if (delta == null || delta.isEmpty) {
+                    return null;
+                  }
+                  return ChatStreamChunk(
+                    content: '',
+                    reasoning: delta,
+                    isDone: false,
+                    totalTokens: 0,
+                    usage: usage,
+                  );
+                }
                 await for (final ch in _ensureTrailingNewline(s2)) {
                   buf2 += ch;
                   final lines2 = buf2.split('\n');
@@ -3556,23 +3585,16 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                             'response.reasoning_summary_text.delta';
                         final delta = (o['delta'] ?? '').toString();
                         if (delta.isNotEmpty) {
-                          final reasoningDelta = _emitResponsesReasoningDelta(
-                            reasoning2TextByKey,
-                            reasoning2StreamedByItemId,
-                            o,
-                            delta,
-                            isSummary: isSummary,
+                          final chunk = reasoningChunk(
+                            _emitResponsesReasoningDelta(
+                              reasoning2TextByKey,
+                              reasoning2StreamedByItemId,
+                              o,
+                              delta,
+                              isSummary: isSummary,
+                            ),
                           );
-                          if (reasoningDelta != null &&
-                              reasoningDelta.isNotEmpty) {
-                            yield ChatStreamChunk(
-                              content: '',
-                              reasoning: reasoningDelta,
-                              isDone: false,
-                              totalTokens: 0,
-                              usage: usage,
-                            );
-                          }
+                          if (chunk != null) yield chunk;
                         }
                       } else if (o is Map &&
                           ((o['type'] ?? '') ==
@@ -3584,47 +3606,38 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                             'response.reasoning_summary_text.done';
                         final doneText = (o['text'] ?? '').toString();
                         if (doneText.isNotEmpty) {
-                          final reasoningDelta = _emitResponsesReasoningDelta(
-                            reasoning2TextByKey,
-                            reasoning2StreamedByItemId,
-                            o,
-                            doneText,
-                            isSummary: isSummary,
-                            isFinal: true,
+                          final chunk = reasoningChunk(
+                            _emitResponsesReasoningDelta(
+                              reasoning2TextByKey,
+                              reasoning2StreamedByItemId,
+                              o,
+                              doneText,
+                              isSummary: isSummary,
+                              isFinal: true,
+                            ),
                           );
-                          if (reasoningDelta != null &&
-                              reasoningDelta.isNotEmpty) {
-                            yield ChatStreamChunk(
-                              content: '',
-                              reasoning: reasoningDelta,
-                              isDone: false,
-                              totalTokens: 0,
-                              usage: usage,
-                            );
-                          }
+                          if (chunk != null) yield chunk;
                         }
                       } else if (o is Map &&
                           (o['type'] ?? '') == 'response.output_item.added') {
                         final item = o['item'];
                         final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
+                        if (item is Map) {
+                          roundItemsByIndex[idx2] = Map<String, dynamic>.from(
+                            item,
+                          );
+                        }
                         if (item is Map &&
                             (item['type'] ?? '') == 'reasoning') {
-                          final reasoningDelta = _emitResponsesReasoningItemText(
-                            reasoning2TextByKey,
-                            reasoning2StreamedByItemId,
-                            item,
-                            outputIndex: idx2,
+                          final chunk = reasoningChunk(
+                            _emitResponsesReasoningItemText(
+                              reasoning2TextByKey,
+                              reasoning2StreamedByItemId,
+                              item,
+                              outputIndex: idx2,
+                            ),
                           );
-                          if (reasoningDelta != null &&
-                              reasoningDelta.isNotEmpty) {
-                            yield ChatStreamChunk(
-                              content: '',
-                              reasoning: reasoningDelta,
-                              isDone: false,
-                              totalTokens: 0,
-                              usage: usage,
-                            );
-                          }
+                          if (chunk != null) yield chunk;
                         } else if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           respCalls2[idx2] = {
@@ -3649,24 +3662,22 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                           (o['type'] ?? '') == 'response.output_item.done') {
                         final item = o['item'];
                         final idx2 = (o['output_index'] ?? 0) as int? ?? 0;
+                        if (item is Map) {
+                          roundItemsByIndex[idx2] = Map<String, dynamic>.from(
+                            item,
+                          );
+                        }
                         if (item is Map &&
                             (item['type'] ?? '') == 'reasoning') {
-                          final reasoningDelta = _emitResponsesReasoningItemText(
-                            reasoning2TextByKey,
-                            reasoning2StreamedByItemId,
-                            item,
-                            outputIndex: idx2,
+                          final chunk = reasoningChunk(
+                            _emitResponsesReasoningItemText(
+                              reasoning2TextByKey,
+                              reasoning2StreamedByItemId,
+                              item,
+                              outputIndex: idx2,
+                            ),
                           );
-                          if (reasoningDelta != null &&
-                              reasoningDelta.isNotEmpty) {
-                            yield ChatStreamChunk(
-                              content: '',
-                              reasoning: reasoningDelta,
-                              isDone: false,
-                              totalTokens: 0,
-                              usage: usage,
-                            );
-                          }
+                          if (chunk != null) yield chunk;
                         } else if (item is Map &&
                             (item['type'] ?? '') == 'function_call') {
                           final args = (item['arguments'] ?? '').toString();
@@ -3688,34 +3699,48 @@ Stream<ChatStreamChunk> _sendOpenAIStream(
                           o['response']?['usage'],
                         );
                         totalTokens = usage?.totalTokens ?? totalTokens;
-                        // capture output items
+                        // Capture output items, falling back to the items
+                        // seen while streaming when the terminal payload omits
+                        // them (mirrors the outer stream's capture map).
+                        final terminalItems = <Map<String, dynamic>>[];
                         final out2 = o['response']?['output'];
                         if (out2 is List) {
-                          outItems2 = [
-                            for (final it in out2)
-                              if (it is Map) (it.cast<String, dynamic>()),
-                          ];
-                          // A terminal item may be the only carrier of the
-                          // round's reasoning; emit what was not streamed.
-                          for (final it in outItems2) {
-                            if (it['type'] != 'reasoning') continue;
-                            final reasoningDelta =
-                                _emitResponsesReasoningItemText(
-                                  reasoning2TextByKey,
-                                  reasoning2StreamedByItemId,
-                                  it,
-                                );
-                            if (reasoningDelta != null &&
-                                reasoningDelta.isNotEmpty) {
-                              yield ChatStreamChunk(
-                                content: '',
-                                reasoning: reasoningDelta,
-                                isDone: false,
-                                totalTokens: 0,
-                                usage: usage,
-                              );
-                            }
+                          for (
+                            var index = 0;
+                            index < out2.length;
+                            index++
+                          ) {
+                            final rawItem = out2[index];
+                            if (rawItem is! Map) continue;
+                            final item = Map<String, dynamic>.from(rawItem);
+                            roundItemsByIndex[index] = item;
+                            terminalItems.add(item);
                           }
+                        }
+                        if (terminalItems.isNotEmpty) {
+                          outItems2 = terminalItems;
+                        } else {
+                          final indexes = roundItemsByIndex.keys.toList()
+                            ..sort();
+                          outItems2 = [
+                            for (final index in indexes)
+                              roundItemsByIndex[index]!,
+                          ];
+                        }
+                        // A terminal item may be the only carrier of the
+                        // round's reasoning; emit what was not streamed.
+                        for (var index = 0; index < outItems2.length; index++) {
+                          final it = outItems2[index];
+                          if (it['type'] != 'reasoning') continue;
+                          final chunk = reasoningChunk(
+                            _emitResponsesReasoningItemText(
+                              reasoning2TextByKey,
+                              reasoning2StreamedByItemId,
+                              it,
+                              outputIndex: index,
+                            ),
+                          );
+                          if (chunk != null) yield chunk;
                         }
                       }
                     } catch (_) {}

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -112,7 +112,7 @@ class _DisplaySettingsBody extends StatelessWidget {
                   _RowDivider(),
                   _ToggleRowAutoCollapseThinking(),
                   _RowDivider(),
-                  _ToggleRowShowCollapsedReasoningPreview(),
+                  _ToggleRowCollapsedReasoningPreview(),
                   _RowDivider(),
                   _ToggleRowCollapseThinkingSteps(),
                   _RowDivider(),
@@ -2459,8 +2459,8 @@ class _ToggleRowAutoCollapseThinking extends StatelessWidget {
   }
 }
 
-class _ToggleRowShowCollapsedReasoningPreview extends StatelessWidget {
-  const _ToggleRowShowCollapsedReasoningPreview();
+class _ToggleRowCollapsedReasoningPreview extends StatelessWidget {
+  const _ToggleRowCollapsedReasoningPreview();
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -112,6 +112,8 @@ class _DisplaySettingsBody extends StatelessWidget {
                   _RowDivider(),
                   _ToggleRowAutoCollapseThinking(),
                   _RowDivider(),
+                  _ToggleRowShowCollapsedReasoningPreview(),
+                  _RowDivider(),
                   _ToggleRowCollapseThinkingSteps(),
                   _RowDivider(),
                   _ToggleRowShowToolResultSummary(),
@@ -2453,6 +2455,21 @@ class _ToggleRowAutoCollapseThinking extends StatelessWidget {
       value: sp.autoCollapseThinking,
       onChanged: (v) =>
           context.read<SettingsProvider>().setAutoCollapseThinking(v),
+    );
+  }
+}
+
+class _ToggleRowShowCollapsedReasoningPreview extends StatelessWidget {
+  const _ToggleRowShowCollapsedReasoningPreview();
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final sp = context.watch<SettingsProvider>();
+    return _ToggleRow(
+      label: l10n.displaySettingsPageShowCollapsedReasoningPreviewTitle,
+      value: sp.showCollapsedReasoningPreview,
+      onChanged: (v) =>
+          context.read<SettingsProvider>().setShowCollapsedReasoningPreview(v),
     );
   }
 }

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -2467,6 +2467,7 @@ class _ToggleRowCollapsedReasoningPreview extends StatelessWidget {
     final sp = context.watch<SettingsProvider>();
     return _ToggleRow(
       label: l10n.displaySettingsPageShowCollapsedReasoningPreviewTitle,
+      subtitle: l10n.displaySettingsPageShowCollapsedReasoningPreviewSubtitle,
       value: sp.showCollapsedReasoningPreview,
       onChanged: (v) =>
           context.read<SettingsProvider>().setShowCollapsedReasoningPreview(v),

--- a/lib/features/chat/utils/reasoning_preview.dart
+++ b/lib/features/chat/utils/reasoning_preview.dart
@@ -1,0 +1,51 @@
+/// Returns the most useful short preview for a collapsed reasoning card.
+///
+/// Providers often stream one cumulative summary string. Keeping the whole
+/// string in a collapsed card makes it look like the expanded card, so prefer
+/// the newest-looking fragment and let the widget animate between updates.
+String latestReasoningPreview(String raw, {int maxCharacters = 96}) {
+  var value = raw.replaceAll('\r', '').trim();
+  if (value.isEmpty) return '';
+
+  final lines = value
+      .split('\n')
+      .map((line) => line.trim())
+      .where((line) => line.isNotEmpty)
+      .toList();
+  if (lines.isNotEmpty) value = lines.last;
+
+  // Summary text is commonly wrapped in Markdown emphasis. Splitting on the
+  // marker keeps the trailing/current fragment when a proxy concatenates
+  // several summary updates without inserting whitespace.
+  final emphasizedFragments = value
+      .split('**')
+      .map((fragment) => fragment.trim())
+      .where((fragment) => fragment.isNotEmpty)
+      .toList();
+  if (emphasizedFragments.length > 1) {
+    value = emphasizedFragments.last;
+  }
+
+  // If the provider did include sentence boundaries, the last sentence is a
+  // better current-step preview than the entire accumulated summary.
+  final sentences = value
+      .split(RegExp(r'[.!?。！？；;]+'))
+      .map((sentence) => sentence.trim())
+      .where((sentence) => sentence.isNotEmpty)
+      .toList();
+  if (sentences.length > 1) value = sentences.last;
+
+  value = value
+      .replaceFirst(RegExp(r'^[\s>*_`~\-]+'), '')
+      .replaceFirst(RegExp(r'[\s>*_`~]+$'), '')
+      .trim();
+  if (value.isEmpty) return '';
+  if (value.length <= maxCharacters) return value;
+
+  var tail = value.substring(value.length - maxCharacters);
+  final firstWhitespace = RegExp(r'\s').firstMatch(tail);
+  if (firstWhitespace != null && firstWhitespace.end < tail.length - 12) {
+    tail = tail.substring(firstWhitespace.end);
+  }
+  return '…${tail.trim()}';
+}

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -6498,8 +6498,8 @@ class _ReasoningSectionState extends State<_ReasoningSection>
     // Android-like surface style
     final curve = const Cubic(0.2, 0.8, 0.2, 1);
 
-    // Build a compact header; the current summary is rendered below it when
-    // the card is collapsed.
+    // Build a compact header; while reasoning is active, the current summary
+    // is rendered below it when the card is collapsed.
     Widget header = IosCardPress(
       borderRadius: BorderRadius.circular(12),
       baseColor: Colors.transparent,

--- a/lib/features/chat/widgets/chat_message_widget.dart
+++ b/lib/features/chat/widgets/chat_message_widget.dart
@@ -53,6 +53,7 @@ import 'screen_time_tool_ui.dart';
 import '../../home/services/tool_approval_service.dart';
 import '../../../core/utils/thinking_tag_parser.dart';
 import '../utils/assistant_paragraph_splitter.dart';
+import '../utils/reasoning_preview.dart';
 import 'citation_sources_sheet.dart';
 import 'chat_suggestion_bubbles.dart';
 import 'token_display_widget.dart';
@@ -3886,6 +3887,143 @@ const double _timelineGap = 8;
 const double _timelineLineGap = 3;
 const double _timelineLineX = (_timelineIconColumnWidth - 1) / 2;
 
+class _AnimatedReasoningPreview extends StatelessWidget {
+  const _AnimatedReasoningPreview({
+    required this.text,
+    required this.loading,
+    required this.style,
+  });
+
+  final String text;
+  final bool loading;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = latestReasoningPreview(text);
+    final visibleText = preview.isEmpty && loading ? '…' : preview;
+    if (visibleText.isEmpty) return const SizedBox.shrink();
+
+    return _Shimmer(
+      enabled: loading,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 260),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeInCubic,
+        transitionBuilder: (child, animation) {
+          final offset = Tween<Offset>(
+            begin: const Offset(0, 0.12),
+            end: Offset.zero,
+          ).animate(animation);
+          return FadeTransition(
+            opacity: animation,
+            child: SlideTransition(position: offset, child: child),
+          );
+        },
+        child: Text(
+          visibleText,
+          key: ValueKey<String>(visibleText),
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: style,
+        ),
+      ),
+    );
+  }
+}
+
+class _ScrollingReasoningPreview extends StatefulWidget {
+  const _ScrollingReasoningPreview({
+    required this.child,
+    required this.loading,
+    required this.maxHeight,
+  });
+
+  final Widget child;
+  final bool loading;
+  final double maxHeight;
+
+  @override
+  State<_ScrollingReasoningPreview> createState() =>
+      _ScrollingReasoningPreviewState();
+}
+
+class _ScrollingReasoningPreviewState
+    extends State<_ScrollingReasoningPreview> {
+  final ScrollController _scroll = ScrollController();
+  bool _hasOverflow = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncAfterLayout();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ScrollingReasoningPreview oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncAfterLayout();
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _syncAfterLayout() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scroll.hasClients) return;
+      final hasOverflow = _scroll.position.maxScrollExtent > 0.5;
+      if (hasOverflow != _hasOverflow) {
+        setState(() => _hasOverflow = hasOverflow);
+      }
+      if (widget.loading) {
+        _scroll.jumpTo(_scroll.position.maxScrollExtent);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget scroller = SingleChildScrollView(
+      controller: _scroll,
+      physics: _hasOverflow
+          ? const BouncingScrollPhysics()
+          : const NeverScrollableScrollPhysics(),
+      child: widget.child,
+    );
+    if (_hasOverflow) {
+      scroller = ShaderMask(
+        shaderCallback: (rect) {
+          final height = rect.height;
+          const topFade = 12.0;
+          const bottomFade = 28.0;
+          final topStop = (topFade / height).clamp(0.0, 1.0);
+          final bottomStop = (1.0 - bottomFade / height).clamp(0.0, 1.0);
+          return LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: const [
+              Color(0x00FFFFFF), // color-gate: ignore (dstIn alpha mask)
+              Color(0xFFFFFFFF), // color-gate: ignore (dstIn alpha mask)
+              Color(0xFFFFFFFF), // color-gate: ignore (dstIn alpha mask)
+              Color(0x00FFFFFF), // color-gate: ignore (dstIn alpha mask)
+            ],
+            stops: [0.0, topStop, bottomStop, 1.0],
+          ).createShader(rect);
+        },
+        blendMode: BlendMode.dstIn,
+        child: scroller,
+      );
+    }
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: widget.maxHeight),
+      child: scroller,
+    );
+  }
+}
+
 class _ChainOfThoughtCard extends StatefulWidget {
   const _ChainOfThoughtCard({required this.steps, this.onRecoveredAnswer});
 
@@ -4193,8 +4331,6 @@ class _ChainOfThoughtReasoningStepState
   late final Ticker _ticker = Ticker((_) {
     if (mounted) _elapsedTick.value++;
   });
-  final ScrollController _scroll = ScrollController();
-  bool _hasOverflow = false;
 
   _ReasoningStepState get _stepState {
     if (widget.step.loading) {
@@ -4225,12 +4361,6 @@ class _ChainOfThoughtReasoningStepState
   void initState() {
     super.initState();
     if (widget.step.loading) _ticker.start();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkOverflow();
-      if (widget.step.loading && _scroll.hasClients) {
-        _scroll.jumpTo(_scroll.position.maxScrollExtent);
-      }
-    });
   }
 
   @override
@@ -4238,31 +4368,16 @@ class _ChainOfThoughtReasoningStepState
     super.didUpdateWidget(oldWidget);
     if (widget.step.loading) {
       if (!_ticker.isActive) _ticker.start();
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (_scroll.hasClients) {
-          _scroll.jumpTo(_scroll.position.maxScrollExtent);
-        }
-      });
     } else if (_ticker.isActive) {
       _ticker.stop();
     }
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
   }
 
   @override
   void dispose() {
     _ticker.dispose();
     _elapsedTick.dispose();
-    _scroll.dispose();
     super.dispose();
-  }
-
-  void _checkOverflow() {
-    if (!_scroll.hasClients) return;
-    final over = _scroll.position.maxScrollExtent > 0.5;
-    if (over != _hasOverflow && mounted) {
-      setState(() => _hasOverflow = over);
-    }
   }
 
   @override
@@ -4270,6 +4385,8 @@ class _ChainOfThoughtReasoningStepState
     final fg = _chatSurfaceForegroundPalette(context);
     final l10n = AppLocalizations.of(context)!;
     final settings = context.watch<SettingsProvider>();
+    final showCollapsedReasoningPreview =
+        settings.showCollapsedReasoningPreview;
     final state = _stepState;
     final rawText = _sanitize(widget.step.text);
     final display = rawText;
@@ -4330,48 +4447,22 @@ class _ChainOfThoughtReasoningStepState
     }
 
     Widget? content;
-    if (state == _ReasoningStepState.preview) {
-      content = ConstrainedBox(
-        constraints: const BoxConstraints(maxHeight: 100),
-        child: _hasOverflow
-            ? ShaderMask(
-                shaderCallback: (rect) {
-                  final h = rect.height;
-                  const double topFade = 12;
-                  const double bottomFade = 28;
-                  final double sTop = (topFade / h).clamp(0.0, 1.0);
-                  final double sBot = (1.0 - bottomFade / h).clamp(0.0, 1.0);
-                  return LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: const [
-                      Color(0x00FFFFFF),
-                      Color(0xFFFFFFFF),
-                      Color(0xFFFFFFFF),
-                      Color(0x00FFFFFF),
-                    ],
-                    stops: [0.0, sTop, sBot, 1.0],
-                  ).createShader(rect);
-                },
-                blendMode: BlendMode.dstIn,
-                child: SingleChildScrollView(
-                  controller: _scroll,
-                  physics: const BouncingScrollPhysics(),
-                  child: SanitizingSelectionArea(
-                    child: reasoningContent(display),
-                  ),
-                ),
-              )
-            : SingleChildScrollView(
-                controller: _scroll,
-                physics: const NeverScrollableScrollPhysics(),
-                child: SanitizingSelectionArea(
-                  child: reasoningContent(display),
-                ),
-              ),
-      );
-    } else if (state == _ReasoningStepState.expanded) {
+    if (state == _ReasoningStepState.expanded) {
       content = SanitizingSelectionArea(child: reasoningContent(display));
+    } else if (showCollapsedReasoningPreview && widget.step.loading) {
+      content = SanitizingSelectionArea(
+        child: _AnimatedReasoningPreview(
+          text: display,
+          loading: widget.step.loading,
+          style: const TextStyle(fontSize: 12.5, height: 1.32),
+        ),
+      );
+    } else if (state == _ReasoningStepState.preview) {
+      content = _ScrollingReasoningPreview(
+        loading: widget.step.loading,
+        maxHeight: 100,
+        child: SanitizingSelectionArea(child: reasoningContent(display)),
+      );
     }
 
     return _TimelineStepShell(
@@ -6357,8 +6448,6 @@ class _ReasoningSectionState extends State<_ReasoningSection>
   late final Ticker _ticker = Ticker((_) {
     if (mounted) _elapsedTick.value++;
   });
-  final ScrollController _scroll = ScrollController();
-  bool _hasOverflow = false;
 
   String _sanitize(String s) {
     return s.replaceAll('\r', '').trim();
@@ -6376,12 +6465,6 @@ class _ReasoningSectionState extends State<_ReasoningSection>
   void initState() {
     super.initState();
     if (widget.loading) _ticker.start();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkOverflow();
-      if (widget.loading && _scroll.hasClients) {
-        _scroll.jumpTo(_scroll.position.maxScrollExtent);
-      }
-    });
   }
 
   @override
@@ -6392,28 +6475,13 @@ class _ReasoningSectionState extends State<_ReasoningSection>
     } else {
       if (_ticker.isActive) _ticker.stop();
     }
-    if (widget.loading) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (_scroll.hasClients) {
-          _scroll.jumpTo(_scroll.position.maxScrollExtent);
-        }
-      });
-    }
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
   }
 
   @override
   void dispose() {
     _ticker.dispose();
     _elapsedTick.dispose();
-    _scroll.dispose();
     super.dispose();
-  }
-
-  void _checkOverflow() {
-    if (!_scroll.hasClients) return;
-    final over = _scroll.position.maxScrollExtent > 0.5;
-    if (over != _hasOverflow && mounted) setState(() => _hasOverflow = over);
   }
 
   @override
@@ -6423,12 +6491,15 @@ class _ReasoningSectionState extends State<_ReasoningSection>
     final fg = _chatSurfaceForegroundPalette(context);
     final l10n = AppLocalizations.of(context)!;
     final settings = context.watch<SettingsProvider>();
+    final showCollapsedReasoningPreview =
+        settings.showCollapsedReasoningPreview;
     final loading = widget.loading;
 
     // Android-like surface style
     final curve = const Cubic(0.2, 0.8, 0.2, 1);
 
-    // Build a compact header with optional scrolling preview when loading
+    // Build a compact header; the current summary is rendered below it when
+    // the card is collapsed.
     Widget header = IosCardPress(
       borderRadius: BorderRadius.circular(12),
       baseColor: Colors.transparent,
@@ -6519,62 +6590,33 @@ class _ReasoningSectionState extends State<_ReasoningSection>
       );
     }
 
-    Widget body = Padding(
-      padding: const EdgeInsets.fromLTRB(8, 2, 8, 6),
-      child: reasoningContent(display),
-    );
-
-    if (isLoading && !widget.expanded) {
+    Widget? body;
+    if (widget.expanded) {
       body = Padding(
         padding: const EdgeInsets.fromLTRB(8, 2, 8, 6),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxHeight: 80),
-          child: _hasOverflow
-              ? ShaderMask(
-                  shaderCallback: (rect) {
-                    final h = rect.height;
-                    const double topFade = 12.0;
-                    const double bottomFade = 28.0;
-                    final double sTop = (topFade / h).clamp(0.0, 1.0);
-                    final double sBot = (1.0 - bottomFade / h).clamp(0.0, 1.0);
-                    return LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: const [
-                        Color(0x00FFFFFF),
-                        Color(0xFFFFFFFF),
-                        Color(0xFFFFFFFF),
-                        Color(0x00FFFFFF),
-                      ],
-                      stops: [0.0, sTop, sBot, 1.0],
-                    ).createShader(rect);
-                  },
-                  blendMode: BlendMode.dstIn,
-                  child: NotificationListener<ScrollUpdateNotification>(
-                    onNotification: (_) {
-                      WidgetsBinding.instance.addPostFrameCallback(
-                        (_) => _checkOverflow(),
-                      );
-                      return false;
-                    },
-                    child: SingleChildScrollView(
-                      controller: _scroll,
-                      physics: const BouncingScrollPhysics(),
-                      child: reasoningContent(display),
-                    ),
-                  ),
-                )
-              : SingleChildScrollView(
-                  controller: _scroll,
-                  physics: const NeverScrollableScrollPhysics(),
-                  child: reasoningContent(display),
-                ),
+        child: SanitizingSelectionArea(child: reasoningContent(display)),
+      );
+    } else if (showCollapsedReasoningPreview && isLoading) {
+      body = Padding(
+        padding: const EdgeInsets.fromLTRB(8, 2, 8, 6),
+        child: SanitizingSelectionArea(
+          child: _AnimatedReasoningPreview(
+            text: display,
+            loading: isLoading,
+            style: baseStyle,
+          ),
+        ),
+      );
+    } else if (isLoading) {
+      body = Padding(
+        padding: const EdgeInsets.fromLTRB(8, 2, 8, 6),
+        child: _ScrollingReasoningPreview(
+          loading: true,
+          maxHeight: 80,
+          child: SanitizingSelectionArea(child: reasoningContent(display)),
         ),
       );
     }
-
-    // Enable long-press text selection in reasoning body
-    body = SanitizingSelectionArea(child: body);
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 300),
@@ -6591,7 +6633,7 @@ class _ReasoningSectionState extends State<_ReasoningSection>
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
-            children: [header, if (widget.expanded || isLoading) body],
+            children: [header, if (body != null) body],
           ),
         ),
       ),

--- a/lib/features/home/webview/web_chat_protocol.dart
+++ b/lib/features/home/webview/web_chat_protocol.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 const int webChatProtocolVersion = 5;
-const String webChatAssetVersion = 'web-chat-v22';
+const String webChatAssetVersion = 'web-chat-v23';
 const int webChatMaxChunkBytes = 128 * 1024;
 const int webChatMaxChunkPayloadBytes = 95 * 1024;
 

--- a/lib/features/home/webview/web_chat_snapshot.dart
+++ b/lib/features/home/webview/web_chat_snapshot.dart
@@ -1030,6 +1030,7 @@ Map<String, dynamic> webChatDisplay(
   'showModelTimestamp': settings.showModelTimestamp,
   'showTokenStats': settings.showTokenStats,
   'autoCollapseThinking': settings.autoCollapseThinking,
+  'showCollapsedReasoningPreview': settings.showCollapsedReasoningPreview,
   'collapseThinkingSteps': settings.collapseThinkingSteps,
   'showToolResultSummary': settings.showToolResultSummary,
   'ttsActive': ttsActive,

--- a/lib/features/settings/pages/display_settings_page.dart
+++ b/lib/features/settings/pages/display_settings_page.dart
@@ -2169,6 +2169,19 @@ class BehaviorStartupSettingsPage extends StatelessWidget {
               _iosDivider(context),
               _iosSwitchRow(
                 context,
+                icon: Lucide.Activity,
+                label:
+                    l10n.displaySettingsPageShowCollapsedReasoningPreviewTitle,
+                subtitle: l10n
+                    .displaySettingsPageShowCollapsedReasoningPreviewSubtitle,
+                value: sp.showCollapsedReasoningPreview,
+                onChanged: (v) => context
+                    .read<SettingsProvider>()
+                    .setShowCollapsedReasoningPreview(v),
+              ),
+              _iosDivider(context),
+              _iosSwitchRow(
+                context,
                 icon: Lucide.ListTree,
                 label: l10n.displaySettingsPageCollapseThinkingStepsTitle,
                 value: sp.collapseThinkingSteps,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2305,6 +2305,8 @@
   "displaySettingsPageShowTokenStatsSubtitle": "Show token usage and message count",
   "displaySettingsPageAutoCollapseThinkingTitle": "Auto-collapse Thinking",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "Collapse reasoning after finish",
+  "displaySettingsPageShowCollapsedReasoningPreviewTitle": "Show Current Thought When Collapsed",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "Show the latest thought with animation while a thinking card is collapsed.",
   "displaySettingsPageCollapseThinkingStepsTitle": "Collapse Thinking Steps",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "Show only the latest steps until expanded",
   "displaySettingsPageShowToolResultSummaryTitle": "Show Tool Result Summary",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2306,7 +2306,7 @@
   "displaySettingsPageAutoCollapseThinkingTitle": "Auto-collapse Thinking",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "Collapse reasoning after finish",
   "displaySettingsPageShowCollapsedReasoningPreviewTitle": "Show Current Thought When Collapsed",
-  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "Show the latest thought with animation while a thinking card is collapsed.",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "Show the latest thought with animation while a thinking card is collapsed",
   "displaySettingsPageCollapseThinkingStepsTitle": "Collapse Thinking Steps",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "Show only the latest steps until expanded",
   "displaySettingsPageShowToolResultSummaryTitle": "Show Tool Result Summary",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10258,6 +10258,18 @@ abstract class AppLocalizations {
   /// **'Collapse reasoning after finish'**
   String get displaySettingsPageAutoCollapseThinkingSubtitle;
 
+  /// No description provided for @displaySettingsPageShowCollapsedReasoningPreviewTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show Current Thought When Collapsed'**
+  String get displaySettingsPageShowCollapsedReasoningPreviewTitle;
+
+  /// No description provided for @displaySettingsPageShowCollapsedReasoningPreviewSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Show the latest thought with animation while a thinking card is collapsed.'**
+  String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle;
+
   /// No description provided for @displaySettingsPageCollapseThinkingStepsTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -10267,7 +10267,7 @@ abstract class AppLocalizations {
   /// No description provided for @displaySettingsPageShowCollapsedReasoningPreviewSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Show the latest thought with animation while a thinking card is collapsed.'**
+  /// **'Show the latest thought with animation while a thinking card is collapsed'**
   String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle;
 
   /// No description provided for @displaySettingsPageCollapseThinkingStepsTitle.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5720,7 +5720,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
-      'Show the latest thought with animation while a thinking card is collapsed.';
+      'Show the latest thought with animation while a thinking card is collapsed';
 
   @override
   String get displaySettingsPageCollapseThinkingStepsTitle =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -5715,6 +5715,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Collapse reasoning after finish';
 
   @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewTitle =>
+      'Show Current Thought When Collapsed';
+
+  @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
+      'Show the latest thought with animation while a thinking card is collapsed.';
+
+  @override
   String get displaySettingsPageCollapseThinkingStepsTitle =>
       'Collapse Thinking Steps';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5475,7 +5475,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
-      '思考卡片折叠时显示最新内容，并以动画更新。';
+      '思考卡片折叠时显示最新内容，并以动画更新';
 
   @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折叠思考步骤';
@@ -15462,7 +15462,7 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
-      '思考卡片折叠时显示最新内容，并以动画更新。';
+      '思考卡片折叠时显示最新内容，并以动画更新';
 
   @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折叠思考步骤';
@@ -25448,7 +25448,7 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
-      '思考卡片摺疊時顯示最新內容，並以動畫更新。';
+      '思考卡片摺疊時顯示最新內容，並以動畫更新';
 
   @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折疊思考步驟';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -5470,6 +5470,14 @@ class AppLocalizationsZh extends AppLocalizations {
       '思考完成后自动折叠，保持界面简洁';
 
   @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewTitle =>
+      '折叠时显示当前思考';
+
+  @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
+      '思考卡片折叠时显示最新内容，并以动画更新。';
+
+  @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折叠思考步骤';
 
   @override
@@ -15449,6 +15457,14 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
       '思考完成后自动折叠，保持界面简洁';
 
   @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewTitle =>
+      '折叠时显示当前思考';
+
+  @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
+      '思考卡片折叠时显示最新内容，并以动画更新。';
+
+  @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折叠思考步骤';
 
   @override
@@ -25425,6 +25441,14 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   @override
   String get displaySettingsPageAutoCollapseThinkingSubtitle =>
       '思考完成後自動折疊，保持介面簡潔';
+
+  @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewTitle =>
+      '摺疊時顯示目前思考';
+
+  @override
+  String get displaySettingsPageShowCollapsedReasoningPreviewSubtitle =>
+      '思考卡片摺疊時顯示最新內容，並以動畫更新。';
 
   @override
   String get displaySettingsPageCollapseThinkingStepsTitle => '折疊思考步驟';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1904,6 +1904,8 @@
   "displaySettingsPageShowTokenStatsSubtitle": "显示 token 用量与消息数量",
   "displaySettingsPageAutoCollapseThinkingTitle": "自动折叠思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成后自动折叠，保持界面简洁",
+  "displaySettingsPageShowCollapsedReasoningPreviewTitle": "折叠时显示当前思考",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新。",
   "displaySettingsPageCollapseThinkingStepsTitle": "折叠思考步骤",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "默认只显示最新步骤，展开后查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "显示工具结果摘要",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1905,7 +1905,7 @@
   "displaySettingsPageAutoCollapseThinkingTitle": "自动折叠思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成后自动折叠，保持界面简洁",
   "displaySettingsPageShowCollapsedReasoningPreviewTitle": "折叠时显示当前思考",
-  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新。",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新",
   "displaySettingsPageCollapseThinkingStepsTitle": "折叠思考步骤",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "默认只显示最新步骤，展开后查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "显示工具结果摘要",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1927,6 +1927,8 @@
   "displaySettingsPageShowTokenStatsSubtitle": "显示 token 用量与消息数量",
   "displaySettingsPageAutoCollapseThinkingTitle": "自动折叠思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成后自动折叠，保持界面简洁",
+  "displaySettingsPageShowCollapsedReasoningPreviewTitle": "折叠时显示当前思考",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新。",
   "displaySettingsPageCollapseThinkingStepsTitle": "折叠思考步骤",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "默认只显示最新步骤，展开后查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "显示工具结果摘要",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1928,7 +1928,7 @@
   "displaySettingsPageAutoCollapseThinkingTitle": "自动折叠思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成后自动折叠，保持界面简洁",
   "displaySettingsPageShowCollapsedReasoningPreviewTitle": "折叠时显示当前思考",
-  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新。",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片折叠时显示最新内容，并以动画更新",
   "displaySettingsPageCollapseThinkingStepsTitle": "折叠思考步骤",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "默认只显示最新步骤，展开后查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "显示工具结果摘要",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1882,6 +1882,8 @@
   "displaySettingsPageShowTokenStatsSubtitle": "顯示 token 用量與訊息數量",
   "displaySettingsPageAutoCollapseThinkingTitle": "自動折疊思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成後自動折疊，保持介面簡潔",
+  "displaySettingsPageShowCollapsedReasoningPreviewTitle": "摺疊時顯示目前思考",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片摺疊時顯示最新內容，並以動畫更新。",
   "displaySettingsPageCollapseThinkingStepsTitle": "折疊思考步驟",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "預設只顯示最新步驟，展開後查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "顯示工具結果摘要",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1883,7 +1883,7 @@
   "displaySettingsPageAutoCollapseThinkingTitle": "自動折疊思考",
   "displaySettingsPageAutoCollapseThinkingSubtitle": "思考完成後自動折疊，保持介面簡潔",
   "displaySettingsPageShowCollapsedReasoningPreviewTitle": "摺疊時顯示目前思考",
-  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片摺疊時顯示最新內容，並以動畫更新。",
+  "displaySettingsPageShowCollapsedReasoningPreviewSubtitle": "思考卡片摺疊時顯示最新內容，並以動畫更新",
   "displaySettingsPageCollapseThinkingStepsTitle": "折疊思考步驟",
   "displaySettingsPageCollapseThinkingStepsSubtitle": "預設只顯示最新步驟，展開後查看全部",
   "displaySettingsPageShowToolResultSummaryTitle": "顯示工具結果摘要",

--- a/test/features/chat/utils/reasoning_preview_test.dart
+++ b/test/features/chat/utils/reasoning_preview_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/features/chat/utils/reasoning_preview.dart';
+
+void main() {
+  test('uses the newest fragment from concatenated summary updates', () {
+    expect(
+      latestReasoningPreview('**Planning**Checking constraints**'),
+      'Checking constraints',
+    );
+  });
+
+  test('uses the last non-empty line or sentence', () {
+    expect(latestReasoningPreview('first step\nsecond step'), 'second step');
+    expect(latestReasoningPreview('first step. second step.'), 'second step');
+  });
+
+  test('trims a long preview from the current tail', () {
+    final preview = latestReasoningPreview(
+      'A very long accumulated reasoning summary that keeps growing',
+      maxCharacters: 24,
+    );
+    expect(preview, startsWith('…'));
+    expect(preview, endsWith('keeps growing'));
+  });
+}

--- a/test/features/chat/widgets/chat_message_widget_background_test.dart
+++ b/test/features/chat/widgets/chat_message_widget_background_test.dart
@@ -1140,4 +1140,40 @@ void main() {
       expect(payload['answers']['scope']['value'], 'Complete');
     });
   });
+
+  testWidgets('collapsed reasoning preview is only visible while loading', (
+    tester,
+  ) async {
+    final settings = _createSettings(ChatMessageBackgroundStyle.defaultStyle);
+
+    Widget message({required bool loading}) => _buildHarness(
+      settings: settings,
+      child: ChatMessageWidget(
+        message: ChatMessage(
+          id: 'reasoning-preview-lifecycle',
+          role: 'assistant',
+          content: loading ? '' : 'FINAL_ANSWER',
+          conversationId: 'c1',
+          isStreaming: loading,
+        ),
+        showModelIcon: false,
+        reasoningSegments: [
+          ReasoningSegment(
+            text: 'CURRENT_REASONING_SUMMARY',
+            expanded: false,
+            loading: loading,
+          ),
+        ],
+      ),
+    );
+
+    await tester.pumpWidget(message(loading: true));
+    await tester.pump();
+    expect(find.textContaining('CURRENT_REASONING_SUMMARY'), findsOneWidget);
+
+    await tester.pumpWidget(message(loading: false));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('CURRENT_REASONING_SUMMARY'), findsNothing);
+    expect(find.textContaining('FINAL_ANSWER'), findsOneWidget);
+  });
 }

--- a/test/features/home/web_chat_protocol_test.dart
+++ b/test/features/home/web_chat_protocol_test.dart
@@ -7,7 +7,7 @@ import 'package:Cuplivo/features/home/webview/web_chat_protocol.dart';
 void main() {
   test('Web chat uses protocol v5 and bundled assets v22', () {
     expect(webChatProtocolVersion, 5);
-    expect(webChatAssetVersion, 'web-chat-v22');
+    expect(webChatAssetVersion, 'web-chat-v23');
   });
 
   group('Web streaming patch buffer', () {

--- a/test/features/home/web_chat_snapshot_test.dart
+++ b/test/features/home/web_chat_snapshot_test.dart
@@ -93,7 +93,7 @@ void main() {
 
     final rendered = (snapshot['messages'] as List).single as Map;
     expect(snapshot['protocolVersion'], 5);
-    expect(snapshot['assetVersion'], 'web-chat-v22');
+    expect(snapshot['assetVersion'], 'web-chat-v23');
     expect(snapshot['initialViewportMode'], 'anchor');
     expect(snapshot['locale'], 'zh-Hans');
     expect(snapshot['textDirection'], 'ltr');

--- a/test/features/home/widgets/message_list_view_padding_test.dart
+++ b/test/features/home/widgets/message_list_view_padding_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:Cuplivo/core/models/chat_message.dart';
@@ -323,13 +324,18 @@ void main() {
         ..expanded = false,
     };
     streamingNotifier.getNotifier(messageId);
+    businessPrefs = BusinessPreferences.memoryForTests({
+      'display_show_collapsed_reasoning_preview_v1': false,
+    });
+    final settings = SettingsProvider(preferences: businessPrefs);
+    // This test exercises the legacy scrolling preview inside the collapsed
+    // card: turn the animated preview off before the card reads the flag.
+    unawaited(settings.setShowCollapsedReasoningPreview(false));
 
     await tester.pumpWidget(
       MultiProvider(
         providers: [
-          ChangeNotifierProvider.value(
-            value: SettingsProvider(preferences: businessPrefs),
-          ),
+          ChangeNotifierProvider.value(value: settings),
           ChangeNotifierProvider.value(
             value: AssistantProvider(preferences: businessPrefs),
           ),

--- a/test/openai_responses_reasoning_preview_test.dart
+++ b/test/openai_responses_reasoning_preview_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/core/services/api/chat_api_service.dart';
+
+ProviderConfig _responsesConfig(String baseUrl) {
+  return ProviderConfig(
+    id: 'ResponsesTest',
+    enabled: true,
+    name: 'ResponsesTest',
+    apiKey: 'test-key',
+    baseUrl: baseUrl,
+    providerType: ProviderKind.openai,
+    useResponseApi: true,
+  );
+}
+
+String _baseUrl(HttpServer server) {
+  return 'http://${server.address.address}:${server.port}/v1';
+}
+
+void main() {
+  group('OpenAI Responses reasoning previews', () {
+    test('reads OAuth summary parts from non-stream output', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'output_text': 'Answer',
+            'output': [
+              {
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Compare the tenths place.'},
+                  {'type': 'summary_text', 'text': 'Choose the larger value.'},
+                ],
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'which is larger, 3.4 or 3.35?'},
+        ],
+        stream: false,
+      ).toList();
+
+      expect(chunks, hasLength(1));
+      expect(chunks.single.content, 'Answer');
+      expect(
+        chunks.single.reasoning,
+        'Compare the tenths place.Choose the larger value.',
+      );
+    });
+
+    test(
+      'streams summary deltas once without duplicating done or terminal text',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        server.listen((request) async {
+          await utf8.decoder.bind(request).join();
+          request.response.statusCode = HttpStatus.ok;
+          request.response.headers.contentType = ContentType(
+            'text',
+            'event-stream',
+          );
+          void send(Map<String, dynamic> event) {
+            request.response.write('data: ${jsonEncode(event)}\n\n');
+          }
+
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 0,
+            'item': {
+              'id': 'rs_1',
+              'type': 'reasoning',
+              'content': const <dynamic>[],
+              'summary': const <dynamic>[],
+              'encrypted_content': 'cipher',
+            },
+          });
+          send({
+            'type': 'response.reasoning_summary_text.delta',
+            'item_id': 'rs_1',
+            'output_index': 0,
+            'summary_index': 0,
+            'delta': 'First step. ',
+          });
+          send({
+            'type': 'response.reasoning_summary_text.delta',
+            'item_id': 'rs_1',
+            'output_index': 0,
+            'summary_index': 0,
+            'delta': 'Second step.',
+          });
+          // Repeats everything streamed so far; must not be emitted twice.
+          send({
+            'type': 'response.reasoning_summary_text.done',
+            'item_id': 'rs_1',
+            'output_index': 0,
+            'summary_index': 0,
+            'text': 'First step. Second step.',
+          });
+          send({'type': 'response.output_text.delta', 'delta': 'Hello'});
+          send({
+            'type': 'response.completed',
+            'response': {
+              'output': [
+                {
+                  'id': 'rs_1',
+                  'type': 'reasoning',
+                  'content': const <dynamic>[],
+                  'summary': const [
+                    {'type': 'summary_text', 'text': 'First step.'},
+                    {'type': 'summary_text', 'text': ' Second step.'},
+                  ],
+                },
+                {
+                  'type': 'message',
+                  'content': const [
+                    {'type': 'output_text', 'text': 'Hello'},
+                  ],
+                },
+              ],
+            },
+          });
+          await request.response.close();
+        });
+
+        final chunks = await ChatApiService.sendMessageStream(
+          config: _responsesConfig(_baseUrl(server)),
+          modelId: 'gpt-5',
+          messages: const [
+            {'role': 'user', 'content': 'hi'},
+          ],
+        ).toList();
+
+        expect(chunks.map((c) => c.content).join(), 'Hello');
+        // The terminal item repeats the streamed summary; the decoder must
+        // emit only what was not streamed yet, so no text is duplicated.
+        expect(chunks.map((c) => c.reasoning ?? '').join(), 'First step. Second step.');
+      },
+    );
+
+    test('replays a reasoning item that never streamed deltas', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        send({
+          'type': 'response.output_item.done',
+          'output_index': 0,
+          'item': {
+            'id': 'rs_2',
+            'type': 'reasoning',
+            'content': const <dynamic>[],
+            'summary': const [
+              {'type': 'summary_text', 'text': 'Only in the final item.'},
+            ],
+          },
+        });
+        send({'type': 'response.output_text.delta', 'delta': 'Hi'});
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': const <dynamic>[],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      expect(chunks.map((c) => c.content).join(), 'Hi');
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'Only in the final item.',
+      );
+    });
+  });
+}

--- a/test/openai_responses_reasoning_preview_test.dart
+++ b/test/openai_responses_reasoning_preview_test.dart
@@ -215,5 +215,198 @@ void main() {
         'Only in the final item.',
       );
     });
+
+    test('keeps one copy when an item carries both content and summary', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        send({
+          'type': 'response.reasoning_text.delta',
+          'item_id': 'rs_mixed',
+          'output_index': 0,
+          'summary_index': 0,
+          'delta': 'Visible reasoning',
+        });
+        send({'type': 'response.output_text.delta', 'delta': 'Answer'});
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': [
+              {
+                'id': 'rs_mixed',
+                'type': 'reasoning',
+                'content': const [
+                  {'type': 'reasoning_text', 'text': 'Visible reasoning'},
+                ],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Summary text'},
+                ],
+              },
+            ],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      expect(chunks.map((c) => c.content).join(), 'Answer');
+      // The terminal item prefers `content`; it must be deduped against the
+      // `reasoning_text.delta` stream instead of being appended again.
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'Visible reasoning',
+      );
+    });
+
+    test('does not replay the previous round after a tool follow-up', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+      var requestCount = 0;
+      final requestBodies = <Map<String, dynamic>>[];
+
+      server.listen((request) async {
+        final rawBody = await utf8.decoder.bind(request).join();
+        requestBodies.add(jsonDecode(rawBody) as Map<String, dynamic>);
+        requestCount += 1;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        if (requestCount == 1) {
+          send({
+            'type': 'response.output_item.done',
+            'output_index': 0,
+            'item': {
+              'id': 'rs_round1',
+              'type': 'reasoning',
+              'content': const <dynamic>[],
+              'summary': const [
+                {'type': 'summary_text', 'text': 'ROUND_ONE_REASONING'},
+              ],
+            },
+          });
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 1,
+            'item': {
+              'id': 'fc_1',
+              'type': 'function_call',
+              'call_id': 'call_1',
+              'name': 'lookup',
+              'arguments': '{}',
+            },
+          });
+          send({
+            'type': 'response.function_call_arguments.delta',
+            'output_index': 1,
+            'delta': '{}',
+          });
+          send({
+            'type': 'response.completed',
+            'response': {
+              'output': [
+                {
+                  'id': 'rs_round1',
+                  'type': 'reasoning',
+                  'content': const <dynamic>[],
+                  'summary': const [
+                    {'type': 'summary_text', 'text': 'ROUND_ONE_REASONING'},
+                  ],
+                },
+                {
+                  'id': 'fc_1',
+                  'type': 'function_call',
+                  'call_id': 'call_1',
+                  'name': 'lookup',
+                  'arguments': '{}',
+                },
+              ],
+            },
+          });
+        } else if (requestCount == 2) {
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 1,
+            'item': {
+              'id': 'fc_2',
+              'type': 'function_call',
+              'call_id': 'call_2',
+              'name': 'lookup',
+              'arguments': '{}',
+            },
+          });
+          send({
+            'type': 'response.function_call_arguments.delta',
+            'output_index': 1,
+            'delta': '{}',
+          });
+          // The terminal payload omits `output`, so the round has to fall back
+          // to items captured from streaming events.
+          send({
+            'type': 'response.completed',
+            'response': const <String, dynamic>{},
+          });
+        } else {
+          send({'type': 'response.output_text.delta', 'delta': 'ROUND_THREE'});
+          send({
+            'type': 'response.completed',
+            'response': const <String, dynamic>{},
+          });
+        }
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+        onToolCall: (name, args, {toolCallId}) async => 'tool-result',
+      ).toList();
+
+      expect(requestCount, 3);
+      expect(chunks.map((c) => c.content).join(), contains('ROUND_THREE'));
+      expect(
+        'ROUND_ONE_REASONING'.allMatches(
+          chunks.map((c) => c.reasoning ?? '').join(),
+        ).length,
+        1,
+      );
+      // Multi-round guard: round 1's reasoning is replayed once through the
+      // accumulated `input`, and the follow-up round must not forward it a
+      // second time.
+      expect(
+        'ROUND_ONE_REASONING'.allMatches(jsonEncode(requestBodies[2])).length,
+        1,
+      );
+    });
   });
 }

--- a/test/openai_responses_reasoning_preview_test.dart
+++ b/test/openai_responses_reasoning_preview_test.dart
@@ -631,5 +631,236 @@ void main() {
         'FOLLOW_UP_REASONING',
       );
     });
+
+    test('keeps id-less reasoning items in separate buckets', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        send({'type': 'response.output_text.delta', 'delta': 'Answer'});
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': [
+              {
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Step one.'},
+                ],
+              },
+              {
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Step one'},
+                ],
+              },
+            ],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      // Without an id the items would share one aggregate, and the second
+      // text (a prefix of the first) would be dropped as already streamed.
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'Step one.Step one',
+      );
+    });
+
+    test('dedupes a done-only stream whose item changes namespace', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        // Only a `done` payload streams the text, under the `reasoning`
+        // namespace...
+        send({
+          'type': 'response.reasoning_text.done',
+          'item_id': 'rs_done',
+          'output_index': 0,
+          'summary_index': 0,
+          'text': 'Done only text',
+        });
+        send({'type': 'response.output_text.delta', 'delta': 'Answer'});
+        // ...while the terminal item exposes it as a summary.
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': [
+              {
+                'id': 'rs_done',
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Done only text'},
+                ],
+              },
+            ],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      expect(chunks.map((c) => c.content).join(), 'Answer');
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'Done only text',
+      );
+    });
+
+    test('replays follow-up reasoning items built from streamed events',
+        () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+      var requestCount = 0;
+      final requestBodies = <Map<String, dynamic>>[];
+
+      server.listen((request) async {
+        final rawBody = await utf8.decoder.bind(request).join();
+        requestBodies.add(jsonDecode(rawBody) as Map<String, dynamic>);
+        requestCount += 1;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        if (requestCount == 1) {
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 0,
+            'item': {
+              'id': 'fc_1',
+              'type': 'function_call',
+              'call_id': 'call_1',
+              'name': 'lookup',
+              'arguments': '{}',
+            },
+          });
+          send({
+            'type': 'response.completed',
+            'response': {
+              'output': [
+                {
+                  'id': 'fc_1',
+                  'type': 'function_call',
+                  'call_id': 'call_1',
+                  'name': 'lookup',
+                  'arguments': '{}',
+                },
+              ],
+            },
+          });
+        } else if (requestCount == 2) {
+          send({
+            'type': 'response.output_item.done',
+            'output_index': 0,
+            'item': {
+              'id': 'rs_round2',
+              'type': 'reasoning',
+              'content': const <dynamic>[],
+              'summary': const [
+                {'type': 'summary_text', 'text': 'ROUND_TWO_REASONING'},
+              ],
+            },
+          });
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 1,
+            'item': {
+              'id': 'fc_2',
+              'type': 'function_call',
+              'call_id': 'call_2',
+              'name': 'lookup',
+              'arguments': '{}',
+            },
+          });
+          // Terminal payload omits `output`; the round has to fall back to
+          // the items captured from streaming events.
+          send({
+            'type': 'response.completed',
+            'response': const <String, dynamic>{},
+          });
+        } else {
+          send({'type': 'response.output_text.delta', 'delta': 'FINAL'});
+          send({
+            'type': 'response.completed',
+            'response': const <String, dynamic>{},
+          });
+        }
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+        onToolCall: (name, args, {toolCallId}) async => 'tool-result',
+      ).toList();
+
+      expect(requestCount, 3);
+      expect(chunks.map((c) => c.content).join(), contains('FINAL'));
+      expect(
+        'ROUND_TWO_REASONING'.allMatches(
+          chunks.map((c) => c.reasoning ?? '').join(),
+        ).length,
+        1,
+      );
+      // The captured item is echoed back with the next round's input.
+      expect(
+        jsonEncode(requestBodies[2]).contains('ROUND_TWO_REASONING'),
+        isTrue,
+      );
+    });
   });
 }

--- a/test/openai_responses_reasoning_preview_test.dart
+++ b/test/openai_responses_reasoning_preview_test.dart
@@ -278,6 +278,67 @@ void main() {
       );
     });
 
+    test('dedupes a summary-only terminal item against reasoning deltas', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        send({
+          'type': 'response.reasoning_text.delta',
+          'item_id': 'rs_namespace',
+          'output_index': 0,
+          'summary_index': 0,
+          'delta': 'Streamed as reasoning text',
+        });
+        send({'type': 'response.output_text.delta', 'delta': 'Answer'});
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': [
+              {
+                'id': 'rs_namespace',
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                // Gateway exposes the same text under `summary` on the
+                // terminal item even though the deltas were reasoning parts.
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'Streamed as reasoning text'},
+                ],
+              },
+            ],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      expect(chunks.map((c) => c.content).join(), 'Answer');
+      // The dedup namespace follows the delta stream, not the terminal field.
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'Streamed as reasoning text',
+      );
+    });
+
     test('does not replay the previous round after a tool follow-up', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {

--- a/test/openai_responses_reasoning_preview_test.dart
+++ b/test/openai_responses_reasoning_preview_test.dart
@@ -339,6 +339,72 @@ void main() {
       );
     });
 
+    test('dedupes multi-part summary deltas against the terminal item', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        send({
+          'type': 'response.reasoning_summary_text.delta',
+          'item_id': 'rs_parts',
+          'output_index': 0,
+          'summary_index': 0,
+          'delta': 'First part. ',
+        });
+        send({
+          'type': 'response.reasoning_summary_text.delta',
+          'item_id': 'rs_parts',
+          'output_index': 0,
+          'summary_index': 1,
+          'delta': 'Second part.',
+        });
+        send({'type': 'response.output_text.delta', 'delta': 'Answer'});
+        send({
+          'type': 'response.completed',
+          'response': {
+            'output': [
+              {
+                'id': 'rs_parts',
+                'type': 'reasoning',
+                'content': const <dynamic>[],
+                'summary': const [
+                  {'type': 'summary_text', 'text': 'First part. '},
+                  {'type': 'summary_text', 'text': 'Second part.'},
+                ],
+              },
+            ],
+          },
+        });
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+      ).toList();
+
+      expect(chunks.map((c) => c.content).join(), 'Answer');
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'First part. Second part.',
+      );
+    });
+
     test('does not replay the previous round after a tool follow-up', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() async {
@@ -467,6 +533,102 @@ void main() {
       expect(
         'ROUND_ONE_REASONING'.allMatches(jsonEncode(requestBodies[2])).length,
         1,
+      );
+    });
+
+    test('keeps reasoning streamed by the tool follow-up round', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() async {
+        await server.close(force: true);
+      });
+      var requestCount = 0;
+
+      server.listen((request) async {
+        await utf8.decoder.bind(request).join();
+        requestCount += 1;
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType(
+          'text',
+          'event-stream',
+        );
+        void send(Map<String, dynamic> event) {
+          request.response.write('data: ${jsonEncode(event)}\n\n');
+        }
+
+        if (requestCount == 1) {
+          send({
+            'type': 'response.output_item.added',
+            'output_index': 0,
+            'item': {
+              'id': 'fc_1',
+              'type': 'function_call',
+              'call_id': 'call_1',
+              'name': 'lookup',
+              'arguments': '{}',
+            },
+          });
+          send({
+            'type': 'response.function_call_arguments.delta',
+            'output_index': 0,
+            'delta': '{}',
+          });
+          send({
+            'type': 'response.completed',
+            'response': {
+              'output': [
+                {
+                  'id': 'fc_1',
+                  'type': 'function_call',
+                  'call_id': 'call_1',
+                  'name': 'lookup',
+                  'arguments': '{}',
+                },
+              ],
+            },
+          });
+        } else {
+          send({
+            'type': 'response.reasoning_summary_text.delta',
+            'item_id': 'rs_followup',
+            'output_index': 0,
+            'summary_index': 0,
+            'delta': 'FOLLOW_UP_REASONING',
+          });
+          send({'type': 'response.output_text.delta', 'delta': 'FINAL'});
+          send({
+            'type': 'response.completed',
+            'response': {
+              'output': [
+                {
+                  'id': 'rs_followup',
+                  'type': 'reasoning',
+                  'content': const <dynamic>[],
+                  'summary': const [
+                    {'type': 'summary_text', 'text': 'FOLLOW_UP_REASONING'},
+                  ],
+                },
+              ],
+            },
+          });
+        }
+        await request.response.close();
+      });
+
+      final chunks = await ChatApiService.sendMessageStream(
+        config: _responsesConfig(_baseUrl(server)),
+        modelId: 'gpt-5',
+        messages: const [
+          {'role': 'user', 'content': 'hi'},
+        ],
+        onToolCall: (name, args, {toolCallId}) async => 'tool-result',
+      ).toList();
+
+      expect(requestCount, 2);
+      expect(chunks.map((c) => c.content).join(), contains('FINAL'));
+      // Reasoning from the follow-up round used to be dropped entirely.
+      expect(
+        chunks.map((c) => c.reasoning ?? '').join(),
+        'FOLLOW_UP_REASONING',
       );
     });
   });

--- a/test/settings_provider_collapsed_reasoning_preview_test.dart
+++ b/test/settings_provider_collapsed_reasoning_preview_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+
+import 'support/business_test_harness.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'collapsed reasoning preview defaults on and persists changes',
+    () async {
+      final settings = await createBusinessTestPreferences();
+
+      expect(settings.showCollapsedReasoningPreview, isTrue);
+
+      await settings.setShowCollapsedReasoningPreview(false);
+      expect(settings.showCollapsedReasoningPreview, isFalse);
+      expect(
+        businessPrefs.getBool('display_show_collapsed_reasoning_preview_v1'),
+        isFalse,
+      );
+
+      final reloaded = SettingsProvider(preferences: businessPrefs);
+      await reloaded.loaded;
+      expect(reloaded.showCollapsedReasoningPreview, isFalse);
+    },
+  );
+}


### PR DESCRIPTION
Port of Chevey339/kelivo#1010 into Cuplivo's merged OpenAI provider implementation (`lib/core/services/api/providers/openai_common.dart`), which does not have the separate `openai/responses_decoder.dart` from upstream.

## Summary
- decode visible reasoning from both `content` and `summary` payloads used by OAuth/Codex-compatible Responses APIs
- handle reasoning summary delta/done and output-item events without duplicating terminal text, while retaining reasoning artifacts for follow-up replay
- show the latest reasoning fragment with animation in collapsed thinking cards and add a default-on display setting to restore the legacy behavior when disabled
- add English, Simplified Chinese, and Traditional Chinese localization plus decoder, preview, persistence, and chat regression coverage

## Port notes
- `_responsesReasoningText` now prefers `content` and falls back to `summary` via a shared `_responsesReasoningValue` helper (non-stream output).
- The streaming loop remembers output items by index/id and accumulated reasoning per stream key, so `*.done` and `response.completed` payloads only emit the fragment that has not been streamed yet.
- `_AnimatedReasoningPreview` is adapted to Cuplivo's local widgets (`_Shimmer`, `SanitizingSelectionArea`) instead of upstream's `ThinkingSheen`/`SelectionArea`, and the collapsed preview is only shown while reasoning is still loading.
- Upstream-only files and tests that do not exist here (the separate `openai/` decoder files, `chat_message_widget_parts_render_test.dart`, and parts of `chat_message_widget_background_test.dart`) are not carried over; equivalent coverage lives in `test/openai_responses_reasoning_preview_test.dart` and the chat widget regression test in `chat_message_widget_background_test.dart`.

## Testing
- `flutter analyze` — no new issues from this change
- `flutter test --no-pub test/openai_responses_reasoning_preview_test.dart test/features/chat/utils/reasoning_preview_test.dart test/settings_provider_collapsed_reasoning_preview_test.dart test/features/chat/widgets/chat_message_widget_background_test.dart test/features/home/widgets/message_list_view_padding_test.dart` — 41 tests, all passing
- manually verified collapsed/expanded reasoning and the setting toggle on Android (upstream PR)

Local verification ran on Flutter 3.44.2 (this workspace pins `>=3.44.9`); no API differences were hit.