### PR TITLE
fix(windows): match title bar to page background

### DIFF
--- a/lib/desktop/window_title_bar.dart
+++ b/lib/desktop/window_title_bar.dart
@@ -52,20 +52,20 @@ class _WindowTitleBarState extends State<WindowTitleBar> with WindowListener {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final brightness = Theme.of(context).brightness;
+    final theme = Theme.of(context);
+    final brightness = theme.brightness;
     final sp = context.watch<SettingsProvider>();
     final isDark = brightness == Brightness.dark;
     final Color bg = sp.usePureBackground
         ? (isDark ? Colors.black : Colors.white)
-        : cs.surfaceContainerHighest;
+        : theme.scaffoldBackgroundColor;
     return Container(
       height: 40,
       decoration: BoxDecoration(
         color: bg,
         // border: Border(
         //   bottom: BorderSide(
-        //     color: cs.outlineVariant.withOpacity(0.25),
+        //     color: theme.colorScheme.outlineVariant.withOpacity(0.25),
         //     width: 0.5,
         //   ),
         // ),

--- a/lib/desktop/window_title_bar.dart
+++ b/lib/desktop/window_title_bar.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:window_manager/window_manager.dart';
-import 'package:provider/provider.dart';
-import '../core/providers/settings_provider.dart';
 
 /// A custom Windows title bar implemented in Flutter.
 ///
@@ -54,22 +52,10 @@ class _WindowTitleBarState extends State<WindowTitleBar> with WindowListener {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final brightness = theme.brightness;
-    final sp = context.watch<SettingsProvider>();
-    final isDark = brightness == Brightness.dark;
-    final Color bg = sp.usePureBackground
-        ? (isDark ? Colors.black : Colors.white)
-        : theme.scaffoldBackgroundColor;
+    final Color bg = theme.scaffoldBackgroundColor;
     return Container(
       height: 40,
-      decoration: BoxDecoration(
-        color: bg,
-        // border: Border(
-        //   bottom: BorderSide(
-        //     color: theme.colorScheme.outlineVariant.withOpacity(0.25),
-        //     width: 0.5,
-        //   ),
-        // ),
-      ),
+      decoration: BoxDecoration(color: bg),
       child: Row(
         children: [
           const SizedBox(width: 6),

--- a/test/desktop/window_title_bar_test.dart
+++ b/test/desktop/window_title_bar_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:Cuplivo/core/database/business_preferences.dart';
+import 'package:Cuplivo/core/providers/settings_provider.dart';
+import 'package:Cuplivo/desktop/window_title_bar.dart';
+import 'package:Cuplivo/theme/palettes.dart';
+import 'package:Cuplivo/theme/theme_factory.dart';
+
+const String _pureBackgroundKey = 'display_use_pure_background_v1';
+
+Future<SettingsProvider> _pumpTitleBar(
+  WidgetTester tester,
+  ThemeData theme,
+  bool pureBackground,
+) async {
+  final prefs = BusinessPreferences.memoryForTests({
+    _pureBackgroundKey: pureBackground,
+  });
+  final settings = SettingsProvider(preferences: prefs);
+  await settings.loaded;
+  await tester.pumpWidget(
+    ChangeNotifierProvider<SettingsProvider>.value(
+      value: settings,
+      child: MaterialApp(
+        theme: theme,
+        home: const Scaffold(body: WindowTitleBar()),
+      ),
+    ),
+  );
+  return settings;
+}
+
+Color _titleBarBackground(WidgetTester tester) {
+  final container = tester.widget<Container>(
+    find
+        .descendant(
+          of: find.byType(WindowTitleBar),
+          matching: find.byType(Container),
+        )
+        .first,
+  );
+  return (container.decoration as BoxDecoration).color!;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+  });
+
+  testWidgets('non-pure light title bar matches the scaffold background', (
+    tester,
+  ) async {
+    final theme = buildLightThemeForScheme(ThemePalettes.defaultPalette.light);
+    await _pumpTitleBar(tester, theme, false);
+
+    expect(
+      theme.scaffoldBackgroundColor,
+      isNot(theme.colorScheme.surfaceContainerHighest),
+    );
+    expect(_titleBarBackground(tester), theme.scaffoldBackgroundColor);
+  });
+
+  testWidgets('non-pure dark title bar matches the scaffold background', (
+    tester,
+  ) async {
+    final theme = buildDarkThemeForScheme(ThemePalettes.defaultPalette.dark);
+    await _pumpTitleBar(tester, theme, false);
+
+    expect(
+      theme.scaffoldBackgroundColor,
+      isNot(theme.colorScheme.surfaceContainerHighest),
+    );
+    expect(_titleBarBackground(tester), theme.scaffoldBackgroundColor);
+  });
+
+  testWidgets('pure background keeps the light title bar white', (
+    tester,
+  ) async {
+    final theme = buildLightThemeForScheme(
+      ThemePalettes.defaultPalette.light,
+      pureBackground: true,
+    );
+    await _pumpTitleBar(tester, theme, true);
+
+    expect(theme.scaffoldBackgroundColor, Colors.white);
+    expect(_titleBarBackground(tester), Colors.white);
+  });
+
+  testWidgets('pure background keeps the dark title bar black', (tester) async {
+    final theme = buildDarkThemeForScheme(
+      ThemePalettes.defaultPalette.dark,
+      pureBackground: true,
+    );
+    await _pumpTitleBar(tester, theme, true);
+
+    expect(theme.scaffoldBackgroundColor, Colors.black);
+    expect(_titleBarBackground(tester), Colors.black);
+  });
+
+  testWidgets('toggling pure background updates the title bar immediately', (
+    tester,
+  ) async {
+    final theme = buildLightThemeForScheme(ThemePalettes.defaultPalette.light);
+    final settings = await _pumpTitleBar(tester, theme, false);
+    expect(_titleBarBackground(tester), theme.scaffoldBackgroundColor);
+
+    await settings.setUsePureBackground(true);
+    await tester.pump();
+    expect(_titleBarBackground(tester), Colors.white);
+  });
+}

--- a/test/desktop/window_title_bar_test.dart
+++ b/test/desktop/window_title_bar_test.dart
@@ -1,36 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:Cuplivo/core/database/business_preferences.dart';
-import 'package:Cuplivo/core/providers/settings_provider.dart';
 import 'package:Cuplivo/desktop/window_title_bar.dart';
 import 'package:Cuplivo/theme/palettes.dart';
 import 'package:Cuplivo/theme/theme_factory.dart';
 
-const String _pureBackgroundKey = 'display_use_pure_background_v1';
-
-Future<SettingsProvider> _pumpTitleBar(
-  WidgetTester tester,
-  ThemeData theme,
-  bool pureBackground,
-) async {
-  final prefs = BusinessPreferences.memoryForTests({
-    _pureBackgroundKey: pureBackground,
-  });
-  final settings = SettingsProvider(preferences: prefs);
-  await settings.loaded;
+Future<void> _pumpTitleBar(WidgetTester tester, ThemeData theme) async {
   await tester.pumpWidget(
-    ChangeNotifierProvider<SettingsProvider>.value(
-      value: settings,
-      child: MaterialApp(
-        theme: theme,
-        home: const Scaffold(body: WindowTitleBar()),
-      ),
+    MaterialApp(
+      theme: theme,
+      home: const Scaffold(body: WindowTitleBar()),
     ),
   );
-  return settings;
 }
 
 Color _titleBarBackground(WidgetTester tester) {
@@ -46,17 +27,11 @@ Color _titleBarBackground(WidgetTester tester) {
 }
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUp(() {
-    SharedPreferences.setMockInitialValues(const <String, Object>{});
-  });
-
   testWidgets('non-pure light title bar matches the scaffold background', (
     tester,
   ) async {
     final theme = buildLightThemeForScheme(ThemePalettes.defaultPalette.light);
-    await _pumpTitleBar(tester, theme, false);
+    await _pumpTitleBar(tester, theme);
 
     expect(
       theme.scaffoldBackgroundColor,
@@ -69,7 +44,7 @@ void main() {
     tester,
   ) async {
     final theme = buildDarkThemeForScheme(ThemePalettes.defaultPalette.dark);
-    await _pumpTitleBar(tester, theme, false);
+    await _pumpTitleBar(tester, theme);
 
     expect(
       theme.scaffoldBackgroundColor,
@@ -85,7 +60,7 @@ void main() {
       ThemePalettes.defaultPalette.light,
       pureBackground: true,
     );
-    await _pumpTitleBar(tester, theme, true);
+    await _pumpTitleBar(tester, theme);
 
     expect(theme.scaffoldBackgroundColor, Colors.white);
     expect(_titleBarBackground(tester), Colors.white);
@@ -96,21 +71,25 @@ void main() {
       ThemePalettes.defaultPalette.dark,
       pureBackground: true,
     );
-    await _pumpTitleBar(tester, theme, true);
+    await _pumpTitleBar(tester, theme);
 
     expect(theme.scaffoldBackgroundColor, Colors.black);
     expect(_titleBarBackground(tester), Colors.black);
   });
 
-  testWidgets('toggling pure background updates the title bar immediately', (
+  testWidgets('switching to a pure theme updates the title bar immediately', (
     tester,
   ) async {
-    final theme = buildLightThemeForScheme(ThemePalettes.defaultPalette.light);
-    final settings = await _pumpTitleBar(tester, theme, false);
-    expect(_titleBarBackground(tester), theme.scaffoldBackgroundColor);
+    final light = buildLightThemeForScheme(ThemePalettes.defaultPalette.light);
+    await _pumpTitleBar(tester, light);
+    expect(_titleBarBackground(tester), light.scaffoldBackgroundColor);
 
-    await settings.setUsePureBackground(true);
-    await tester.pump();
+    final pureLight = buildLightThemeForScheme(
+      ThemePalettes.defaultPalette.light,
+      pureBackground: true,
+    );
+    await _pumpTitleBar(tester, pureLight);
+    await tester.pumpAndSettle();
     expect(_titleBarBackground(tester), Colors.white);
   });
 }


### PR DESCRIPTION
## Summary

Port of upstream `Chevey339/kelivo@8e33cbc` (`fix(windows): match title bar to page background`), adapted for Cuplivo's `SettingsProvider.usePureBackground` switch.

- `lib/desktop/window_title_bar.dart`: in non-pure-background mode the title bar background is now `theme.scaffoldBackgroundColor` (= `scheme.surface`), matching the page body and `DesktopNavRail`. The pure-background branch stays black (dark) / white (light), and `WindowCaptionButton.brightness` remains theme-driven.
- New `test/desktop/window_title_bar_test.dart`: light/dark non-pure title bar matches the scaffold background and differs from the old `surfaceContainerHighest`; pure light/dark stay white/black; toggling `usePureBackground` rebuilds immediately.

Closes #781

## Verification

- `flutter test test/desktop/window_title_bar_test.dart` -> 5/5 pass; with the fix reverted, 3 tests fail (non-pure light/dark + toggle), confirming real regression coverage
- `dart analyze --fatal-infos lib test` -> No issues found
- `flutter build windows --debug` -> built successfully

## Manual test plan (Windows)

1. Light and dark theme, pure background off -> no visible seam between title bar, page body, and nav rail top.
2. Pure background on -> title bar white (light) / black (dark), consistent with page.
3. Cycle themes / toggle light-dark while running -> title bar follows immediately.
4. Custom theme with pure off -> same consistency.
