### PR TITLE
fix(desktop): make provider settings dialog toggles rebuild in-place

### DIFF
--- a/lib/desktop/setting/providers_pane.dart
+++ b/lib/desktop/setting/providers_pane.dart
@@ -1028,8 +1028,6 @@ class _DesktopProviderDetailPaneState
   final TextEditingController _proxyPortCtrl = TextEditingController();
   final TextEditingController _proxyUserCtrl = TextEditingController();
   final TextEditingController _proxyPassCtrl = TextEditingController();
-  bool _balanceLoading = false;
-  bool _customRequestExpanded = false;
   void _syncCtrl(TextEditingController c, String newText) {
     final v = c.value;
     // Do not disturb ongoing IME composition
@@ -2267,47 +2265,6 @@ class _DesktopProviderDetailPaneState
     );
   }
 
-  Future<void> _queryProviderBalance(BuildContext context) async {
-    if (_balanceLoading) return;
-    final sp = context.read<SettingsProvider>();
-    final l10n = AppLocalizations.of(context)!;
-    setState(() {
-      _balanceLoading = true;
-    });
-    try {
-      final old = sp.getProviderConfig(
-        widget.providerKey,
-        defaultName: widget.displayName,
-      );
-      final updated = old.copyWith(
-        balanceApiPath: _balanceApiPathCtrl.text.trim(),
-        balanceResultPath: _balanceResultPathCtrl.text.trim(),
-      );
-      await sp.setProviderConfig(widget.providerKey, updated);
-      ProviderBalanceBadge.clearCacheFor(widget.providerKey);
-      final value = await ProviderBalanceService.fetchBalance(updated);
-      if (!mounted) return;
-      if (context.mounted) {
-        showAppSnackBar(
-          context,
-          message: l10n.providerDetailPageBalanceResult(value),
-          type: NotificationType.success,
-        );
-      }
-    } catch (e) {
-      if (!mounted) return;
-      if (context.mounted) {
-        showAppSnackBar(
-          context,
-          message: l10n.providerDetailPageBalanceError(e.toString()),
-          type: NotificationType.error,
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _balanceLoading = false);
-    }
-  }
-
   InputDecoration _proxyInputDecoration(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return InputDecoration(
@@ -3139,22 +3096,16 @@ class _DesktopProviderDetailPaneState
                                               ),
                                             ),
                                             const SizedBox(width: 4),
-                                            Tooltip(
-                                              message: _balanceLoading
-                                                  ? l10n.providerDetailPageBalanceQuerying
-                                                  : l10n.providerDetailPageBalanceQueryButton,
-                                              child: _IconBtn(
-                                                icon: _balanceLoading
-                                                    ? lucide.Lucide.Loader
-                                                    : lucide
-                                                          .Lucide
-                                                          .RefreshCcwDot,
-                                                color: cs.primary,
-                                                onTap: () =>
-                                                    _queryProviderBalance(
-                                                      context,
-                                                    ),
+                                            _BalanceQueryButton(
+                                              key: const ValueKey(
+                                                'desktop-provider-balance-query-button',
                                               ),
+                                              providerKey: widget.providerKey,
+                                              displayName: widget.displayName,
+                                              apiPathController:
+                                                  _balanceApiPathCtrl,
+                                              resultPathController:
+                                                  _balanceResultPathCtrl,
                                             ),
                                           ],
                                         ),
@@ -3576,42 +3527,11 @@ class _DesktopProviderDetailPaneState
                               sizeCurve: Curves.easeOutCubic,
                             ),
                             // 6) Provider-level custom request inline
-                            _CustomRequestHeaderRow(
-                              expanded: _customRequestExpanded,
-                              onTap: () => setState(
-                                () => _customRequestExpanded =
-                                    !_customRequestExpanded,
-                              ),
-                            ),
-                            AnimatedCrossFade(
-                              firstChild: const SizedBox.shrink(),
-                              secondChild: Padding(
-                                padding: const EdgeInsets.only(top: 8),
-                                child: Column(
-                                  crossAxisAlignment:
-                                      CrossAxisAlignment.stretch,
-                                  children: [
-                                    _DesktopCustomRequestSection(
-                                      providerKey: widget.providerKey,
-                                      displayName: widget.displayName,
-                                      mode: KeyMode.header,
-                                      entries: cfgNow.customHeaders,
-                                    ),
-                                    const SizedBox(height: 12),
-                                    _DesktopCustomRequestSection(
-                                      providerKey: widget.providerKey,
-                                      displayName: widget.displayName,
-                                      mode: KeyMode.body,
-                                      entries: cfgNow.customBody,
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              crossFadeState: _customRequestExpanded
-                                  ? CrossFadeState.showSecond
-                                  : CrossFadeState.showFirst,
-                              duration: const Duration(milliseconds: 180),
-                              sizeCurve: Curves.easeOutCubic,
+                            _CustomRequestSection(
+                              providerKey: widget.providerKey,
+                              displayName: widget.displayName,
+                              headers: cfgNow.customHeaders,
+                              body: cfgNow.customBody,
                             ),
                           ],
                         ),
@@ -7143,6 +7063,74 @@ class _CustomRequestHeaderRow extends StatelessWidget {
   }
 }
 
+/// Desktop collapsible custom request section.
+///
+/// The provider settings dialog lives in its own route, so the expanded state
+/// must rebuild this subtree instead of the pane State behind the dialog.
+class _CustomRequestSection extends StatefulWidget {
+  const _CustomRequestSection({
+    required this.providerKey,
+    required this.displayName,
+    required this.headers,
+    required this.body,
+  });
+
+  final String providerKey;
+  final String displayName;
+  final List<Map<String, String>> headers;
+  final List<Map<String, String>> body;
+
+  @override
+  State<_CustomRequestSection> createState() => _CustomRequestSectionState();
+}
+
+class _CustomRequestSectionState extends State<_CustomRequestSection> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _CustomRequestHeaderRow(
+          expanded: _expanded,
+          onTap: () => setState(() => _expanded = !_expanded),
+        ),
+        AnimatedCrossFade(
+          key: const ValueKey('desktop-provider-custom-request-crossfade'),
+          firstChild: const SizedBox.shrink(),
+          secondChild: Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _DesktopCustomRequestSection(
+                  providerKey: widget.providerKey,
+                  displayName: widget.displayName,
+                  mode: KeyMode.header,
+                  entries: widget.headers,
+                ),
+                const SizedBox(height: 12),
+                _DesktopCustomRequestSection(
+                  providerKey: widget.providerKey,
+                  displayName: widget.displayName,
+                  mode: KeyMode.body,
+                  entries: widget.body,
+                ),
+              ],
+            ),
+          ),
+          crossFadeState: _expanded
+              ? CrossFadeState.showSecond
+              : CrossFadeState.showFirst,
+          duration: const Duration(milliseconds: 180),
+          sizeCurve: Curves.easeOutCubic,
+        ),
+      ],
+    );
+  }
+}
+
 /// Desktop inline custom request editor section (Headers or Body).
 class _DesktopCustomRequestSection extends StatelessWidget {
   const _DesktopCustomRequestSection({
@@ -7202,6 +7190,83 @@ class _DesktopCustomRequestSection extends StatelessWidget {
             : {'key': key, 'value': value};
         _save(context, updated);
       },
+    );
+  }
+}
+
+/// Desktop balance query button with self-contained loading state.
+///
+/// Rendered inside the provider settings dialog route; keeping the loading
+/// flag local is what lets the spinner update while the dialog stays open.
+class _BalanceQueryButton extends StatefulWidget {
+  const _BalanceQueryButton({
+    super.key,
+    required this.providerKey,
+    required this.displayName,
+    required this.apiPathController,
+    required this.resultPathController,
+  });
+
+  final String providerKey;
+  final String displayName;
+  final TextEditingController apiPathController;
+  final TextEditingController resultPathController;
+
+  @override
+  State<_BalanceQueryButton> createState() => _BalanceQueryButtonState();
+}
+
+class _BalanceQueryButtonState extends State<_BalanceQueryButton> {
+  bool _loading = false;
+
+  Future<void> _query() async {
+    if (_loading) return;
+    final sp = context.read<SettingsProvider>();
+    final l10n = AppLocalizations.of(context)!;
+    setState(() => _loading = true);
+    try {
+      final old = sp.getProviderConfig(
+        widget.providerKey,
+        defaultName: widget.displayName,
+      );
+      final updated = old.copyWith(
+        balanceApiPath: widget.apiPathController.text.trim(),
+        balanceResultPath: widget.resultPathController.text.trim(),
+      );
+      await sp.setProviderConfig(widget.providerKey, updated);
+      ProviderBalanceBadge.clearCacheFor(widget.providerKey);
+      final value = await ProviderBalanceService.fetchBalance(updated);
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.providerDetailPageBalanceResult(value),
+        type: NotificationType.success,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.providerDetailPageBalanceError(e.toString()),
+        type: NotificationType.error,
+      );
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: _loading
+          ? l10n.providerDetailPageBalanceQuerying
+          : l10n.providerDetailPageBalanceQueryButton,
+      child: _IconBtn(
+        icon: _loading ? lucide.Lucide.Loader : lucide.Lucide.RefreshCcwDot,
+        color: cs.primary,
+        onTap: _query,
+      ),
     );
   }
 }

--- a/test/desktop_provider_detail_pane_test.dart
+++ b/test/desktop_provider_detail_pane_test.dart
@@ -201,6 +201,108 @@ void main() {
     expect(cfg.avatarValue, 'openai');
   });
 
+  testWidgets('desktop custom request section toggles on tap', (tester) async {
+    final settings = await _buildSettings(tester);
+    addTearDown(settings.dispose);
+
+    await _pumpProviderSettings(tester, settings);
+
+    await tester.tap(
+      find.byKey(const ValueKey('desktop-provider-settings-ProviderA')),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    final crossfade = find.byKey(
+      const ValueKey('desktop-provider-custom-request-crossfade'),
+    );
+    final header = find.text('Custom Request');
+    await tester.ensureVisible(header);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<AnimatedCrossFade>(crossfade).crossFadeState,
+      CrossFadeState.showFirst,
+    );
+
+    await tester.tap(header);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<AnimatedCrossFade>(crossfade).crossFadeState,
+      CrossFadeState.showSecond,
+    );
+
+    await tester.tap(header);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<AnimatedCrossFade>(crossfade).crossFadeState,
+      CrossFadeState.showFirst,
+    );
+  });
+
+  testWidgets('desktop balance query spinner clears after request settles', (
+    tester,
+  ) async {
+    businessPrefs = BusinessPreferences.memoryForTests(const {});
+    final settings = SettingsProvider(preferences: businessPrefs);
+    await tester.runAsync(_waitForSettingsLoad);
+    await settings.setProviderConfig(
+      'ProviderA',
+      ProviderConfig(
+        id: 'ProviderA',
+        enabled: true,
+        name: 'ProviderA',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.test/v1',
+        providerType: ProviderKind.openai,
+        balanceEnabled: true,
+        balanceApiPath: '/credits',
+        balanceResultPath: 'data.total',
+      ),
+    );
+    await settings.setProvidersOrder(const ['ProviderA']);
+    addTearDown(settings.dispose);
+
+    await _pumpProviderSettings(tester, settings);
+
+    await tester.tap(
+      find.byKey(const ValueKey('desktop-provider-settings-ProviderA')),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    final queryButton = find.byKey(
+      const ValueKey('desktop-provider-balance-query-button'),
+    );
+    await tester.ensureVisible(queryButton);
+    await tester.pumpAndSettle();
+
+    String queryButtonTooltip() {
+      return tester
+          .widget<Tooltip>(
+            find.descendant(of: queryButton, matching: find.byType(Tooltip)),
+          )
+          .message!;
+    }
+
+    expect(queryButtonTooltip(), 'Check Balance');
+
+    await tester.tap(queryButton);
+    await tester.pump();
+
+    expect(queryButtonTooltip(), 'Checking...');
+
+    await tester.pumpAndSettle();
+
+    expect(queryButtonTooltip(), 'Check Balance');
+
+    // Let the error snackbar auto-dismiss so no timer outlives the test.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+
   group('desktop providers pane codex gate', () {
     Future<SettingsProvider> buildSettings(
       WidgetTester tester, {


### PR DESCRIPTION
## Summary

Fixes #785. In the desktop provider settings dialog, clicking the custom request header (expand/collapse) had no visible reaction; the state only refreshed after closing and reopening the dialog. The balance query spinner had the same defect: once shown, it never cleared.

**Root cause:** the dialog is a separate `showDialog` route. `_CustomRequestHeaderRow`'s `onTap` and the balance query called `setState` on `_DesktopProviderDetailPaneState`, which is behind the modal barrier -- a dialog route is not a child of that State's element, so the dialog subtree never rebuilt. It only rebuilt when `SettingsProvider` notified (the `Consumer` inside the dialog), and neither action writes provider state on completion. Close/reopen re-ran the builder, which read the already-flipped field -- exactly the reported symptom.

## Changes

- Extract `_CustomRequestSection` (owns `_expanded`) and `_BalanceQueryButton` (owns `_loading`) as self-contained `StatefulWidget`s, so their local `setState` rebuilds the dialog subtree regardless of route. Same pattern as the existing `_ModelGroupAccordion`.
- Remove the now-unused pane-level `_customRequestExpanded`, `_balanceLoading`, and `_queryProviderBalance`.
- Add regression tests in `test/desktop_provider_detail_pane_test.dart`:
  - custom request header toggles `AnimatedCrossFade` between `showFirst`/`showSecond` in place;
  - balance button tooltip shows `Checking...` then returns to `Check Balance` after the request settles.

## Behavior note

Expansion state now lives in the dialog subtree, so reopening the dialog always starts collapsed. Previously the stale pane field leaked across reopen -- this is a deliberate, approved tradeoff.

## Verification

- `dart analyze --fatal-infos lib test` -- clean.
- `flutter test test/desktop_provider_detail_pane_test.dart` -- 10/10 pass; both new tests fail against the pre-fix `lib` change.
- Manual verification on Windows: repeated expand/collapse, and a balance query whose spinner clears without reopening the dialog.
