### PR TITLE
fix(backup): re-split quick instructions for Kelivo legacy export

### DIFF
--- a/lib/core/services/backup/data_sync.dart
+++ b/lib/core/services/backup/data_sync.dart
@@ -27,6 +27,7 @@ import '../workspace/workspace_terminal_native_bridge.dart';
 import '../../database/business_preferences.dart';
 import '../../database/business_key_registry.dart';
 import 'kelivo_image_settings_mapper.dart';
+import 'kelivo_quick_instruction_mapper.dart';
 import 'kelivo_v2_exception.dart';
 import 'double_pref_keys.dart';
 import '../../../utils/app_directories.dart';
@@ -329,7 +330,7 @@ class DataSync {
       // settings.json — section-aware: assistant keys ride the chats bit,
       // everything else rides the settings bit.
       if (explicitScope ? scope.anySettings : scope.settings) {
-        final payloads = await _exportSettingsPayloads();
+        final payloads = await _exportSettingsPayloads(format: format);
         var settingsMap = payloads.settings;
         var settingsMeta = payloads.updatedAt;
         if (!scope.chatsAndAssistants || !scope.settings) {
@@ -1622,7 +1623,7 @@ class DataSync {
   /// written) are absent from the meta file and fall back to legacy merge
   /// semantics on restore. Local-only/entity keys never appear in either.
   Future<({Map<String, dynamic> settings, Map<String, int> updatedAt})>
-  _exportSettingsPayloads() async {
+  _exportSettingsPayloads({required BackupFormat format}) async {
     final prefs = SharedPreferencesAsync(_preferences);
     final map = await prefs.snapshot();
     // `assistants_v1` removed from SharedPreferences
@@ -1640,6 +1641,14 @@ class DataSync {
     // prefs never hold a mirror copy (no dual truth, no staleness).
     map.addAll(KelivoImageSettingsMapper.translateToUpstream(map));
     _retainCloudAsrForExport(map);
+
+    if (format == BackupFormat.kelivoLegacy) {
+      // Original Kelivo predates the ADR-0061 quick-instruction unification:
+      // re-split the unified library into its legacy quick_phrases_v1 /
+      // instruction_injections_v1 keys. Cuplivo-native (JSONL) exports keep
+      // the unified payload losslessly.
+      KelivoQuickInstructionMapper.translateToLegacy(map);
+    }
 
     // Kelivo's business router validates search_services_v1 entries and
     // requires `apiKeys` to be a plain List<String> (round-robin pool).

--- a/lib/core/services/backup/kelivo_quick_instruction_mapper.dart
+++ b/lib/core/services/backup/kelivo_quick_instruction_mapper.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../models/quick_instruction.dart';
+import '../../models/quick_phrase.dart';
+
+/// Splits Cuplivo's unified quick-instruction library back into the two legacy
+/// Kelivo preference keys for the `kelivoLegacy` backup format.
+///
+/// ADR-0061 unified Quick Phrases (composer insertion) and Instruction
+/// Injections (system/user-message placement) into one
+/// `instruction_injections_v1` JSON list. Original Kelivo only understands the
+/// pre-unification split:
+/// - `quick_phrases_v1`: `QuickPhrase {id, title, content, isGlobal,
+///   assistantId}` — items that write into the composer.
+/// - `instruction_injections_v1`: `InstructionInjection {id, title, prompt,
+///   group}` — items injected into the prompt.
+///
+/// An export meant for original Kelivo must therefore re-partition by
+/// placement: `inputBox` items become quick phrases, everything else stays an
+/// instruction injection.
+///
+/// Non-inputBox entries keep Cuplivo's full unified JSON (extra `placement` /
+/// `triggerMode` / `toolPolicy` fields included). Original Kelivo's `fromJson`
+/// ignores unknown keys, while Cuplivo's own restore reads them back to
+/// preserve placement — projecting down to the v1 shape would downgrade
+/// `beforeUserMessage` / `afterUserMessage` items to `systemPrompt` on
+/// round-trip.
+///
+/// The unified model stores no assistant scope for `inputBox` items, so every
+/// reconstructed quick phrase is global (`isGlobal: true`, no `assistantId`).
+/// This mirrors the loss already accepted by the unification migration.
+class KelivoQuickInstructionMapper {
+  KelivoQuickInstructionMapper._();
+
+  static const String unifiedKey = 'instruction_injections_v1';
+  static const String quickPhrasesKey = 'quick_phrases_v1';
+
+  /// Re-partitions `settings[unifiedKey]` into the legacy keys, in place.
+  ///
+  /// A no-op when [unifiedKey] is absent or unusable; in the latter case the
+  /// original payload is left untouched and the failure is logged, so an
+  /// export never silently drops the user's definitions.
+  static void translateToLegacy(Map<String, dynamic> settings) {
+    final raw = settings[unifiedKey];
+    if (raw == null) return;
+
+    final List<QuickInstruction> items;
+    try {
+      items = _decode(raw);
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[KelivoQuickInstructionMapper] $unifiedKey decode failed: '
+        '$error\n$stackTrace',
+      );
+      return;
+    }
+
+    final phrases = <Map<String, dynamic>>[];
+    final injections = <Map<String, dynamic>>[];
+    for (final item in items) {
+      if (item.isInputBox) {
+        phrases.add(
+          QuickPhrase(
+            id: item.id,
+            title: item.title,
+            content: item.prompt,
+          ).toJson(),
+        );
+      } else {
+        injections.add(item.toJson());
+      }
+    }
+
+    settings[unifiedKey] = jsonEncode(injections);
+    settings[quickPhrasesKey] = jsonEncode(phrases);
+  }
+
+  static List<QuickInstruction> _decode(Object? raw) {
+    final decoded = raw is String ? jsonDecode(raw) : raw;
+    if (decoded is! List) {
+      throw const FormatException(
+        'Unified quick instruction payload is not a list.',
+      );
+    }
+    final items = <QuickInstruction>[];
+    for (final value in decoded) {
+      if (value is! Map) {
+        throw const FormatException(
+          'Unified quick instruction item is not a map.',
+        );
+      }
+      items.add(QuickInstruction.fromJson(value.cast<String, dynamic>()));
+    }
+    return items;
+  }
+}

--- a/test/core/services/backup/data_sync_jsonl_lww_test.dart
+++ b/test/core/services/backup/data_sync_jsonl_lww_test.dart
@@ -120,7 +120,16 @@ void main() {
         chatService: chatService,
       );
       final backupFile = await sync.prepareBackupFile(
-        const WebDavConfig(content: BackupContentScope(chatsAndAssistants: true, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+        const WebDavConfig(
+          content: BackupContentScope(
+            chatsAndAssistants: true,
+            attachments: false,
+            workspaces: false,
+            fontsAndAvatars: false,
+            settings: true,
+            skills: true,
+          ),
+        ),
       );
       addTearDown(() => DataSync.cleanupTemporaryBackupFile(backupFile));
 
@@ -150,7 +159,16 @@ void main() {
       );
       await restoreSync.restoreFromLocalFile(
         backupFile,
-        const WebDavConfig(content: BackupContentScope(chatsAndAssistants: true, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+        const WebDavConfig(
+          content: BackupContentScope(
+            chatsAndAssistants: true,
+            attachments: false,
+            workspaces: false,
+            fontsAndAvatars: false,
+            settings: true,
+            skills: true,
+          ),
+        ),
         mode: RestoreMode.overwrite,
       );
       await restoreService.reloadCachesFromDb();
@@ -220,7 +238,16 @@ void main() {
     );
     await sync.restoreFromLocalFile(
       zipFile,
-      const WebDavConfig(content: BackupContentScope(chatsAndAssistants: true, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+      const WebDavConfig(
+        content: BackupContentScope(
+          chatsAndAssistants: true,
+          attachments: false,
+          workspaces: false,
+          fontsAndAvatars: false,
+          settings: true,
+          skills: true,
+        ),
+      ),
       mode: RestoreMode.merge,
     );
 
@@ -261,7 +288,16 @@ void main() {
     final sync = DataSync(preferences: businessPrefs, chatService: chatService);
     await sync.restoreFromLocalFile(
       zipFile,
-      const WebDavConfig(content: BackupContentScope(chatsAndAssistants: false, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+      const WebDavConfig(
+        content: BackupContentScope(
+          chatsAndAssistants: false,
+          attachments: false,
+          workspaces: false,
+          fontsAndAvatars: false,
+          settings: true,
+          skills: true,
+        ),
+      ),
       mode: RestoreMode.merge,
     );
 
@@ -305,7 +341,16 @@ void main() {
         chatService: chatService,
       );
       final backupFile = await sync.prepareBackupFile(
-        const WebDavConfig(content: BackupContentScope(chatsAndAssistants: true, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+        const WebDavConfig(
+          content: BackupContentScope(
+            chatsAndAssistants: true,
+            attachments: false,
+            workspaces: false,
+            fontsAndAvatars: false,
+            settings: true,
+            skills: true,
+          ),
+        ),
         format: BackupFormat.kelivoLegacy,
       );
       addTearDown(() => DataSync.cleanupTemporaryBackupFile(backupFile));
@@ -344,13 +389,98 @@ void main() {
       );
       await restoreSync.restoreFromLocalFile(
         backupFile,
-        const WebDavConfig(content: BackupContentScope(chatsAndAssistants: true, attachments: false, workspaces: false, fontsAndAvatars: false, settings: true, skills: true)),
+        const WebDavConfig(
+          content: BackupContentScope(
+            chatsAndAssistants: true,
+            attachments: false,
+            workspaces: false,
+            fontsAndAvatars: false,
+            settings: true,
+            skills: true,
+          ),
+        ),
         mode: RestoreMode.overwrite,
       );
       await restoreService.reloadCachesFromDb();
       expect(restoreService.getAllCompleteConversations(), hasLength(1));
       expect(restoreService.getMessages('legacy-conv'), hasLength(1));
       expect(restoreService.getToolEvents('legacy-msg'), hasLength(1));
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'kelivoLegacy export re-splits unified quick instructions by placement',
+    () async {
+      businessPrefs = BusinessPreferences.memoryForTests({
+        'instruction_injections_v1': jsonEncode([
+          {
+            'id': 'sys',
+            'title': 'System',
+            'prompt': 'sys prompt',
+            'group': 'G',
+            'placement': 'systemPrompt',
+          },
+          {
+            'id': 'phrase',
+            'title': 'Phrase',
+            'prompt': 'insert me',
+            'group': 'Quick Phrases',
+            'placement': 'inputBox',
+          },
+        ]),
+      });
+      final chatService = await createService();
+      final sync = DataSync(
+        preferences: businessPrefs,
+        chatService: chatService,
+      );
+
+      Future<Map<String, dynamic>> exportSettings(BackupFormat format) async {
+        final file = await sync.prepareBackupFile(
+          const WebDavConfig(
+            content: BackupContentScope(
+              chatsAndAssistants: false,
+              attachments: false,
+              workspaces: false,
+              fontsAndAvatars: false,
+              settings: true,
+              skills: false,
+            ),
+          ),
+          format: format,
+        );
+        addTearDown(() => DataSync.cleanupTemporaryBackupFile(file));
+        final archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+        try {
+          final entry = archive.findFile('settings.json')!;
+          return jsonDecode(utf8.decode(entry.readBytes()!))
+              as Map<String, dynamic>;
+        } finally {
+          archive.clearSync();
+        }
+      }
+
+      // Legacy: inputBox items move to quick_phrases_v1 in the Kelivo shape.
+      final legacy = await exportSettings(BackupFormat.kelivoLegacy);
+      final phrases = (jsonDecode(legacy['quick_phrases_v1'] as String) as List)
+          .cast<Map<String, dynamic>>();
+      expect(phrases, hasLength(1));
+      expect(phrases.single['id'], 'phrase');
+      expect(phrases.single['content'], 'insert me');
+      expect(phrases.single['isGlobal'], isTrue);
+      final legacyInjections =
+          (jsonDecode(legacy['instruction_injections_v1'] as String) as List)
+              .cast<Map<String, dynamic>>();
+      expect(legacyInjections.map((json) => json['id']), ['sys']);
+
+      // Cuplivo-native: the unified library must survive unsplit.
+      final jsonl = await exportSettings(BackupFormat.jsonl);
+      expect(jsonl.containsKey('quick_phrases_v1'), isFalse);
+      final unified =
+          (jsonDecode(jsonl['instruction_injections_v1'] as String) as List)
+              .cast<Map<String, dynamic>>();
+      expect(unified.map((json) => json['id']), ['sys', 'phrase']);
     },
     timeout: const Timeout(Duration(minutes: 2)),
   );

--- a/test/core/services/backup/kelivo_quick_instruction_mapper_test.dart
+++ b/test/core/services/backup/kelivo_quick_instruction_mapper_test.dart
@@ -1,0 +1,199 @@
+import 'dart:convert';
+
+import 'package:Cuplivo/core/models/quick_instruction.dart';
+import 'package:Cuplivo/core/services/backup/kelivo_quick_instruction_mapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  String encodeUnified(List<QuickInstruction> items) =>
+      jsonEncode(items.map((item) => item.toJson()).toList(growable: false));
+
+  QuickInstruction item({
+    required String id,
+    required QuickInstructionPlacement placement,
+    String title = '',
+    String prompt = '',
+    String group = '',
+    QuickInstructionTriggerMode triggerMode =
+        QuickInstructionTriggerMode.oneShot,
+  }) {
+    return QuickInstruction(
+      id: id,
+      title: title,
+      prompt: prompt,
+      group: group,
+      placement: placement,
+      triggerMode: triggerMode,
+    );
+  }
+
+  group('KelivoQuickInstructionMapper.translateToLegacy', () {
+    test('splits inputBox items into quick_phrases_v1 only', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: encodeUnified([
+          item(
+            id: 'sys',
+            placement: QuickInstructionPlacement.systemPrompt,
+            title: 'System',
+            prompt: 'sys prompt',
+            group: 'Group A',
+          ),
+          item(
+            id: 'phrase-global',
+            placement: QuickInstructionPlacement.inputBox,
+            title: 'Global Phrase',
+            prompt: 'insert me',
+          ),
+          item(
+            id: 'before',
+            placement: QuickInstructionPlacement.beforeUserMessage,
+            title: 'Before',
+            prompt: 'before prompt',
+            triggerMode: QuickInstructionTriggerMode.persistent,
+          ),
+          item(
+            id: 'after',
+            placement: QuickInstructionPlacement.afterUserMessage,
+            title: 'After',
+            prompt: 'after prompt',
+          ),
+        ]),
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      final injections =
+          (jsonDecode(
+                    settings[KelivoQuickInstructionMapper.unifiedKey] as String,
+                  )
+                  as List)
+              .cast<Map<String, dynamic>>();
+      expect(injections.map((json) => json['id']), [
+        'sys',
+        'before',
+        'after',
+      ], reason: 'inputBox items must be removed from the injection list');
+      expect(injections.first['title'], 'System');
+      expect(injections.first['prompt'], 'sys prompt');
+      expect(injections.first['group'], 'Group A');
+
+      final phrases =
+          (jsonDecode(
+                    settings[KelivoQuickInstructionMapper.quickPhrasesKey]
+                        as String,
+                  )
+                  as List)
+              .cast<Map<String, dynamic>>();
+      expect(phrases, hasLength(1));
+      expect(phrases.single, {
+        'id': 'phrase-global',
+        'title': 'Global Phrase',
+        'content': 'insert me',
+        'isGlobal': true,
+        'assistantId': null,
+      });
+    });
+
+    test('preserves unified fields for non-inputBox items', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: encodeUnified([
+          item(
+            id: 'before',
+            placement: QuickInstructionPlacement.beforeUserMessage,
+            title: 'Before',
+            prompt: 'before prompt',
+            triggerMode: QuickInstructionTriggerMode.persistent,
+          ),
+        ]),
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      final injections =
+          (jsonDecode(
+                    settings[KelivoQuickInstructionMapper.unifiedKey] as String,
+                  )
+                  as List)
+              .cast<Map<String, dynamic>>();
+      final json = injections.single;
+      expect(json['placement'], 'beforeUserMessage');
+      expect(json['triggerMode'], 'persistent');
+      expect(json.containsKey('toolPolicy'), isTrue);
+    });
+
+    test('is a no-op when the unified key is absent', () {
+      final settings = <String, dynamic>{'theme_mode_v1': 'light'};
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      expect(settings, {'theme_mode_v1': 'light'});
+    });
+
+    test('leaves the payload untouched when it is not valid JSON', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: 'not json',
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      expect(settings[KelivoQuickInstructionMapper.unifiedKey], 'not json');
+      expect(
+        settings.containsKey(KelivoQuickInstructionMapper.quickPhrasesKey),
+        isFalse,
+      );
+    });
+
+    test('leaves the payload untouched when an item is not a map', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: jsonEncode(['bad']),
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      expect(
+        settings[KelivoQuickInstructionMapper.unifiedKey],
+        jsonEncode(['bad']),
+      );
+      expect(
+        settings.containsKey(KelivoQuickInstructionMapper.quickPhrasesKey),
+        isFalse,
+      );
+    });
+
+    test('empty library yields empty legacy lists', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: '[]',
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      expect(settings[KelivoQuickInstructionMapper.unifiedKey], '[]');
+      expect(settings[KelivoQuickInstructionMapper.quickPhrasesKey], '[]');
+    });
+
+    test('accepts an already-decoded list payload', () {
+      final settings = <String, dynamic>{
+        KelivoQuickInstructionMapper.unifiedKey: [
+          item(
+            id: 'phrase',
+            placement: QuickInstructionPlacement.inputBox,
+            title: 'P',
+            prompt: 'body',
+          ).toJson(),
+        ],
+      };
+
+      KelivoQuickInstructionMapper.translateToLegacy(settings);
+
+      final phrases =
+          (jsonDecode(
+                    settings[KelivoQuickInstructionMapper.quickPhrasesKey]
+                        as String,
+                  )
+                  as List)
+              .cast<Map<String, dynamic>>();
+      expect(phrases.single['id'], 'phrase');
+      expect(phrases.single['content'], 'body');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

ADR-0061 unified **Quick Phrases** (composer insertion) and **Instruction Injections** (prompt placement) into one `instruction_injections_v1` library. Original Kelivo predates that unification and only reads the split keys:

- `quick_phrases_v1` — `{id, title, content, isGlobal, assistantId}`
- `instruction_injections_v1` — `{id, title, prompt, group}`

As a result, a `kelivoLegacy` export shipped the unified payload under a key original Kelivo cannot interpret, so quick phrases silently vanished on the target.

## Fix

Re-partition the unified library by placement at export time, only for `BackupFormat.kelivoLegacy`:

- `inputBox` items → `quick_phrases_v1` (reconstructed as global quick phrases)
- everything else → `instruction_injections_v1`, keeping Cuplivo's full unified JSON so `placement` / `triggerMode` / `toolPolicy` survive a Cuplivo round-trip (original Kelivo ignores unknown keys)

Cuplivo-native JSONL exports are untouched and remain lossless.

New `KelivoQuickInstructionMapper` leaves the original payload untouched and logs on malformed input, so an export never silently drops definitions.

## Tests

- `kelivo_quick_instruction_mapper_test.dart` — split by placement, field preservation, absent key, invalid JSON, non-map item, empty library, already-decoded list
- `data_sync_jsonl_lww_test.dart` — export integration asserts the legacy split and the unsplit JSONL format

## Verification

- `dart format --set-exit-if-changed` — clean
- `dart analyze --fatal-infos` (changed paths) — no issues
- `flutter test test/core/services/backup/kelivo_quick_instruction_mapper_test.dart` — 7 passed
- `flutter test test/core/services/backup/data_sync_jsonl_lww_test.dart --plain-name "kelivoLegacy export re-splits..."` — passed
