### PR TITLE
fix(mobile): keep selection toolbar after Select All in chat input

### DIFF
--- a/lib/features/home/widgets/chat_input_bar.dart
+++ b/lib/features/home/widgets/chat_input_bar.dart
@@ -1708,7 +1708,6 @@ class _ChatInputBarState extends State<ChatInputBar>
                     ),
                   );
                 } catch (_) {}
-                state.hideToolbar();
               },
               label: materialL10n.selectAllButtonLabel,
             ),


### PR DESCRIPTION
## Problem

Android chat input box: long-press on typed text → tap **Select All** → no Cut/Copy/Paste toolbar appears. Long-pressing again then collapses the whole selection to a single word, making text selection nearly impossible to operate.

## Root cause

`_buildContextMenu` in `lib/features/home/widgets/chat_input_bar.dart` is the iOS-style custom selection menu. Its **Select All** handler expanded the selection and then called `state.hideToolbar()`, dismissing the toolbar entirely.

The menu guard is `Platform.isIOS || _quickEditingController != null`, and the chat input controller is always a `QuickInstructionEditingController` (`chat_input_bar.dart:1051`), so this originally iOS-only path runs on Android too. The line dates back to the iOS-only implementation in `4706a7c9`; the Android exposure came with `68b8d907` (quick-instruction merge) broadening the guard.

## Fix

Remove `state.hideToolbar()` from the **Select All** handler only. The selection change makes the framework rebuild the menu (`TextSelectionOverlay.update → markNeedsBuild`), so it stays visible and refreshes to Cut/Copy/Paste/Insert newline — matching native Android/iOS behavior. Cut/Copy/Paste/Insert newline keep their existing post-action dismiss.

## Verification

- `dart format lib/features/home/widgets/chat_input_bar.dart` (0 changed)
- `dart analyze --fatal-infos lib test` → No issues found
- `flutter test test/features/home/widgets/chat_input_bar_content_insertion_test.dart test/features/home/widgets/chat_input_bar_buttons_test.dart test/features/home/widgets/chat_input_bar_draft_test.dart` → 26 passed

**Not run:** Android device/emulator (none attached locally; only Windows/Edge available).

Manual plan:
- Happy path: type text → long-press → Select All → toolbar stays with Cut/Copy/Paste/Insert newline → Copy works
- Edge: empty input long-press shows only Paste; with quick-instruction markers (U+FFFC) Select All → Copy does not leak marker characters
- Regression: settings dialogs use the default framework menu, unaffected
