### PR TITLE
fix(desktop): open the logs folder via platform commands

### DIFF
--- a/lib/desktop/desktop_settings_page.dart
+++ b/lib/desktop/desktop_settings_page.dart
@@ -52,7 +52,6 @@ import '../features/group_chat/pages/group_chat_settings_page.dart';
 import '../features/group_chat/widgets/group_chat_settings_card.dart';
 import '../utils/sandbox_path_resolver.dart';
 import 'dart:io' show Directory, File, Platform;
-import '../utils/app_directories.dart';
 import 'add_provider_dialog.dart' show showDesktopAddProviderDialog;
 import 'model_edit_dialog.dart'
     show showDesktopCreateModelDialog, showDesktopModelEditDialog;
@@ -68,7 +67,9 @@ import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart' as p;
 import 'desktop_context_menu.dart';
 import 'desktop_settings_navigation_bus.dart';
+import 'widgets/logs_folder_button.dart';
 import '../shared/widgets/snackbar.dart';
+import '../shared/widgets/windows_ax_tree_safe_tooltip.dart';
 import 'setting/default_model_pane.dart';
 import 'setting/search_services_pane.dart';
 import 'setting/mcp_pane.dart';

--- a/lib/desktop/setting/display_pane.dart
+++ b/lib/desktop/setting/display_pane.dart
@@ -642,7 +642,7 @@ class _ThemeActionDotState extends State<_ThemeActionDot> {
       onEnter: (_) => setState(() => _hover = true),
       onExit: (_) => setState(() => _hover = false),
       cursor: SystemMouseCursors.click,
-      child: Tooltip(
+      child: WindowsAxTreeSafeTooltip(
         message: widget.tooltip,
         child: GestureDetector(
           onTap: widget.onTap,
@@ -1712,7 +1712,7 @@ class _DesktopAppFontRow extends StatelessWidget {
             },
           ),
           const SizedBox(width: 8),
-          Tooltip(
+          WindowsAxTreeSafeTooltip(
             message: l10n.displaySettingsPageFontResetLabel,
             child: _IconBtn(
               icon: lucide.Lucide.RotateCcw,
@@ -1759,7 +1759,7 @@ class _DesktopCodeFontRow extends StatelessWidget {
             },
           ),
           const SizedBox(width: 8),
-          Tooltip(
+          WindowsAxTreeSafeTooltip(
             message: l10n.displaySettingsPageFontResetLabel,
             child: _IconBtn(
               icon: lucide.Lucide.RotateCcw,
@@ -2601,29 +2601,7 @@ class _ToggleRowRequestLogging extends StatelessWidget {
               ),
             ),
           ),
-          Tooltip(
-            message: l10n.logViewerOpenFolder,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(6),
-              onTap: () async {
-                final dir = await AppDirectories.getAppDataDirectory();
-                final logsDir = Directory('${dir.path}/logs');
-                if (!await logsDir.exists()) {
-                  await logsDir.create(recursive: true);
-                }
-                final uri = Uri.file(logsDir.path);
-                await launchUrl(uri);
-              },
-              child: Padding(
-                padding: const EdgeInsets.all(6),
-                child: Icon(
-                  lucide.Lucide.FolderOpen,
-                  size: 18,
-                  color: cs.primary,
-                ),
-              ),
-            ),
-          ),
+          const LogsFolderButton(),
           const SizedBox(width: 8),
           IosSwitch(
             value: sp.requestLogEnabled,
@@ -2700,29 +2678,7 @@ class _ToggleRowFlutterLogging extends StatelessWidget {
               ),
             ),
           ),
-          Tooltip(
-            message: l10n.logViewerOpenFolder,
-            child: InkWell(
-              borderRadius: BorderRadius.circular(6),
-              onTap: () async {
-                final dir = await AppDirectories.getAppDataDirectory();
-                final logsDir = Directory('${dir.path}/logs');
-                if (!await logsDir.exists()) {
-                  await logsDir.create(recursive: true);
-                }
-                final uri = Uri.file(logsDir.path);
-                await launchUrl(uri);
-              },
-              child: Padding(
-                padding: const EdgeInsets.all(6),
-                child: Icon(
-                  lucide.Lucide.FolderOpen,
-                  size: 18,
-                  color: cs.primary,
-                ),
-              ),
-            ),
-          ),
+          const LogsFolderButton(),
           const SizedBox(width: 8),
           IosSwitch(
             value: sp.flutterLogEnabled,

--- a/lib/desktop/widgets/logs_folder_button.dart
+++ b/lib/desktop/widgets/logs_folder_button.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+
+import '../../icons/lucide_adapter.dart' as lucide;
+import '../../l10n/app_localizations.dart';
+import '../../shared/widgets/snackbar.dart';
+import '../../shared/widgets/windows_ax_tree_safe_tooltip.dart';
+import '../../utils/app_directories.dart';
+import '../../utils/open_directory.dart';
+
+/// Resolves the application `logs` directory, creating it when missing, then
+/// opens it in the system file manager.
+Future<void> _openLogsDirectory() async {
+  final base = await AppDirectories.getAppDataDirectory();
+  final logsDir = Directory(p.join(base.path, 'logs'));
+  if (!await logsDir.exists()) {
+    await logsDir.create(recursive: true);
+  }
+  await openDirectoryInFileManager(logsDir.path);
+}
+
+/// Folder button shown next to the log toggles in desktop settings.
+///
+/// Opens the application `logs` directory in the system file manager and
+/// reports failures through an error snackbar instead of staying silent
+/// (issue #789: a `file://` URI handed to `url_launcher` did nothing).
+class LogsFolderButton extends StatelessWidget {
+  const LogsFolderButton({super.key, this.openFolder = _openLogsDirectory});
+
+  /// Injectable for tests; production uses [_openLogsDirectory].
+  final Future<void> Function() openFolder;
+
+  Future<void> _handleTap(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      await openFolder();
+    } catch (e) {
+      debugPrint('LogsFolderButton: failed to open logs folder: $e');
+      if (!context.mounted) return;
+      showAppSnackBar(
+        context,
+        message: l10n.logViewerOpenFolderFailed('$e'),
+        type: NotificationType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final cs = Theme.of(context).colorScheme;
+    return WindowsAxTreeSafeTooltip(
+      message: l10n.logViewerOpenFolder,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(6),
+        onTap: () => _handleTap(context),
+        child: Padding(
+          padding: const EdgeInsets.all(6),
+          child: Icon(lucide.Lucide.FolderOpen, size: 18, color: cs.primary),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3121,6 +3121,14 @@
   "logViewerCurrentLog": "Current Log",
   "logViewerExport": "Export",
   "logViewerOpenFolder": "Open Logs Folder",
+  "logViewerOpenFolderFailed": "Couldn't open the logs folder: {error}",
+  "@logViewerOpenFolderFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "logViewerRequestsCount": "{count} requests",
   "@logViewerRequestsCount": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -13879,6 +13879,12 @@ abstract class AppLocalizations {
   /// **'Open Logs Folder'**
   String get logViewerOpenFolder;
 
+  /// No description provided for @logViewerOpenFolderFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the logs folder: {error}'**
+  String logViewerOpenFolderFailed(String error);
+
   /// No description provided for @logViewerRequestsCount.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -7726,6 +7726,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logViewerOpenFolder => 'Open Logs Folder';
 
   @override
+  String logViewerOpenFolderFailed(String error) {
+    return 'Couldn\'t open the logs folder: $error';
+  }
+
+  @override
   String logViewerRequestsCount(int count) {
     return '$count requests';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -7387,6 +7387,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get logViewerOpenFolder => '打开日志目录';
 
   @override
+  String logViewerOpenFolderFailed(String error) {
+    return '无法打开日志目录：$error';
+  }
+
+  @override
   String logViewerRequestsCount(int count) {
     return '$count 条请求';
   }
@@ -17364,6 +17369,11 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get logViewerOpenFolder => '打开日志目录';
+
+  @override
+  String logViewerOpenFolderFailed(String error) {
+    return '无法打开日志目录：$error';
+  }
 
   @override
   String logViewerRequestsCount(int count) {
@@ -27345,6 +27355,11 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get logViewerOpenFolder => '開啟日誌目錄';
+
+  @override
+  String logViewerOpenFolderFailed(String error) {
+    return '無法開啟日誌目錄：$error';
+  }
 
   @override
   String logViewerRequestsCount(int count) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -2625,6 +2625,7 @@
   "logViewerCurrentLog": "当前日志",
   "logViewerExport": "导出",
   "logViewerOpenFolder": "打开日志目录",
+  "logViewerOpenFolderFailed": "无法打开日志目录：{error}",
   "logViewerRequestsCount": "{count} 条请求",
   "logViewerFieldId": "ID",
   "logViewerFieldMethod": "方法",

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -2629,6 +2629,7 @@
   "logViewerCurrentLog": "当前日志",
   "logViewerExport": "导出",
   "logViewerOpenFolder": "打开日志目录",
+  "logViewerOpenFolderFailed": "无法打开日志目录：{error}",
   "logViewerRequestsCount": "{count} 条请求",
   "logViewerFieldId": "ID",
   "logViewerFieldMethod": "方法",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -2625,6 +2625,7 @@
   "logViewerCurrentLog": "目前日誌",
   "logViewerExport": "匯出",
   "logViewerOpenFolder": "開啟日誌目錄",
+  "logViewerOpenFolderFailed": "無法開啟日誌目錄：{error}",
   "logViewerRequestsCount": "{count} 個請求",
   "logViewerFieldId": "ID",
   "logViewerFieldMethod": "方法",

--- a/lib/utils/open_directory.dart
+++ b/lib/utils/open_directory.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, visibleForTesting;
+
+/// Opens [directoryPath] in the system file manager.
+///
+/// `Uri.file` + `url_launcher` is deliberately NOT used here: on Windows the
+/// `file:` scheme is routed through `ShellExecuteW` as a URL, and opening a
+/// directory that way is unreliable (issue #789: clicks appeared to do
+/// nothing). Platform commands treat the path as a plain path instead.
+///
+/// On Windows the path is normalized to backslashes first: `explorer.exe`
+/// does not resolve forward-slash paths and opens the wrong folder (its
+/// command line treats `/`-prefixed tokens as switches, e.g. `/select,`).
+///
+/// Throws [UnsupportedError] on non-desktop platforms and [ProcessException]
+/// when the platform command exits with a non-zero status.
+Future<void> openDirectoryInFileManager(String directoryPath) async {
+  final platform = defaultTargetPlatform;
+  final command = directoryOpenCommandFor(platform, directoryPath);
+  if (command == null) {
+    throw UnsupportedError(
+      'Opening a directory is only supported on desktop platforms',
+    );
+  }
+  final (executable, arguments) = command;
+  if (platform == TargetPlatform.windows) {
+    // explorer.exe can report a non-zero exit code (or keep running) even
+    // when the folder opens, so launch it detached and ignore the result.
+    await Process.start(executable, arguments, mode: ProcessStartMode.detached);
+    return;
+  }
+  final result = await Process.run(executable, arguments);
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      executable,
+      arguments,
+      result.stderr?.toString() ?? '',
+      result.exitCode,
+    );
+  }
+}
+
+/// Executable and arguments that open [path] in the system file manager for
+/// [platform], or null when [platform] has no known implementation.
+@visibleForTesting
+(String, List<String>)? directoryOpenCommandFor(
+  TargetPlatform platform,
+  String path,
+) {
+  return switch (platform) {
+    // explorer.exe only resolves backslash paths; forward slashes can make it
+    // open the default folder or the parent instead (issue #789 follow-up).
+    TargetPlatform.windows => (
+      'explorer',
+      <String>[path.replaceAll('/', r'\')],
+    ),
+    TargetPlatform.macOS => ('open', <String>[path]),
+    TargetPlatform.linux => ('xdg-open', <String>[path]),
+    _ => null,
+  };
+}

--- a/test/desktop/widgets/logs_folder_button_test.dart
+++ b/test/desktop/widgets/logs_folder_button_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:Cuplivo/desktop/widgets/logs_folder_button.dart';
+import 'package:Cuplivo/l10n/app_localizations.dart';
+import 'package:Cuplivo/l10n/app_localizations_en.dart';
+import 'package:Cuplivo/shared/widgets/snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final l10n = AppLocalizationsEn();
+
+  setUp(() => AppSnackBarManager().dismissAll());
+  tearDown(() => AppSnackBarManager().dismissAll());
+
+  Widget harness(Future<void> Function() openFolder) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: AppSnackBarOverlay(
+        child: Scaffold(
+          body: Center(child: LogsFolderButton(openFolder: openFolder)),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('tapping the button invokes the logs folder opener once', (
+    tester,
+  ) async {
+    var calls = 0;
+    await tester.pumpWidget(harness(() async => calls++));
+
+    await tester.tap(find.byType(LogsFolderButton));
+    await tester.pump();
+
+    expect(calls, 1);
+  });
+
+  testWidgets('opener failure surfaces an error snackbar instead of silence', (
+    tester,
+  ) async {
+    final error = ProcessException('explorer', const <String>[], 'boom', 1);
+    await tester.pumpWidget(harness(() async => throw error));
+
+    await tester.tap(find.byType(LogsFolderButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text(l10n.logViewerOpenFolderFailed('$error')), findsOneWidget);
+
+    // Drain the snackbar timer and exit animation so no ticker is left.
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+}

--- a/test/utils/open_directory_test.dart
+++ b/test/utils/open_directory_test.dart
@@ -1,0 +1,58 @@
+import 'package:Cuplivo/utils/open_directory.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('directoryOpenCommandFor', () {
+    test('windows opens with explorer using the plain path', () {
+      const path = r'C:\Users\me\AppData\Roaming\Cuplivo\logs';
+      final command = directoryOpenCommandFor(TargetPlatform.windows, path);
+      expect(command?.$1, 'explorer');
+      expect(command?.$2, [path]);
+      // Regression guard for issue #789: never hand a file:/// URL to
+      // url_launcher for a directory.
+      expect(command!.$2.single.startsWith('file:'), isFalse);
+    });
+
+    test('windows normalizes forward slashes to backslashes', () {
+      // Regression for issue #789: a path built as '...\\cuplivo/logs' made
+      // explorer.exe open the wrong folder because it cannot resolve
+      // forward-slash paths.
+      final command = directoryOpenCommandFor(
+        TargetPlatform.windows,
+        'C:/Users/me/AppData/Roaming/com.psyche/cuplivo/logs',
+      );
+      expect(command?.$1, 'explorer');
+      expect(command?.$2, [
+        r'C:\Users\me\AppData\Roaming\com.psyche\cuplivo\logs',
+      ]);
+    });
+
+    test('macOS opens with open', () {
+      const path = '/Users/me/Library/Application Support/Cuplivo/logs';
+      final command = directoryOpenCommandFor(TargetPlatform.macOS, path);
+      expect(command?.$1, 'open');
+      // POSIX separators must pass through untouched.
+      expect(command?.$2, [path]);
+    });
+
+    test('linux opens with xdg-open', () {
+      const path = '/home/me/.local/share/Cuplivo/logs';
+      final command = directoryOpenCommandFor(TargetPlatform.linux, path);
+      expect(command?.$1, 'xdg-open');
+      expect(command?.$2, [path]);
+    });
+
+    test('non-desktop platforms have no directory opener', () {
+      expect(
+        directoryOpenCommandFor(TargetPlatform.android, '/data/logs'),
+        isNull,
+      );
+      expect(directoryOpenCommandFor(TargetPlatform.iOS, '/data/logs'), isNull);
+      expect(
+        directoryOpenCommandFor(TargetPlatform.fuchsia, '/data/logs'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #789.

## Summary

Desktop Preferences -> 请求日志打印 / 应用日志打印 folder buttons did nothing when clicked, and repeated clicking was reported to crash on Windows. This replaces the directory-opening path and hardens the tooltips on that pane.

## Root cause

- Both rows built the logs directory as `Uri.file(...)` and called `launchUrl(uri)`. On Windows that reaches `ShellExecuteW` as a `file:` URL, which does not reliably open a directory — the click silently did nothing.
- Found while testing the fix: the runtime path was `<support>\cuplivo/logs` (mixed separators). `explorer.exe` cannot resolve forward-slash paths and opened the wrong folder. It now receives a backslash-only path.
- The reported native crash (0xC0000005 / 0xC000041D class) matches this repo's documented Windows AXTree failure mode (AGENTS 3.21, `WindowsAxTreeSafeTooltip`); the buttons used a raw `Tooltip`. This is mitigation, not a proven fix — crash dumps are still wanted if it persists.

## Changes

- `lib/utils/open_directory.dart` (new): `openDirectoryInFileManager()` uses Explorer (detached) / `open` / `xdg-open`, and normalizes Windows paths to backslashes.
- `lib/desktop/widgets/logs_folder_button.dart` (new): shared `LogsFolderButton`; resolves and creates `<app data>/logs`, reports failures with an error snackbar instead of silence.
- `display_pane.dart`: both folder buttons use the shared widget; the pane's five tooltips use `WindowsAxTreeSafeTooltip`.
- l10n: `logViewerOpenFolderFailed` added to all 4 ARB files.
- Tests: `test/utils/open_directory_test.dart`, `test/desktop/widgets/logs_folder_button_test.dart`.

## Verification

- `dart analyze --fatal-infos lib test` — no issues.
- `flutter test test/utils/open_directory_test.dart test/desktop/widgets/logs_folder_button_test.dart` — 7/7.
- `flutter test test/desktop_provider_detail_pane_test.dart test/desktop_group_chat_create_regression_test.dart` — 9/9 (they pump `DesktopSettingsPage`).
- `flutter build windows --debug` — built successfully.

## Manual test plan

1. Settings -> Preferences -> click the folder next to 请求日志打印 and 应用日志打印 -> Explorer opens `C:\Users\<user>\AppData\Roaming\com.psyche\cuplivo\logs`.
2. Delete the `logs` folder first -> it is recreated and opened.
3. Repeated clicks do not crash.

## Notes / residual risk

- macOS/Linux branches are unit-tested for mapping only; no macOS/Linux smoke test on this change.
- Native crash cause remains unconfirmed without Event Viewer data (error code + faulting module, assistive-tech state).
