### PR TITLE
fix(desktop): address logs folder opener review

### DIFF
--- a/lib/core/services/logging/daily_log_sink.dart
+++ b/lib/core/services/logging/daily_log_sink.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
+/// Ensures [logsDir] exists, rotates the active log aside when its last
+/// modification was on an earlier day, and returns an append sink for
+/// [activeFileName].
+///
+/// The rotated file is named `<rotatedFilePrefix>yyyy-MM-dd.txt`, with a
+/// `_<n>` suffix when that name already exists. Failures are reported with the
+/// resolved active path and rethrown so callers keep control over error
+/// handling.
+Future<IOSink> openDailyRotatingLogSink({
+  required Directory logsDir,
+  required String activeFileName,
+  required String rotatedFilePrefix,
+  required DateTime now,
+}) async {
+  final activePath = p.join(logsDir.path, activeFileName);
+  try {
+    if (!await logsDir.exists()) {
+      await logsDir.create(recursive: true);
+    }
+
+    final today = DateTime(now.year, now.month, now.day);
+    final active = File(activePath);
+    if (await active.exists()) {
+      final stat = await active.stat();
+      final local = stat.modified.toLocal();
+      final fileDay = DateTime(local.year, local.month, local.day);
+      if (fileDay != today) {
+        final suffix = _formatDay(fileDay);
+        var rotated = File(
+          p.join(logsDir.path, '$rotatedFilePrefix$suffix.txt'),
+        );
+        if (await rotated.exists()) {
+          var i = 1;
+          while (await File(
+            p.join(logsDir.path, '$rotatedFilePrefix${suffix}_$i.txt'),
+          ).exists()) {
+            i++;
+          }
+          rotated = File(
+            p.join(logsDir.path, '$rotatedFilePrefix${suffix}_$i.txt'),
+          );
+        }
+        await active.rename(rotated.path);
+      }
+    }
+
+    return active.openWrite(mode: FileMode.append);
+  } catch (e) {
+    debugPrint('openDailyRotatingLogSink: failed for $activePath: $e');
+    rethrow;
+  }
+}
+
+String _two(int v) => v.toString().padLeft(2, '0');
+
+String _formatDay(DateTime dt) =>
+    '${dt.year}-${_two(dt.month)}-${_two(dt.day)}';

--- a/lib/core/services/logging/flutter_logger.dart
+++ b/lib/core/services/logging/flutter_logger.dart
@@ -3,17 +3,20 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
-import 'package:path/path.dart' as p;
 
 import '../../../utils/app_directories.dart';
+import 'daily_log_sink.dart';
 
 class FlutterLogger {
   FlutterLogger._();
 
-  /// Active log file name; also referenced by the log viewer to label the
-  /// current app-log file.
+  /// Append target of the current day. Consumers match app logs by
+  /// [activeFileName] or [rotatedFilePrefix]; the log viewer also uses it to
+  /// badge the current file.
   static const String activeFileName = 'flutter_logs.txt';
-  static const String _rotatedFilePrefix = 'flutter_logs_';
+
+  /// Prefix shared by rotated app logs (`flutter_logs_yyyy-MM-dd.txt`).
+  static const String rotatedFilePrefix = 'flutter_logs_';
 
   static bool _enabled = false;
   static bool get enabled => _enabled;
@@ -105,39 +108,12 @@ class FlutterLogger {
     _sinkDate = today;
 
     final logsDir = await AppDirectories.getLogsDirectory();
-    if (!await logsDir.exists()) {
-      await logsDir.create(recursive: true);
-    }
-
-    final active = File(p.join(logsDir.path, activeFileName));
-    if (await active.exists()) {
-      try {
-        final stat = await active.stat();
-        final fileDay = _dayOf(stat.modified.toLocal());
-        if (fileDay != today) {
-          final suffix = _formatDate(fileDay);
-          var rotated = File(
-            p.join(logsDir.path, '$_rotatedFilePrefix$suffix.txt'),
-          );
-          if (await rotated.exists()) {
-            int i = 1;
-            while (await File(
-              p.join(logsDir.path, '$_rotatedFilePrefix${suffix}_$i.txt'),
-            ).exists()) {
-              i++;
-            }
-            rotated = File(
-              p.join(logsDir.path, '$_rotatedFilePrefix${suffix}_$i.txt'),
-            );
-          }
-          await active.rename(rotated.path);
-        }
-      } catch (e) {
-        debugPrint('FlutterLogger: failed to rotate active log: $e');
-      }
-    }
-
-    _sink = active.openWrite(mode: FileMode.append);
+    _sink = await openDailyRotatingLogSink(
+      logsDir: logsDir,
+      activeFileName: activeFileName,
+      rotatedFilePrefix: rotatedFilePrefix,
+      now: now,
+    );
     return _sink!;
   }
 

--- a/lib/core/services/logging/flutter_logger.dart
+++ b/lib/core/services/logging/flutter_logger.dart
@@ -3,13 +3,16 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
 
 import '../../../utils/app_directories.dart';
 
 class FlutterLogger {
   FlutterLogger._();
 
-  static const String _activeFileName = 'flutter_logs.txt';
+  /// Active log file name; also referenced by the log viewer to label the
+  /// current app-log file.
+  static const String activeFileName = 'flutter_logs.txt';
   static const String _rotatedFilePrefix = 'flutter_logs_';
 
   static bool _enabled = false;
@@ -106,28 +109,32 @@ class FlutterLogger {
       await logsDir.create(recursive: true);
     }
 
-    final active = File('${logsDir.path}/$_activeFileName');
+    final active = File(p.join(logsDir.path, activeFileName));
     if (await active.exists()) {
       try {
         final stat = await active.stat();
         final fileDay = _dayOf(stat.modified.toLocal());
         if (fileDay != today) {
           final suffix = _formatDate(fileDay);
-          var rotated = File('${logsDir.path}/$_rotatedFilePrefix$suffix.txt');
+          var rotated = File(
+            p.join(logsDir.path, '$_rotatedFilePrefix$suffix.txt'),
+          );
           if (await rotated.exists()) {
             int i = 1;
             while (await File(
-              '${logsDir.path}/$_rotatedFilePrefix${suffix}_$i.txt',
+              p.join(logsDir.path, '$_rotatedFilePrefix${suffix}_$i.txt'),
             ).exists()) {
               i++;
             }
             rotated = File(
-              '${logsDir.path}/$_rotatedFilePrefix${suffix}_$i.txt',
+              p.join(logsDir.path, '$_rotatedFilePrefix${suffix}_$i.txt'),
             );
           }
           await active.rename(rotated.path);
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('FlutterLogger: failed to rotate active log: $e');
+      }
     }
 
     _sink = active.openWrite(mode: FileMode.append);

--- a/lib/core/services/logging/flutter_logger.dart
+++ b/lib/core/services/logging/flutter_logger.dart
@@ -101,8 +101,7 @@ class FlutterLogger {
     _sink = null;
     _sinkDate = today;
 
-    final dir = await AppDirectories.getAppDataDirectory();
-    final logsDir = Directory('${dir.path}/logs');
+    final logsDir = await AppDirectories.getLogsDirectory();
     if (!await logsDir.exists()) {
       await logsDir.create(recursive: true);
     }

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -2,10 +2,17 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
 import '../../../utils/app_directories.dart';
 
 class RequestLogger {
   RequestLogger._();
+
+  /// Active request log file name; also referenced by the log viewer to label
+  /// the current request-log file.
+  static const String activeFileName = 'logs.txt';
 
   /// Log categories. Each is independently toggleable; the master
   /// [enabled] getter reflects "any category on".
@@ -135,26 +142,28 @@ class RequestLogger {
       await logsDir.create(recursive: true);
     }
 
-    final active = File('${logsDir.path}/logs.txt');
+    final active = File(p.join(logsDir.path, activeFileName));
     if (await active.exists()) {
       try {
         final stat = await active.stat();
         final fileDay = _dayOf(stat.modified.toLocal());
         if (fileDay != today) {
           final suffix = _formatDate(fileDay);
-          var rotated = File('${logsDir.path}/logs_$suffix.txt');
+          var rotated = File(p.join(logsDir.path, 'logs_$suffix.txt'));
           if (await rotated.exists()) {
             int i = 1;
             while (await File(
-              '${logsDir.path}/logs_${suffix}_$i.txt',
+              p.join(logsDir.path, 'logs_${suffix}_$i.txt'),
             ).exists()) {
               i++;
             }
-            rotated = File('${logsDir.path}/logs_${suffix}_$i.txt');
+            rotated = File(p.join(logsDir.path, 'logs_${suffix}_$i.txt'));
           }
           await active.rename(rotated.path);
         }
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('RequestLogger: failed to rotate active log: $e');
+      }
     }
 
     _sink = active.openWrite(mode: FileMode.append);
@@ -270,6 +279,8 @@ class RequestLogger {
           }
         }
       }
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('RequestLogger: log cleanup failed: $e');
+    }
   }
 }

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -6,13 +6,19 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../utils/app_directories.dart';
+import '../logging/daily_log_sink.dart';
 
 class RequestLogger {
   RequestLogger._();
 
-  /// Active request log file name; also referenced by the log viewer to label
-  /// the current request-log file.
+  /// Append target of the current day. Consumers match request logs by
+  /// [activeFileName] or [rotatedFilePrefix]; the log viewer also uses it to
+  /// badge the current file.
   static const String activeFileName = 'logs.txt';
+
+  /// Prefix shared by rotated request logs (`logs_yyyy-MM-dd.txt`), also used
+  /// to scope [cleanupLogs] to the request-log family.
+  static const String rotatedFilePrefix = 'logs_';
 
   /// Log categories. Each is independently toggleable; the master
   /// [enabled] getter reflects "any category on".
@@ -138,35 +144,12 @@ class RequestLogger {
     _sinkDate = today;
 
     final logsDir = await AppDirectories.getLogsDirectory();
-    if (!await logsDir.exists()) {
-      await logsDir.create(recursive: true);
-    }
-
-    final active = File(p.join(logsDir.path, activeFileName));
-    if (await active.exists()) {
-      try {
-        final stat = await active.stat();
-        final fileDay = _dayOf(stat.modified.toLocal());
-        if (fileDay != today) {
-          final suffix = _formatDate(fileDay);
-          var rotated = File(p.join(logsDir.path, 'logs_$suffix.txt'));
-          if (await rotated.exists()) {
-            int i = 1;
-            while (await File(
-              p.join(logsDir.path, 'logs_${suffix}_$i.txt'),
-            ).exists()) {
-              i++;
-            }
-            rotated = File(p.join(logsDir.path, 'logs_${suffix}_$i.txt'));
-          }
-          await active.rename(rotated.path);
-        }
-      } catch (e) {
-        debugPrint('RequestLogger: failed to rotate active log: $e');
-      }
-    }
-
-    _sink = active.openWrite(mode: FileMode.append);
+    _sink = await openDailyRotatingLogSink(
+      logsDir: logsDir,
+      activeFileName: activeFileName,
+      rotatedFilePrefix: rotatedFilePrefix,
+      now: now,
+    );
     return _sink!;
   }
 
@@ -225,6 +208,14 @@ class RequestLogger {
         .replaceAll('\t', r'\t');
   }
 
+  /// True for [RequestLogger]'s own files (active + rotated) and false for
+  /// every other file in the shared logs directory, notably app logs.
+  static bool _isRequestLogFileName(String fileName) {
+    final name = fileName.toLowerCase();
+    return name.endsWith('.txt') &&
+        (name == activeFileName || name.startsWith(rotatedFilePrefix));
+  }
+
   static Future<void> cleanupLogs({
     required int autoDeleteDays,
     required int maxSizeMB,
@@ -233,9 +224,11 @@ class RequestLogger {
       final logsDir = await AppDirectories.getLogsDirectory();
       if (!await logsDir.exists()) return;
 
+      // Only the request-log family: app logs share this directory and are
+      // never subject to the request-log retention settings.
       final files = await logsDir
           .list()
-          .where((e) => e is File && e.path.toLowerCase().endsWith('.txt'))
+          .where((e) => e is File && _isRequestLogFileName(p.basename(e.path)))
           .cast<File>()
           .toList();
       if (files.isEmpty) return;

--- a/lib/core/services/network/request_logger.dart
+++ b/lib/core/services/network/request_logger.dart
@@ -130,8 +130,7 @@ class RequestLogger {
     _sink = null;
     _sinkDate = today;
 
-    final dir = await AppDirectories.getAppDataDirectory();
-    final logsDir = Directory('${dir.path}/logs');
+    final logsDir = await AppDirectories.getLogsDirectory();
     if (!await logsDir.exists()) {
       await logsDir.create(recursive: true);
     }
@@ -222,8 +221,7 @@ class RequestLogger {
     required int maxSizeMB,
   }) async {
     try {
-      final dir = await AppDirectories.getAppDataDirectory();
-      final logsDir = Directory('${dir.path}/logs');
+      final logsDir = await AppDirectories.getLogsDirectory();
       if (!await logsDir.exists()) return;
 
       final files = await logsDir

--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -270,9 +270,11 @@ abstract final class StorageUsageService {
             case 'logs':
               byCat[StorageUsageCategoryKey.logs]!.add(bytes);
               final name = parts.last.toLowerCase();
-              if (name.startsWith('flutter_logs')) {
+              if (name == FlutterLogger.activeFileName ||
+                  name.startsWith(FlutterLogger.rotatedFilePrefix)) {
                 logsSubs['flutter_logs']!.add(bytes);
-              } else if (name.startsWith('logs')) {
+              } else if (name == RequestLogger.activeFileName ||
+                  name.startsWith(RequestLogger.rotatedFilePrefix)) {
                 logsSubs['request_logs']!.add(bytes);
               } else {
                 logsSubs['other_logs']!.add(bytes);

--- a/lib/core/services/storage/storage_usage_service.dart
+++ b/lib/core/services/storage/storage_usage_service.dart
@@ -772,8 +772,7 @@ abstract final class StorageUsageService {
     } catch (_) {}
 
     try {
-      final root = await AppDirectories.getAppDataDirectory();
-      final logsDir = Directory(p.join(root.path, 'logs'));
+      final logsDir = await AppDirectories.getLogsDirectory();
       await _deleteDirectoryContents(logsDir);
     } finally {
       try {

--- a/lib/desktop/widgets/logs_folder_button.dart
+++ b/lib/desktop/widgets/logs_folder_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../icons/lucide_adapter.dart' as lucide;
 import '../../l10n/app_localizations.dart';
+import '../../shared/widgets/ios_tactile.dart';
 import '../../shared/widgets/snackbar.dart';
 import '../../shared/widgets/windows_ax_tree_safe_tooltip.dart';
 import '../../utils/app_directories.dart';
@@ -49,23 +50,12 @@ class LogsFolderButton extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     return WindowsAxTreeSafeTooltip(
       message: l10n.logViewerOpenFolder,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: Semantics(
-          button: true,
-          child: InkWell(
-            borderRadius: BorderRadius.circular(6),
-            onTap: () => _handleTap(context),
-            child: Padding(
-              padding: const EdgeInsets.all(11),
-              child: Icon(
-                lucide.Lucide.FolderOpen,
-                size: 18,
-                color: cs.primary,
-              ),
-            ),
-          ),
-        ),
+      child: IosIconButton(
+        icon: lucide.Lucide.FolderOpen,
+        size: 18,
+        color: cs.primary,
+        semanticLabel: l10n.logViewerOpenFolder,
+        onTap: () => _handleTap(context),
       ),
     );
   }

--- a/lib/desktop/widgets/logs_folder_button.dart
+++ b/lib/desktop/widgets/logs_folder_button.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-import 'package:path/path.dart' as p;
 
 import '../../icons/lucide_adapter.dart' as lucide;
 import '../../l10n/app_localizations.dart';
@@ -13,8 +10,7 @@ import '../../utils/open_directory.dart';
 /// Resolves the application `logs` directory, creating it when missing, then
 /// opens it in the system file manager.
 Future<void> _openLogsDirectory() async {
-  final base = await AppDirectories.getAppDataDirectory();
-  final logsDir = Directory(p.join(base.path, 'logs'));
+  final logsDir = await AppDirectories.getLogsDirectory();
   if (!await logsDir.exists()) {
     await logsDir.create(recursive: true);
   }
@@ -53,12 +49,22 @@ class LogsFolderButton extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     return WindowsAxTreeSafeTooltip(
       message: l10n.logViewerOpenFolder,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(6),
-        onTap: () => _handleTap(context),
-        child: Padding(
-          padding: const EdgeInsets.all(6),
-          child: Icon(lucide.Lucide.FolderOpen, size: 18, color: cs.primary),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: Semantics(
+          button: true,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(6),
+            onTap: () => _handleTap(context),
+            child: Padding(
+              padding: const EdgeInsets.all(11),
+              child: Icon(
+                lucide.Lucide.FolderOpen,
+                size: 18,
+                color: cs.primary,
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -142,9 +142,11 @@ class _LogViewerPageState extends State<LogViewerPage>
         final app = <File>[];
         for (final f in all) {
           final name = p.basename(f.path).toLowerCase();
-          if (name.startsWith('flutter_logs')) {
+          if (name == FlutterLogger.activeFileName ||
+              name.startsWith(FlutterLogger.rotatedFilePrefix)) {
             app.add(f);
-          } else if (name.startsWith('logs')) {
+          } else if (name == RequestLogger.activeFileName ||
+              name.startsWith(RequestLogger.rotatedFilePrefix)) {
             request.add(f);
           } else {
             // Keep "other" logs in the simpler viewer.

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -128,8 +128,7 @@ class _LogViewerPageState extends State<LogViewerPage>
   Future<void> _loadLogFiles() async {
     setState(() => _loading = true);
     try {
-      final dir = await AppDirectories.getAppDataDirectory();
-      final logsDir = Directory('${dir.path}/logs');
+      final logsDir = await AppDirectories.getLogsDirectory();
       if (await logsDir.exists()) {
         final all = await logsDir
             .list()

--- a/lib/features/settings/pages/log_viewer_page.dart
+++ b/lib/features/settings/pages/log_viewer_page.dart
@@ -12,6 +12,8 @@ import '../../../icons/lucide_adapter.dart';
 import '../../../core/models/chat_input_data.dart';
 import '../../../core/providers/assistant_provider.dart';
 import '../../../core/services/chat/external_chat_draft_handoff.dart';
+import '../../../core/services/logging/flutter_logger.dart';
+import '../../../core/services/network/request_logger.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../shared/widgets/ios_tactile.dart';
 import '../../../shared/widgets/ios_switch.dart';
@@ -99,8 +101,8 @@ Future<void> _startRequestLogAiAnalysis(
 
 class _LogViewerPageState extends State<LogViewerPage>
     with SingleTickerProviderStateMixin {
-  static const String _activeRequestLog = 'logs.txt';
-  static const String _activeAppLog = 'flutter_logs.txt';
+  static const String _activeRequestLog = RequestLogger.activeFileName;
+  static const String _activeAppLog = FlutterLogger.activeFileName;
 
   late final TabController _tab;
 
@@ -173,7 +175,8 @@ class _LogViewerPageState extends State<LogViewerPage>
           _loading = false;
         });
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('LogViewerPage: failed to load log files: $e');
       setState(() {
         _requestLogFiles = <File>[];
         _appLogFiles = <File>[];

--- a/lib/utils/app_directories.dart
+++ b/lib/utils/app_directories.dart
@@ -62,6 +62,14 @@ class AppDirectories {
     return Directory('${root.path}/skills');
   }
 
+  /// Gets the directory holding application log files (`logs.txt`,
+  /// `flutter_logs*.txt`). Single source of truth for the loggers, the log
+  /// viewer, and the settings folder button, so they can never diverge.
+  static Future<Directory> getLogsDirectory() async {
+    final root = await getAppDataDirectory();
+    return Directory(p.join(root.path, 'logs'));
+  }
+
   /// Root directory that holds all workspace sandboxes (`default/`,
   /// `workspace_N/`, …). Desktop users may relocate this root via
   /// `workspaces_dir_v1` (honored on desktop only).

--- a/lib/utils/app_directories.dart
+++ b/lib/utils/app_directories.dart
@@ -64,7 +64,8 @@ class AppDirectories {
 
   /// Gets the directory holding application log files (`logs.txt`,
   /// `flutter_logs*.txt`). Single source of truth for the loggers, the log
-  /// viewer, and the settings folder button, so they can never diverge.
+  /// viewer, the storage usage scan/clear, and the settings folder button, so
+  /// they can never diverge.
   static Future<Directory> getLogsDirectory() async {
     final root = await getAppDataDirectory();
     return Directory(p.join(root.path, 'logs'));

--- a/lib/utils/open_directory.dart
+++ b/lib/utils/open_directory.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart'
-    show TargetPlatform, defaultTargetPlatform, visibleForTesting;
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 
 /// Opens [directoryPath] in the system file manager.
 ///
@@ -14,15 +14,26 @@ import 'package:flutter/foundation.dart'
 /// does not resolve forward-slash paths and opens the wrong folder (its
 /// command line treats `/`-prefixed tokens as switches, e.g. `/select,`).
 ///
-/// Throws [UnsupportedError] on non-desktop platforms and [ProcessException]
-/// when the platform command exits with a non-zero status.
+/// Throws [UnsupportedError] on web (where `defaultTargetPlatform` still
+/// reports the browser's host OS) and on non-desktop platforms,
+/// [FileSystemException] when the directory does not exist (a detached
+/// Windows launch would otherwise fail with no signal), and
+/// [ProcessException] when the platform command exits with a non-zero status.
 Future<void> openDirectoryInFileManager(String directoryPath) async {
+  if (kIsWeb) {
+    throw UnsupportedError(
+      'Opening a directory is only supported on desktop platforms',
+    );
+  }
   final platform = defaultTargetPlatform;
   final command = directoryOpenCommandFor(platform, directoryPath);
   if (command == null) {
     throw UnsupportedError(
       'Opening a directory is only supported on desktop platforms',
     );
+  }
+  if (!await Directory(directoryPath).exists()) {
+    throw FileSystemException('Directory does not exist', directoryPath);
   }
   final (executable, arguments) = command;
   if (platform == TargetPlatform.windows) {
@@ -44,7 +55,10 @@ Future<void> openDirectoryInFileManager(String directoryPath) async {
 
 /// Executable and arguments that open [path] in the system file manager for
 /// [platform], or null when [platform] has no known implementation.
-@visibleForTesting
+///
+/// Deliberately not `@visibleForTesting`: [openDirectoryInFileManager] calls
+/// it in production. It is public so tests can assert the mapping without
+/// spawning a process.
 (String, List<String>)? directoryOpenCommandFor(
   TargetPlatform platform,
   String path,

--- a/test/core/services/logging/daily_log_sink_test.dart
+++ b/test/core/services/logging/daily_log_sink_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/services/logging/daily_log_sink.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'cuplivo_daily_log_sink_test_',
+    );
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Future<IOSink> open(
+    Directory logsDir,
+    DateTime now, {
+    String activeFileName = 'logs.txt',
+    String rotatedFilePrefix = 'logs_',
+  }) {
+    return openDailyRotatingLogSink(
+      logsDir: logsDir,
+      activeFileName: activeFileName,
+      rotatedFilePrefix: rotatedFilePrefix,
+      now: now,
+    );
+  }
+
+  test('creates the logs directory and appends to the active file', () async {
+    final logsDir = Directory(p.join(tempDir.path, 'logs'));
+    final sink = await open(logsDir, DateTime(2026, 9, 12, 8));
+    sink.write('hello');
+    await sink.flush();
+    await sink.close();
+
+    expect(await logsDir.exists(), isTrue);
+    expect(
+      await File(p.join(logsDir.path, 'logs.txt')).readAsString(),
+      'hello',
+    );
+  });
+
+  test('rotates an active file whose last write was an earlier day', () async {
+    final logsDir = Directory(p.join(tempDir.path, 'logs'));
+    await logsDir.create(recursive: true);
+    final active = File(p.join(logsDir.path, 'logs.txt'));
+    await active.writeAsString('old', flush: true);
+    await active.setLastModified(DateTime(2026, 9, 10, 23, 59));
+
+    final sink = await open(logsDir, DateTime(2026, 9, 12, 8));
+    await sink.close();
+
+    final rotated = File(p.join(logsDir.path, 'logs_2026-09-10.txt'));
+    expect(await rotated.exists(), isTrue);
+    expect(await rotated.readAsString(), 'old');
+    // The append sink re-creates the active file for the new day.
+    expect(await active.readAsString(), '');
+  });
+
+  test('collision probe appends a numeric suffix', () async {
+    final logsDir = Directory(p.join(tempDir.path, 'logs'));
+    await logsDir.create(recursive: true);
+    await File(
+      p.join(logsDir.path, 'logs_2026-09-10.txt'),
+    ).writeAsString('first', flush: true);
+    final active = File(p.join(logsDir.path, 'logs.txt'));
+    await active.writeAsString('second', flush: true);
+    await active.setLastModified(DateTime(2026, 9, 10, 23, 59));
+
+    final sink = await open(logsDir, DateTime(2026, 9, 12, 8));
+    await sink.close();
+
+    final rotated = File(p.join(logsDir.path, 'logs_2026-09-10_1.txt'));
+    expect(await rotated.exists(), isTrue);
+    expect(await rotated.readAsString(), 'second');
+  });
+
+  test('keeps an active file from the same day in place', () async {
+    final logsDir = Directory(p.join(tempDir.path, 'logs'));
+    await logsDir.create(recursive: true);
+    final active = File(p.join(logsDir.path, 'logs.txt'));
+    await active.writeAsString('today', flush: true);
+    await active.setLastModified(DateTime(2026, 9, 12, 0, 1));
+
+    final sink = await open(logsDir, DateTime(2026, 9, 12, 23, 59));
+    sink.write('+');
+    await sink.flush();
+    await sink.close();
+
+    expect(await active.readAsString(), 'today+');
+    expect(
+      await File(p.join(logsDir.path, 'logs_2026-09-12.txt')).exists(),
+      isFalse,
+    );
+  });
+}

--- a/test/core/services/network/request_logger_cleanup_test.dart
+++ b/test/core/services/network/request_logger_cleanup_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:Cuplivo/core/services/network/request_logger.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async =>
+      p.join(root, 'documents');
+
+  @override
+  Future<String?> getApplicationSupportPath() async => p.join(root, 'support');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Directory logsDir;
+  late PathProviderPlatform previousPathProvider;
+
+  setUp(() async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    tempDir = await Directory.systemTemp.createTemp(
+      'cuplivo_request_log_cleanup_test_',
+    );
+    logsDir = Directory(p.join(tempDir.path, 'support', 'logs'));
+    await logsDir.create(recursive: true);
+    previousPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+  });
+
+  tearDown(() async {
+    debugDefaultTargetPlatformOverride = null;
+    PathProviderPlatform.instance = previousPathProvider;
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('age cleanup deletes old request logs but never app logs', () async {
+    final old = DateTime.now().subtract(const Duration(days: 30));
+    final requestLog = File(p.join(logsDir.path, 'logs_2026-01-01.txt'));
+    final appLog = File(p.join(logsDir.path, 'flutter_logs_2026-01-01.txt'));
+    await requestLog.writeAsString('request', flush: true);
+    await appLog.writeAsString('app', flush: true);
+    await requestLog.setLastModified(old);
+    await appLog.setLastModified(old);
+
+    await RequestLogger.cleanupLogs(autoDeleteDays: 7, maxSizeMB: 0);
+
+    expect(await requestLog.exists(), isFalse);
+    expect(await appLog.exists(), isTrue);
+  });
+
+  test('size cap counts only request logs', () async {
+    final requestOld = File(p.join(logsDir.path, 'logs_2026-01-01.txt'));
+    final requestNew = File(p.join(logsDir.path, 'logs_2026-06-01.txt'));
+    final appLog = File(p.join(logsDir.path, 'flutter_logs.txt'));
+    await requestOld.writeAsBytes(List<int>.filled(700 * 1024, 1));
+    await requestNew.writeAsBytes(List<int>.filled(700 * 1024, 2));
+    await appLog.writeAsBytes(List<int>.filled(2 * 1024 * 1024, 3));
+    await appLog.setLastModified(DateTime(2020, 1, 1));
+    await requestOld.setLastModified(DateTime(2026, 1, 1));
+    await requestNew.setLastModified(DateTime(2026, 6, 1));
+
+    await RequestLogger.cleanupLogs(autoDeleteDays: 0, maxSizeMB: 1);
+
+    expect(await requestOld.exists(), isFalse);
+    expect(await requestNew.exists(), isTrue);
+    expect(await appLog.exists(), isTrue);
+  });
+}

--- a/test/utils/app_directories_test.dart
+++ b/test/utils/app_directories_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:Cuplivo/utils/app_directories.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+// ignore: depend_on_referenced_packages
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProviderPlatform extends PathProviderPlatform {
+  _FakePathProviderPlatform({
+    required this.supportPath,
+    required this.documentsPath,
+  });
+
+  final String supportPath;
+  final String documentsPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => supportPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late PathProviderPlatform previousPathProvider;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'cuplivo_app_directories_test_',
+    );
+    previousPathProvider = PathProviderPlatform.instance;
+    PathProviderPlatform.instance = _FakePathProviderPlatform(
+      supportPath: p.join(tempDir.path, 'support'),
+      documentsPath: p.join(tempDir.path, 'documents'),
+    );
+  });
+
+  tearDown(() async {
+    debugDefaultTargetPlatformOverride = null;
+    PathProviderPlatform.instance = previousPathProvider;
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('getLogsDirectory resolves under the support dir on desktop', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    final dir = await AppDirectories.getLogsDirectory();
+    expect(dir.path, p.join(tempDir.path, 'support', 'logs'));
+  });
+
+  test('getLogsDirectory resolves under the documents dir on mobile', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    final dir = await AppDirectories.getLogsDirectory();
+    expect(dir.path, p.join(tempDir.path, 'documents', 'logs'));
+  });
+}

--- a/test/utils/open_directory_test.dart
+++ b/test/utils/open_directory_test.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:Cuplivo/utils/open_directory.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 
 void main() {
   group('directoryOpenCommandFor', () {
@@ -52,6 +55,34 @@ void main() {
       expect(
         directoryOpenCommandFor(TargetPlatform.fuchsia, '/data/logs'),
         isNull,
+      );
+    });
+  });
+
+  group('openDirectoryInFileManager', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('throws FileSystemException when the directory is missing', () async {
+      // Desktop platform override so command resolution succeeds; the missing
+      // path must fail before any process is spawned (Windows detached
+      // launches give no failure feedback otherwise).
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      final missing = p.join(
+        Directory.systemTemp.path,
+        'cuplivo-missing-${DateTime.now().microsecondsSinceEpoch}',
+      );
+      expect(Directory(missing).existsSync(), isFalse);
+      await expectLater(
+        openDirectoryInFileManager(missing),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('throws UnsupportedError on mobile platforms', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await expectLater(
+        openDirectoryInFileManager(Directory.systemTemp.path),
+        throwsA(isA<UnsupportedError>()),
       );
     });
   });


### PR DESCRIPTION
Follow-up to #824 (merged before these review fixes landed).

## Summary

Addresses the review findings on #824: web/missing-directory hardening for the directory opener, a single source of truth for the logs path, and desktop polish for the folder button.

## Changes

- `open_directory.dart`: `kIsWeb` early-throw so web builds get the documented `UnsupportedError`; `FileSystemException` when the directory is missing (a detached Windows launch otherwise gives no failure signal); removed the contradictory `@visibleForTesting` from `directoryOpenCommandFor` (it is called by production code).
- `app_directories.dart`: new `getLogsDirectory()`, now used by the request logger (×2), flutter logger, log viewer, and `LogsFolderButton`, so the button cannot diverge from where logs are written.
- `logs_folder_button.dart`: click cursor, 40×40dp tap target, button semantics.

## Verification

- `dart analyze --fatal-infos lib test` — No issues found.
- `flutter test` on the two changed test files plus `request_logger_redact_test.dart` and `flutter_logger_test.dart` — 15/15 passed.
- Manual: `explorer "<dir with spaces>"` opened the correct folder (asserted via Shell.Application `LocationURL`), so the plain argument form is kept.

The per-comment review disposition (adopted vs rejected) is posted as a PR comment.
